### PR TITLE
Class and member scoping cleanup

### DIFF
--- a/amplify-core/src/androidTest/java/com/amplifyframework/hub/HubInstrumentedTest.java
+++ b/amplify-core/src/androidTest/java/com/amplifyframework/hub/HubInstrumentedTest.java
@@ -51,7 +51,7 @@ public final class HubInstrumentedTest {
      * {@link BackgroundExecutorHubPlugin} to satisfy the Hub category.
      */
     @BeforeClass
-    public static void setUpBeforeClass() {
+    public static void configureAmplify() {
         Context context = ApplicationProvider.getApplicationContext();
         AmplifyConfiguration configuration = new AmplifyConfiguration();
         configuration.populateFromConfigFile(context, R.raw.amplifyconfiguration);

--- a/amplify-core/src/main/java/com/amplifyframework/api/graphql/GraphQLRequest.java
+++ b/amplify-core/src/main/java/com/amplifyframework/api/graphql/GraphQLRequest.java
@@ -140,7 +140,7 @@ public final class GraphQLRequest {
     /**
      * Wrapper to contain field value and its name.
      */
-    final class FieldValue {
+    static final class FieldValue {
         private final String name;
         private final String value;
 
@@ -174,7 +174,7 @@ public final class GraphQLRequest {
     /**
      * Wrapper to contain variable value and its name.
      */
-    final class VariableValues {
+    static final class VariableValues {
         private final String name;
         private final String value;
 

--- a/aws-amplify-api-aws/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-amplify-api-aws/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -183,7 +183,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     /**
      * Wrapper class to pair http client with dedicated endpoint.
      */
-    class ClientDetails {
+    static class ClientDetails {
         private final String endpoint;
         private final OkHttpClient client;
 

--- a/aws-amplify-api-aws/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncV4Signer.java
+++ b/aws-amplify-api-aws/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncV4Signer.java
@@ -32,7 +32,6 @@ final class AppSyncV4Signer extends AWS4Signer {
     private static final String TAG = AppSyncV4Signer.class.getSimpleName();
 
     private static final String SERVICE_NAME_SCOPE = "appsync";
-
     private static final String RESOURCE_PATH = "/graphql";
 
     AppSyncV4Signer(String region) {


### PR DESCRIPTION
1. Prefer `static` on inner classes, to encourage decoupling;
2. Avoid non-final static fields and class-scoped instance variables
   where possible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
