### PR TITLE
[DataStore] Create RemoteModelState class

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelMetadata.java
@@ -79,27 +79,45 @@ public final class ModelMetadata implements Model {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object thatObject) {
+        if (this == thatObject) {
             return true;
-        } else if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        } else {
-            ModelMetadata metadata = (ModelMetadata) obj;
-            return ObjectsCompat.equals(getId(), metadata.getId()) &&
-                    ObjectsCompat.equals(isDeleted(), metadata.isDeleted()) &&
-                    ObjectsCompat.equals(getVersion(), metadata.getVersion()) &&
-                    ObjectsCompat.equals(getLastChangedAt(), metadata.getLastChangedAt());
         }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        ModelMetadata metadata = (ModelMetadata) thatObject;
+
+        if (!ObjectsCompat.equals(id, metadata.id)) {
+            return false;
+        }
+        if (!ObjectsCompat.equals(_deleted, metadata._deleted)) {
+            return false;
+        }
+        if (!ObjectsCompat.equals(_version, metadata._version)) {
+            return false;
+        }
+        return ObjectsCompat.equals(_lastChangedAt, metadata._lastChangedAt);
+    }
+
+    @SuppressWarnings("checkstyle:MagicNumber")
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (_deleted != null ? _deleted.hashCode() : 0);
+        result = 31 * result + (_version != null ? _version.hashCode() : 0);
+        result = 31 * result + (_lastChangedAt != null ? _lastChangedAt.hashCode() : 0);
+        return result;
     }
 
     @Override
-    public int hashCode() {
-        return ObjectsCompat.hash(
-                getId(),
-                isDeleted(),
-                getVersion(),
-                getLastChangedAt()
-        );
+    public String toString() {
+        return "ModelMetadata{" +
+            "id='" + id + '\'' +
+            ", _deleted=" + _deleted +
+            ", _version=" + _version +
+            ", _lastChangedAt=" + _lastChangedAt +
+            '}';
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelWithMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/ModelWithMetadata.java
@@ -15,9 +15,12 @@
 
 package com.amplifyframework.datastore.network;
 
+import androidx.annotation.NonNull;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.model.Model;
+
+import java.util.Objects;
 
 /**
  * Container class to hold an instance of an object with it's metadata.
@@ -32,15 +35,16 @@ public final class ModelWithMetadata<M extends Model> {
      * @param model An instance of a model
      * @param syncMetadata The metadata for this model about it's synchronization history.
      */
-    public ModelWithMetadata(M model, ModelMetadata syncMetadata) {
-        this.model = model;
-        this.syncMetadata = syncMetadata;
+    public ModelWithMetadata(@NonNull M model, @NonNull ModelMetadata syncMetadata) {
+        this.model = Objects.requireNonNull(model);
+        this.syncMetadata = Objects.requireNonNull(syncMetadata);
     }
 
     /**
      * Get the model instance.
      * @return the model instance
      */
+    @NonNull
     public M getModel() {
         return model;
     }
@@ -49,28 +53,41 @@ public final class ModelWithMetadata<M extends Model> {
      * Get the sync/version metadata for the model instance.
      * @return the sync/version metadata
      */
+    @NonNull
     public ModelMetadata getSyncMetadata() {
         return syncMetadata;
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object thatObject) {
+        if (this == thatObject) {
             return true;
-        } else if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        } else {
-            ModelWithMetadata<?> modelWithMetadata = (ModelWithMetadata) obj;
-            return ObjectsCompat.equals(getModel(), modelWithMetadata.getModel()) &&
-                    ObjectsCompat.equals(getSyncMetadata(), modelWithMetadata.getSyncMetadata());
         }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        ModelWithMetadata<?> that = (ModelWithMetadata<?>) thatObject;
+
+        if (!ObjectsCompat.equals(model, that.model)) {
+            return false;
+        }
+        return ObjectsCompat.equals(syncMetadata, that.syncMetadata);
+    }
+
+    @SuppressWarnings("checkstyle:MagicNumber")
+    @Override
+    public int hashCode() {
+        int result = model != null ? model.hashCode() : 0;
+        result = 31 * result + (syncMetadata != null ? syncMetadata.hashCode() : 0);
+        return result;
     }
 
     @Override
-    public int hashCode() {
-        return ObjectsCompat.hash(
-                getModel(),
-                getSyncMetadata()
-        );
+    public String toString() {
+        return "ModelWithMetadata{" +
+            "model=" + model +
+            ", syncMetadata=" + syncMetadata +
+            '}';
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelMutations.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelMutations.java
@@ -35,7 +35,7 @@ import java.util.Set;
 import io.reactivex.Emitter;
 import io.reactivex.Observable;
 
-class RemoteModelMutations {
+final class RemoteModelMutations {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
     private final AppSyncEndpoint appSyncEndpoint;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelState.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelState.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.async.Cancelable;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.datastore.DataStoreException;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.SingleEmitter;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
+
+@SuppressWarnings("unused") // one sec
+final class RemoteModelState {
+    private final AppSyncEndpoint endpoint;
+    private final ModelProvider modelProvider;
+    private final ConfiguredApiProvider configuredApiProvider;
+
+    RemoteModelState(
+            AppSyncEndpoint endpoint,
+            ModelProvider modelProvider,
+            ConfiguredApiProvider configuredApiProvider) {
+        this.endpoint = endpoint;
+        this.modelProvider = modelProvider;
+        this.configuredApiProvider = configuredApiProvider;
+    }
+
+    /**
+     * Observes the current state of all models in a remote system.
+     * @return An observable onto which the state of all managed models
+     *         is emitted. This Observable will complete when all
+     *         models have been described.
+     */
+    Observable<ModelWithMetadata<? extends Model>> observe() {
+        // Get an observable stream of the set of model classes.
+        return Observable.fromIterable(modelProvider.models())
+            // Heavy network traffic, we require this to be done on IO scheduler.
+            .subscribeOn(Schedulers.io())
+            .observeOn(Schedulers.io())
+            // For each, get an Iterable<ModelWithMetadata<T>>, the result of a network sync
+            .flatMapSingle(model -> syncModel(model, null))
+            // Okay, but we want to flatten the Iterable back onto our Observable stream.
+            .flatMap(Observable::fromIterable);
+    }
+
+    private <T extends Model> Single<Iterable<ModelWithMetadata<T>>> syncModel(
+            final Class<T> modelClazz,
+            @SuppressWarnings("SameParameterValue") @Nullable final Long lastSync) {
+        return Single.create(emitter -> {
+            final String apiName;
+            try {
+                apiName = configuredApiProvider.getDataStoreApiName();
+            } catch (DataStoreException noApiConfiguredException) {
+                emitter.onError(noApiConfiguredException);
+                return;
+            }
+            final Cancelable cancelable =
+                endpoint.sync(apiName, modelClazz, lastSync, new MetadataEmitter<>(emitter));
+            emitter.setDisposable(asDisposable(cancelable));
+        });
+    }
+
+    /**
+     * A utility method to convert a cancelable to a Disposable.
+     * TODO: Move this out to a more generic location?
+     * @param cancelable An Amplify Cancelable
+     * @return An RxJava2 Disposable that disposed by invoking the cancelation.
+     */
+    private Disposable asDisposable(Cancelable cancelable) {
+        return new Disposable() {
+            private final AtomicReference<Boolean> isCanceled = new AtomicReference<>(false);
+            @Override
+            public void dispose() {
+                synchronized (isCanceled) {
+                    cancelable.cancel();
+                    isCanceled.set(true);
+                }
+            }
+
+            @Override
+            public boolean isDisposed() {
+                synchronized (isCanceled) {
+                    return isCanceled.get();
+                }
+            }
+        };
+    }
+
+    static final class MetadataEmitter<T extends Model>
+            implements ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> {
+
+        private final SingleEmitter<Iterable<ModelWithMetadata<T>>> emitter;
+
+        MetadataEmitter(final SingleEmitter<Iterable<ModelWithMetadata<T>>> emitter) {
+            this.emitter = emitter;
+        }
+
+        @Override
+        public void onResult(GraphQLResponse<Iterable<ModelWithMetadata<T>>> resultFromEndpoint) {
+            if (resultFromEndpoint.hasErrors()) {
+                emitter.onError(new DataStoreException(String.format(
+                    "A model sync failed: %s", resultFromEndpoint.getErrors()
+                ), "Check your schema."));
+            } else if (!resultFromEndpoint.hasData()) {
+                emitter.onError(new DataStoreException("Empty response from AppSync.", "Report to AWS team."));
+            } else {
+                final Set<ModelWithMetadata<T>> emittedValue = new HashSet<>();
+                for (ModelWithMetadata<T> modelWithMetadata : resultFromEndpoint.getData()) {
+                    emittedValue.add(modelWithMetadata);
+                }
+                emitter.onSuccess(emittedValue);
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            emitter.onError(new DataStoreException(
+                "Failed to sync a model.", error, "Check error details."
+            ));
+        }
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/RemoteModelStateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/RemoteModelStateTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testmodels.commentsblog.Post;
+import com.amplifyframework.testmodels.commentsblog.PostStatus;
+import com.amplifyframework.testutils.RandomString;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.reactivex.observers.TestObserver;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the {@link RemoteModelState}.
+ */
+@SuppressWarnings("checkstyle:MagicNumber") // Arranged data picked arbitrarily
+public final class RemoteModelStateTest {
+    private static final ModelWithMetadata<BlogOwner> BLOGGER_JAMESON =
+        new ModelWithMetadata<>(
+            BlogOwner.builder()
+                .name("Jameson")
+                .id("d5b44350-b8e9-4deb-94c2-7fe986d6a0e1")
+                .build(),
+            new ModelMetadata("d5b44350-b8e9-4deb-94c2-7fe986d6a0e1", null, 3, 223344L)
+        );
+    private static final ModelWithMetadata<BlogOwner> BLOGGER_ISLA =
+        new ModelWithMetadata<>(
+            BlogOwner.builder()
+            .name("Isla")
+                .id("c0601168-2931-4bc0-bf13-5963cd31f828")
+                .build(),
+            new ModelMetadata("c0601168-2931-4bc0-bf13-5963cd31f828", null, 11, 998877L)
+        );
+    private static final ModelWithMetadata<Post> DRUM_POST =
+        new ModelWithMetadata<>(
+            Post.builder()
+                .title("Inactive Post About Drums")
+                .status(PostStatus.INACTIVE)
+                .rating(3)
+                .id("83ceb757-c8c8-4b6a-bee0-a43afb53a73a")
+                .build(),
+            new ModelMetadata("83ceb757-c8c8-4b6a-bee0-a43afb53a73a", null, 5, 123123L)
+        );
+    private static final ModelWithMetadata<Post> GUITAR_POST =
+        new ModelWithMetadata<>(
+            Post.builder()
+                .title("Active Post About Guitars")
+                .status(PostStatus.ACTIVE)
+                .rating(9)
+                .id("28a02356-c560-4b63-b629-efc4b75b63c2")
+                .build(),
+            new ModelMetadata("28a02356-c560-4b63-b629-efc4b75b63c2", Boolean.TRUE, 12, 333222L)
+        );
+
+    private String apiName;
+    private AppSyncEndpoint endpoint;
+    private ModelProvider modelProvider;
+    private RemoteModelState remoteModelState;
+
+    /**
+     * Mock out our dependencies. We'll want to pretend we have some different models
+     * being provided by the system. And, we want to mock away the AppSyncEndpoint, so we
+     * can test our logic in isolation without going out to the network / depending
+     * on some backend to have a certain configuration / state.
+     */
+    @Before
+    public void setup() {
+        apiName = RandomString.string();
+        endpoint = mock(AppSyncEndpoint.class);
+        modelProvider = mock(ModelProvider.class);
+        remoteModelState = new RemoteModelState(endpoint, modelProvider, () -> apiName);
+    }
+
+    /**
+     * Observe the remote model state, via {@link RemoteModelState#observe()}.
+     * Validate that the observed items are the ones that were provided by our
+     * arranged {@link AppSyncEndpoint} mock.
+     */
+    @Test
+    public void observeReceivesAllModelInstances() {
+        // Arrange: ModelProvider deals with Post and BlogOwner types.
+        provideModels(Post.class, BlogOwner.class);
+
+        // Arrange: the AppSync endpoint will give us some MetaData for items
+        // having these types.
+        mockSuccessfulResponse(Post.class, DRUM_POST, GUITAR_POST);
+        mockSuccessfulResponse(BlogOwner.class, BLOGGER_JAMESON, BLOGGER_ISLA);
+
+        // Act: Observe the RemoteModelState via observe().
+        TestObserver<ModelWithMetadata<? extends Model>> observer = TestObserver.create();
+        remoteModelState.observe().subscribe(observer);
+        observer.awaitTerminalEvent();
+        observer.assertValueCount(4);
+
+        // assertValueSet(..., varargs, ...) would be cleanest. But equals() is broken
+        // on the generated models right now. So, instead, use our own assertEquals() for right now...
+        assertEquals(
+            Arrays.asList(BLOGGER_JAMESON, BLOGGER_ISLA, DRUM_POST, GUITAR_POST),
+            observer.values()
+        );
+        observer.dispose();
+    }
+
+    /**
+     * Configures the {@link ModelProvider} mock to return the named models.
+     * @param models Classes of models to return from ModelProvider mock
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs") // arguments
+    private final void provideModels(Class<? extends Model>... models) {
+        when(modelProvider.models()).thenReturn(new HashSet<>(Arrays.asList(models)));
+    }
+
+    /**
+     * Mocks a response from the {@link AppSyncEndpoint}.
+     * @param clazz Class of models for which to respond
+     * @param responseItems The items that should be included in the mocked response, for the model class
+     * @param <T> Type of models for which a response is mocked
+     */
+    @SuppressWarnings("varargs") // matchers, arguments
+    @SafeVarargs
+    private final <T extends Model> void mockSuccessfulResponse(
+        Class<T> clazz, ModelWithMetadata<T>... responseItems) {
+        doAnswer(invocation -> {
+            // Get a handle to the listener that is passed into the sync() method
+            // ResultListener is the fourth and final param (@0, @1, @2, @3).
+            final int argumentPositionForResultListener = 3;
+            final ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> listener =
+                invocation.getArgument(argumentPositionForResultListener);
+
+            // Call its onResult(), and pass the mocked items inside of a GraphQLResponse wrapper
+            final Iterable<ModelWithMetadata<T>> data = new HashSet<>(Arrays.asList(responseItems));
+            listener.onResult(new GraphQLResponse<>(data, Collections.emptyList()));
+
+            // Return a NoOp cancelable via the sync() method's return.
+            return new NoOpCancelable();
+        }).when(endpoint).sync(
+            eq(apiName),
+            eq(clazz),
+            any(),
+            any()
+        );
+    }
+
+    private void assertEquals(
+            Collection<ModelWithMetadata<? extends Model>> expected,
+            Collection<ModelWithMetadata<? extends Model>> actual) {
+
+        final Set<String> actualModelIds = new HashSet<>();
+        for (final ModelWithMetadata<? extends Model> modelWithMetadata : actual) {
+            actualModelIds.add(modelWithMetadata.getModel().getId());
+        }
+        final Set<String> expectedModelIds = new HashSet<>();
+        for (final ModelWithMetadata<? extends Model> modelWithMetadata : expected) {
+            expectedModelIds.add(modelWithMetadata.getModel().getId());
+        }
+        org.junit.Assert.assertEquals(expectedModelIds, actualModelIds);
+    }
+}


### PR DESCRIPTION
Provides and observe() signature though which an actor can obtain
all current values of all models in an App Sync endpoint, by means
of k-many base syncs, for k, the number of models managed by the system.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
