### PR TITLE
[DataStore] Add SQLiteHelper and setUp implementation

### DIFF
--- a/amplify-core/src/main/java/com/amplifyframework/core/Immutable.java
+++ b/amplify-core/src/main/java/com/amplifyframework/core/Immutable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core;
+
+import androidx.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Contains methods for immutability.
+ */
+public final class Immutable {
+    private Immutable() {
+    }
+
+    /**
+     * Create an immutable copy of the map passed in.
+     *
+     * @param mutableMap the input map for which an immutable map
+     *                   is created and returned.
+     * @param <K> the key type of the mutableMap.
+     * @param <V> the value type of the mutableMap.
+     * @return the immutable copy of the mutableMap.
+     */
+    public static <K, V> Map<K, V> of(@Nullable final Map<K, V> mutableMap) {
+        if (mutableMap == null) {
+            return null;
+        }
+
+        final Map<K, V> copy = new HashMap<>(mutableMap);
+        return Collections.unmodifiableMap(copy);
+    }
+}

--- a/aws-amplify-datastore/build.gradle
+++ b/aws-amplify-datastore/build.gradle
@@ -36,6 +36,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -44,6 +49,10 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    // Required for instrumented tests
+    androidTestImplementation 'androidx.annotation:annotation:1.1.0'
+    androidTestImplementation 'androidx.test:core:1.2.0' // Core Library
+    androidTestImplementation 'androidx.test:runner:1.2.0' // Test Runner
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1' // Assertions
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/aws-amplify-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelperTest.java
+++ b/aws-amplify-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelperTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test the functions of {@link SQLiteStorageHelper}.
+ */
+public class SQLiteStorageHelperTest {
+
+    private SQLiteStorageHelper sqLiteStorageHelper;
+
+    private Set<CreateSqlCommand> createTableCommands;
+
+    /**
+     * Setup the required information for SQLiteStorageHelper construction.
+     */
+    @Before
+    public void setUp() {
+        createTableCommands = new HashSet<>();
+        createTableCommands.add(new CreateSqlCommand("PERSON",
+                "CREATE TABLE IF NOT EXISTS PERSON (ID TEXT PRIMARY KEY, NAME TEXT NOT NULL);"));
+        createTableCommands.add(new CreateSqlCommand("CAR",
+                "CREATE TABLE IF NOT EXISTS CAR (ID TEXT PRIMARY KEY, NAME TEXT NOT NULL);"));
+        sqLiteStorageHelper = SQLiteStorageHelper.getInstance(
+                ApplicationProvider.getApplicationContext(),
+                createTableCommands);
+    }
+
+    /**
+     * Drop all tables and database, close and delete the database.
+     */
+    @After
+    public void tearDown() {
+        SQLiteDatabase sqLiteDatabase = sqLiteStorageHelper.getWritableDatabase();
+        dropAllTables(sqLiteDatabase);
+        sqLiteDatabase.close();
+        sqLiteStorageHelper.close();
+        ApplicationProvider.getApplicationContext().deleteDatabase(sqLiteStorageHelper.getDatabaseName());
+        sqLiteDatabase = null;
+        sqLiteStorageHelper = null;
+    }
+
+    /**
+     * Assert the construction of the SQLiteStorageHelper.
+     */
+    @Test
+    public void getInstanceIsNotNull() {
+        assertNotNull(sqLiteStorageHelper);
+    }
+
+    /**
+     * Assert if the database connection is opened.
+     */
+    @Test
+    public void isDatabaseOpen() {
+        assertTrue(sqLiteStorageHelper.getWritableDatabase().isOpen());
+    }
+
+    /**
+     * Assert that {@link SQLiteStorageHelper#onCreate(SQLiteDatabase)}
+     * creates the specified tables.
+     */
+    @Test
+    public void onCreateCreatesTables() {
+        // Getting an instance to the writable database
+        // invokes onCreate on the SQLiteStorageHelper.
+        final SQLiteDatabase sqLiteDatabase = sqLiteStorageHelper.getWritableDatabase();
+        final List<String> tableNamesFromDatabase = getTableNames(sqLiteDatabase);
+        for (CreateSqlCommand createSqlCommand: createTableCommands) {
+            assertTrue(tableNamesFromDatabase.contains(createSqlCommand.tableName()));
+        }
+    }
+
+    private List<String> getTableNames(SQLiteDatabase sqLiteDatabase) {
+        final ArrayList<String> tableNamesFromDatabase = new ArrayList<>();
+        final Cursor cursor = sqLiteDatabase.rawQuery(
+                "SELECT name FROM sqlite_master WHERE type='table'",
+                null);
+
+        if (cursor.moveToFirst()) {
+            while (!cursor.isAfterLast()) {
+                if (!"android_metadata".equals(cursor.getColumnIndex("name"))) {
+                    tableNamesFromDatabase.add(cursor.getString(cursor.getColumnIndex("name")));
+                }
+                cursor.moveToNext();
+            }
+        }
+        return tableNamesFromDatabase;
+    }
+
+    private void dropAllTables(SQLiteDatabase sqLiteDatabase) {
+        // call DROP TABLE on every table name
+        for (final String table: getTableNames(sqLiteStorageHelper.getWritableDatabase())) {
+            String dropQuery = "DROP TABLE IF EXISTS " + table;
+            sqLiteDatabase.execSQL(dropQuery);
+        }
+    }
+}

--- a/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/model/ModelRegistry.java
+++ b/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/model/ModelRegistry.java
@@ -17,6 +17,8 @@ package com.amplifyframework.datastore.model;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.core.Immutable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +30,7 @@ public final class ModelRegistry {
     // Singleton instance
     private static ModelRegistry modelRegistryInstance;
 
-    // ClassName => ModelSchema map
+    // Model ClassName => ModelSchema map
     private Map<String, ModelSchema> modelSchemaMap;
 
     private ModelRegistry() {
@@ -54,6 +56,14 @@ public final class ModelRegistry {
      */
     public synchronized ModelSchema getModelSchemaForModelClass(@NonNull String className) {
         return modelSchemaMap.get(className);
+    }
+
+    /**
+     * Retrieve the map of Model ClassName => ModelSchema.
+     * @return an immutable map of Model ClassName => ModelSchema
+     */
+    public Map<String, ModelSchema> getModelSchemaMap() {
+        return Immutable.of(modelSchemaMap);
     }
 
     /**

--- a/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.datastore.storage;
 
+import android.content.Context;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.ResultListener;
@@ -35,9 +36,11 @@ public interface LocalStorageAdapter {
      * This setUp is a pre-requisite for all other operations
      * of a LocalStorageAdapter.
      *
+     * @param context Android application context required to
+     *                interact with a storage mechanism in Android.
      * @param models list of Model classes
      */
-    void setUp(@NonNull List<Class<? extends Model>> models);
+    void setUp(@NonNull Context context, @NonNull List<Class<? extends Model>> models);
 
     /**
      * Save a {@link Model} to the local storage engine.

--- a/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/CreateSqlCommand.java
+++ b/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/CreateSqlCommand.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.datastore.model.ModelSchema;
+
+/**
+ * An encapsulation of the information required to
+ * create a SQL table.
+ */
+final class CreateSqlCommand {
+
+    // name of the SQL table
+    private final String tableName;
+
+    // create table command in string representation
+    private final String sqlStatement;
+
+    /**
+     * Construct a CreateSqlCommand object.
+     *
+     * @param tableName name of the SQL table
+     * @param sqlStatement create table command in string representation
+     */
+    CreateSqlCommand(@NonNull String tableName,
+                     @NonNull String sqlStatement) {
+        this.tableName = tableName;
+        this.sqlStatement = sqlStatement;
+    }
+
+    /**
+     * Create the CREATE TABLE SQL command for the corresponding
+     * ModelSchema.
+     *
+     * @param modelSchema the schema of the model
+     * @return the CREATE TABLE SQL command
+     */
+    static CreateSqlCommand fromModelSchema(@NonNull ModelSchema modelSchema) {
+        final String tableName = modelSchema.getName();
+        final String sqlCreateStatement = getCreateSqlCommandForModelSchema(modelSchema);
+        return new CreateSqlCommand(tableName, sqlCreateStatement);
+    }
+
+    private static String getCreateSqlCommandForModelSchema(ModelSchema modelSchema) {
+        /* TODO */
+        return null;
+    }
+
+    /**
+     * Return the name of the SQL table.
+     * @return the name of the SQL table.
+     */
+    String tableName() {
+        return tableName;
+    }
+
+    /**
+     * Return the create table SQL command in string representation.
+     * @return the create table SQL command in string representation.
+     */
+    String sqlStatement() {
+        return sqlStatement;
+    }
+}

--- a/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.datastore.model.Model;
+import com.amplifyframework.datastore.model.ModelRegistry;
+import com.amplifyframework.datastore.model.ModelSchema;
+import com.amplifyframework.datastore.storage.LocalStorageAdapter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * An implementation of {@link LocalStorageAdapter} using {@link android.database.sqlite.SQLiteDatabase}.
+ */
+public final class SQLiteStorageAdapter implements LocalStorageAdapter {
+
+    // ModelRegistry instance that gives the ModelSchema and Model objects
+    // based on Model class name lookup mechanism.
+    private final ModelRegistry modelRegistry;
+
+    // Represents a connection to the SQLite database. This database reference
+    // can be used to do all SQL operations against the underlying database
+    // that this handle represents.
+    private SQLiteDatabase sqLiteDatabase;
+
+    /**
+     * Construct the SQLiteStorageAdapter object.
+     * @param modelRegistry modelRegistry that hosts the models and their schema.
+     */
+    public SQLiteStorageAdapter(@NonNull ModelRegistry modelRegistry) {
+        this.modelRegistry = modelRegistry;
+    }
+
+    /**
+     * Return the default instance of the SQLiteStorageAdapter.
+     * @return the default instance of the SQLiteStorageAdapter.
+     */
+    public static SQLiteStorageAdapter defaultInstance() {
+        return new SQLiteStorageAdapter(ModelRegistry.getInstance());
+    }
+
+    /**
+     * Setup the storage engine with the models. For each {@link Model}, construct a
+     * {@link ModelSchema} and setup the necessities for persisting a {@link Model}.
+     * This setUp is a pre-requisite for all other operations of a {@link LocalStorageAdapter}.
+     *
+     * The setup is synchronous and the completion of this method guarantees completion
+     * of the creation of SQL database and tables for the corresponding data models
+     * passed in.
+     *
+     * @param context Android application context required to
+     *                interact with a storage mechanism in Android.
+     * @param models  list of data {@link Model} classes
+     */
+    @Override
+    public void setUp(@NonNull Context context,
+                      @NonNull List<Class<? extends Model>> models) {
+        final Set<CreateSqlCommand> createTableCommands = new HashSet<>();
+
+        modelRegistry.createModelSchemaForModels(models);
+        for (Class<? extends Model> model: models) {
+            final ModelSchema modelSchema = ModelRegistry.getInstance()
+                    .getModelSchemaForModelClass(model.getSimpleName());
+            final CreateSqlCommand createSqlCommand = CreateSqlCommand.fromModelSchema(modelSchema);
+            createTableCommands.add(createSqlCommand);
+        }
+
+        final SQLiteStorageHelper dbHelper = SQLiteStorageHelper.getInstance(
+                context,
+                createTableCommands);
+        sqLiteDatabase = dbHelper.getWritableDatabase();
+    }
+
+    /**
+     * Save a {@link Model} to the local storage engine.
+     * The {@link ResultListener} will be invoked when the
+     * save operation is completed to notify the success and
+     * failure.
+     *
+     * @param model    the Model object
+     * @param listener the listener to be invoked when the
+     */
+    @Override
+    public void save(@NonNull Model model, @NonNull ResultListener<Model> listener) {
+        /* TODO */
+    }
+}

--- a/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
+++ b/aws-amplify-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.text.TextUtils;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
+import java.util.Set;
+
+/**
+ * A helper class to manage database creation and version management.
+ */
+final class SQLiteStorageHelper extends SQLiteOpenHelper {
+
+    // Database Version
+    @VisibleForTesting
+    static final int DATABASE_VERSION = 1;
+
+    // Logcat tag
+    private static final String TAG = SQLiteStorageHelper.class.getSimpleName();
+
+    // Database Name
+    private static final String DATABASE_NAME = "AmplifyDatastore.db";
+
+    // The singleton instance.
+    private static SQLiteStorageHelper sQLiteStorageHelperInstance;
+
+    // Contains all table name string list.
+    private final Set<CreateSqlCommand> createSqlCommands;
+
+    private SQLiteStorageHelper(@NonNull Context context,
+                                @NonNull Set<CreateSqlCommand> createSqlCommands) {
+        // Passing null to CursorFactory which is used to create cursor objects
+        // as there is no need for a CursorFactory so far.
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+        this.createSqlCommands = createSqlCommands;
+    }
+
+    /**
+     * Create / Retrieve the singleton instance of the SQLiteStorageHelper.
+     *
+     * @param context Android context
+     * @param createTableCommands set of table names and their create table sql commands
+     * @return the singleton instance
+     */
+    public static synchronized SQLiteStorageHelper getInstance(@NonNull Context context,
+                                                               @NonNull Set<CreateSqlCommand> createTableCommands) {
+        if (sQLiteStorageHelperInstance == null) {
+            sQLiteStorageHelperInstance = new SQLiteStorageHelper(context, createTableCommands);
+        }
+        return sQLiteStorageHelperInstance;
+    }
+
+    /**
+     * Create all the required SQL tables.
+     *
+     * @param sqLiteDatabase the connection handle to the database.
+     */
+    @Override
+    public synchronized void onCreate(SQLiteDatabase sqLiteDatabase) {
+        // Loop all the create table sql command string in the list.
+        // each sql will create a table in SQLite database.
+        sqLiteDatabase.beginTransaction();
+        try {
+            for (final CreateSqlCommand createSqlCommand: createSqlCommands) {
+                Log.i(TAG, "Creating table: " + createSqlCommand.tableName());
+                sqLiteDatabase.execSQL(createSqlCommand.sqlStatement());
+            }
+            sqLiteDatabase.setTransactionSuccessful();
+        } finally {
+            sqLiteDatabase.endTransaction();
+        }
+    }
+
+    /**
+     * When the new db version is bigger than current exist db version, this method will be invoked.
+     * It always drop all tables and then call onCreate() method to create all table again.
+     *
+     * @param sqLiteDatabase the connection handle to the database.
+     * @param oldVersion older version number
+     * @param newVersion newer version number
+     */
+    @Override
+    public synchronized void onUpgrade(SQLiteDatabase sqLiteDatabase, int oldVersion, int newVersion) {
+        // Loop all the tables in the list and drop them if they exist
+        // and re-create all the tables.
+        sqLiteDatabase.beginTransaction();
+        try {
+            for (final CreateSqlCommand createSqlCommand: createSqlCommands) {
+                if (!TextUtils.isEmpty(createSqlCommand.tableName())) {
+                    sqLiteDatabase.execSQL("drop table if exists " + createSqlCommand.tableName());
+                }
+            }
+            sqLiteDatabase.setTransactionSuccessful();
+        } finally {
+            sqLiteDatabase.endTransaction();
+        }
+
+        // After drop all exist tables, create all tables again.
+        onCreate(sqLiteDatabase);
+    }
+}


### PR DESCRIPTION
*Description of changes:*

1) Add implementation of the `SQLiteHelper` that will be used for database and table creation and upgrades. `SQLiteHelper` also helps get a connection handle to the database.

2) Added Android instrumentation tests for the helper.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
