### PR TITLE
[DataStore] Add Data Hydrator

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/DataHydration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/DataHydration.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.storage.LocalStorageAdapter;
+import com.amplifyframework.datastore.storage.StorageItemChange;
+
+import io.reactivex.Completable;
+import io.reactivex.CompletableEmitter;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * "Hydrates" the local DataStore, using model metadata receive from the
+ * {@link RemoteModelState}. Hydration refers to populating the local storage
+ * with values from a remote system.
+ */
+@SuppressWarnings("unused")
+final class DataHydration {
+    private final RemoteModelState remoteModelState;
+    private final LocalStorageAdapter localStorageAdapter;
+
+    DataHydration(
+            RemoteModelState remoteModelState,
+            LocalStorageAdapter localStorageAdapter) {
+        this.remoteModelState = remoteModelState;
+        this.localStorageAdapter = localStorageAdapter;
+    }
+
+    /**
+     * The task of hydrating the DataStore either succeeds (with no return value),
+     * or it fails, with an explanation.
+     * @return An Rx {@link Completable} which can be used to perform the operation.
+     */
+    Completable hydrate() {
+        // Observe the remote model states,
+        return remoteModelState.observe()
+            .subscribeOn(Schedulers.io())
+            .observeOn(Schedulers.io())
+            // For each model state, provide it as an input to a completable operation
+            .flatMapCompletable(modelWithMetadata ->
+                // Save the metadata if the data save succeeds
+                saveItemToStorage(modelWithMetadata)
+                    .andThen(saveMetadataToStorage(modelWithMetadata))
+            );
+    }
+
+    private <T extends Model> Completable saveItemToStorage(ModelWithMetadata<T> modelWithMetadata) {
+        return Completable.create(emitter -> {
+            // Save the model portion
+            final ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
+            final T item = modelWithMetadata.getModel();
+            final StorageItemChangeListener listener = new StorageItemChangeListener(emitter);
+            if (Boolean.TRUE.equals(metadata.isDeleted())) {
+                localStorageAdapter.delete(item, StorageItemChange.Initiator.SYNC_ENGINE, listener);
+            } else {
+                localStorageAdapter.save(item, StorageItemChange.Initiator.SYNC_ENGINE, listener);
+            }
+        });
+    }
+
+    private <T extends Model> Completable saveMetadataToStorage(ModelWithMetadata<T> modelWithMetadata) {
+        return Completable.create(emitter -> {
+            // Save the metadata portion
+            // This is separate from the model save since they have two distinct completions.
+            final ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
+            final StorageItemChangeListener metadataSaveListener = new StorageItemChangeListener(emitter);
+            localStorageAdapter.save(metadata, StorageItemChange.Initiator.SYNC_ENGINE, metadataSaveListener);
+        });
+    }
+
+    /**
+     * Listens to change record on the {@link LocalStorageAdapter}, for
+     * {@link LocalStorageAdapter#save(Model, StorageItemChange.Initiator, ResultListener)} and
+     * {@link LocalStorageAdapter#delete(Model, StorageItemChange.Initiator, ResultListener)}.
+     *  Publishes the values onto a {@link CompletableEmitter}, ignoring the result that is
+     *  provided in {@link ResultListener#onResult(Object)}, if/when that is invoked.
+     */
+    static final class StorageItemChangeListener implements ResultListener<StorageItemChange.Record> {
+        private final CompletableEmitter emitter;
+
+        StorageItemChangeListener(CompletableEmitter emitter) {
+            this.emitter = emitter;
+        }
+
+        @Override
+        public void onResult(StorageItemChange.Record result) {
+            emitter.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            emitter.onError(error);
+        }
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/DataHydrationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/DataHydrationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
+import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
+import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testmodels.commentsblog.Post;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import io.reactivex.observers.TestObserver;
+
+import static com.amplifyframework.datastore.network.TestModelWithMetadataInstances.BLOGGER_ISLA;
+import static com.amplifyframework.datastore.network.TestModelWithMetadataInstances.BLOGGER_JAMESON;
+import static com.amplifyframework.datastore.network.TestModelWithMetadataInstances.DELETED_DRUM_POST;
+import static com.amplifyframework.datastore.network.TestModelWithMetadataInstances.DRUM_POST;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests the {@link DataHydration}.
+ */
+public final class DataHydrationTest {
+    private static final long OP_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);
+
+    private StorageItemChange.StorageItemChangeFactory storageRecordDeserializer;
+    private AppSyncEndpoint appSyncEndpoint;
+    private InMemoryStorageAdapter inMemoryStorageAdapter;
+
+    private DataHydration dataHydration;
+
+    /**
+     * Wire up dependencies for the DataHydration, and build one for testing.
+     */
+    @Before
+    public void setup() {
+        this.storageRecordDeserializer = new GsonStorageItemChangeConverter();
+        this.inMemoryStorageAdapter = InMemoryStorageAdapter.create();
+
+        final ModelProvider modelProvider = ModelProviderFactory.including(Post.class, BlogOwner.class);
+        this.appSyncEndpoint = mock(AppSyncEndpoint.class);
+        final RemoteModelState remoteModelState = new RemoteModelState(appSyncEndpoint, modelProvider);
+
+        this.dataHydration = new DataHydration(remoteModelState, inMemoryStorageAdapter);
+    }
+
+    /**
+     * When {@link DataHydration#hydrate()}'s {@link Completable} completes,
+     * then the local storage adapter should have all of the remote model state.
+     */
+    @SuppressWarnings({"unchecked", "checkstyle:MagicNumber"})
+    @Test
+    public void localStorageAdapterIsHydratedFromRemoteModelState() {
+        // Arrange: drum post is already in the adapter before hydration.
+        inMemoryStorageAdapter.items().add(DRUM_POST.getModel());
+
+        // Arrange a subscription to the storage adapter. We're going to watch for changes.
+        // We expect to see content here as a result of the DataHydration applying updates.
+        final TestObserver<StorageItemChange<? extends Model>> adapterObserver = TestObserver.create();
+        inMemoryStorageAdapter.observe()
+            .map(record -> record.toStorageItemChange(storageRecordDeserializer))
+            .subscribe(adapterObserver);
+
+        // Arrange: return some responses for the sync() call on the RemoteModelState
+        MockAppSyncEndpoint.configure(appSyncEndpoint)
+            .mockSuccessResponse(Post.class, DELETED_DRUM_POST)
+            .mockSuccessResponse(BlogOwner.class, BLOGGER_ISLA, BLOGGER_JAMESON);
+
+        // Act: Call hydrate, and await its completion - assert it completed without error
+        TestObserver<ModelWithMetadata<? extends Model>> hydratorObserver = TestObserver.create();
+        dataHydration.hydrate().subscribe(hydratorObserver);
+        assertTrue(hydratorObserver.awaitTerminalEvent(OP_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        hydratorObserver.assertNoErrors();
+
+        // Since hydrate() completed, the storage adapter observer should see some values.
+        // There should be a total of six changes on storage adapter
+        // A model and a metadata save for each of the two BlogOwner-type items,
+        // and a model deletion and a metadata save for the deleted post about drums.
+        adapterObserver.awaitCount(6);
+
+        // Validate the changes emitted from the storage adapter's observe().
+        assertEquals(
+            // Expect 6 items as described above.
+            Observable.fromArray(DELETED_DRUM_POST, BLOGGER_JAMESON, BLOGGER_ISLA)
+                // flatten each item into two items, the item's model, and the item's metadata
+                .flatMap(modelWithMutation ->
+                    Observable.fromArray(modelWithMutation.getModel(), modelWithMutation.getSyncMetadata()))
+                // Get the items into a Single<List>, where the list is sorted by model ID
+                .toSortedList(SortByModelId::compare)
+                // Resolve the single into a success/error
+                .blockingGet(),
+            // Actually...
+            Observable.fromIterable(adapterObserver.values())
+                .map(StorageItemChange::item)
+                .toSortedList(SortByModelId::compare)
+                .blockingGet()
+        );
+
+        // Lastly: validate the current contents of the storage adapter.
+        // There should be 2 BlogOwners, 0 Posts, and 3 MetaData records - two for the BlogOwner,
+        // and 1 for the deleted drum post
+        assertEquals(5, inMemoryStorageAdapter.items().size());
+        assertEquals(
+            // Expect the 4 items for the bloggers (2 models and their metadata)
+            Observable.fromArray(BLOGGER_ISLA, BLOGGER_JAMESON)
+                .flatMap(blogger -> Observable.fromArray(blogger.getModel(), blogger.getSyncMetadata()))
+                // And also the one metadata record for a deleted post
+                .startWith(DELETED_DRUM_POST.getSyncMetadata())
+                .toSortedList(SortByModelId::compare)
+                .blockingGet(),
+            Observable.fromIterable(inMemoryStorageAdapter.items())
+                .toSortedList(SortByModelId::compare)
+                .blockingGet()
+        );
+
+        adapterObserver.dispose();
+        hydratorObserver.dispose();
+    }
+
+    static final class SortByModelId {
+        @SuppressWarnings("checkstyle:all") private SortByModelId() {}
+
+        static int compare(Model left, Model right) {
+            return left.getId().compareTo(right.getId());
+        }
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/ModelProviderFactory.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/ModelProviderFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import com.amplifyframework.core.Immutable;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+final class ModelProviderFactory {
+    @SuppressWarnings("checkstyle:all") private ModelProviderFactory() {}
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    static ModelProvider including(final Class<? extends Model>... modelClasses) {
+        final Set<Class<? extends Model>> models = new HashSet<>(Arrays.asList(modelClasses));
+        return new SimpleModelProvider(UUID.randomUUID().toString(), models);
+    }
+
+    static final class SimpleModelProvider implements ModelProvider {
+        private final String version;
+        private final Set<Class<? extends Model>> models;
+
+        SimpleModelProvider(final String version, final Set<Class<? extends Model>> models) {
+            this.version = version;
+            this.models = models;
+        }
+
+        @Override
+        public Set<Class<? extends Model>> models() {
+            return Immutable.of(models);
+        }
+
+        @Override
+        public String version() {
+            return version;
+        }
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/RemoteModelStateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/RemoteModelStateTest.java
@@ -15,75 +15,30 @@
 
 package com.amplifyframework.datastore.network;
 
-import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testmodels.commentsblog.Post;
-import com.amplifyframework.testmodels.commentsblog.PostStatus;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import io.reactivex.observers.TestObserver;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
+import static com.amplifyframework.datastore.network.TestModelWithMetadataInstances.BLOGGER_ISLA;
+import static com.amplifyframework.datastore.network.TestModelWithMetadataInstances.BLOGGER_JAMESON;
+import static com.amplifyframework.datastore.network.TestModelWithMetadataInstances.DELETED_DRUM_POST;
+import static com.amplifyframework.datastore.network.TestModelWithMetadataInstances.DRUM_POST;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests the {@link RemoteModelState}.
  */
 @SuppressWarnings("checkstyle:MagicNumber") // Arranged data picked arbitrarily
 public final class RemoteModelStateTest {
-    private static final ModelWithMetadata<BlogOwner> BLOGGER_JAMESON =
-        new ModelWithMetadata<>(
-            BlogOwner.builder()
-                .name("Jameson")
-                .id("d5b44350-b8e9-4deb-94c2-7fe986d6a0e1")
-                .build(),
-            new ModelMetadata("d5b44350-b8e9-4deb-94c2-7fe986d6a0e1", null, 3, 223344L)
-        );
-    private static final ModelWithMetadata<BlogOwner> BLOGGER_ISLA =
-        new ModelWithMetadata<>(
-            BlogOwner.builder()
-            .name("Isla")
-                .id("c0601168-2931-4bc0-bf13-5963cd31f828")
-                .build(),
-            new ModelMetadata("c0601168-2931-4bc0-bf13-5963cd31f828", null, 11, 998877L)
-        );
-    private static final ModelWithMetadata<Post> DRUM_POST =
-        new ModelWithMetadata<>(
-            Post.builder()
-                .title("Inactive Post About Drums")
-                .status(PostStatus.INACTIVE)
-                .rating(3)
-                .id("83ceb757-c8c8-4b6a-bee0-a43afb53a73a")
-                .build(),
-            new ModelMetadata("83ceb757-c8c8-4b6a-bee0-a43afb53a73a", null, 5, 123123L)
-        );
-    private static final ModelWithMetadata<Post> GUITAR_POST =
-        new ModelWithMetadata<>(
-            Post.builder()
-                .title("Active Post About Guitars")
-                .status(PostStatus.ACTIVE)
-                .rating(9)
-                .id("28a02356-c560-4b63-b629-efc4b75b63c2")
-                .build(),
-            new ModelMetadata("28a02356-c560-4b63-b629-efc4b75b63c2", Boolean.TRUE, 12, 333222L)
-        );
-
     private AppSyncEndpoint endpoint;
-    private ModelProvider modelProvider;
     private RemoteModelState remoteModelState;
 
     /**
@@ -95,7 +50,7 @@ public final class RemoteModelStateTest {
     @Before
     public void setup() {
         endpoint = mock(AppSyncEndpoint.class);
-        modelProvider = mock(ModelProvider.class);
+        final ModelProvider modelProvider = ModelProviderFactory.including(Post.class, BlogOwner.class);
         remoteModelState = new RemoteModelState(endpoint, modelProvider);
     }
 
@@ -106,13 +61,11 @@ public final class RemoteModelStateTest {
      */
     @Test
     public void observeReceivesAllModelInstances() {
-        // Arrange: ModelProvider deals with Post and BlogOwner types.
-        provideModels(Post.class, BlogOwner.class);
-
         // Arrange: the AppSync endpoint will give us some MetaData for items
         // having these types.
-        mockSuccessfulResponse(Post.class, DRUM_POST, GUITAR_POST);
-        mockSuccessfulResponse(BlogOwner.class, BLOGGER_JAMESON, BLOGGER_ISLA);
+        MockAppSyncEndpoint.configure(endpoint)
+            .mockSuccessResponse(Post.class, DRUM_POST, DELETED_DRUM_POST)
+            .mockSuccessResponse(BlogOwner.class, BLOGGER_JAMESON, BLOGGER_ISLA);
 
         // Act: Observe the RemoteModelState via observe().
         TestObserver<ModelWithMetadata<? extends Model>> observer = TestObserver.create();
@@ -122,65 +75,11 @@ public final class RemoteModelStateTest {
 
         // assertValueSet(..., varargs, ...) would be cleanest. But equals() is broken
         // on the generated models right now. So, instead, use our own assertEquals() for right now...
-        assertEquals(
-            Arrays.asList(BLOGGER_JAMESON, BLOGGER_ISLA, DRUM_POST, GUITAR_POST),
+        TestModelWithMetadataInstances.assertEquals(
+            Arrays.asList(BLOGGER_JAMESON, BLOGGER_ISLA, DRUM_POST, DELETED_DRUM_POST),
             observer.values()
         );
         observer.dispose();
     }
-
-    /**
-     * Configures the {@link ModelProvider} mock to return the named models.
-     * @param models Classes of models to return from ModelProvider mock
-     */
-    @SafeVarargs
-    @SuppressWarnings("varargs") // arguments
-    private final void provideModels(Class<? extends Model>... models) {
-        when(modelProvider.models()).thenReturn(new HashSet<>(Arrays.asList(models)));
-    }
-
-    /**
-     * Mocks a response from the {@link AppSyncEndpoint}.
-     * @param clazz Class of models for which to respond
-     * @param responseItems The items that should be included in the mocked response, for the model class
-     * @param <T> Type of models for which a response is mocked
-     */
-    @SuppressWarnings("varargs") // matchers, arguments
-    @SafeVarargs
-    private final <T extends Model> void mockSuccessfulResponse(
-        Class<T> clazz, ModelWithMetadata<T>... responseItems) {
-        doAnswer(invocation -> {
-            // Get a handle to the listener that is passed into the sync() method
-            // ResultListener is the third and final param (@0, @1, @2).
-            final int argumentPositionForResultListener = 2;
-            final ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> listener =
-                invocation.getArgument(argumentPositionForResultListener);
-
-            // Call its onResult(), and pass the mocked items inside of a GraphQLResponse wrapper
-            final Iterable<ModelWithMetadata<T>> data = new HashSet<>(Arrays.asList(responseItems));
-            listener.onResult(new GraphQLResponse<>(data, Collections.emptyList()));
-
-            // Return a NoOp cancelable via the sync() method's return.
-            return new NoOpCancelable();
-        }).when(endpoint).sync(
-            eq(clazz),
-            any(),
-            any()
-        );
-    }
-
-    private void assertEquals(
-            Collection<ModelWithMetadata<? extends Model>> expected,
-            Collection<ModelWithMetadata<? extends Model>> actual) {
-
-        final Set<String> actualModelIds = new HashSet<>();
-        for (final ModelWithMetadata<? extends Model> modelWithMetadata : actual) {
-            actualModelIds.add(modelWithMetadata.getModel().getId());
-        }
-        final Set<String> expectedModelIds = new HashSet<>();
-        for (final ModelWithMetadata<? extends Model> modelWithMetadata : expected) {
-            expectedModelIds.add(modelWithMetadata.getModel().getId());
-        }
-        org.junit.Assert.assertEquals(expectedModelIds, actualModelIds);
-    }
 }
+

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/TestModelWithMetadataInstances.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/TestModelWithMetadataInstances.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.network;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testmodels.commentsblog.Post;
+import com.amplifyframework.testmodels.commentsblog.PostStatus;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A bucket for some test data that is cumbersome/verbose to write out.
+ */
+@SuppressWarnings("checkstyle:MagicNumber")
+final class TestModelWithMetadataInstances {
+    static final ModelWithMetadata<BlogOwner> BLOGGER_JAMESON =
+        new ModelWithMetadata<>(
+            BlogOwner.builder()
+                .name("Jameson")
+                .id("d5b44350-b8e9-4deb-94c2-7fe986d6a0e1")
+                .build(),
+            new ModelMetadata("d5b44350-b8e9-4deb-94c2-7fe986d6a0e1", null, 3, 223344L)
+        );
+    static final ModelWithMetadata<BlogOwner> BLOGGER_ISLA =
+        new ModelWithMetadata<>(
+            BlogOwner.builder()
+                .name("Isla")
+                .id("c0601168-2931-4bc0-bf13-5963cd31f828")
+                .build(),
+            new ModelMetadata("c0601168-2931-4bc0-bf13-5963cd31f828", null, 11, 998877L)
+        );
+    static final ModelWithMetadata<Post> DRUM_POST =
+        new ModelWithMetadata<>(
+            Post.builder()
+                .title("Inactive Post About Drums")
+                .status(PostStatus.INACTIVE)
+                .rating(3)
+                .id("83ceb757-c8c8-4b6a-bee0-a43afb53a73a")
+                .build(),
+            new ModelMetadata("83ceb757-c8c8-4b6a-bee0-a43afb53a73a", null, 5, 123123L)
+        );
+    static final ModelWithMetadata<Post> DELETED_DRUM_POST =
+        new ModelWithMetadata<>(
+            DRUM_POST.getModel(),
+            new ModelMetadata("83ceb757-c8c8-4b6a-bee0-a43afb53a73a", Boolean.TRUE, 5, 123123L)
+        );
+
+    @SuppressWarnings("checkstyle:all") private TestModelWithMetadataInstances() {}
+
+    /**
+     * Asserts that two collections of {@link ModelWithMetadata} are equals.
+     * This is a WORKAROUND until equals() and hashCode() work correctly for these.
+     * @param expected Expected collection
+     * @param actual Actual collection to compare to expected
+     */
+    static void assertEquals(
+        // They're "equal" if they deal with the same item ID... for now...
+        // (it's not actually true, though, this is not a sufficient equality condition.)
+
+        Collection<ModelWithMetadata<? extends Model>> expected,
+        Collection<ModelWithMetadata<? extends Model>> actual) {
+
+        final Set<String> actualModelIds = new HashSet<>();
+        for (final ModelWithMetadata<? extends Model> modelWithMetadata : actual) {
+            actualModelIds.add(modelWithMetadata.getModel().getId());
+        }
+        final Set<String> expectedModelIds = new HashSet<>();
+        for (final ModelWithMetadata<? extends Model> modelWithMetadata : expected) {
+            expectedModelIds.add(modelWithMetadata.getModel().getId());
+        }
+        org.junit.Assert.assertEquals(expectedModelIds, actualModelIds);
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -109,19 +109,19 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull final StorageItemChange.Initiator initiator,
             @NonNull final ResultListener<StorageItemChange.Record> itemDeletionListener) {
 
-        while (items.iterator().hasNext()) {
-            Model next = items.iterator().next();
-            if (next.equals(item)) {
+        for (Model savedItem : items) {
+            if (savedItem.getId().equals(item.getId())) {
                 items.remove(item);
                 StorageItemChange.Record deletion = StorageItemChange.<T>builder()
-                    .item(item)
-                    .itemClass((Class<T>) item.getClass())
+                    .item((T) savedItem)
+                    .itemClass((Class<T>) savedItem.getClass())
                     .type(StorageItemChange.Type.DELETE)
                     .initiator(initiator)
                     .build()
                     .toRecord(storageItemChangeConverter);
-                itemDeletionListener.onResult(deletion);
                 changeRecordStream.onNext(deletion);
+                itemDeletionListener.onResult(deletion);
+                return;
             }
         }
     }


### PR DESCRIPTION
DataHydrator consumes RemoteModelState's observe(). For each model
emitted on the Observable, the Hydrator populates the local data store
with the model data, and the metadata about that model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
