### PR TITLE
[API] Update API key used for GraphQLInstrumentationTest

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Validates the functionality of the {@link AWSApiPlugin}.
@@ -129,7 +130,9 @@ public final class GraphQLInstrumentationTest {
         );
         GraphQLResponse<Comment> response =
             creationListener.awaitTerminalEvent().assertResponse().getResponse();
-        assertFalse(response.hasErrors());
+        if (response.hasErrors()) {
+            fail(response.getErrors().iterator().next().getMessage());
+        }
         assertTrue(response.hasData());
         Comment comment = response.getData();
         assertEquals("It's going to be fun!", comment.content());
@@ -144,8 +147,11 @@ public final class GraphQLInstrumentationTest {
     private void validateSubscribedComments(List<GraphQLResponse<Comment>> subscriptionResponses) {
         // Validate that the subscription received data.
         assertEquals(1, subscriptionResponses.size());
-        assertFalse(subscriptionResponses.get(0).hasErrors());
-        Comment subscriptionComment = subscriptionResponses.get(0).getData();
+        GraphQLResponse<Comment> commentResponse = subscriptionResponses.get(0);
+        if (commentResponse.hasErrors()) {
+            fail(commentResponse.getErrors().iterator().next().getMessage());
+        }
+        Comment subscriptionComment = commentResponse.getData();
         assertEquals("It's going to be fun!", subscriptionComment.content());
     }
 
@@ -179,7 +185,9 @@ public final class GraphQLInstrumentationTest {
 
         // Validate the response. No errors are expected.
         GraphQLResponse<Event> creationResponse = creationListener.awaitTerminalEvent().getResponse();
-        assertFalse(creationResponse.hasErrors());
+        if (creationResponse.hasErrors()) {
+            fail(creationResponse.getErrors().iterator().next().getMessage());
+        }
 
         // The echo-d response mimics what we provided.
         Event createdEvent = creationResponse.getData();

--- a/aws-api/src/androidTest/res/raw/amplifyconfiguration.json
+++ b/aws-api/src/androidTest/res/raw/amplifyconfiguration.json
@@ -39,7 +39,7 @@
           "Endpoint": "https://57qnjcavhbdatfveg5dccboqji.appsync-api.us-west-2.amazonaws.com/graphql",
           "Region": "us-east-1",
           "AuthorizationType": "API_KEY",
-          "ApiKey": "da2-2gvk5ltfync4linsd2mhxx35my"
+          "ApiKey": "da2-b6dnxr7f5fchzgpi7vl5ftxogm"
         },
         "personApi": {
           "__comment": "This is in David's developer account, right now.",


### PR DESCRIPTION
Also: fail with error message, if transaction with backend fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
