### PR TITLE
[API] Document the output of the AppSync Request Factory

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -216,8 +216,8 @@ final class AppSyncGraphQLRequestFactory {
             Class<T> modelClass,
             QueryPredicate predicate,
             SubscriptionType type
-    ) throws AmplifyException {
-        return null;
+    ) {
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     private static Map<String, Object> parsePredicate(QueryPredicate queryPredicate) throws AmplifyException {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.graphql.GraphQLRequest;
+import com.amplifyframework.api.graphql.MutationType;
+import com.amplifyframework.api.graphql.SubscriptionType;
+import com.amplifyframework.testmodels.MaritalStatus;
+import com.amplifyframework.testmodels.Person;
+import com.amplifyframework.testutils.Resources;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link AppSyncGraphQLRequestFactory}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public final class AppSyncGraphQLRequestFactoryTest {
+
+    /**
+     * Validate construction of a GraphQL query from a class and an object ID.
+     */
+    @Test
+    public void buildQueryFromClassAndId() {
+        // Arrange a hard-coded ID as found int the expected data file.
+        final String uuidForExpectedQuery = "9a1bee5c-248f-4746-a7da-58f703ec572d";
+
+        // Act: create a request
+        GraphQLRequest<Person> request =
+            AppSyncGraphQLRequestFactory.buildQuery(Person.class, uuidForExpectedQuery);
+
+        // Assert: content is expected content
+        assertEquals(
+            Resources.readAsString("query-for-person-by-id.txt"),
+            request.getContent()
+        );
+    }
+
+    /**
+     * Validate construction of a GraphQL query from a class and a predicate.
+     * @throws AmplifyException from buildQuery().
+     */
+    @Test
+    public void buildQueryFromClassAndPredicate() throws AmplifyException {
+        // Arrange - ID for predicate, hard-coded version of what's in the expected txt
+        final String expectedId = "aca4a318-181e-445a-beb9-7656f5005c7b";
+
+        // Act: generate query
+        GraphQLRequest<Person> request =
+            AppSyncGraphQLRequestFactory.buildQuery(Person.class, Person.ID.eq(expectedId));
+
+        // Validate request is expected request
+        assertEquals(
+            Resources.readAsString("query-person-by-predicate.txt"),
+            request.getContent()
+        );
+    }
+
+    /**
+     * Validates construction of a mutation query from a Person instance, a predicate,
+     * and an {@link MutationType}.
+     * @throws AmplifyException From buildMutation().
+     */
+    @SuppressWarnings({"deprecation", "checkstyle:MagicNumber"})
+    @Test
+    public void buildMutationFromPredicateAndMutationType() throws AmplifyException {
+        // Arrange a person to delete, using UUID from test resource file
+        final String expectedId = "dfcdac69-0662-41df-a67b-48c62a023f97";
+        final Person tony = Person.builder()
+            .firstName("Tony")
+            .lastName("Swanson")
+            .age(19)
+            .dob(new Date(2000, 1, 15))
+            .id(expectedId)
+            .relationship(MaritalStatus.single)
+            .build();
+
+        // Act: build a mutation
+        GraphQLRequest<Person> requestToDeleteTony = AppSyncGraphQLRequestFactory.buildMutation(
+            tony, Person.ID.beginsWith("e6"), MutationType.DELETE
+        );
+
+        // Assert: expected is actual
+        assertEquals(
+            Resources.readAsString("mutate-person-with-predicate.txt"),
+            requestToDeleteTony.getContent()
+        );
+    }
+
+    /**
+     * Validates construction of a subscription request using a class and an
+     * {@link SubscriptionType}.
+     */
+    @Test
+    public void buildSubscriptionFromClassAndSubscriptionType() {
+        GraphQLRequest<Person> subscriptionRequest = AppSyncGraphQLRequestFactory.buildSubscription(
+            Person.class, SubscriptionType.ON_CREATE
+        );
+
+        assertEquals(
+            Resources.readAsString("subscription-request-for-on-create.txt"),
+            subscriptionRequest.getContent()
+        );
+    }
+}

--- a/aws-api/src/test/resources/mutate-person-with-predicate.txt
+++ b/aws-api/src/test/resources/mutate-person-with-predicate.txt
@@ -1,0 +1,1 @@
+{"query":"mutation DeletePerson($input: DeletePersonInput!, $condition: ModelPersonConditionInput){ deletePerson(input: $input, condition: $condition) { dob age first_name relationship id last_name }}","variables":{"input":{"id":"dfcdac69-0662-41df-a67b-48c62a023f97"},"condition":{"id":{"beginsWith":"e6"}}}}

--- a/aws-api/src/test/resources/query-for-person-by-id.txt
+++ b/aws-api/src/test/resources/query-for-person-by-id.txt
@@ -1,0 +1,1 @@
+{"query":"query GetPerson($id: ID!) { getPerson(id: $id) { dob age first_name relationship id last_name }}","variables":{"id":"9a1bee5c-248f-4746-a7da-58f703ec572d"}}

--- a/aws-api/src/test/resources/query-person-by-predicate.txt
+++ b/aws-api/src/test/resources/query-person-by-predicate.txt
@@ -1,0 +1,1 @@
+{"query":"query ListPerson($filter: ModelPersonFilterInput $limit: Int $nextToken: String) { listPersons(filter: $filter, limit: $limit, nextToken: $nextToken) { items {dob age first_name relationship id last_name } nextToken }}","variables":{"filter":{"id":{"eq":"aca4a318-181e-445a-beb9-7656f5005c7b"}},"limit":1000}}

--- a/aws-api/src/test/resources/subscription-request-for-on-create.txt
+++ b/aws-api/src/test/resources/subscription-request-for-on-create.txt
@@ -1,0 +1,1 @@
+{"query":"subscription OnCreatePerson{onCreatePerson{dob age first_name relationship id last_name }}","variables":null}

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLRequest.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLRequest.java
@@ -110,7 +110,7 @@ public final class GraphQLRequest<T> {
             contentString = contentString.replace("\\\\", "\\");
         }
 
-        return contentString;
+        return contentString + "\n";
     }
 
     /**


### PR DESCRIPTION
Create a unit test which validates stable output for the request
factory.

This work is a precondition to further changes to this file, to add
support for metadata fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
