### PR TITLE
[DataStore] Update Code Base to Use New Code Gen Models & API

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
@@ -156,13 +156,15 @@ public final class CodeGenerationInstrumentationTest {
                 streamListener
         );
 
+        LatchedSingleResponseListener<Person> creationListener = new LatchedSingleResponseListener<>();
         Amplify.API.mutate(
                 PERSON_API_NAME,
                 person,
                 null,
                 MutationType.CREATE,
-                null
+                creationListener
         );
+        creationListener.awaitSuccessResponse();
 
         // Validate that subscription received the newly created person.
         List<Person> peopleOnSubscription = streamListener.awaitSuccessfulResponses();

--- a/aws-api/src/androidTest/res/raw/amplifyconfiguration.json
+++ b/aws-api/src/androidTest/res/raw/amplifyconfiguration.json
@@ -1,20 +1,20 @@
 {
-  "UserAgent": "aws-amplify-cli/2.0",
-  "Version": "1.0",
-  "Storage": {
+  "userAgent": "aws-amplify-cli/2.0",
+  "version": "1.0",
+  "storage": {
     "plugins": {
-      "AWSS3StoragePlugin": {
-        "Bucket": "my-s3-bucket",
-        "Region": "us-west-2",
-        "TransferAcceleration": true
+      "awsS3StoragePlugin": {
+        "bucket": "my-s3-bucket",
+        "region": "us-west-2",
+        "transferAcceleration": true
       }
     }
   },
   "analytics": {
     "plugins": {
-      "AmazonPinpointAnalyticsPlugin": {
-        "AppId": "xx113344",
-        "Region": "us-east-1",
+      "amazonPinpointAnalyticsPlugin": {
+        "appId": "xx113344",
+        "region": "us-east-1",
         "optOut": "ALL",
         "globalUserAttributes": {
           "interests": [
@@ -24,10 +24,10 @@
           ]
         }
       },
-      "AmazonKinesisAnalyticsPlugin": {
-        "Stream": "my-kinesis-stream",
-        "PartitionKey": "my-kinesis-partition-key",
-        "Region": "us-east-1"
+      "amazonKinesisAnalyticsPlugin": {
+        "stream": "my-kinesis-stream",
+        "partitionKey": "my-kinesis-partition-key",
+        "region": "us-east-1"
       }
     }
   },

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SingleItemResultOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SingleItemResultOperation.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.api.aws;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
@@ -27,6 +28,7 @@ import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.logging.Logger;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -120,6 +122,7 @@ public final class SingleItemResultOperation<T> extends GraphQLOperation<T> {
     }
 
     class OkHttpCallback implements Callback {
+        @SuppressLint("SyntheticAccessor")
         @Override
         public void onResponse(@NonNull Call call,
                                @NonNull Response response) {
@@ -148,6 +151,7 @@ public final class SingleItemResultOperation<T> extends GraphQLOperation<T> {
             }
         }
 
+        @SuppressLint("SyntheticAccessor")
         @Override
         public void onFailure(@NonNull Call call,
                               @NonNull IOException exception) {
@@ -191,13 +195,15 @@ public final class SingleItemResultOperation<T> extends GraphQLOperation<T> {
             return this;
         }
 
+        @SuppressLint("SyntheticAccessor")
         SingleItemResultOperation<T> build() {
             return new SingleItemResultOperation<>(
-                    endpoint,
-                    client,
-                    request,
-                    responseFactory,
-                    responseListener);
+                Objects.requireNonNull(endpoint),
+                Objects.requireNonNull(client),
+                Objects.requireNonNull(request),
+                Objects.requireNonNull(responseFactory),
+                Objects.requireNonNull(responseListener)
+            );
         }
     }
 }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
@@ -25,7 +25,7 @@ import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.datastore.storage.sqlite.SQLiteStorageAdapter;
-import com.amplifyframework.testmodels.personcar.Person;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testutils.LatchedResultListener;
 
 import org.junit.After;
@@ -34,6 +34,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -46,7 +48,6 @@ import static org.junit.Assert.assertEquals;
  * Tests that the {@link SQLiteStorageAdapter} is able to serve as as repository
  * for our {@link StorageItemChange.Record}s.
  */
-@SuppressWarnings("rawtypes")
 public final class StorageItemChangeRecordIntegrationTest {
     private static final String DATABASE_NAME = "AmplifyDatastore.db";
 
@@ -65,16 +66,22 @@ public final class StorageItemChangeRecordIntegrationTest {
         ApplicationProvider.getApplicationContext().deleteDatabase(DATABASE_NAME);
 
         LatchedResultListener<List<ModelSchema>> schemaListener = LatchedResultListener.instance();
-        ModelProvider personProvider = ModelProviderFactory.createProviderOf(Person.class);
-        this.localStorageAdapter = SQLiteStorageAdapter.forModels(personProvider);
+        ModelProvider modelProvider = ModelProviderFactory.createProviderOf(BlogOwner.class);
+        this.localStorageAdapter = SQLiteStorageAdapter.forModels(modelProvider);
         localStorageAdapter.initialize(ApplicationProvider.getApplicationContext(), schemaListener);
 
         // Evaluate the returned set of ModelSchema. Make sure that there is one
-        // for the StorageItemChange.Record system class.
-        List<ModelSchema> schema = schemaListener.awaitResult();
+        // for the StorageItemChange.Record system class, and one for
+        // the PersistentModelVersion.
+
+        final List<String> actualNames = new ArrayList<>();
+        for (ModelSchema modelSchema : schemaListener.awaitResult()) {
+            actualNames.add(modelSchema.getName());
+        }
+        Collections.sort(actualNames);
         assertEquals(
-            "Wanted 2 schema, but got " + schema,
-            2, schema.size()
+            Arrays.asList("BlogOwner", "PersistentModelVersion", "Record"),
+            actualNames
         );
     }
 
@@ -94,22 +101,20 @@ public final class StorageItemChangeRecordIntegrationTest {
      * had saved.
      * @throws DataStoreException from storage item change
      */
-    @SuppressWarnings("checkstyle:MagicNumber") // Tony's age is randomly chosen as 45 for no reason.
     @Test
     public void adapterCanSaveAndQueryChangeRecords() throws DataStoreException {
-        final Person tony = Person.builder()
-            .firstName("Tony")
-            .lastName("Daniels")
-            .age(45)
+        final BlogOwner tonyDaniels = BlogOwner.builder()
+            .name("Tony Daniels")
             .build();
-        final StorageItemChange<Person> originalSaveForTony = StorageItemChange.<Person>builder()
-            .item(tony)
-            .itemClass(Person.class)
+
+        final StorageItemChange<BlogOwner> originalSaveForTony = StorageItemChange.<BlogOwner>builder()
+            .item(tonyDaniels)
+            .itemClass(BlogOwner.class)
             .type(StorageItemChange.Type.SAVE)
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
             .build();
 
-        // Save the creation mutation for tony, as a Record object.
+        // Save the creation mutation for Tony, as a Record object.
         StorageItemChange.Record saveForTonyAsRecord =
             originalSaveForTony.toRecord(storageItemChangeConverter);
         save(saveForTonyAsRecord);
@@ -125,7 +130,7 @@ public final class StorageItemChangeRecordIntegrationTest {
 
         // After we convert back from record, we should get back a copy of
         // what we created above
-        StorageItemChange<Person> reconstructedSaveForTony =
+        StorageItemChange<BlogOwner> reconstructedSaveForTony =
             firstResultRecord.toStorageItemChange(storageItemChangeConverter);
         assertEquals(originalSaveForTony, reconstructedSaveForTony);
     }
@@ -144,13 +149,12 @@ public final class StorageItemChangeRecordIntegrationTest {
         localStorageAdapter.observe().subscribe(observer);
 
         // Save something ..
-        StorageItemChange.Record record = StorageItemChange.<Person>builder()
+        StorageItemChange.Record record = StorageItemChange.<BlogOwner>builder()
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
-            .item(Person.builder()
-                .firstName("Juan")
-                .lastName("Gonzales")
+            .item(BlogOwner.builder()
+                .name("Juan Gonzales")
                 .build())
-            .itemClass(Person.class)
+            .itemClass(BlogOwner.class)
             .type(StorageItemChange.Type.SAVE)
             .build()
             .toRecord(new GsonStorageItemChangeConverter());
@@ -179,12 +183,10 @@ public final class StorageItemChangeRecordIntegrationTest {
      *
      * Similarly, when we update the record that we had just saved, we should see an update
      * record on the observable. The type will be StorageItemChange.Record and inside of it
-     * will be a StorageItemChange.Record which itself contains a Person.
-     *
+     * will be a StorageItemChange.Record which itself contains a BlogOwner.
      * @throws DataStoreException from storage item change
      */
     @Ignore("update operations are not currently implemented! TODO: validate this, once available")
-    @SuppressWarnings("checkstyle:MagicNumber")
     @Test
     public void updatesAreObservedForChangeRecords() throws DataStoreException {
         // Establish a subscription to listen for storage change records
@@ -192,71 +194,64 @@ public final class StorageItemChangeRecordIntegrationTest {
         localStorageAdapter.observe().subscribe(recordObserver);
 
         // Create a record for Joe, and a change to save him into storage
-        Person joeWrongAge = Person.builder()
-            .firstName("Joe")
-            .lastName(("Sweeney"))
-            .age(39)
+        BlogOwner joeLastNameMispelled = BlogOwner.builder()
+            .name("Joe Sweeneyy")
             .build();
-        StorageItemChange<Person> saveJoeWrongAge = StorageItemChange.<Person>builder()
+        StorageItemChange<BlogOwner> saveJoeWrongLastName = StorageItemChange.<BlogOwner>builder()
             .type(StorageItemChange.Type.SAVE)
-            .item(joeWrongAge)
-            .itemClass(Person.class)
+            .item(joeLastNameMispelled)
+            .itemClass(BlogOwner.class)
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
             .build();
-        StorageItemChange.Record saveJoeWrongAgeRecord =
-            saveJoeWrongAge.toRecord(storageItemChangeConverter);
+        StorageItemChange.Record saveJoeWrongLastNameRecord =
+            saveJoeWrongLastName.toRecord(storageItemChangeConverter);
 
-        // Save our saveJoeWrongAge change, as a record.
-        save(saveJoeWrongAgeRecord);
+        // Save our saveJoeWrongLastName change item, as a record.
+        save(saveJoeWrongLastNameRecord);
 
         // Now, suppose we have to update that change object. Maybe it contained a bad item payload.
-        Person joeWithCorrectAge = Person.builder()
-            .firstName(joeWrongAge.getFirstName())
-            .lastName(joeWrongAge.getLastName())
-            .age(41) // Joe is actually 41, not 39, oops.
-            .id(joeWrongAge.getId())
+        BlogOwner joeWithLastNameFix = BlogOwner.builder()
+            .name("Joe Sweeney")
             .build();
-        StorageItemChange<Person> saveJoeCorrectAge = StorageItemChange.<Person>builder()
-            .changeId(saveJoeWrongAge.changeId().toString()) // Same ID
-            .item(joeWithCorrectAge) // But with a patch to the item
-            .itemClass(Person.class)
+        StorageItemChange<BlogOwner> saveJoeCorrectLastName = StorageItemChange.<BlogOwner>builder()
+            .changeId(saveJoeWrongLastName.changeId().toString()) // Same ID
+            .item(joeWithLastNameFix) // But with a patch to the item
+            .itemClass(BlogOwner.class)
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
             .type(StorageItemChange.Type.SAVE) // We're still saving Joe, we're updating this change.
             .build();
-        StorageItemChange.Record saveJoeCorrectAgeRecord =
-            saveJoeCorrectAge.toRecord(storageItemChangeConverter);
+        StorageItemChange.Record saveJoeCorrectLastNameRecord =
+            saveJoeCorrectLastName.toRecord(storageItemChangeConverter);
 
         // Save an update (same model type, same unique ID) to the thing we saved before.
-        save(saveJoeCorrectAgeRecord);
+        save(saveJoeCorrectLastNameRecord);
 
         // Our observer got the records to save Joe with wrong age, and also to save joe with right age
         recordObserver.awaitCount(2);
         recordObserver.assertNoErrors();
-        recordObserver.assertValues(saveJoeWrongAgeRecord, saveJoeCorrectAgeRecord);
+        recordObserver.assertValues(saveJoeWrongLastNameRecord, saveJoeCorrectLastNameRecord);
     }
 
     /**
      * When an {@link StorageItemChange.Record} is deleted from the DataStore, the
      * {@link Observable} returned by {@link LocalStorageAdapter#observe()} shall
      * emit that same change record.
-     *
      * @throws DataStoreException from storage item change
      */
     @Ignore("delete() is not currently implemented! Validate this test when it is.")
     @Test
     public void deletionIsObservedForChangeRecord() throws DataStoreException {
         // What we are really observing are items of type StorageItemChange.Record that contain
-        // StorageItemChange.Record of Person
+        // StorageItemChange.Record of BlogOwner
         TestObserver<StorageItemChange.Record> saveObserver = TestObserver.create();
         localStorageAdapter.observe().subscribe(saveObserver);
 
-        Person beatrice = Person.builder()
-            .firstName("Beatrice")
-            .lastName("Stone")
+        BlogOwner beatrice = BlogOwner.builder()
+            .name("Beatrice Stone")
             .build();
-        StorageItemChange<Person> saveBeatrice = StorageItemChange.<Person>builder()
+        StorageItemChange<BlogOwner> saveBeatrice = StorageItemChange.<BlogOwner>builder()
             .item(beatrice)
-            .itemClass(Person.class)
+            .itemClass(BlogOwner.class)
             .type(StorageItemChange.Type.SAVE)
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
             .build();
@@ -297,11 +292,11 @@ public final class StorageItemChangeRecordIntegrationTest {
         localStorageAdapter.save(storageItemChangeRecord,
             StorageItemChange.Initiator.SYNC_ENGINE, saveResultListener);
 
-        final StorageItemChange convertedResult =
+        final StorageItemChange<?> convertedResult =
             saveResultListener.awaitResult().toStorageItemChange(storageItemChangeConverter);
 
         // Peel out the item from the save result - the item inside is the thing we tried to save,
-        // e.g., the mutation to create person
+        // e.g., the mutation to create BlogOwner
         // It should be identical to the thing that we tried to save.
         assertEquals(storageItemChangeRecord, convertedResult.item());
     }
@@ -324,7 +319,7 @@ public final class StorageItemChangeRecordIntegrationTest {
 
     private void delete(StorageItemChange.Record record) throws DataStoreException {
         // The thing we are deleting is a StorageItemChange.Record, which is wrapping
-        // a StorageItemChange.Record, which is wrapping a Person.
+        // a StorageItemChange.Record, which is wrapping an item.
         LatchedResultListener<StorageItemChange.Record> recordDeletionListener =
             LatchedResultListener.instance();
 
@@ -332,7 +327,7 @@ public final class StorageItemChangeRecordIntegrationTest {
 
         // Peel out the inner record out from the save result -
         // the record inside is the thing we tried to save,
-        // that is, the record to change a person
+        // that is, the record to change an item
         // That interior record should be identical to the thing that we tried to save.
         StorageItemChange<StorageItemChange.Record> recordOfDeletion =
             recordDeletionListener.awaitResult().toStorageItemChange(storageItemChangeConverter);

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/TestConfiguration.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/TestConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.aws.AWSApiPlugin;
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.AmplifyConfiguration;
+import com.amplifyframework.core.category.CategoryType;
+import com.amplifyframework.datastore.test.R.raw;
+import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
+
+final class TestConfiguration {
+    private static TestConfiguration singleton;
+    private final AWSDataStorePlugin plugin;
+    private final String apiName;
+
+    private TestConfiguration(Context context) throws AmplifyException {
+        plugin = AWSDataStorePlugin.singleton(AmplifyModelProvider.getInstance());
+
+        // We need to use an API plugin, so that we can validate remote sync.
+        Amplify.addPlugin(new AWSApiPlugin());
+        Amplify.addPlugin(plugin);
+
+        AmplifyConfiguration amplifyConfiguration = new AmplifyConfiguration();
+        amplifyConfiguration.populateFromConfigFile(context, raw.amplifyconfiguration);
+        Amplify.configure(amplifyConfiguration, context);
+
+        // Get the first configured API.
+        apiName = amplifyConfiguration.forCategoryType(CategoryType.API)
+            .getPluginConfig("awsAPIPlugin")
+            .keys()
+            .next();
+    }
+
+    /**
+     * Process-wide configuration for the DataStore instrumentation tests.
+     * @return A TestConfiguration instance
+     */
+    @NonNull
+    static synchronized TestConfiguration configureIfNotConfigured() throws AmplifyException {
+        if (singleton == null) {
+            singleton = new TestConfiguration(ApplicationProvider.getApplicationContext());
+        }
+        return singleton;
+    }
+
+    AWSDataStorePlugin plugin() {
+        return plugin;
+    }
+
+    String apiName() {
+        return apiName;
+    }
+}

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
@@ -20,6 +20,7 @@ import android.os.StrictMode;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testmodels.personcar.AmplifyCliGeneratedModelProvider;
 import com.amplifyframework.testmodels.personcar.RandomVersionModelProvider;
 import com.amplifyframework.testutils.LatchedResultListener;
@@ -75,18 +76,20 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
 
     /**
      * Drop all tables and database, terminate and delete the database.
+     * @throws DataStoreException On failure to terminate adapter
      */
     @After
-    public void tearDown() {
+    public void tearDown() throws DataStoreException {
         sqliteStorageAdapter.terminate();
         context.deleteDatabase(DATABASE_NAME);
     }
 
     /**
      * Asserts if the model version change updates the new version in local storage.
+     * @throws DataStoreException On failure to terminate adapter
      */
     @Test
-    public void modelVersionStoredCorrectlyBeforeAndAfterUpgrade() {
+    public void modelVersionStoredCorrectlyBeforeAndAfterUpgrade() throws DataStoreException {
         // Initialize StorageAdapter with models
         LatchedResultListener<List<ModelSchema>> setupListener =
                 LatchedResultListener.waitFor(SQLITE_OPERATION_TIMEOUT_MS);

--- a/aws-datastore/src/androidTest/res/raw/amplifyconfiguration.json
+++ b/aws-datastore/src/androidTest/res/raw/amplifyconfiguration.json
@@ -1,25 +1,26 @@
 {
-  "UserAgent": "aws-amplify-cli/2.0",
-  "Version": "1.0",
-  "API": {
+  "userAgent": "aws-amplify-cli/2.0",
+  "version": "1.0",
+  "api": {
     "plugins": {
-      "AWSAPIPlugin": {
-        "personAndCarApi": {
+      "awsAPIPlugin": {
+        "commentsBlogApi": {
           "__comment": "This is in Jameson's developer account, right now.",
-          "Endpoint": "https://otpxpxnof5g3hoflqbbq6wr6g4.appsync-api.us-east-1.amazonaws.com/graphql",
-          "Region": "us-east-1",
-          "AuthorizationType": "API_KEY",
-          "ApiKey": "da2-gmrb7ggz6fcttmlote5d7gu3n4"
+          "endpoint": "https://q754zly6erdshd5lbeku75u6qq.appsync-api.us-east-1.amazonaws.com/graphql",
+          "region": "us-east-1",
+          "authorizationType": "API_KEY",
+          "apiKey": "da2-umufvrvebnadnkv5hl3yudoj4m"
         }
       }
     }
   },
-  "DataStore": {
+  "dataStore": {
     "plugins": {
-      "AWSDataStorePlugin": {
+      "awsDataStorePlugin": {
         "syncMode": "api",
-        "apiName": "personAndCarApi"
+        "apiName": "commentsBlogApi"
       }
     }
   }
 }
+

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelMutations.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelMutations.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.datastore.network;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.AmplifyException;
@@ -59,22 +60,24 @@ class RemoteModelMutations {
         return Observable.defer(() -> Observable.create(emitter -> {
             emitter.setCancellable(() -> {
                 synchronized (subscriptions) {
-                    for (Subscription<? extends Model> subscription : subscriptions) {
+                    for (final Subscription<?> subscription : subscriptions) {
                         subscription.end();
                     }
                     subscriptions.clear();
                 }
             });
 
-            for (Class<? extends Model> modelClass : modelProvider.models()) {
-                for (SubscriptionType subscriptionType : SubscriptionType.values()) {
-                    subscriptions.add(Subscription.request()
-                        .api(api)
-                        .apiNameProvider(apiNameProvider)
-                        .modelClass(modelClass)
-                        .subscriptionType(subscriptionType)
-                        .commonEmitter(emitter)
-                        .begin());
+            synchronized (subscriptions) {
+                for (Class<? extends Model> modelClass : modelProvider.models()) {
+                    for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+                        subscriptions.add(Subscription.request()
+                            .api(api)
+                            .apiNameProvider(apiNameProvider)
+                            .modelClass(modelClass)
+                            .subscriptionType(subscriptionType)
+                            .commonEmitter(emitter)
+                            .begin());
+                    }
                 }
             }
         }));
@@ -188,6 +191,7 @@ class RemoteModelMutations {
                 }
             }
 
+            @SuppressLint("SyntheticAccessor")
             @Override
             public void onComplete() {
                 LOG.info(String.format(

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -23,7 +23,6 @@ import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.core.Immutable;
 import com.amplifyframework.core.model.Model;
-import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelIndex;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
@@ -48,7 +47,7 @@ import java.util.Set;
  */
 final class SQLiteCommandFactory implements SQLCommandFactory {
 
-    // Connection handle to a Sqlite Database.
+    // Connection handle to a SQLiteDatabase.
     private final SQLiteDatabase databaseConnectionHandle;
 
     /**
@@ -186,12 +185,10 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
             selectColumns.append(column.getColumnName());
 
             // Alias primary keys to avoid duplicate column names
-            if (column.isPrimaryKey()) {
-                selectColumns.append(SqlKeyword.DELIMITER)
-                        .append(SqlKeyword.AS)
-                        .append(SqlKeyword.DELIMITER)
-                        .append(column.getAliasedName());
-            }
+            selectColumns.append(SqlKeyword.DELIMITER)
+                    .append(SqlKeyword.AS)
+                    .append(SqlKeyword.DELIMITER)
+                    .append(column.getAliasedName());
 
             if (columnsIterator.hasNext()) {
                 selectColumns.append(",").append(SqlKeyword.DELIMITER);
@@ -292,12 +289,16 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                 .append("UPDATE ")
                 .append(table.getName())
                 .append(" SET ");
-        final List<ModelField> fields = modelSchema.getSortedFields();
-        final Iterator<ModelField> fieldsIterator = fields.iterator();
-        while (fieldsIterator.hasNext()) {
-            final ModelField field = fieldsIterator.next();
-            stringBuilder.append(field.getName()).append(" = ?");
-            if (fieldsIterator.hasNext()) {
+
+        // Previously, we figured out the correct column names from the model schema.
+        // Instead of figuring out the correct column names again, just iterate
+        // over whatever is actually there (since it was "right".)
+        final List<SQLiteColumn> columns = table.getSortedColumns();
+        final Iterator<SQLiteColumn> columnsIterator = columns.iterator();
+        while (columnsIterator.hasNext()) {
+            final String columnName = columnsIterator.next().getName();
+            stringBuilder.append(columnName + " = ?");
+            if (columnsIterator.hasNext()) {
                 stringBuilder.append(", ");
             }
         }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -491,10 +491,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             if (column == null) {
                 continue;
             }
-            final String columnName = column.isPrimaryKey()
-                    ? column.getAliasedName()
-                    : column.getName();
-
+            final String columnName = column.getAliasedName();
             final JavaFieldType javaFieldType;
             if (Model.class.isAssignableFrom(field.getType())) {
                 javaFieldType = JavaFieldType.MODEL;
@@ -585,10 +582,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 if (column == null) {
                     continue;
                 }
-                final String columnName = column.isPrimaryKey()
-                        ? column.getAliasedName()
-                        : column.getName();
-
+                final String columnName = column.getAliasedName();
                 final ModelField modelField = entry.getValue();
                 final String fieldGraphQlType = entry.getValue().getTargetType();
                 final JavaFieldType fieldJavaType;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
@@ -41,9 +41,6 @@ final class SQLiteStorageHelper extends SQLiteOpenHelper implements ModelUpgrade
     // SQLiteDatabase Metadata is stored in tables prefixed by this prefix.
     private static final String SQLITE_SYSTEM_TABLE_PREFIX = "sqlite_";
 
-    // The singleton instance.
-    private static SQLiteStorageHelper sqliteStorageHelperInstance;
-
     // Contains all create table and create index commands.
     private final CreateSqlCommands createSqlCommands;
 
@@ -58,24 +55,19 @@ final class SQLiteStorageHelper extends SQLiteOpenHelper implements ModelUpgrade
     }
 
     /**
-     * Create / Retrieve the singleton instance of the SQLiteStorageHelper.
-     *
+     * Creates an instance of the SQLiteStorageHelper.
      * @param context Android context
      * @param databaseName name of the database
      * @param databaseVersion version of the database
      * @param createSqlCommands set of create table and create index sql commands
-     * @return the singleton instance
+     * @return A new instance of the SQLiteStorageHelper
      */
-    static synchronized SQLiteStorageHelper getInstance(
+    static SQLiteStorageHelper getInstance(
             @NonNull Context context,
             @NonNull String databaseName,
             int databaseVersion,
             @NonNull CreateSqlCommands createSqlCommands) {
-        if (sqliteStorageHelperInstance == null) {
-            sqliteStorageHelperInstance = new SQLiteStorageHelper(
-                    context, databaseName, databaseVersion, createSqlCommands);
-        }
-        return sqliteStorageHelperInstance;
+        return new SQLiteStorageHelper(context, databaseName, databaseVersion, createSqlCommands);
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/StorageItemChangeJournalTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/StorageItemChangeJournalTest.java
@@ -19,7 +19,7 @@ import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
-import com.amplifyframework.testmodels.personcar.Person;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -61,19 +61,18 @@ public class StorageItemChangeJournalTest {
         TestObserver<StorageItemChange<? extends Model>> queueObserver = TestObserver.create();
         storageItemChangeJournal.observe().subscribe(queueObserver);
 
-        StorageItemChange<Person> saveJameson = StorageItemChange.<Person>builder()
+        StorageItemChange<BlogOwner> saveJameson = StorageItemChange.<BlogOwner>builder()
             .type(StorageItemChange.Type.SAVE)
-            .itemClass(Person.class)
-            .item(Person.builder()
-                .firstName("Jameson")
-                .lastName("Williams")
+            .itemClass(BlogOwner.class)
+            .item(BlogOwner.builder()
+                .name("Jameson Williams")
                 .build())
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
             .build();
 
-        // Enqueue an save for a Jameson person object,
+        // Enqueue an save for a Jameson BlogOwner object,
         // and make sure that it calls back onSuccess().
-        TestObserver<StorageItemChange<Person>> saveObserver = TestObserver.create();
+        TestObserver<StorageItemChange<BlogOwner>> saveObserver = TestObserver.create();
         storageItemChangeJournal.enqueue(saveJameson).subscribe(saveObserver);
         saveObserver.awaitTerminalEvent();
         saveObserver.dispose();
@@ -102,11 +101,10 @@ public class StorageItemChangeJournalTest {
         storageItemChangeJournal.observe().subscribe(testObserver);
 
         // Enqueue something, but don't subscribe to the observable just yet.
-        storageItemChangeJournal.enqueue(StorageItemChange.<Person>builder()
-            .itemClass(Person.class)
-            .item(Person.builder()
-                .firstName("Tony")
-                .lastName("Daniels")
+        storageItemChangeJournal.enqueue(StorageItemChange.<BlogOwner>builder()
+            .itemClass(BlogOwner.class)
+            .item(BlogOwner.builder()
+                .name("Tony Daniels")
                 .build())
             .type(StorageItemChange.Type.SAVE)
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
@@ -131,31 +129,28 @@ public class StorageItemChangeJournalTest {
     public void observeReplaysUnprocessedChangesOnSubscribe() {
 
         // Arrange: some mutations.
-        StorageItemChange<Person> updateTony = StorageItemChange.<Person>builder()
+        StorageItemChange<BlogOwner> updateTony = StorageItemChange.<BlogOwner>builder()
             .type(StorageItemChange.Type.SAVE)
-            .item(Person.builder()
-                .firstName("Tony")
-                .lastName("Daniels")
+            .item(BlogOwner.builder()
+                .name("Tony Daniels")
                 .build())
-            .itemClass(Person.class)
+            .itemClass(BlogOwner.class)
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
             .build();
-        StorageItemChange<Person> insertSam = StorageItemChange.<Person>builder()
+        StorageItemChange<BlogOwner> insertSam = StorageItemChange.<BlogOwner>builder()
             .type(StorageItemChange.Type.SAVE)
-            .item(Person.builder()
-                .firstName("Sam")
-                .lastName("Watson")
+            .item(BlogOwner.builder()
+                .name("Sam Watson")
                 .build())
-            .itemClass(Person.class)
+            .itemClass(BlogOwner.class)
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
             .build();
-        StorageItemChange<Person> deleteBetty = StorageItemChange.<Person>builder()
+        StorageItemChange<BlogOwner> deleteBetty = StorageItemChange.<BlogOwner>builder()
             .type(StorageItemChange.Type.DELETE)
-            .item(Person.builder()
-                .firstName("Betty")
-                .lastName("Smith")
+            .item(BlogOwner.builder()
+                .name("Betty Smith")
                 .build())
-            .itemClass(Person.class)
+            .itemClass(BlogOwner.class)
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
             .build();
 
@@ -179,18 +174,17 @@ public class StorageItemChangeJournalTest {
     @Test
     public void removeRemovesChangesFromQueue() {
         // Arrange: there is a change in the queue.
-        StorageItemChange<Person> deleteBillGates = StorageItemChange.<Person>builder()
+        StorageItemChange<BlogOwner> deleteBillGates = StorageItemChange.<BlogOwner>builder()
             .type(StorageItemChange.Type.DELETE)
-            .itemClass(Person.class)
-            .item(Person.builder()
-                .firstName("Bill")
-                .lastName("Gates")
+            .itemClass(BlogOwner.class)
+            .item(BlogOwner.builder()
+                .name("Bill Gates")
                 .build())
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
             .build();
         inMemoryStorageAdapter.items().add(deleteBillGates.toRecord(storageItemChangeConverter));
 
-        TestObserver<StorageItemChange<Person>> testObserver = TestObserver.create();
+        TestObserver<StorageItemChange<BlogOwner>> testObserver = TestObserver.create();
         storageItemChangeJournal.remove(deleteBillGates).subscribe(testObserver);
 
         testObserver.assertValue(deleteBillGates);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/SyncEngineTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/SyncEngineTest.java
@@ -23,7 +23,7 @@ import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
-import com.amplifyframework.testmodels.personcar.Person;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testutils.LatchedResultListener;
 import com.amplifyframework.testutils.RandomString;
 
@@ -69,10 +69,9 @@ public class SyncEngineTest {
         // Arrange: storage engine is running
         syncEngine.start();
 
-        // Arrange: create a person
-        final Person susan = Person.builder()
-            .firstName("Susan")
-            .lastName("Quimby")
+        // Arrange: create a BlogOwner
+        final BlogOwner susan = BlogOwner.builder()
+            .name("Susan Quimby")
             .build();
 
         CountDownLatch apiInvoked = new CountDownLatch(1);
@@ -86,7 +85,7 @@ public class SyncEngineTest {
             any()
         );
 
-        // Act: Put person into storage, and wait for it to complete.
+        // Act: Put BlogOwner into storage, and wait for it to complete.
         LatchedResultListener<StorageItemChange.Record> listener =
             LatchedResultListener.waitFor(OPERATIONS_TIMEOUT_MS);
         localStorageAdapter.save(susan, StorageItemChange.Initiator.DATA_STORE_API, listener);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/GsonStorageItemChangeConverterTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/GsonStorageItemChangeConverterTest.java
@@ -16,8 +16,8 @@
 package com.amplifyframework.datastore.storage;
 
 import com.amplifyframework.datastore.DataStoreException;
-import com.amplifyframework.testmodels.personcar.MaritalStatus;
-import com.amplifyframework.testmodels.personcar.Person;
+import com.amplifyframework.testmodels.commentsblog.Blog;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 
 import org.junit.Test;
 
@@ -40,16 +40,16 @@ public class GsonStorageItemChangeConverterTest {
     @SuppressWarnings("checkstyle:MagicNumber")
     @Test
     public void convertStorageItemChangeToRecordAndBack() throws DataStoreException {
-        // Arrange a StorageItemChange<Person> with an expected change ID
+        // Arrange a StorageItemChange<Blog> with an expected change ID
         String expectedChangeId = UUID.randomUUID().toString();
-        StorageItemChange<Person> originalItemChange = StorageItemChange.<Person>builder()
+        StorageItemChange<Blog> originalItemChange = StorageItemChange.<Blog>builder()
             .changeId(expectedChangeId)
-            .itemClass(Person.class)
-            .item(Person.builder()
-                .firstName("Tabitha")
-                .lastName("Stevens")
-                .age(52)
-                .relationship(MaritalStatus.married)
+            .itemClass(Blog.class)
+            .item(Blog.builder()
+                .name("A neat blog")
+                .owner(BlogOwner.builder()
+                    .name("Joe Swanson")
+                    .build())
                 .build())
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
             .type(StorageItemChange.Type.SAVE)
@@ -64,7 +64,7 @@ public class GsonStorageItemChangeConverterTest {
         assertEquals(expectedChangeId, record.getId());
 
         // Now, try to convert it back...
-        StorageItemChange<Person> reconstructedItemChange = converter.fromRecord(record);
+        StorageItemChange<Blog> reconstructedItemChange = converter.fromRecord(record);
         assertEquals(expectedChangeId, reconstructedItemChange.changeId().toString());
         assertEquals(originalItemChange, reconstructedItemChange);
     }

--- a/core/src/androidTest/res/raw/amplifyconfiguration.json
+++ b/core/src/androidTest/res/raw/amplifyconfiguration.json
@@ -1,12 +1,11 @@
 {
-  "UserAgent": "aws-amplify-cli/2.0",
-  "Version": "1.0",
-  "Hub": {
+  "userAgent": "aws-amplify-cli/2.0",
+  "version": "1.0",
+  "hub": {
     "plugins": {
-      "BackgroundExecutorHubPlugin": {
+      "backgroundExecutorHubPlugin": {
       }
     }
   }
 }
-
 

--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -32,7 +32,7 @@ import com.amplifyframework.logging.LoggingCategory;
 import com.amplifyframework.storage.StorageCategory;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -81,7 +81,7 @@ public final class Amplify {
         Hub = new HubCategory();
         DataStore = new DataStoreCategory();
 
-        final Map<CategoryType, Category<? extends Plugin<?>>> modifiableCategories = new HashMap<>();
+        final Map<CategoryType, Category<? extends Plugin<?>>> modifiableCategories = new LinkedHashMap<>();
         modifiableCategories.put(CategoryType.ANALYTICS, Analytics);
         modifiableCategories.put(CategoryType.API, API);
         modifiableCategories.put(CategoryType.LOGGING, Logging);

--- a/core/src/main/java/com/amplifyframework/hub/BackgroundExecutorHubPlugin.java
+++ b/core/src/main/java/com/amplifyframework/hub/BackgroundExecutorHubPlugin.java
@@ -124,7 +124,7 @@ public final class BackgroundExecutorHubPlugin extends HubPlugin<Void> {
 
     @Override
     public String getPluginKey() {
-        return BackgroundExecutorHubPlugin.class.getSimpleName();
+        return "backgroundExecutorHubPlugin";
     }
 
     @Override

--- a/testmodels/src/test/java/com/amplifyframework/testmodels/commentsblog/BlogOwnerTest.java
+++ b/testmodels/src/test/java/com/amplifyframework/testmodels/commentsblog/BlogOwnerTest.java
@@ -54,7 +54,6 @@ public class BlogOwnerTest {
         assertEquals(one, two);
     }
 
-
     /**
      * When you construct a {@link BlogOwner} twice in the same fashion,
      * the {@link BlogOwner#hashCode()} should be the same for both instances.
@@ -83,3 +82,4 @@ public class BlogOwnerTest {
         );
     }
 }
+


### PR DESCRIPTION
The DataStore requires special metadata fields for models:
  - _deleted
  - _version
  - _lastChangedAt

These are only available in the schema if you have created your backend
with a contemporary version of the Amplify CLI, which is newly
DataStore-aware.

So, we need to use an API that was created with this in mind. To do so,
we move all DataStore integration tests to a consistent model suite,
with this accomodation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
