### PR TITLE
[API] Allow deserialization of a List of String into an array response

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
@@ -162,14 +162,19 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
     }
 
     // Cannot use the same TypeToken trick used in parseErrors due to type erasure
+    @SuppressWarnings("unchecked") // (T) current.toString() IS CHECKED by String.class.isAssignableFrom(...)
     private <T> Iterable<T> parseDataAsList(JsonElement jsonData, Class<T> classToCast) throws ApiException {
         try {
             ArrayList<T> dataAsList = new ArrayList<>();
             Iterator<JsonElement> iterator = jsonData.getAsJsonArray().iterator();
 
             while (iterator.hasNext()) {
-                T data = gson.fromJson(iterator.next(), classToCast);
-                dataAsList.add(data);
+                final JsonElement current = iterator.next();
+                if (String.class.isAssignableFrom(classToCast)) {
+                    dataAsList.add((T) current.toString());
+                } else {
+                    dataAsList.add(gson.fromJson(current, classToCast));
+                }
             }
             return dataAsList;
         } catch (ClassCastException classCastException) {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReaderTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReaderTest.java
@@ -63,7 +63,7 @@ public final class AWSApiPluginConfigurationReaderTest {
     public void readFromWellFormedJsonObjectProducesValidConfig() throws JSONException {
 
         // Arrange an input JSONObject
-        final JSONObject json = new JSONObject(Resources.readAsString("single-api.config"));
+        final JSONObject json = Resources.readAsJson("single-api.config");
 
         // Act: try to parse it to a modeled configuration object
         final AWSApiPluginConfiguration config = AWSApiPluginConfigurationReader.readFrom(json);

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -137,8 +138,7 @@ public final class GsonGraphQLResponseFactoryTest {
     @Test
     public void partialResponseCanBeRenderedAsStringType() throws JSONException {
         // Arrange some known JSON response
-        final JSONObject partialResponseJson =
-                new JSONObject(Resources.readAsString("partial-gql-response.json"));
+        final JSONObject partialResponseJson = Resources.readAsJson("partial-gql-response.json");
 
         // Act! Parse it into a String data type.
         final GraphQLResponse<String> response =
@@ -148,6 +148,29 @@ public final class GsonGraphQLResponseFactoryTest {
         assertEquals(
                 partialResponseJson.getJSONObject("data").getJSONObject("listTodos").toString(),
                 response.getData()
+        );
+    }
+
+    /**
+     * The response to a base sync query must be resolvable by the response factory.
+     */
+    @Test
+    public void syncQueryResponseCanBeRenderedAsStringType() {
+        final JSONObject baseQueryResponseJson =
+            Resources.readAsJson("base-sync-posts-response.json");
+
+        final Iterable<String> queryResults =
+            responseFactory.buildSingleArrayResponse(baseQueryResponseJson.toString(), String.class)
+                .getData();
+
+        final List<String> resultJsons = new ArrayList<>();
+        for (final String queryResult : queryResults) {
+            resultJsons.add(queryResult);
+        }
+
+        assertEquals(
+            Resources.readLines("base-sync-posts-response-items.json"),
+            resultJsons
         );
     }
 }

--- a/aws-api/src/test/resources/base-sync-posts-response-items.json
+++ b/aws-api/src/test/resources/base-sync-posts-response-items.json
@@ -1,0 +1,2 @@
+{"id":"5A11A110-11E5-4996-B544-43AC41F98B94","title":"Post title 1","status":"ACTIVE","rating":5,"_version":3,"_deleted":null,"_lastChangedAt":1575157431299}
+{"id":"id1","title":"Post title 1","status":"ACTIVE","rating":5,"_version":5,"_deleted":null,"_lastChangedAt":1575157367139}

--- a/aws-api/src/test/resources/base-sync-posts-response.json
+++ b/aws-api/src/test/resources/base-sync-posts-response.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "syncPosts": {
+      "items": [
+        {
+          "id": "5A11A110-11E5-4996-B544-43AC41F98B94",
+          "title": "Post title 1",
+          "status": "ACTIVE",
+          "rating": 5,
+          "_version": 3,
+          "_deleted": null,
+          "_lastChangedAt": 1575157431299
+        },
+        {
+          "id": "id1",
+          "title": "Post title 1",
+          "status": "ACTIVE",
+          "rating": 5,
+          "_version": 5,
+          "_deleted": null,
+          "_lastChangedAt": 1575157367139
+        }
+      ],
+      "nextToken": null,
+      "startedAt": 1575157616210
+    }
+  }
+}
+

--- a/testutils/src/main/java/com/amplifyframework/testutils/Resources.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Resources.java
@@ -16,13 +16,19 @@
 package com.amplifyframework.testutils;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import androidx.annotation.RawRes;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A little utility to load test content from src/test/resources.
@@ -81,5 +87,35 @@ public final class Resources {
      */
     public static String readAsString(Context context, @RawRes int rawResourceId) {
         return stringFromStream(context.getResources().openRawResource(rawResourceId));
+    }
+
+    /**
+     * Gets a test resource as a JSONObject, given its path relative to the
+     * resources directory. For example, the file at
+     * ${PROJECT_ROOT}/src/test/resources/foo/bar.json would have a
+     * relative path value of "foo/bar.json".
+     * @param path Relative path of the test resource
+     * @return Contents of the test resource as a JSONObject, if it is
+     *         available
+     */
+    @NonNull
+    public static JSONObject readAsJson(String path) {
+        try {
+            return new JSONObject(readAsString(path));
+        } catch (JSONException jsonException) {
+            throw new RuntimeException(jsonException);
+        }
+    }
+
+    /**
+     * Read lines of test from a resource. Each sequential line is a new item in the list.
+     * @param path A path relative to the resources directory. For example, the file at
+     *             ${PROJECT_ROOT}/src/test/resources/foo/bar.lines would have a relative
+     *             path value of "foo/bar.lines".
+     * @return A list of strings, one for each line of text found in the resource file
+     *         that exists at the the provided path.
+     */
+    public static List<String> readLines(String path) {
+        return Arrays.asList(readAsString(path).split("\\r?\\n"));
     }
 }


### PR DESCRIPTION
This will be used by the Base and Delta Sync of the DataStore component,
which will interact with API only using String type, so that API doesn't
have to shared a concern for the DataStore Metadata fields, directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
