### PR TITLE
[DataStore] ModelSync Contract and Data Objects

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelSync.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelSync.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.api.graphql.GraphQLOperation;
+import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.api.graphql.MutationType;
+import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+
+/**
+ * Convenience class to extend API query and mutate capabilities to also support versioning.
+ */
+public final class ModelSync {
+    private ModelSync() { }
+
+    /**
+     * Uses Amplify API category to get a list of changes which have happened since a last sync time.
+     * @param apiName The name of a configured API
+     * @param modelClass The class of the Model we are querying on
+     * @param predicate Filtering conditions for the query
+     * @param lastSync The time you last synced - all changes since this time are retrieved.
+     * @param responseListener Invoked when response data/errors are available.  If null,
+     *        response can still be obtained via Hub.
+     * @param <T> The type of data in the response, if available. Must extend Model.
+     * @return A {@link GraphQLOperation} to track progress and provide
+     *        a means to cancel the asynchronous operation
+     */
+    public static <T extends Model> GraphQLOperation<T> query(
+            @NonNull String apiName,
+            @NonNull Class<T> modelClass,
+            QueryPredicate predicate,
+            @NonNull Long lastSync,
+            @Nullable ResultListener<GraphQLResponse<Iterable<ModelSyncEntry<T>>>> responseListener
+    ) {
+        throw new UnsupportedOperationException("Coming soon...");
+    }
+
+    /**
+     * Uses Amplify API to make a mutation and record versioning information.
+     * @param apiName The name of a configured API
+     * @param model An instance of the Model with the values to mutate
+     * @param predicate Conditions on the current data to determine whether to go through
+     *                   with an UPDATE or DELETE operation
+     * @param type What type of mutation to perform (e.g. Create, Update, Delete)
+     * @param lastSync The time you last synced - all changes since this time are retrieved.
+     * @param responseListener Invoked when response data/errors are available.  If null,
+     *        response can still be obtained via Hub.
+     * @param <T> The type of data in the response, if available. Must extend Model.
+     * @return A {@link GraphQLOperation} to track progress and provide
+     *        a means to cancel the asynchronous operation
+     */
+    public static <T extends Model> GraphQLOperation<T> mutate(
+            @NonNull String apiName,
+            @NonNull T model,
+            QueryPredicate predicate,
+            @NonNull MutationType type,
+            @NonNull Long lastSync,
+            @Nullable ResultListener<GraphQLResponse<ModelSyncEntry<T>>> responseListener
+    ) {
+        throw new UnsupportedOperationException("Coming soon...");
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelSyncEntry.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelSyncEntry.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import com.amplifyframework.core.model.Model;
+
+/**
+ * Container class to hold an instance of an object with it's metadata.
+ * @param <M> The model represented by this container
+ */
+public class ModelSyncEntry<M extends Model> {
+    private M model;
+    private ModelSyncMetadata syncMetadata;
+
+    /**
+     * Holds an instance of a model in one object and its sync metadata in another.
+     * @param model An instance of a model
+     * @param syncMetadata The metadata for this model about it's synchronization history.
+     */
+    public ModelSyncEntry(M model, ModelSyncMetadata syncMetadata) {
+        this.model = model;
+        this.syncMetadata = syncMetadata;
+    }
+
+    /**
+     * Get the model instance.
+     * @return the model instance
+     */
+    public M getModel() {
+        return model;
+    }
+
+    /**
+     * Get the sync/version metadata for the model instance.
+     * @return the sync/version metadata
+     */
+    public ModelSyncMetadata getSyncMetadata() {
+        return syncMetadata;
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelSyncMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelSyncMetadata.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+
+/**
+ * System model to represent the versioning/sync metadata for an object.
+ */
+@ModelConfig
+@SuppressWarnings({"MemberName", "ParameterName"})
+public final class ModelSyncMetadata implements Model {
+    private final @ModelField(targetType = "ID", isRequired = true) String id;
+    private final @ModelField(targetType = "Boolean", isRequired = true) Boolean _deleted;
+    private final @ModelField(targetType = "Int", isRequired = true) Integer _version;
+    private final @ModelField(targetType = "AWSTimestamp", isRequired = true) Long _lastChangedAt;
+
+    /**
+     * Constructor for this metadata model.
+     * @param id The ID of the object this is holding the metadata for (also this object's own ID)
+     * @param deleted Whether this object was deleted since the last sync time specified
+     * @param version What version this object was last seen at
+     * @param lastChangedAt When was this object last changed
+     */
+    public ModelSyncMetadata(String id, Boolean deleted, Integer version, Long lastChangedAt) {
+        this.id = id;
+        this._deleted = deleted;
+        this._version = version;
+        this._lastChangedAt = lastChangedAt;
+    }
+
+    /**
+     * Gets ID.
+     * @return ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the deleted status.
+     * @return True if deleted, False otherwise
+     */
+    public Boolean isDeleted() {
+        return _deleted;
+    }
+
+    /**
+     * Gets the version.
+     * @return version
+     */
+    public Integer getVersion() {
+        return _version;
+    }
+
+    /**
+     * Gets last changed at time.
+     * @return last changed at time
+     */
+    public Long getLastChangedAt() {
+        return _lastChangedAt;
+    }
+}


### PR DESCRIPTION
Defines the methods and classes which would be used by data store to perform version control mutations and query for sync information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
