### PR TITLE
Resolve Java compiler warnings

### DIFF
--- a/amplify-core/src/main/java/com/amplifyframework/analytics/AnalyticsCategory.java
+++ b/amplify-core/src/main/java/com/amplifyframework/analytics/AnalyticsCategory.java
@@ -25,7 +25,7 @@ import com.amplifyframework.core.category.CategoryType;
  * Internally routes the calls to the Analytics CategoryType
  * plugins registered.
  */
-public class AnalyticsCategory extends Category<AnalyticsPlugin> implements AnalyticsCategoryBehavior {
+public class AnalyticsCategory extends Category<AnalyticsPlugin<?>> implements AnalyticsCategoryBehavior {
 
     /**
      * Protect enabling and disabling of Analytics event
@@ -89,3 +89,4 @@ public class AnalyticsCategory extends Category<AnalyticsPlugin> implements Anal
         }
     }
 }
+

--- a/amplify-core/src/main/java/com/amplifyframework/analytics/AnalyticsPlugin.java
+++ b/amplify-core/src/main/java/com/amplifyframework/analytics/AnalyticsPlugin.java
@@ -23,7 +23,7 @@ import com.amplifyframework.core.plugin.Plugin;
  * would extend. This includes the client behavior dictated by
  * {@link AnalyticsCategoryBehavior} and {@link Plugin}.
  */
-public abstract class AnalyticsPlugin<C, E> implements AnalyticsCategoryBehavior, Plugin<C, E> {
+public abstract class AnalyticsPlugin<E> implements AnalyticsCategoryBehavior, Plugin<E> {
     @Override
     public final CategoryType getCategoryType() {
         return CategoryType.ANALYTICS;

--- a/amplify-core/src/main/java/com/amplifyframework/api/ApiCategory.java
+++ b/amplify-core/src/main/java/com/amplifyframework/api/ApiCategory.java
@@ -18,7 +18,7 @@ package com.amplifyframework.api;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryType;
 
-public class ApiCategory extends Category<ApiPlugin> implements ApiCategoryBehavior {
+public class ApiCategory extends Category<ApiPlugin<?>> implements ApiCategoryBehavior {
     @Override
     public final CategoryType getCategoryType() {
         return CategoryType.API;

--- a/amplify-core/src/main/java/com/amplifyframework/api/ApiPlugin.java
+++ b/amplify-core/src/main/java/com/amplifyframework/api/ApiPlugin.java
@@ -18,7 +18,7 @@ package com.amplifyframework.api;
 import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.core.plugin.Plugin;
 
-public abstract class ApiPlugin<C, E> implements ApiCategoryBehavior, Plugin<C, E> {
+public abstract class ApiPlugin<E> implements ApiCategoryBehavior, Plugin<E> {
     @Override
     public final CategoryType getCategoryType() {
         return CategoryType.API;

--- a/amplify-core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/amplify-core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -137,7 +137,7 @@ public final class Amplify {
      * @throws PluginException when a plugin cannot be registered for the category type it belongs to
      *                         or when when the plugin's category type is not supported by Amplify.
      */
-    public static <P extends Plugin> void addPlugin(@NonNull final P plugin) throws PluginException {
+    public static <P extends Plugin<?>> void addPlugin(@NonNull final P plugin) throws PluginException {
         synchronized (LOCK) {
             if (plugin.getPluginKey() == null || plugin.getPluginKey().isEmpty()) {
                 throw new PluginException.EmptyKeyException();
@@ -186,7 +186,7 @@ public final class Amplify {
         }
     }
 
-    public static <P extends Plugin> void removePlugin(@NonNull final P plugin) throws PluginException {
+    public static <P extends Plugin<?>> void removePlugin(@NonNull final P plugin) throws PluginException {
         synchronized (LOCK) {
             switch (plugin.getCategoryType()) {
                 case API:

--- a/amplify-core/src/main/java/com/amplifyframework/core/async/EventCallback.java
+++ b/amplify-core/src/main/java/com/amplifyframework/core/async/EventCallback.java
@@ -17,6 +17,6 @@ package com.amplifyframework.core.async;
 
 import com.amplifyframework.core.task.AmplifyEvent;
 
-public interface EventCallback extends Callback {
+public interface EventCallback extends Callback<AmplifyEvent> {
     void onEvent(AmplifyEvent event);
 }

--- a/amplify-core/src/main/java/com/amplifyframework/core/category/Category.java
+++ b/amplify-core/src/main/java/com/amplifyframework/core/category/Category.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-public abstract class Category<P extends Plugin> implements CategoryTypeable {
+public abstract class Category<P extends Plugin<?>> implements CategoryTypeable {
     /**
      * Map of the { pluginKey => plugin } object
      */

--- a/amplify-core/src/main/java/com/amplifyframework/core/exception/ConfigurationException.java
+++ b/amplify-core/src/main/java/com/amplifyframework/core/exception/ConfigurationException.java
@@ -19,7 +19,13 @@ package com.amplifyframework.core.exception;
  * Exceptions associated with configuring and inspecting Amplify Categories
  */
 public class ConfigurationException extends AmplifyRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
     public static class AmplifyAlreadyConfiguredException extends ConfigurationException {
+
+        private static final long serialVersionUID = 1L;
+
         public AmplifyAlreadyConfiguredException() {
             super("The client issued a subsequent call to `Amplify.configure` after the first had already succeeded.");
         }
@@ -38,6 +44,9 @@ public class ConfigurationException extends AmplifyRuntimeException {
     }
 
     public static class InvalidAmplifyConfigurationFileException extends ConfigurationException {
+
+        private static final long serialVersionUID = 1L;
+
         public InvalidAmplifyConfigurationFileException() {
             super("The specified `amplifyconfiguration.json` file was not present or unreadable.");
         }
@@ -56,6 +65,9 @@ public class ConfigurationException extends AmplifyRuntimeException {
     }
 
     public static class UnableToDecodeException extends ConfigurationException {
+
+        private static final long serialVersionUID = 1L;
+
         public UnableToDecodeException() {
             super("Unable to decode `amplifyconfiguration.json` into a valid AmplifyConfiguration object");
         }
@@ -102,3 +114,4 @@ public class ConfigurationException extends AmplifyRuntimeException {
         super(throwable);
     }
 }
+

--- a/amplify-core/src/main/java/com/amplifyframework/core/plugin/Plugin.java
+++ b/amplify-core/src/main/java/com/amplifyframework/core/plugin/Plugin.java
@@ -23,7 +23,7 @@ import com.amplifyframework.core.category.CategoryTypeable;
  * Interface that defines the contract that every plugin
  * in Amplify System will adhere to.
  */
-public interface Plugin<C, E> extends CategoryTypeable {
+public interface Plugin<E> extends CategoryTypeable {
     /**
      * @return the identifier that identifies
      *         the plugin implementation
@@ -36,7 +36,7 @@ public interface Plugin<C, E> extends CategoryTypeable {
      * @param pluginConfiguration plugin-specific configuration
      * @throws PluginException when configuration for a plugin was not found
      */
-    void configure(@NonNull C pluginConfiguration) throws PluginException;
+    void configure(@NonNull Object pluginConfiguration) throws PluginException;
 
     /**
      * Returns escape hatch for plugin to enable lower-level client use-cases

--- a/amplify-core/src/main/java/com/amplifyframework/core/plugin/PluginException.java
+++ b/amplify-core/src/main/java/com/amplifyframework/core/plugin/PluginException.java
@@ -21,10 +21,16 @@ import com.amplifyframework.core.exception.AmplifyRuntimeException;
  * Exceptions associated with configuring and inspecting Amplify Plugins
  */
 public class PluginException extends AmplifyRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
     /**
      * The plugin encountered an error during configuration
      */
     public static class PluginConfigurationException extends PluginException {
+
+        private static final long serialVersionUID = 1L;
+
         public PluginConfigurationException() {
             super("The plugin encountered an error during configuration");
         }
@@ -46,6 +52,9 @@ public class PluginException extends AmplifyRuntimeException {
      * The plugin's `key` property is empty
      */
     public static class EmptyKeyException extends PluginException {
+
+        private static final long serialVersionUID = 1L;
+
         public EmptyKeyException() {
             super("The plugin's `key` property is empty");
         }
@@ -67,6 +76,9 @@ public class PluginException extends AmplifyRuntimeException {
      * A plugin is being added to the wrong category
      */
     public static class MismatchedPluginException extends PluginException {
+
+        private static final long serialVersionUID = 1L;
+
         public MismatchedPluginException() {
             super("A plugin is being added to the wrong category");
         }
@@ -88,6 +100,9 @@ public class PluginException extends AmplifyRuntimeException {
      * The plugin specified by `getPlugin(key)` does not exist
      */
     public static class NoSuchPluginException extends PluginException {
+
+        private static final long serialVersionUID = 1L;
+
         public NoSuchPluginException() {
             super("The plugin specified by `getPlugin(key)` does not exist");
         }
@@ -107,6 +122,9 @@ public class PluginException extends AmplifyRuntimeException {
 
     /** There are multiple registered plugins for a category */
     public static class MultiplePluginsException extends PluginException {
+
+        private static final long serialVersionUID = 1L;
+
         public MultiplePluginsException() {
             super("There is more than one plugin registered in this category");
         }

--- a/amplify-core/src/main/java/com/amplifyframework/hub/DefaultHubPlugin.java
+++ b/amplify-core/src/main/java/com/amplifyframework/hub/DefaultHubPlugin.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-public class DefaultHubPlugin extends HubPlugin {
+public class DefaultHubPlugin extends HubPlugin<Object> {
 
     private static final String TAG = DefaultHubPlugin.class.getSimpleName();
 

--- a/amplify-core/src/main/java/com/amplifyframework/hub/HubCategory.java
+++ b/amplify-core/src/main/java/com/amplifyframework/hub/HubCategory.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-public class HubCategory extends Category<HubPlugin> implements HubCategoryBehavior {
+public class HubCategory extends Category<HubPlugin<?>> implements HubCategoryBehavior {
     private static Map<HubChannel, ArrayList<Callback<? extends Result>>> callbacks =
             new HashMap<HubChannel, ArrayList<Callback<? extends Result>>>();
 

--- a/amplify-core/src/main/java/com/amplifyframework/hub/HubPlugin.java
+++ b/amplify-core/src/main/java/com/amplifyframework/hub/HubPlugin.java
@@ -23,7 +23,7 @@ import com.amplifyframework.core.plugin.Plugin;
  * would extend. This includes the client behavior dictated by
  * {@link HubCategoryBehavior} and {@link Plugin}.
  */
-public abstract class HubPlugin<C, E> implements HubCategoryBehavior, Plugin<C, E> {
+public abstract class HubPlugin<E> implements HubCategoryBehavior, Plugin<E> {
     @Override
     public final CategoryType getCategoryType() {
         return CategoryType.HUB;

--- a/amplify-core/src/main/java/com/amplifyframework/logging/LoggingCategory.java
+++ b/amplify-core/src/main/java/com/amplifyframework/logging/LoggingCategory.java
@@ -18,7 +18,7 @@ package com.amplifyframework.logging;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryType;
 
-public class LoggingCategory extends Category<LoggingPlugin> implements LoggingCategoryBehavior {
+public class LoggingCategory extends Category<LoggingPlugin<?>> implements LoggingCategoryBehavior {
     @Override
     public final CategoryType getCategoryType() {
         return CategoryType.LOGGING;

--- a/amplify-core/src/main/java/com/amplifyframework/logging/LoggingPlugin.java
+++ b/amplify-core/src/main/java/com/amplifyframework/logging/LoggingPlugin.java
@@ -23,7 +23,7 @@ import com.amplifyframework.core.plugin.Plugin;
  * would extend. This includes the client behavior dictated by
  * {@link LoggingCategoryBehavior} and {@link Plugin}.
  */
-public abstract class LoggingPlugin<C, E> implements LoggingCategoryBehavior, Plugin<C, E> {
+public abstract class LoggingPlugin<E> implements LoggingCategoryBehavior, Plugin<E> {
     @Override
     public final CategoryType getCategoryType() {
         return CategoryType.LOGGING;

--- a/amplify-core/src/main/java/com/amplifyframework/storage/StorageCategory.java
+++ b/amplify-core/src/main/java/com/amplifyframework/storage/StorageCategory.java
@@ -43,7 +43,7 @@ import com.amplifyframework.storage.result.StorageRemoveResult;
  * plugins registered.
  */
 
-public class StorageCategory extends Category<StoragePlugin> implements StorageCategoryBehavior {
+public class StorageCategory extends Category<StoragePlugin<?>> implements StorageCategoryBehavior {
     /**
      * Retrieve the Storage category type enum
      *

--- a/amplify-core/src/main/java/com/amplifyframework/storage/StoragePlugin.java
+++ b/amplify-core/src/main/java/com/amplifyframework/storage/StoragePlugin.java
@@ -23,7 +23,7 @@ import com.amplifyframework.core.plugin.Plugin;
  * would extend. This includes the client behavior dictated by
  * {@link StorageCategoryBehavior} and {@link Plugin}.
  */
-public abstract class StoragePlugin<C, E> implements StorageCategoryBehavior, Plugin<C, E> {
+public abstract class StoragePlugin<E> implements StorageCategoryBehavior, Plugin<E> {
     @Override
     public final CategoryType getCategoryType() {
         return CategoryType.STORAGE;

--- a/amplify-core/src/main/java/com/amplifyframework/storage/exception/StorageException.java
+++ b/amplify-core/src/main/java/com/amplifyframework/storage/exception/StorageException.java
@@ -19,7 +19,12 @@ import com.amplifyframework.core.exception.ConfigurationException;
 
 public class StorageException extends ConfigurationException {
 
+    private static final long serialVersionUID = 1L;
+
     public static class StorageNotConfiguredException extends StorageException {
+
+        private static final long serialVersionUID = 1L;
+
         public StorageNotConfiguredException() {
             super("Storage category is not configured. Please configure it through Amplify.configure(context)");
         }
@@ -66,3 +71,4 @@ public class StorageException extends ConfigurationException {
         super(throwable);
     }
 }
+

--- a/amplify-core/src/main/java/com/amplifyframework/storage/exception/StorageGetException.java
+++ b/amplify-core/src/main/java/com/amplifyframework/storage/exception/StorageGetException.java
@@ -22,10 +22,15 @@ import com.amplifyframework.core.exception.AmplifyException;
  */
 public class StorageGetException extends AmplifyException {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Specifies that exception was due to object not being found
      */
     public static class NotFoundException extends StorageGetException {
+
+        private static final long serialVersionUID = 1L;
+
         public NotFoundException() {
             super("No object is associated with provided key.");
         }

--- a/amplify-core/src/main/java/com/amplifyframework/storage/exception/StorageListException.java
+++ b/amplify-core/src/main/java/com/amplifyframework/storage/exception/StorageListException.java
@@ -22,10 +22,15 @@ import com.amplifyframework.core.exception.AmplifyException;
  */
 public class StorageListException extends AmplifyException {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Specifies that access to storage was denied
      */
     public static class AccessDeniedException extends StorageListException {
+
+        private static final long serialVersionUID = 1L;
+
         public AccessDeniedException() {
             super("Access to storage denied.");
         }
@@ -72,3 +77,4 @@ public class StorageListException extends AmplifyException {
         super(throwable);
     }
 }
+

--- a/amplify-core/src/main/java/com/amplifyframework/storage/exception/StoragePutException.java
+++ b/amplify-core/src/main/java/com/amplifyframework/storage/exception/StoragePutException.java
@@ -22,10 +22,15 @@ import com.amplifyframework.core.exception.AmplifyException;
  */
 public class StoragePutException extends AmplifyException {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Specifies that exception was due to missing file
      */
     public static class MissingFileException extends StoragePutException {
+
+        private static final long serialVersionUID = 1L;
+
         public MissingFileException() {
             super("Missing file to store.");
         }

--- a/amplify-core/src/main/java/com/amplifyframework/storage/exception/StorageRemoveException.java
+++ b/amplify-core/src/main/java/com/amplifyframework/storage/exception/StorageRemoveException.java
@@ -22,6 +22,8 @@ import com.amplifyframework.core.exception.AmplifyException;
  */
 public class StorageRemoveException extends AmplifyException {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Creates a new StorageRemoveException with the specified message, and root
      * cause.

--- a/aws-amplify-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AmazonPinpointAnalyticsPlugin.java
+++ b/aws-amplify-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AmazonPinpointAnalyticsPlugin.java
@@ -28,7 +28,7 @@ import com.amplifyframework.core.plugin.PluginException;
 /**
  * The plugin implementation for Amazon Pinpoint in Analytics category.
  */
-public class AmazonPinpointAnalyticsPlugin extends AnalyticsPlugin {
+public class AmazonPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
 
     private static final String TAG = AmazonPinpointAnalyticsPlugin.class.getSimpleName();
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,12 @@ allprojects {
         google()
         jcenter()
     }
+
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:all" << "-Werror"
+        }
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
Add `-Xlint:all`, `-Werror` to project-wide javac arguments, so as to prevent
drift to occur again.

*Issue #, if available:* N/A 

*Description of changes:*

Tested with `./gradlew build`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
