### PR TITLE
[API] Support casting list objects

### DIFF
--- a/amplify-core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
+++ b/amplify-core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,6 +30,7 @@ import java.util.Objects;
  */
 public final class GraphQLResponse<T> {
     private final T data;
+    private final List<T> dataAsList;
     private final List<Error> errors;
 
     /**
@@ -39,6 +41,26 @@ public final class GraphQLResponse<T> {
      */
     public GraphQLResponse(@Nullable T data, @Nullable List<Error> errors) {
         this.data = data;
+        this.dataAsList = Collections.emptyList();
+        this.errors = new ArrayList<>();
+        if (errors != null) {
+            this.errors.addAll(errors);
+        }
+    }
+
+    /**
+     * Constructs a wrapper for graphql response containing
+     * a list of data objects.
+     * @param data response data list with user-defined cast type
+     * @param errors list of error responses as defined
+     *               by graphql doc
+     */
+    public GraphQLResponse(@Nullable List<T> data, @Nullable List<Error> errors) {
+        this.data = null;
+        this.dataAsList = new ArrayList<>();
+        if (data != null) {
+            this.dataAsList.addAll(data);
+        }
         this.errors = new ArrayList<>();
         if (errors != null) {
             this.errors.addAll(errors);
@@ -70,11 +92,20 @@ public final class GraphQLResponse<T> {
     }
 
     /**
+     * Gets the data sent back by API in the
+     * form of a list.
+     * @return API response body
+     */
+    public List<T> getDataAsList() {
+        return dataAsList;
+    }
+
+    /**
      * Checks that data was returned.
      * @return true if data exists, false otherwise
      */
     public boolean hasData() {
-        return data != null;
+        return data != null || !dataAsList.isEmpty();
     }
 
     @SuppressWarnings({"NeedBraces", "EqualsReplaceableByObjectsCall"})

--- a/aws-amplify-api-aws/src/androidTest/assets/list-todos-individually.graphql
+++ b/aws-amplify-api-aws/src/androidTest/assets/list-todos-individually.graphql
@@ -1,0 +1,8 @@
+query listIndividually {
+    list {
+        id
+        name
+        description
+    }
+}
+

--- a/aws-amplify-api-aws/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
+++ b/aws-amplify-api-aws/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -70,6 +71,40 @@ public final class GraphQLInstrumentationTest {
         configuration.populateFromConfigFile(context, R.raw.amplifyconfiguration);
         Amplify.addPlugin(new AWSApiPlugin());
         Amplify.configure(configuration, context);
+    }
+
+    /**
+     * Tests API graphql query with raw list response.
+     * @throws Exception when interrupted
+     */
+    @Test
+    public void testList() throws Exception {
+        String document = TestAssets.readAsString("list-todos-individually.graphql");
+        latch = new CountDownLatch(1);
+        Amplify.API.query(
+                "mygraphql",
+                document,
+                Collections.emptyMap(),
+                Todo.class,
+                new TestGraphQLResultListener<>());
+        latch.await(THREAD_WAIT_DURATION, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Tests API graphql query with nested response object.
+     * @throws Exception when interrupted
+     */
+    @Test
+    public void testNested() throws Exception {
+        String document = TestAssets.readAsString("list-todos.graphql");
+        latch = new CountDownLatch(1);
+        Amplify.API.query(
+                "mygraphql",
+                document,
+                Collections.emptyMap(),
+                Todos.class,
+                new TestGraphQLResultListener<>());
+        latch.await(THREAD_WAIT_DURATION, TimeUnit.SECONDS);
     }
 
     /**
@@ -147,6 +182,18 @@ public final class GraphQLInstrumentationTest {
 
         public String getDescription() {
             return description;
+        }
+    }
+
+    class Todos {
+        private final List<Todo> items;
+
+        Todos(List<Todo> items) {
+            this.items = items;
+        }
+
+        public List<Todo> getItems() {
+            return items;
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
* Allow casting to raw list type. Although it is recommended to use a wrapper around list as return type for list queries, GraphQL can return a raw list of models. This update will detect a json array and cast it to an ArrayList of custom data type.
* `JsonElement` will be used as "default" data type as return type if `classToCast` is not specified. In such case, the return type will not be a list, but rather a `JsonArray` data.
* `GraphQLResponse` will contain both `data` and `dataAsList` instance variable, and only one of them will be assigned. `hasData()` will return true if either exists.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
