### PR TITLE
[StorageEngine] Chain upgrade models async calls using flatMap

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/TestConfiguration.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/TestConfiguration.java
@@ -33,7 +33,7 @@ final class TestConfiguration {
     private final String apiName;
 
     private TestConfiguration(Context context) throws AmplifyException {
-        plugin = AWSDataStorePlugin.singleton(AmplifyModelProvider.getInstance());
+        plugin = AWSDataStorePlugin.forModels(AmplifyModelProvider.getInstance());
 
         // We need to use an API plugin, so that we can validate remote sync.
         Amplify.addPlugin(new AWSApiPlugin());

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Test the functionality of {@link SQLiteStorageAdapter} with model upgrade operations.
+ * Test the functionality of {@link SQLiteStorageAdapter} with model update operations.
  */
 public final class ModelUpgradeSQLiteInstrumentedTest {
     private static final long SQLITE_OPERATION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);
@@ -114,7 +114,7 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
 
         // Terminate storage adapter and create a new storage adapter with
         // a model provider that upgrades version to mimic restartability with
-        // version upgrade.
+        // version update.
         sqliteStorageAdapter.terminate();
         sqliteStorageAdapter = null;
         sqliteStorageAdapter = SQLiteStorageAdapter.forModels(modelProviderThatUpgradesVersion);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.AmplifyException;
@@ -49,9 +50,6 @@ import io.reactivex.schedulers.Schedulers;
  * An AWS implementation of the {@link DataStorePlugin}.
  */
 public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
-    // Singleton instance
-    private static AWSDataStorePlugin singleton;
-
     // Reference to an implementation of the Local Storage Adapter that
     // manages the persistence of data on-device.
     private final SQLiteStorageAdapter sqliteStorageAdapter;
@@ -73,17 +71,13 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     }
 
     /**
-     * Return the singleton instance if it exists, otherwise create, assign
-     * and return.
+     * Return the instance for the model provider.
      * @param modelProvider Provider of models to be usable by plugin
-     * @return the singleton instance.
+     * @return the plugin instance for the model provider.
      */
     @SuppressWarnings("WeakerAccess")
-    public static synchronized AWSDataStorePlugin singleton(@NonNull final ModelProvider modelProvider) {
-        if (singleton == null) {
-            singleton = new AWSDataStorePlugin(modelProvider);
-        }
-        return singleton;
+    public static synchronized AWSDataStorePlugin forModels(@NonNull final ModelProvider modelProvider) {
+        return new AWSDataStorePlugin(modelProvider);
     }
 
     /**
@@ -217,6 +211,17 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
             @NonNull Class<T> itemClass,
             @NonNull ResultListener<Iterator<T>> queryResultsListener) {
         sqliteStorageAdapter.query(itemClass, queryResultsListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T extends Model> void query(
+            @NonNull Class<T> itemClass,
+            @Nullable QueryPredicate predicate,
+            @NonNull ResultListener<Iterator<T>> queryResultsListener) {
+        sqliteStorageAdapter.query(itemClass, predicate, queryResultsListener);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/ModelUpdateStrategy.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/ModelUpdateStrategy.java
@@ -16,19 +16,19 @@
 package com.amplifyframework.datastore.storage.sqlite;
 
 /**
- * A Strategy to upgrade the models of type {@link com.amplifyframework.core.model.Model} 
+ * A Strategy to update the models of type {@link com.amplifyframework.core.model.Model}
  * when the version of the models change.
  *
- * @param <U> type of modelUpgrader that can do the model upgrade
+ * @param <U> type of modelUpdater that can do the model update
  * @param <V> type of the version object
  */
-interface ModelUpgradeStrategy<U, V> {
+interface ModelUpdateStrategy<U, V> {
     /**
      * Upgrades the models from oldVersion to newVersion.
      *
-     * @param modelUpgrader implementation that can perform the model upgrade
+     * @param modelUpdater implementation that can perform the model update
      * @param oldVersion older version of models to be upgraded from
      * @param newVersion newer version of models to be upgraded to
      */
-    void upgrade(U modelUpgrader, V oldVersion, V newVersion);
+    void update(U modelUpdater, V oldVersion, V newVersion);
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/PersistentModelVersion.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/PersistentModelVersion.java
@@ -46,7 +46,7 @@ final class PersistentModelVersion implements Model {
     // and can be used to identify a ModelProvider.
     // 
     // Once the limitation is addressed, remove this static identifier and provide an appropriate
-    // upgrade strategy for the PersistentModelVersion to move to the new architecture.
+    // update strategy for the PersistentModelVersion to move to the new architecture.
     private static final String STATIC_IDENTIFIER_FOR_VERSION = "version-in-local-storage";
 
     @ModelField(targetType = "ID", isRequired = true)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
@@ -34,7 +34,7 @@ import java.util.Set;
 /**
  * A helper class to manage database creation and version management.
  */
-final class SQLiteStorageHelper extends SQLiteOpenHelper implements ModelUpgradeStrategy<SQLiteDatabase, String> {
+final class SQLiteStorageHelper extends SQLiteOpenHelper implements ModelUpdateStrategy<SQLiteDatabase, String> {
 
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
@@ -152,7 +152,7 @@ final class SQLiteStorageHelper extends SQLiteOpenHelper implements ModelUpgrade
      * {@inheritDoc}.
      */
     @Override
-    public synchronized void upgrade(
+    public synchronized void update(
             @NonNull SQLiteDatabase sqliteDatabase,
             @NonNull String oldVersion,
             @NonNull String newVersion) {

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.datastore;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.category.Category;
@@ -71,6 +72,16 @@ public class DataStoreCategory
     public <T extends Model> void query(@NonNull Class<T> itemClass,
                                         @NonNull ResultListener<Iterator<T>> queryResultsListener) {
         getSelectedPlugin().query(itemClass, queryResultsListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T extends Model> void query(@NonNull Class<T> itemClass,
+                                        @Nullable QueryPredicate predicate,
+                                        @NonNull ResultListener<Iterator<T>> queryResultsListener) {
+        getSelectedPlugin().query(itemClass, predicate, queryResultsListener);
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.datastore;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
@@ -69,6 +70,21 @@ public interface DataStoreCategoryBehavior {
     <T extends Model> void query(
             @NonNull Class<T> itemClass,
             @NonNull ResultListener<Iterator<T>> queryResultsListener);
+
+    /**
+     * Query the DataStore to find all items of the requested Java class that fulfills the
+     * predicate.
+     * @param itemClass Items of this class will be targeted by this query
+     * @param predicate Predicate condition to apply to query
+     * @param queryResultsListener
+     *        An optional listener which will be invoked when the query returns
+     *        results, or if there is a failure to query
+     * @param <T> The type of items being queried
+     */
+    <T extends Model> void query(@NonNull Class<T> itemClass,
+                                 @Nullable QueryPredicate predicate,
+                                 @NonNull ResultListener<Iterator<T>> queryResultsListener);
+
 
     /**
      * Observe all changes to any/all item(s) in the DataStore.


### PR DESCRIPTION
```
[StorageEngine] Chain upgrade models async calls using flatMap

[AWSDataStorePlugin] Add method for query with predicates and
                     chain it to call SQLiteStorageAdapter
                     Renamed singleton to forModels

[StorageEngine] Fix a bug where the control doesn't return from
                query when cursor is null.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
