### PR TITLE
Use a single version of the AWS SDK across all modules

### DIFF
--- a/amplify-core/build.gradle
+++ b/amplify-core/build.gradle
@@ -44,7 +44,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.annotation:annotation:1.1.0'
 
@@ -56,3 +55,4 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.2.0' // Test Runner
     androidTestImplementation 'androidx.test.ext:junit:1.1.1' // Assertions
 }
+

--- a/aws-amplify-analytics-pinpoint/build.gradle
+++ b/aws-amplify-analytics-pinpoint/build.gradle
@@ -41,9 +41,8 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation project(':amplify-core')
-    implementation 'com.amazonaws:aws-android-sdk-pinpoint:2.16.1'
+    implementation "com.amazonaws:aws-android-sdk-pinpoint:$awsSdkVersion"
 }
 

--- a/aws-amplify-api-aws/build.gradle
+++ b/aws-amplify-api-aws/build.gradle
@@ -51,9 +51,8 @@ dependencies {
     implementation "com.google.code.gson:gson:2.8.6"
 
     // AWS dependencies
-    def aws_version = '2.16.2'
-    implementation "com.amazonaws:aws-android-sdk-auth-core:$aws_version"
-    implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version") { transitive = true }
+    implementation "com.amazonaws:aws-android-sdk-auth-core:$awsSdkVersion"
+    implementation ("com.amazonaws:aws-android-sdk-mobile-client:$awsSdkVersion") { transitive = true }
 
     // Unit test dependencies
     testImplementation "junit:junit:4.12"

--- a/aws-amplify-datastore/build.gradle
+++ b/aws-amplify-datastore/build.gradle
@@ -47,3 +47,4 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
+

--- a/aws-amplify-storage-s3/build.gradle
+++ b/aws-amplify-storage-s3/build.gradle
@@ -38,15 +38,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation project(':amplify-core')
 
-    def aws_version = '2.16.2'
-    implementation "com.amazonaws:aws-android-sdk-s3:$aws_version"
-    implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version") { transitive = true }
+    implementation "com.amazonaws:aws-android-sdk-s3:$awsSdkVersion"
+    implementation ("com.amazonaws:aws-android-sdk-mobile-client:$awsSdkVersion") { transitive = true }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,3 +46,7 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
+ext {
+    awsSdkVersion = '2.16.2'
+}
+


### PR DESCRIPTION
`./gradlew clean build` works again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
