### PR TITLE
[API] Adds tests/fixes for hasOne and many to many relationships

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
@@ -20,12 +20,16 @@ import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.model.annotations.BelongsTo;
 import com.amplifyframework.testmodels.Blog;
 import com.amplifyframework.testmodels.MaritalStatus;
 import com.amplifyframework.testmodels.Person;
 import com.amplifyframework.testmodels.Post;
+import com.amplifyframework.testmodels.PostEditor;
 import com.amplifyframework.testmodels.Projectfields;
+import com.amplifyframework.testmodels.Rating;
 import com.amplifyframework.testmodels.Team;
+import com.amplifyframework.testmodels.User;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -251,9 +255,10 @@ public final class CodeGenerationInstrumentationTest {
     }
 
     /**
-     * The primary purpose of this test is to ensure that an all lower case model name works.
-     * TODO: Add mutate with condition and list with predicate since those are the ones that actually use the original
-     *       model name
+     * For a model having an {@link BelongsTo} relationship to another model, validate
+     * successful query, mutations, subscription.
+     * TODO: Add mutate with condition and list with predicate since those are the ones
+     *       that actually use the original model name
      * @throws Throwable If we timeout while talking to the endpoint, or if any response comes back invalid
      */
     @Test
@@ -366,7 +371,11 @@ public final class CodeGenerationInstrumentationTest {
         );
 
         Post postCreateResult = postCreateListener.awaitTerminalEvent().getResponse().getData();
-        assertEquals(post, postCreateResult);
+        assertEquals(post.getId(), postCreateResult.getId());
+        assertEquals(post.getTitle(), postCreateResult.getTitle());
+        assertEquals(post.getBlog().getId(), postCreateResult.getBlog().getId());
+        assertEquals(post.getBlog().getName(), postCreateResult.getBlog().getName());
+        assertEquals(post.getBlog().getTags(), postCreateResult.getBlog().getTags());
 
         Amplify.API.query(
                 BLOG_API_NAME,
@@ -379,5 +388,152 @@ public final class CodeGenerationInstrumentationTest {
         Post blogGetResultPost = blogGetResult.getPosts().get(0);
         assertEquals(post.getId(), blogGetResultPost.getId());
         assertEquals(post.getTitle(), blogGetResultPost.getTitle());
+    }
+
+    /**
+     * Tests the code generation for HAS_ONE relationship.
+     */
+    @SuppressWarnings("checkstyle:MagicNumber")
+    @Test
+    public void hasOneRelationship() {
+        LatchedSingleResponseListener<Blog> blogCreateListener = new LatchedSingleResponseListener<>();
+        LatchedSingleResponseListener<Post> postCreateListener = new LatchedSingleResponseListener<>();
+        LatchedSingleResponseListener<Rating> ratingCreateListener = new LatchedSingleResponseListener<>();
+
+        Blog blog = Blog.builder()
+                .name("Necessary blog for post")
+                .build();
+
+        Amplify.API.mutate(
+                BLOG_API_NAME,
+                blog,
+                MutationType.CREATE,
+                blogCreateListener
+        );
+
+        blogCreateListener.awaitTerminalEvent();
+
+        Post post = Post.builder().title("Test post").blog(blog).build();
+
+        Amplify.API.mutate(
+                BLOG_API_NAME,
+                post,
+                MutationType.CREATE,
+                postCreateListener
+        );
+
+        postCreateListener.awaitTerminalEvent();
+
+        Rating rating = Rating.builder().stars(5).post(post).build();
+
+        Amplify.API.mutate(
+                BLOG_API_NAME,
+                rating,
+                MutationType.CREATE,
+                ratingCreateListener
+        );
+
+        Rating ratingCreateResult = ratingCreateListener.awaitTerminalEvent().getResponse().getData();
+        assertEquals(post, ratingCreateResult.getPost());
+
+        /*
+        TODO: This condition should work. However there is a bug on the AppSync transformer side which
+            sets up the HasOne / BelongsTo relationship as two independent BelongsTo relationships so it fails.
+            Once the AppSync transformer bug is fixed, we can uncomment this part of the test.
+
+        LatchedSingleResponseListener<Post> postGetListener = new LatchedSingleResponseListener<>();
+
+        Amplify.API.query(
+                BLOG_API_NAME,
+                Post.class,
+                post.getId(),
+                postGetListener
+        );
+
+        Post postGetResult = postGetListener.awaitTerminalEvent().getResponse().getData();
+        assertEquals(rating, postGetResult.getRating());
+         */
+    }
+
+    /**
+     * Tests the code generation for a Many to Many relationship simulated through two HasMany relationships.
+     */
+    @Test
+    public void manyToManyRelationship() {
+        LatchedSingleResponseListener<Blog> blogCreateListener = new LatchedSingleResponseListener<>();
+        LatchedSingleResponseListener<Post> postCreateListener = new LatchedSingleResponseListener<>();
+        LatchedSingleResponseListener<User> userCreateListener = new LatchedSingleResponseListener<>();
+        LatchedSingleResponseListener<PostEditor> editorCreateListener = new LatchedSingleResponseListener<>();
+        LatchedSingleResponseListener<Post> postGetListener = new LatchedSingleResponseListener<>();
+        LatchedSingleResponseListener<User> userGetListener = new LatchedSingleResponseListener<>();
+
+        Blog blog = Blog.builder()
+                .name("Necessary blog for post")
+                .build();
+
+        Amplify.API.mutate(
+                BLOG_API_NAME,
+                blog,
+                MutationType.CREATE,
+                blogCreateListener
+        );
+
+        blogCreateListener.awaitTerminalEvent();
+
+        Post post = Post.builder().title("Test post").blog(blog).build();
+
+        Amplify.API.mutate(
+                BLOG_API_NAME,
+                post,
+                MutationType.CREATE,
+                postCreateListener
+        );
+
+        postCreateListener.awaitTerminalEvent();
+
+        User user = User.builder().username("Patches46").build();
+
+        Amplify.API.mutate(
+                BLOG_API_NAME,
+                user,
+                MutationType.CREATE,
+                userCreateListener
+        );
+
+        userCreateListener.awaitTerminalEvent();
+
+        PostEditor editor = PostEditor.builder().post(post).editor(user).build();
+
+        Amplify.API.mutate(
+                BLOG_API_NAME,
+                editor,
+                MutationType.CREATE,
+                editorCreateListener
+        );
+
+        editorCreateListener.awaitTerminalEvent();
+
+        Amplify.API.query(
+                BLOG_API_NAME,
+                Post.class,
+                post.getId(),
+                postGetListener
+        );
+
+        Amplify.API.query(
+                BLOG_API_NAME,
+                User.class,
+                user.getId(),
+                userGetListener
+        );
+
+        Post postGetResult = postGetListener.awaitTerminalEvent().getResponse().getData();
+        User userGetResult = userGetListener.awaitTerminalEvent().getResponse().getData();
+
+        assertEquals(1, postGetResult.getEditors().size());
+        assertEquals(user, postGetResult.getEditors().get(0).getEditor());
+        assertEquals(1, userGetResult.getPosts().size());
+        assertEquals(post.getTitle(), userGetResult.getPosts().get(0).getPost().getTitle());
+        assertEquals(post.getId(), userGetResult.getPosts().get(0).getPost().getId());
     }
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -341,14 +341,14 @@ final class AppSyncGraphQLRequestFactory {
 
             if (schema.getAssociations().containsKey(fieldName)) {
                 if (List.class.isAssignableFrom(field.getType())) {
-                    if (levelsDeepToGo >= 2) {
+                    if (levelsDeepToGo >= 1) {
                         result.append(fieldName).append(" ");
 
                         ParameterizedType listType = (ParameterizedType) field.getGenericType();
                         Class<Model> listTypeClass = (Class<Model>) listType.getActualTypeArguments()[0];
 
                         result.append("{ items {")
-                                .append(getModelFields(listTypeClass, levelsDeepToGo - 2)) // cast checked above
+                                .append(getModelFields(listTypeClass, levelsDeepToGo - 1)) // cast checked above
                                 .append("} nextToken }");
                     }
                 } else if (levelsDeepToGo >= 1) {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonListDeserializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonListDeserializer.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.api.aws;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -37,13 +38,15 @@ public final class GsonListDeserializer implements JsonDeserializer<List<Object>
     @SuppressWarnings("unchecked")
     public List<Object> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
             throws JsonParseException {
-        Gson gson = new Gson();
 
         // If the json we got is not really a List and this List has a generics type...
         if (json.isJsonObject() && typeOfT instanceof ParameterizedType) {
             // Because this is a list and typeOfT is ParameterizedType we can be sure this is a safe cast.
             Class<Object> clazz = (Class<Object>) ((ParameterizedType) typeOfT).getActualTypeArguments()[0];
             JsonObject jsonObject = json.getAsJsonObject();
+            Gson gson = new GsonBuilder()
+                    .registerTypeAdapter(List.class, new GsonListDeserializer())
+                    .create();
 
             // ...and it is in the format we expect from AppSync for a list of objects in a relationship
             if (jsonObject.has("items") && jsonObject.get("items").isJsonArray()) {
@@ -67,6 +70,6 @@ public final class GsonListDeserializer implements JsonDeserializer<List<Object>
             }
         }
 
-        return gson.fromJson(json, typeOfT);
+        return new Gson().fromJson(json, typeOfT);
     }
 }


### PR DESCRIPTION
Handles parsing custom list return types within custom list return types and adds tests for hasOne and the faux many to many relationship.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
