### PR TITLE
Increase operation timeout in failing SyncEngine test

### DIFF
--- a/aws-amplify-datastore/src/test/java/com/amplifyframework/datastore/network/SyncEngineTest.java
+++ b/aws-amplify-datastore/src/test/java/com/amplifyframework/datastore/network/SyncEngineTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 @RunWith(RobolectricTestRunner.class)
 public class SyncEngineTest {
     // A "reasonable" amount of time our test(s) will wait for async operations to complete
-    private static final int OPERATIONS_TIMEOUT_MS = 100;
+    private static final int OPERATIONS_TIMEOUT_MS = 500;
 
     private ApiCategoryBehavior api;
     private String apiName;


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
