### PR TITLE
Add path to store test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,4 +29,7 @@ jobs:
       - run:
           name: Build the project
           command: bash gradlew build
+      - store_test_results:
+          path: test-results
+
 


### PR DESCRIPTION
Add a path to store the test results for viewing failed tests and troubleshooting them.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
