### PR TITLE
Adds correct serialization for Date properties

### DIFF
--- a/aws-amplify-api-aws/src/main/java/com/amplifyframework/api/aws/GsonVariablesSerializer.java
+++ b/aws-amplify-api-aws/src/main/java/com/amplifyframework/api/aws/GsonVariablesSerializer.java
@@ -17,8 +17,17 @@ package com.amplifyframework.api.aws;
 
 import com.amplifyframework.api.graphql.GraphQLRequest;
 
-import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 
+import java.lang.reflect.Type;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -27,6 +36,16 @@ import java.util.Map;
 public final class GsonVariablesSerializer implements GraphQLRequest.VariablesSerializer {
     @Override
     public String serialize(Map<String, Object> variables) {
-        return new Gson().toJson(variables);
+        return new GsonBuilder()
+                .registerTypeAdapter(Date.class, new DateSerializer())
+                .create()
+                .toJson(variables);
+    }
+
+    class DateSerializer implements JsonSerializer<Date> {
+        public JsonElement serialize(Date date, Type typeOfSrc, JsonSerializationContext context) {
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+            return new JsonPrimitive(df.format(new Date()));
+        }
     }
 }


### PR DESCRIPTION
Date properties from the CLI generated models were breaking on being serialized and sent to the server because the default format of the serialization was incompatible with AppSync. This formats the Date objects in the format accepted by AppSync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
