### PR TITLE
[DataStore] Rx-ify the DataStore contract

### DIFF
--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -18,14 +18,12 @@ package com.amplifyframework.datastore;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 
-import java.util.Iterator;
-
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 
 /**
@@ -42,6 +40,7 @@ public class DataStoreCategory
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public CategoryType getCategoryType() {
         return CategoryType.DATASTORE;
@@ -50,38 +49,37 @@ public class DataStoreCategory
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
-    public <T extends Model> void save(@NonNull T object,
-                                       @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
-        getSelectedPlugin().save(object, saveItemListener);
+    public <T extends Model> Completable save(@NonNull T object) {
+        return getSelectedPlugin().save(object);
     }
 
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
-    public <T extends Model> void delete(@NonNull T object,
-                                         @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener) {
-        getSelectedPlugin().delete(object, deleteItemListener);
+    public <T extends Model> Completable delete(@NonNull T object) {
+        return getSelectedPlugin().delete(object);
     }
 
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
-    public <T extends Model> void query(@NonNull Class<T> itemClass,
-                                        @NonNull ResultListener<Iterator<T>> queryResultsListener) {
-        getSelectedPlugin().query(itemClass, queryResultsListener);
+    public <T extends Model> Observable<T> query(@NonNull Class<T> itemClass) {
+        return getSelectedPlugin().query(itemClass);
     }
 
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
-    public <T extends Model> void query(@NonNull Class<T> itemClass,
-                                        @Nullable QueryPredicate predicate,
-                                        @NonNull ResultListener<Iterator<T>> queryResultsListener) {
-        getSelectedPlugin().query(itemClass, predicate, queryResultsListener);
+    public <T extends Model> Observable<T> query(@NonNull Class<T> itemClass, @Nullable QueryPredicate predicate) {
+        return getSelectedPlugin().query(itemClass, predicate);
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -18,13 +18,11 @@ package com.amplifyframework.datastore;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 
-import java.util.Iterator;
-
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 
 /**
@@ -40,51 +38,50 @@ public interface DataStoreCategoryBehavior {
     /**
      * Saves an item into the DataStore.
      * @param item An item to save
-     * @param saveItemListener
-     *        An optional listener which will be callback'd when the save succeeds or fails
-     * @param <T> The time of item being saved
+     * @param <T> The type of item being saved
+     * @return A Completable which fires success or failure depending on the
+     *         result of the save operation.
      */
-    <T extends Model> void save(
-            @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener);
+    @NonNull
+    <T extends Model> Completable save(@NonNull T item);
 
     /**
      * Deletes an item from the DataStore.
      * @param item An item to delete from the DataStore
-     * @param deleteItemListener
-     *        An optional listener which will be invoked when the deletion succeeds or fails
      * @param <T> The type of item being deleted
+     * @return A Completable which fires success or failure depending on the
+     *         result of the delete operation.
      */
-    <T extends Model> void delete(
-            @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener);
+    @NonNull
+    <T extends Model> Completable delete(@NonNull T item);
 
     /**
      * Query the DataStore to find all items of the requested Java class.
      * @param itemClass Items of this class will be targeted by this query
-     * @param queryResultsListener
-     *        An optional listener which will be invoked when the query returns
-     *        results, or if there is a failure to query
      * @param <T> The type of items being queried
+     * @return An observable stream of query results. The query will not begin until
+     *         the observable is subscribed. The observable fires onComplete when all
+     *         query results have been emitted. The observable will terminate with an
+     *         error, in case of any issues while handling the query.
      */
-    <T extends Model> void query(
-            @NonNull Class<T> itemClass,
-            @NonNull ResultListener<Iterator<T>> queryResultsListener);
+    @NonNull
+    <T extends Model> Observable<T> query(@NonNull Class<T> itemClass);
 
     /**
      * Query the DataStore to find all items of the requested Java class that fulfills the
      * predicate.
      * @param itemClass Items of this class will be targeted by this query
      * @param predicate Predicate condition to apply to query
-     * @param queryResultsListener
-     *        An optional listener which will be invoked when the query returns
-     *        results, or if there is a failure to query
      * @param <T> The type of items being queried
+     * @return An observable stream of query results. The query will not begin until
+     *         the observable is subscribed. The observable fires onComplete when all
+     *         query results have been emitted. The observable will terminate with an
+     *         error, in case of any issues while handling the query.
      */
-    <T extends Model> void query(@NonNull Class<T> itemClass,
-                                 @Nullable QueryPredicate predicate,
-                                 @NonNull ResultListener<Iterator<T>> queryResultsListener);
-
+    @NonNull
+    <T extends Model> Observable<T> query(
+            @NonNull Class<T> itemClass,
+            @Nullable QueryPredicate predicate);
 
     /**
      * Observe all changes to any/all item(s) in the DataStore.

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreItemChange.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreItemChange.java
@@ -17,7 +17,6 @@ package com.amplifyframework.datastore;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
 
 import java.util.Objects;
@@ -251,8 +250,8 @@ public final class DataStoreItemChange<T extends Model> {
 
     /**
      * A DataStoreItemChange can either be caused by a call to one of the
-     * {@link DataStoreCategoryBehavior#save(Model, ResultListener)} family of methods,
-     * or to one of the {@link DataStoreCategoryBehavior#delete(Model, ResultListener)}
+     * {@link DataStoreCategoryBehavior#save(Model)} family of methods,
+     * or to one of the {@link DataStoreCategoryBehavior#delete(Model)}
      * methods.
      */
     public enum Type {


### PR DESCRIPTION
Don't use the ResultListener callback on the DataStore APIs.
Instead, return an Rx Observable for the query() method, and return
Completables for the save() and delete() methods.

observe() is already returning an Rx Observable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
