### PR TITLE
GraphQLRequest generation string case fix

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
@@ -22,7 +22,7 @@ import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.testmodels.MaritalStatus;
 import com.amplifyframework.testmodels.Person;
-import com.amplifyframework.testmodels.Project;
+import com.amplifyframework.testmodels.Projectfields;
 import com.amplifyframework.testmodels.Team;
 
 import org.junit.BeforeClass;
@@ -255,13 +255,16 @@ public final class CodeGenerationInstrumentationTest {
     @Test
     public void belongsToCreateQuerySubscribe() throws Throwable {
         LatchedSingleResponseListener<Team> teamMutationListener = new LatchedSingleResponseListener<>();
-        LatchedSingleResponseListener<Project> projectMutationListener = new LatchedSingleResponseListener<>();
-        LatchedSingleResponseListener<Project> projectQueryListener = new LatchedSingleResponseListener<>();
-        LatchedResponseStreamListener<Project> projectSubscriptionListener = new LatchedResponseStreamListener<>(1);
+        LatchedSingleResponseListener<Projectfields> projectMutationListener =
+                new LatchedSingleResponseListener<>();
+        LatchedSingleResponseListener<Projectfields> projectQueryListener =
+                new LatchedSingleResponseListener<>();
+        LatchedResponseStreamListener<Projectfields> projectSubscriptionListener =
+                new LatchedResponseStreamListener<>(1);
 
-        GraphQLOperation<Project> operation = Amplify.API.subscribe(
+        GraphQLOperation<Projectfields> operation = Amplify.API.subscribe(
                 PROJECT_API_NAME,
-                Project.class,
+                Projectfields.class,
                 null,
                 SubscriptionType.ON_CREATE,
                 projectSubscriptionListener
@@ -280,7 +283,7 @@ public final class CodeGenerationInstrumentationTest {
         assertFalse(teamMutationResponse.hasErrors());
         assertTrue(teamMutationResponse.hasData());
 
-        Project project = Project
+        Projectfields projectfields = Projectfields
                 .builder()
                 .name("API Codegen")
                 .team(Team.justId(teamMutationResponse.getData().getId()))
@@ -288,32 +291,34 @@ public final class CodeGenerationInstrumentationTest {
 
         Amplify.API.mutate(
                 PROJECT_API_NAME,
-                project,
+                projectfields,
                 MutationType.CREATE,
                 projectMutationListener
         );
 
-        GraphQLResponse<Project> projectMutationResponse = projectMutationListener.awaitTerminalEvent().getResponse();
+        GraphQLResponse<Projectfields> projectMutationResponse =
+                projectMutationListener.awaitTerminalEvent().getResponse();
         assertFalse(projectMutationResponse.hasErrors());
         assertTrue(projectMutationResponse.hasData());
 
         Amplify.API.query(
                 PROJECT_API_NAME,
-                Project.class,
+                Projectfields.class,
                 projectMutationResponse.getData().getId(),
                 projectQueryListener
         );
 
-        GraphQLResponse<Project> projectQueryResponse = projectQueryListener.awaitTerminalEvent().getResponse();
+        GraphQLResponse<Projectfields> projectQueryResponse =
+                projectQueryListener.awaitTerminalEvent().getResponse();
         assertEquals(team, projectQueryResponse.getData().getTeam());
 
         // Validate that subscription received the newly created person.
-        List<GraphQLResponse<Project>> subscriptionResponses = projectSubscriptionListener.awaitItems();
+        List<GraphQLResponse<Projectfields>> subscriptionResponses = projectSubscriptionListener.awaitItems();
         assertEquals(1, subscriptionResponses.size());
         assertFalse(subscriptionResponses.get(0).hasErrors());
-        Project responseProject = subscriptionResponses.get(0).getData();
-        assertEquals(project.getName(), responseProject.getName());
-        assertEquals(team, responseProject.getTeam());
+        Projectfields responseProjectfields = subscriptionResponses.get(0).getData();
+        assertEquals(projectfields.getName(), responseProjectfields.getName());
+        assertEquals(team, responseProjectfields.getTeam());
 
         // Cancel the subscription.
         operation.cancel();

--- a/aws-api/src/androidTest/res/raw/amplifyconfiguration.json
+++ b/aws-api/src/androidTest/res/raw/amplifyconfiguration.json
@@ -50,10 +50,10 @@
         },
         "projectApi": {
           "__comment": "This is in David's developer account, right now.",
-          "Endpoint": "https://yfztylfvg5bxxhjgjc7u7czmmq.appsync-api.us-east-1.amazonaws.com/graphql",
+          "Endpoint": "https://xsbadeypwbgozoy6hpffr2utom.appsync-api.us-east-1.amazonaws.com/graphql",
           "Region": "us-east-1",
           "AuthorizationType": "API_KEY",
-          "ApiKey": "da2-rke4gdhdabgg7jutjbspfdrple"
+          "ApiKey": "da2-66qwellewfcjfefzjww56luqs4"
         }
       }
     }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -54,6 +54,8 @@ import java.util.Set;
  * AppSync specifications.
  */
 final class AppSyncGraphQLRequestFactory {
+    private static final int FIXED_QUERY_LIMIT = 1000;
+
     // This class should not be instantiated
     private AppSyncGraphQLRequestFactory() { }
 
@@ -64,14 +66,14 @@ final class AppSyncGraphQLRequestFactory {
         StringBuilder doc = new StringBuilder();
         Map<String, Object> variables = new HashMap<>();
         ModelSchema schema = ModelSchema.fromModelClass(modelClass);
-        String modelName = schema.getTargetModelName();
+        String graphQlTypeName = schema.getTargetModelName();
 
         doc.append("query ")
             .append("Get")
-            .append(StringUtils.capitalize(modelName))
+            .append(StringUtils.capitalizeFirst(graphQlTypeName))
             .append("(")
             .append("$id: ID!) { get")
-            .append(StringUtils.capitalize(modelName))
+            .append(StringUtils.capitalizeFirst(graphQlTypeName))
             .append("(id: $id) { ")
             .append(getModelFields(modelClass))
             .append("}}");
@@ -97,19 +99,20 @@ final class AppSyncGraphQLRequestFactory {
 
         doc.append("query ")
             .append("List")
-            .append(StringUtils.capitalize(graphQlTypeName))
+            .append(StringUtils.capitalizeFirst(graphQlTypeName))
             .append("(")
             .append("$filter: Model")
-            .append(StringUtils.capitalize(graphQlTypeName))
+            .append(StringUtils.capitalizeFirst(graphQlTypeName))
             .append("FilterInput ")
             .append("$limit: Int $nextToken: String) { list")
-            .append(StringUtils.capitalize(graphQlTypeName))
+            .append(StringUtils.capitalizeFirst(graphQlTypeName))
             .append("s(filter: $filter, limit: $limit, nextToken: $nextToken) { items {")
             .append(getModelFields(modelClass))
             .append("} nextToken }}");
 
         if (!predicateIsEmpty(predicate)) {
             variables.put("filter", parsePredicate(predicate));
+            variables.put("limit", FIXED_QUERY_LIMIT);
         }
 
         return new GraphQLRequest<>(
@@ -136,21 +139,21 @@ final class AppSyncGraphQLRequestFactory {
 
         doc.append("mutation ")
             .append(StringUtils.capitalize(typeStr))
-            .append(StringUtils.capitalize(graphQlTypeName))
+            .append(StringUtils.capitalizeFirst(graphQlTypeName))
             .append("($input: ")
             .append(StringUtils.capitalize(typeStr))
-            .append(StringUtils.capitalize(graphQlTypeName))
+            .append(StringUtils.capitalizeFirst(graphQlTypeName))
             .append("Input!");
 
         if (!predicateIsEmpty(predicate)) {
             doc.append(", $condition: Model")
-                    .append(StringUtils.capitalize(graphQlTypeName))
+                    .append(StringUtils.capitalizeFirst(graphQlTypeName))
                     .append("ConditionInput");
         }
 
         doc.append("){ ")
             .append(typeStr.toLowerCase(Locale.getDefault()))
-            .append(StringUtils.capitalize(graphQlTypeName))
+            .append(StringUtils.capitalizeFirst(graphQlTypeName))
             .append("(input: $input");
 
         if (!predicateIsEmpty(predicate)) {
@@ -192,10 +195,10 @@ final class AppSyncGraphQLRequestFactory {
 
         doc.append("subscription ")
                 .append(StringUtils.allCapsToPascalCase(typeStr))
-                .append(StringUtils.capitalize(graphQlTypeName))
+                .append(StringUtils.capitalizeFirst(graphQlTypeName))
                 .append("{")
                 .append(StringUtils.allCapsToCamelCase(typeStr))
-                .append(StringUtils.capitalize(graphQlTypeName))
+                .append(StringUtils.capitalizeFirst(graphQlTypeName))
                 .append("{")
                 .append(getModelFields(modelClass))
                 .append("}}");

--- a/core/src/main/java/com/amplifyframework/util/StringUtils.java
+++ b/core/src/main/java/com/amplifyframework/util/StringUtils.java
@@ -79,6 +79,19 @@ public final class StringUtils {
     }
 
     /**
+     * Returns original string with first character capitalized and remaining string left unchanged.
+     * @param original Original string to modify
+     * @return Original string but with first character capitalized (if it already was, String is unchanged)
+     */
+    public static String capitalizeFirst(String original) {
+        if (TextUtils.isEmpty(original)) {
+            return original;
+        }
+
+        return original.substring(0, 1).toUpperCase(Locale.getDefault()) + original.substring(1);
+    }
+
+    /**
      * Returns original string wrapped with single quotes.
      * @param original Original string to modify
      * @return Original string wrapped with single quotes.

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/ProjectWithoutFields.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/ProjectWithoutFields.java
@@ -25,16 +25,16 @@ import com.amplifyframework.core.model.query.predicate.QueryField;
 
 import java.util.UUID;
 
-/** This is an auto generated class representing the Project type in your schema. */
+/** This is an auto generated class representing the ProjectWithoutFields type in your schema. */
 @SuppressWarnings("all")
-@ModelConfig(targetName = "Project")
-public final class Project implements Model {
+@ModelConfig(targetName = "ProjectWithoutFields")
+public final class ProjectWithoutFields implements Model {
     public static final QueryField ID = QueryField.field("id");
     public static final QueryField NAME = QueryField.field("name");
     public static final QueryField TEAM = QueryField.field("team");
     private final @ModelField(targetName="id", targetType="ID", isRequired = true) String id;
     private final @ModelField(targetName="name", targetType="String") String name;
-    private final @ModelField(targetName="team", targetType="Team") @BelongsTo(targetName = "projectTeamId", type = Team.class) Team team;
+    private final @ModelField(targetName="team", targetType="Team") @BelongsTo(targetName = "projectWithoutFieldsTeamId", type = Team.class) Team team;
     public String getId() {
         return id;
     }
@@ -47,7 +47,7 @@ public final class Project implements Model {
         return team;
     }
 
-    private Project(String id, String name, Team team) {
+    private ProjectWithoutFields(String id, String name, Team team) {
         this.id = id;
         this.name = name;
         this.team = team;
@@ -60,10 +60,10 @@ public final class Project implements Model {
         } else if(obj == null || getClass() != obj.getClass()) {
             return false;
         } else {
-            Project project = (Project) obj;
-            return ObjectsCompat.equals(getId(), project.getId()) &&
-                    ObjectsCompat.equals(getName(), project.getName()) &&
-                    ObjectsCompat.equals(getTeam(), project.getTeam());
+            ProjectWithoutFields projectWithoutFields = (ProjectWithoutFields) obj;
+            return ObjectsCompat.equals(getId(), projectWithoutFields.getId()) &&
+                    ObjectsCompat.equals(getName(), projectWithoutFields.getName()) &&
+                    ObjectsCompat.equals(getTeam(), projectWithoutFields.getTeam());
         }
     }
 
@@ -76,16 +76,20 @@ public final class Project implements Model {
                 .hashCode();
     }
 
+    public static BuildStep builder() {
+        return new Builder();
+    }
+
     /**
      * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
-     *
      * This is a convenience method to return an instance of the object with only its ID populated
      * to be used in the context of a parameter in a delete mutation or referencing a foreign key
      * in a relationship.
      * @param id the id of the existing item this instance will represent
      * @return an instance of this model with only ID populated
+     * @throws IllegalArgumentException Checks that ID is in the proper format
      */
-    public static Project justId(String id) {
+    public static ProjectWithoutFields justId(String id) {
         try {
             UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
         } catch (Exception exception) {
@@ -95,25 +99,20 @@ public final class Project implements Model {
                             "creating a new object, use the standard builder method and leave the ID field blank."
             );
         }
-
-        return new Project(
+        return new ProjectWithoutFields(
                 id,
                 null,
                 null
         );
     }
 
-    public static BuildStep builder() {
-        return new Builder();
-    }
-
-    public NewBuilder newBuilder() {
-        return new NewBuilder(id,
+    public CopyOfBuilder copyOfBuilder() {
+        return new CopyOfBuilder(id,
                 name,
                 team);
     }
     public interface BuildStep {
-        Project build();
+        ProjectWithoutFields build();
         BuildStep id(String id) throws IllegalArgumentException;
         BuildStep name(String name);
         BuildStep team(Team team);
@@ -125,10 +124,10 @@ public final class Project implements Model {
         private String name;
         private Team team;
         @Override
-        public Project build() {
+        public ProjectWithoutFields build() {
             String id = this.id != null ? this.id : UUID.randomUUID().toString();
 
-            return new Project(
+            return new ProjectWithoutFields(
                     id,
                     name,
                     team);
@@ -152,7 +151,7 @@ public final class Project implements Model {
          * @param id id
          * @return Current Builder instance, for fluent method chaining
          * @throws IllegalArgumentException Checks that ID is in the proper format
-         **/
+         */
         public BuildStep id(String id) throws IllegalArgumentException {
             this.id = id;
 
@@ -168,21 +167,21 @@ public final class Project implements Model {
     }
 
 
-    public final class NewBuilder extends Builder {
-        private NewBuilder(String id, String name, Team team) {
+    public final class CopyOfBuilder extends Builder {
+        private CopyOfBuilder(String id, String name, Team team) {
             super.id(id);
             super.name(name)
                     .team(team);
         }
 
         @Override
-        public NewBuilder name(String name) {
-            return (NewBuilder) super.name(name);
+        public CopyOfBuilder name(String name) {
+            return (CopyOfBuilder) super.name(name);
         }
 
         @Override
-        public NewBuilder team(Team team) {
-            return (NewBuilder) super.team(team);
+        public CopyOfBuilder team(Team team) {
+            return (CopyOfBuilder) super.team(team);
         }
     }
 

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/Projectfields.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/Projectfields.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testmodels;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import java.util.UUID;
+
+/** This is an auto generated class representing the projectfields type in your schema. */
+@SuppressWarnings("all")
+@ModelConfig(targetName = "projectfields")
+public final class Projectfields implements Model {
+    public static final QueryField ID = QueryField.field("id");
+    public static final QueryField NAME = QueryField.field("name");
+    public static final QueryField TEAM = QueryField.field("team");
+    private final @ModelField(targetName="id", targetType="ID", isRequired = true) String id;
+    private final @ModelField(targetName="name", targetType="String") String name;
+    private final @ModelField(targetName="team", targetType="Team") @BelongsTo(targetName = "teamID", type = Team.class) Team team;
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    private Projectfields(String id, String name, Team team) {
+        this.id = id;
+        this.name = name;
+        this.team = team;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if(obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            Projectfields projectfields = (Projectfields) obj;
+            return ObjectsCompat.equals(getId(), projectfields.getId()) &&
+                    ObjectsCompat.equals(getName(), projectfields.getName()) &&
+                    ObjectsCompat.equals(getTeam(), projectfields.getTeam());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return new StringBuilder()
+                .append(getId())
+                .append(getName())
+                .append(getTeam())
+                .hashCode();
+    }
+
+    public static BuildStep builder() {
+        return new Builder();
+    }
+
+    /**
+     * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+     * This is a convenience method to return an instance of the object with only its ID populated
+     * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+     * in a relationship.
+     * @param id the id of the existing item this instance will represent
+     * @return an instance of this model with only ID populated
+     * @throws IllegalArgumentException Checks that ID is in the proper format
+     */
+    public static Projectfields justId(String id) {
+        try {
+            UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+        } catch (Exception exception) {
+            throw new IllegalArgumentException(
+                    "Model IDs must be unique in the format of UUID. This method is for creating instances " +
+                            "of an existing object with only its ID field for sending as a mutation parameter. When " +
+                            "creating a new object, use the standard builder method and leave the ID field blank."
+            );
+        }
+        return new Projectfields(
+                id,
+                null,
+                null
+        );
+    }
+
+    public CopyOfBuilder copyOfBuilder() {
+        return new CopyOfBuilder(id,
+                name,
+                team);
+    }
+    public interface BuildStep {
+        Projectfields build();
+        BuildStep id(String id) throws IllegalArgumentException;
+        BuildStep name(String name);
+        BuildStep team(Team team);
+    }
+
+
+    public static class Builder implements BuildStep {
+        private String id;
+        private String name;
+        private Team team;
+        @Override
+        public Projectfields build() {
+            String id = this.id != null ? this.id : UUID.randomUUID().toString();
+
+            return new Projectfields(
+                    id,
+                    name,
+                    team);
+        }
+
+        @Override
+        public BuildStep name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        @Override
+        public BuildStep team(Team team) {
+            this.team = team;
+            return this;
+        }
+
+        /**
+         * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
+         * This should only be set when referring to an already existing object.
+         * @param id id
+         * @return Current Builder instance, for fluent method chaining
+         * @throws IllegalArgumentException Checks that ID is in the proper format
+         */
+        public BuildStep id(String id) throws IllegalArgumentException {
+            this.id = id;
+
+            try {
+                UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+            } catch (Exception exception) {
+                throw new IllegalArgumentException("Model IDs must be unique in the format of UUID.",
+                        exception);
+            }
+
+            return this;
+        }
+    }
+
+
+    public final class CopyOfBuilder extends Builder {
+        private CopyOfBuilder(String id, String name, Team team) {
+            super.id(id);
+            super.name(name)
+                    .team(team);
+        }
+
+        @Override
+        public CopyOfBuilder name(String name) {
+            return (CopyOfBuilder) super.name(name);
+        }
+
+        @Override
+        public CopyOfBuilder team(Team team) {
+            return (CopyOfBuilder) super.team(team);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixed a problem in how model names were being capitalized to match what AppSync does.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
