### PR TITLE
Codegen for Query LIST type + predicate translation

### DIFF
--- a/aws-amplify-api-aws/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
+++ b/aws-amplify-api-aws/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
@@ -18,6 +18,7 @@ package com.amplifyframework.api.aws;
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
+import com.amplifyframework.api.aws.test.R;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.api.graphql.QueryType;
@@ -50,7 +51,7 @@ public final class CodeGenerationInstrumentationTest {
     public static void configureAmplify() {
         Context context = ApplicationProvider.getApplicationContext();
         AmplifyConfiguration configuration = new AmplifyConfiguration();
-        configuration.populateFromConfigFile(context, com.amplifyframework.api.aws.test.R.raw.amplifyconfiguration);
+        configuration.populateFromConfigFile(context, R.raw.amplifyconfiguration);
         Amplify.addPlugin(new AWSApiPlugin());
         Amplify.configure(configuration, context);
     }

--- a/aws-amplify-api-aws/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-amplify-api-aws/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -213,7 +213,7 @@ final class AppSyncGraphQLRequestFactory {
             throw new AmplifyException(
                     "Tried to parse an unsupported QueryPredicate",
                     null,
-                    "We currently only support QueryPredicateOperation and QueryPredicateGroup",
+                    "Try changing to one of the supported values: QueryPredicateOperation, QueryPredicateGroup.",
                     false
             );
         }


### PR DESCRIPTION
Finishes the ability to construct GraphQL requests for Query LIST type which includes Predicate translation into the proper format for AppSync List functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
