### PR TITLE
[Analytics] Update configuration structure reduce auto flush interval for tests

### DIFF
--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
@@ -46,7 +46,7 @@ public class AnalyticsPinpointInstrumentedTest {
      */
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-analytics");
     private static final int EVENT_FLUSH_TIMEOUT = 60;
-    private static final int EVENT_FLUSH_WAIT = 5;
+    private static final int EVENT_FLUSH_WAIT = 2;
 
     /**
      * Configure the Amplify framework.
@@ -75,7 +75,7 @@ public class AnalyticsPinpointInstrumentedTest {
 
         // Flush any events from previous tests.
         Amplify.Analytics.flushEvents();
-        waitForAutoFlush(analyticsClient.getAllEvents().size());
+        waitForAutoFlush(analyticsClient);
 
         BasicAnalyticsEvent event = new BasicAnalyticsEvent("Amplify-event" + UUID.randomUUID().toString(),
                 PinpointProperties.builder()
@@ -101,7 +101,7 @@ public class AnalyticsPinpointInstrumentedTest {
 
         // Flush any events from previous tests.
         Amplify.Analytics.flushEvents();
-        waitForAutoFlush(analyticsClient.getAllEvents().size());
+        waitForAutoFlush(analyticsClient);
 
         BasicAnalyticsEvent event = new BasicAnalyticsEvent("Amplify-event" + UUID.randomUUID().toString(),
                 PinpointProperties.builder()
@@ -113,7 +113,7 @@ public class AnalyticsPinpointInstrumentedTest {
 
         assertEquals(1, analyticsClient.getAllEvents().size());
 
-        waitForAutoFlush(analyticsClient.getAllEvents().size());
+        waitForAutoFlush(analyticsClient);
 
         LOG.debug("Events in database after calling submitEvents() after submitting: " +
                 analyticsClient.getAllEvents().size());
@@ -130,7 +130,7 @@ public class AnalyticsPinpointInstrumentedTest {
 
         assertEquals(1, analyticsClient.getAllEvents().size());
 
-        waitForAutoFlush(analyticsClient.getAllEvents().size());
+        waitForAutoFlush(analyticsClient);
 
         LOG.debug("Events in database after calling submitEvents() after submitting: " +
                 analyticsClient.getAllEvents().size());
@@ -138,12 +138,12 @@ public class AnalyticsPinpointInstrumentedTest {
         assertEquals(0, analyticsClient.getAllEvents().size());
     }
 
-    private void waitForAutoFlush(int numOfEvents) {
+    private void waitForAutoFlush(AnalyticsClient analyticsClient) {
         long timeSleptSoFar = 0;
         while (timeSleptSoFar < TimeUnit.SECONDS.toMillis(EVENT_FLUSH_TIMEOUT)) {
             Sleep.milliseconds(TimeUnit.SECONDS.toMillis(EVENT_FLUSH_WAIT));
             timeSleptSoFar += TimeUnit.SECONDS.toMillis(EVENT_FLUSH_WAIT);
-            if (numOfEvents == 0) {
+            if (analyticsClient.getAllEvents().size() == 0) {
                 break;
             }
         }

--- a/aws-analytics-pinpoint/src/androidTest/res/raw/amplifyconfiguration.json
+++ b/aws-analytics-pinpoint/src/androidTest/res/raw/amplifyconfiguration.json
@@ -4,8 +4,11 @@
   "analytics": {
     "plugins": {
       "amazonPinpointAnalyticsPlugin": {
-        "appId": "3d052968a8514a778b5a87891a98a4b7",
-        "region": "us-west-2"
+        "pinpointAnalytics": {
+          "appId": "3d052968a8514a778b5a87891a98a4b7",
+          "region": "us-west-2"
+        },
+        "autoFlushEventsInterval" : 1000
       }
     }
   }

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AmazonPinpointAnalyticsPlugin.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AmazonPinpointAnalyticsPlugin.java
@@ -159,10 +159,10 @@ public final class AmazonPinpointAnalyticsPlugin extends AnalyticsPlugin<Object>
         // Read all the data from the configuration object to be used for record event
         try {
             configurationBuilder
-                    .withAppId(pluginConfiguration
+                    .withAppId(pluginConfiguration.getJSONObject("pinpointAnalytics")
                             .getString(PinpointConfigurationKey.APP_ID.getConfigurationKey()));
             configurationBuilder
-                    .withRegion(pluginConfiguration
+                    .withRegion(pluginConfiguration.getJSONObject("pinpointAnalytics")
                             .getString(PinpointConfigurationKey.REGION.getConfigurationKey()));
 
             if (pluginConfiguration.has(PinpointConfigurationKey.AUTO_FLUSH_INTERVAL.getConfigurationKey())) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Reduce the auto flush interval for test
2. Also includes changes to account for following configuration file structure (different from what was initially assumed) 

```json
{
    "UserAgent": "aws-amplify-cli/2.0",
    "Version": "1.0",
    "analytics": {
        "plugins": {
            "awsPinpointAnalyticsPlugin": {
                "pinpointAnalytics": {
                    "appId": "AppID",
                    "region": "Region"
                },
                "pinpointTargeting": {
                    "region": "Region"
                },
                "autoFlushEventsInterval": 60
            }
        }
    }
}

```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
