### PR TITLE
[DataStore] Implement conditional save for Storage Engine

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterInstrumentedTest.java
@@ -29,7 +29,6 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
-import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.Blog;
@@ -158,7 +157,7 @@ public final class SQLiteStorageAdapterInstrumentedTest {
         final BlogOwner blogOwner = BlogOwner.builder()
             .name("Alan Turing")
             .build();
-        assertEquals(blogOwner, saveModel(blogOwner));
+        saveModel(blogOwner);
 
         final Cursor cursor = sqliteStorageAdapter.getQueryAllCursor("BlogOwner");
         assertNotNull(cursor);
@@ -183,7 +182,7 @@ public final class SQLiteStorageAdapterInstrumentedTest {
             .name("Tony Danielsen")
             .wea(null)
             .build();
-        assertEquals(blogOwner, saveModel(blogOwner));
+        saveModel(blogOwner);
 
         final Cursor cursor = sqliteStorageAdapter.getQueryAllCursor("BlogOwner");
         assertNotNull(cursor);
@@ -336,7 +335,7 @@ public final class SQLiteStorageAdapterInstrumentedTest {
         final BlogOwner blogOwner = BlogOwner.builder()
             .name("Alan Turing")
             .build();
-        assertEquals(blogOwner, saveModel(blogOwner));
+        saveModel(blogOwner);
 
         Iterator<BlogOwner> result = queryModel(BlogOwner.class);
         assertNotNull(result);
@@ -575,26 +574,24 @@ public final class SQLiteStorageAdapterInstrumentedTest {
         deleteModel(raphael);
 
         // Get the BlogOwner record from the database
-        Iterator<BlogOwner> blogOwnerterator = queryModel(BlogOwner.class);
-        assertFalse(blogOwnerterator.hasNext());
+        Iterator<BlogOwner> blogOwnerIterator = queryModel(BlogOwner.class);
+        assertFalse(blogOwnerIterator.hasNext());
 
         // Get the Blog record from the database
         Iterator<Blog> blogIterator = queryModel(Blog.class);
         assertFalse(blogIterator.hasNext());
     }
 
-    private <T extends Model> T saveModel(@NonNull T model) throws DataStoreException {
-        return saveModel(model, null);
+    private <T extends Model> void saveModel(@NonNull T model) {
+        saveModel(model, null);
     }
 
-    private <T extends Model> T saveModel(
-            @NonNull T model, @Nullable QueryPredicate predicate) throws DataStoreException {
+    private <T extends Model> void saveModel(
+            @NonNull T model, @Nullable QueryPredicate predicate) {
         LatchedResultListener<StorageItemChange.Record> saveListener =
                 LatchedResultListener.waitFor(SQLITE_OPERATION_TIMEOUT_MS);
         sqliteStorageAdapter.save(model, StorageItemChange.Initiator.DATA_STORE_API, predicate, saveListener);
-        return saveListener.awaitResult()
-                .<T>toStorageItemChange(new GsonStorageItemChangeConverter())
-                .item();
+        saveListener.awaitTerminalEvent();
     }
 
     private <T extends Model> Iterator<T> queryModel(@NonNull Class<T> modelClass) {
@@ -610,13 +607,11 @@ public final class SQLiteStorageAdapterInstrumentedTest {
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    private <T extends Model> T deleteModel(@NonNull T model) throws DataStoreException {
+    private <T extends Model> void deleteModel(@NonNull T model) {
         LatchedResultListener<StorageItemChange.Record> deleteListener =
             LatchedResultListener.waitFor(SQLITE_OPERATION_TIMEOUT_MS);
         sqliteStorageAdapter.delete(model, StorageItemChange.Initiator.DATA_STORE_API, deleteListener);
-        return deleteListener.awaitResult()
-            .<T>toStorageItemChange(new GsonStorageItemChangeConverter())
-            .item();
+        deleteListener.awaitTerminalEvent();
     }
 }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -186,7 +186,8 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> void save(
             @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
+            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener
+    ) {
         sqliteStorageAdapter.save(item, StorageItemChange.Initiator.DATA_STORE_API,
             new ResultConversionListener<>(saveItemListener, this::toDataStoreItemChange));
     }
@@ -198,7 +199,8 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     public <T extends Model> void save(
             @NonNull T item,
             @NonNull QueryPredicate predicate,
-            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
+            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener
+    ) {
         sqliteStorageAdapter.save(item, StorageItemChange.Initiator.DATA_STORE_API, predicate,
                 new ResultConversionListener<>(saveItemListener, this::toDataStoreItemChange));
     }
@@ -209,7 +211,8 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> void delete(
             @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener) {
+            @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener
+    ) {
         sqliteStorageAdapter.delete(item, StorageItemChange.Initiator.DATA_STORE_API,
             new ResultConversionListener<>(deleteItemListener, this::toDataStoreItemChange));
     }
@@ -220,7 +223,8 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> void query(
             @NonNull Class<T> itemClass,
-            @NonNull ResultListener<Iterator<T>> queryResultsListener) {
+            @NonNull ResultListener<Iterator<T>> queryResultsListener
+    ) {
         sqliteStorageAdapter.query(itemClass, queryResultsListener);
     }
 
@@ -231,7 +235,8 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     public <T extends Model> void query(
             @NonNull Class<T> itemClass,
             @NonNull QueryPredicate predicate,
-            @NonNull ResultListener<Iterator<T>> queryResultsListener) {
+            @NonNull ResultListener<Iterator<T>> queryResultsListener
+    ) {
         sqliteStorageAdapter.query(itemClass, predicate, queryResultsListener);
     }
 
@@ -263,7 +268,8 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> Observable<DataStoreItemChange<T>> observe(
             @NonNull Class<T> itemClass,
-            @NonNull String uniqueId) {
+            @NonNull String uniqueId
+    ) {
         return observe(itemClass)
             .filter(dataStoreItemChange -> uniqueId.equals(dataStoreItemChange.item().getId()));
     }
@@ -275,7 +281,8 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> Observable<DataStoreItemChange<T>> observe(
             @NonNull Class<T> itemClass,
-            @NonNull QueryPredicate selectionCriteria) {
+            @NonNull QueryPredicate selectionCriteria
+    ) {
         return Observable.error(new DataStoreException("Not implemented yet, buster!", "Check back later!"));
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -197,7 +197,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> void save(
             @NonNull T item,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
         sqliteStorageAdapter.save(item, StorageItemChange.Initiator.DATA_STORE_API, predicate,
                 new ResultConversionListener<>(saveItemListener, this::toDataStoreItemChange));
@@ -230,7 +230,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> void query(
             @NonNull Class<T> itemClass,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull ResultListener<Iterator<T>> queryResultsListener) {
         sqliteStorageAdapter.query(itemClass, predicate, queryResultsListener);
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -195,6 +195,18 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
      * {@inheritDoc}
      */
     @Override
+    public <T extends Model> void save(
+            @NonNull T item,
+            @Nullable QueryPredicate predicate,
+            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
+        sqliteStorageAdapter.save(item, StorageItemChange.Initiator.DATA_STORE_API, predicate,
+                new ResultConversionListener<>(saveItemListener, this::toDataStoreItemChange));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public <T extends Model> void delete(
             @NonNull T item,
             @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/GsonStorageItemChangeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/GsonStorageItemChangeConverter.java
@@ -17,6 +17,8 @@ package com.amplifyframework.datastore.storage;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryOperator;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
 
 import com.google.gson.Gson;
@@ -43,17 +45,19 @@ public final class GsonStorageItemChangeConverter implements
      */
     public GsonStorageItemChangeConverter() {
         this.gson = new GsonBuilder()
-            .registerTypeAdapterFactory(new ClassTypeAdapterFactory())
-            .create();
+                .registerTypeAdapterFactory(new ClassTypeAdapterFactory())
+                .registerTypeAdapter(QueryPredicate.class, new PredicateInterfaceAdapter())
+                .registerTypeAdapter(QueryOperator.class, new OperatorInterfaceAdapter())
+                .create();
     }
 
     @Override
     public <T extends Model> StorageItemChange.Record toRecord(StorageItemChange<T> storageItemChange) {
         return StorageItemChange.Record.builder()
-            .id(storageItemChange.changeId().toString())
-            .entry(gson.toJson(storageItemChange))
-            .itemClass(storageItemChange.itemClass().getName())
-            .build();
+                .id(storageItemChange.changeId().toString())
+                .entry(gson.toJson(storageItemChange))
+                .itemClass(storageItemChange.itemClass().getName())
+                .build();
     }
 
     @Override

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -76,6 +76,22 @@ public interface LocalStorageAdapter {
             @NonNull ResultListener<StorageItemChange.Record> itemSaveListener);
 
     /**
+     * Save an item into local storage only if the data being overwritten meets the
+     * specific conditions. The {@link ResultListener} will be invoked when the
+     * save operation is completed, to notify the caller of success or failure.
+     * @param item the item to save into the repository
+     * @param initiator An identification of the actor who initiated this save
+     * @param predicate Predicate condition for conditional write
+     * @param itemSaveListener A listener that will be invoked when the save terminates.
+     * @param <T> The type of the item being stored
+     */
+    <T extends Model> void save(
+            @NonNull T item,
+            @NonNull StorageItemChange.Initiator initiator,
+            @Nullable QueryPredicate predicate,
+            @NonNull ResultListener<StorageItemChange.Record> itemSaveListener);
+
+    /**
      * Query the storage for items of a given type.
      * @param itemClass Items that have this class will be solicited
      * @param queryResultsListener A listener that will be notified when the query terminates

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/OperatorInterfaceAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/OperatorInterfaceAdapter.java
@@ -49,8 +49,15 @@ final class OperatorInterfaceAdapter implements
      * {@inheritDoc}
      */
     @Override
-    public QueryOperator deserialize(JsonElement json, Type type,
-                         JsonDeserializationContext context) throws JsonParseException {
+    public QueryOperator deserialize(
+            JsonElement json,
+            Type type,
+            JsonDeserializationContext context
+    ) throws JsonParseException {
+        if (json == null || json.isJsonNull()) {
+            return null;
+        }
+
         JsonObject jsonObject = json.getAsJsonObject();
         String operatorType = jsonObject.get(TYPE).getAsString();
         switch (QueryOperator.Type.valueOf(operatorType)) {
@@ -73,7 +80,8 @@ final class OperatorInterfaceAdapter implements
             case BEGINS_WITH:
                 return context.deserialize(json, BeginsWithQueryOperator.class);
             default:
-                throw new JsonParseException("Unable to deserialize to QueryOperator.");
+                throw new JsonParseException("Unable to deserialize " +
+                        json.toString() + " to QueryOperator instance.");
         }
     }
 
@@ -81,7 +89,11 @@ final class OperatorInterfaceAdapter implements
      * {@inheritDoc}
      */
     @Override
-    public JsonElement serialize(QueryOperator operator, Type type, JsonSerializationContext context) {
+    public JsonElement serialize(
+            QueryOperator operator,
+            Type type,
+            JsonSerializationContext context
+    ) {
         if (operator instanceof ContainsQueryOperator) {
             return context.serialize(operator, ContainsQueryOperator.class);
         } else if (operator instanceof GreaterOrEqualQueryOperator) {
@@ -101,7 +113,8 @@ final class OperatorInterfaceAdapter implements
         } else if (operator instanceof BeginsWithQueryOperator) {
             return context.serialize(operator, BeginsWithQueryOperator.class);
         } else {
-            throw new JsonParseException("Unable to serialize this instance of QueryOperator.");
+            throw new JsonParseException("Unable to serialize a QueryOperator " +
+                    "of type " + operator.type().name() + ".");
         }
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/OperatorInterfaceAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/OperatorInterfaceAdapter.java
@@ -1,0 +1,91 @@
+package com.amplifyframework.datastore.storage;
+
+import com.amplifyframework.core.model.query.predicate.BeginsWithQueryOperator;
+import com.amplifyframework.core.model.query.predicate.BetweenQueryOperator;
+import com.amplifyframework.core.model.query.predicate.ContainsQueryOperator;
+import com.amplifyframework.core.model.query.predicate.EqualQueryOperator;
+import com.amplifyframework.core.model.query.predicate.GreaterOrEqualQueryOperator;
+import com.amplifyframework.core.model.query.predicate.GreaterThanQueryOperator;
+import com.amplifyframework.core.model.query.predicate.LessOrEqualQueryOperator;
+import com.amplifyframework.core.model.query.predicate.LessThanQueryOperator;
+import com.amplifyframework.core.model.query.predicate.NotEqualQueryOperator;
+import com.amplifyframework.core.model.query.predicate.QueryOperator;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+/**
+ * Custom logic to serialize and deserialize an instance of {@link QueryOperator}.
+ */
+final class OperatorInterfaceAdapter implements
+        JsonDeserializer<QueryOperator>,
+        JsonSerializer<QueryOperator> {
+
+    private static final String TYPE = "type";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public QueryOperator deserialize(JsonElement json, Type type,
+                         JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        String operatorType = jsonObject.get(TYPE).getAsString();
+        switch (QueryOperator.Type.valueOf(operatorType)) {
+            case CONTAINS:
+                return context.deserialize(json, ContainsQueryOperator.class);
+            case GREATER_OR_EQUAL:
+                return context.deserialize(json, GreaterOrEqualQueryOperator.class);
+            case LESS_OR_EQUAL:
+                return context.deserialize(json, LessOrEqualQueryOperator.class);
+            case GREATER_THAN:
+                return context.deserialize(json, GreaterThanQueryOperator.class);
+            case LESS_THAN:
+                return context.deserialize(json, LessThanQueryOperator.class);
+            case BETWEEN:
+                return context.deserialize(json, BetweenQueryOperator.class);
+            case EQUAL:
+                return context.deserialize(json, EqualQueryOperator.class);
+            case NOT_EQUAL:
+                return context.deserialize(json, NotEqualQueryOperator.class);
+            case BEGINS_WITH:
+                return context.deserialize(json, BeginsWithQueryOperator.class);
+            default:
+                throw new JsonParseException("Unable to deserialize to QueryOperator.");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JsonElement serialize(QueryOperator operator, Type type, JsonSerializationContext context) {
+        if (operator instanceof ContainsQueryOperator) {
+            return context.serialize(operator, ContainsQueryOperator.class);
+        } else if (operator instanceof GreaterOrEqualQueryOperator) {
+            return context.serialize(operator, GreaterOrEqualQueryOperator.class);
+        } else if (operator instanceof LessOrEqualQueryOperator) {
+            return context.serialize(operator, LessOrEqualQueryOperator.class);
+        } else if (operator instanceof GreaterThanQueryOperator) {
+            return context.serialize(operator, GreaterThanQueryOperator.class);
+        } else if (operator instanceof LessThanQueryOperator) {
+            return context.serialize(operator, LessThanQueryOperator.class);
+        } else if (operator instanceof BetweenQueryOperator) {
+            return context.serialize(operator, BetweenQueryOperator.class);
+        } else if (operator instanceof EqualQueryOperator) {
+            return context.serialize(operator, EqualQueryOperator.class);
+        } else if (operator instanceof NotEqualQueryOperator) {
+            return context.serialize(operator, NotEqualQueryOperator.class);
+        } else if (operator instanceof BeginsWithQueryOperator) {
+            return context.serialize(operator, BeginsWithQueryOperator.class);
+        } else {
+            throw new JsonParseException("Unable to serialize this instance of QueryOperator.");
+        }
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/OperatorInterfaceAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/OperatorInterfaceAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amplifyframework.datastore.storage;
 
 import com.amplifyframework.core.model.query.predicate.BeginsWithQueryOperator;
@@ -10,6 +25,7 @@ import com.amplifyframework.core.model.query.predicate.LessOrEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessThanQueryOperator;
 import com.amplifyframework.core.model.query.predicate.NotEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryOperator;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/PredicateInterfaceAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/PredicateInterfaceAdapter.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amplifyframework.datastore.storage;
 
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/PredicateInterfaceAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/PredicateInterfaceAdapter.java
@@ -47,8 +47,15 @@ final class PredicateInterfaceAdapter implements
      * {@inheritDoc}
      */
     @Override
-    public QueryPredicate deserialize(JsonElement json, Type type,
-                         JsonDeserializationContext context) throws JsonParseException {
+    public QueryPredicate deserialize(
+            JsonElement json,
+            Type type,
+            JsonDeserializationContext context
+    ) throws JsonParseException {
+        if (json == null || json.isJsonNull()) {
+            return null;
+        }
+
         JsonObject jsonObject = json.getAsJsonObject();
         String predicateType = jsonObject.get(TYPE).getAsString();
         switch (PredicateType.valueOf(predicateType)) {
@@ -57,7 +64,8 @@ final class PredicateInterfaceAdapter implements
             case GROUP:
                 return context.deserialize(json, QueryPredicateGroup.class);
             default:
-                throw new JsonParseException("Unable to deserialize to QueryPredicate.");
+                throw new JsonParseException("Unable to deserialize " +
+                        json.toString() + " to QueryPredicate instance.");
         }
     }
 
@@ -65,7 +73,11 @@ final class PredicateInterfaceAdapter implements
      * {@inheritDoc}
      */
     @Override
-    public JsonElement serialize(QueryPredicate predicate, Type type, JsonSerializationContext context) {
+    public JsonElement serialize(
+            QueryPredicate predicate,
+            Type type,
+            JsonSerializationContext context
+    ) throws JsonParseException {
         JsonElement json;
         PredicateType predicateType;
         if (predicate instanceof QueryPredicateOperation) {
@@ -75,7 +87,7 @@ final class PredicateInterfaceAdapter implements
             json = context.serialize(predicate, QueryPredicateGroup.class);
             predicateType = PredicateType.GROUP;
         } else {
-            throw new JsonParseException("Unable to serialize this instance of QueryPredicate.");
+            throw new JsonParseException("Unable to identify the predicate type.");
         }
         JsonObject jsonObject = json.getAsJsonObject();
         jsonObject.addProperty(TYPE, predicateType.name());

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/PredicateInterfaceAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/PredicateInterfaceAdapter.java
@@ -1,0 +1,68 @@
+package com.amplifyframework.datastore.storage;
+
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup;
+import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+/**
+ * Custom logic to serialize and deserialize an instance of {@link QueryPredicate}.
+ */
+final class PredicateInterfaceAdapter implements
+        JsonDeserializer<QueryPredicate>,
+        JsonSerializer<QueryPredicate> {
+
+    private static final String TYPE = "_type";
+
+    private enum PredicateType {
+        OPERATION,
+        GROUP
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public QueryPredicate deserialize(JsonElement json, Type type,
+                         JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        String predicateType = jsonObject.get(TYPE).getAsString();
+        switch (PredicateType.valueOf(predicateType)) {
+            case OPERATION:
+                return context.deserialize(json, QueryPredicateOperation.class);
+            case GROUP:
+                return context.deserialize(json, QueryPredicateGroup.class);
+            default:
+                throw new JsonParseException("Unable to deserialize to QueryPredicate.");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JsonElement serialize(QueryPredicate predicate, Type type, JsonSerializationContext context) {
+        JsonElement json;
+        PredicateType predicateType;
+        if (predicate instanceof QueryPredicateOperation) {
+            json = context.serialize(predicate, QueryPredicateOperation.class);
+            predicateType = PredicateType.OPERATION;
+        } else if (predicate instanceof QueryPredicateGroup) {
+            json = context.serialize(predicate, QueryPredicateGroup.class);
+            predicateType = PredicateType.GROUP;
+        } else {
+            throw new JsonParseException("Unable to serialize this instance of QueryPredicate.");
+        }
+        JsonObject jsonObject = json.getAsJsonObject();
+        jsonObject.addProperty(TYPE, predicateType.name());
+        return jsonObject;
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.storage;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.annotations.Index;
@@ -156,7 +157,7 @@ public final class StorageItemChange<T extends Model> {
         if (type != that.type) {
             return false;
         }
-        if (predicate != that.predicate) {
+        if (!ObjectsCompat.equals(predicate, that.predicate)) {
             return false;
         }
         if (!item.equals(that.item)) {
@@ -171,7 +172,7 @@ public final class StorageItemChange<T extends Model> {
         int result = changeId.hashCode();
         result = 31 * result + initiator.hashCode();
         result = 31 * result + type.hashCode();
-        result = 31 * result + predicate.hashCode();
+        result = 31 * result + (predicate != null ? predicate.hashCode() : 0);
         result = 31 * result + item.hashCode();
         result = 31 * result + itemClass.hashCode();
         return result;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
@@ -16,11 +16,13 @@
 package com.amplifyframework.datastore.storage;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.annotations.Index;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
 
 import java.util.Objects;
@@ -37,6 +39,7 @@ public final class StorageItemChange<T extends Model> {
     private final UUID changeId;
     private final Initiator initiator;
     private final Type type;
+    private final QueryPredicate predicate;
     private final T item;
     private final Class<T> itemClass;
 
@@ -46,9 +49,20 @@ public final class StorageItemChange<T extends Model> {
             @NonNull Type type,
             @NonNull T item,
             @NonNull Class<T> itemClass) {
+        this(changeId, initiator, type, null, item, itemClass);
+    }
+
+    private StorageItemChange(
+            @NonNull UUID changeId,
+            @NonNull Initiator initiator,
+            @NonNull Type type,
+            @Nullable QueryPredicate predicate,
+            @NonNull T item,
+            @NonNull Class<T> itemClass) {
         this.changeId = changeId;
         this.initiator = initiator;
         this.type = type;
+        this.predicate = predicate;
         this.item = item;
         this.itemClass = itemClass;
     }
@@ -75,6 +89,14 @@ public final class StorageItemChange<T extends Model> {
      */
     public Type type() {
         return type;
+    }
+
+    /**
+     * Gets the predicate that was applied before this item change.
+     * @return Predicate applied for this item change
+     */
+    public QueryPredicate predicate() {
+        return predicate;
     }
 
     /**
@@ -134,6 +156,9 @@ public final class StorageItemChange<T extends Model> {
         if (type != that.type) {
             return false;
         }
+        if (predicate != that.predicate) {
+            return false;
+        }
         if (!item.equals(that.item)) {
             return false;
         }
@@ -146,6 +171,7 @@ public final class StorageItemChange<T extends Model> {
         int result = changeId.hashCode();
         result = 31 * result + initiator.hashCode();
         result = 31 * result + type.hashCode();
+        result = 31 * result + predicate.hashCode();
         result = 31 * result + item.hashCode();
         result = 31 * result + itemClass.hashCode();
         return result;
@@ -154,12 +180,13 @@ public final class StorageItemChange<T extends Model> {
     @Override
     public String toString() {
         return "StorageItemChange{" +
-            "changeId=" + changeId +
-            ", initiator=" + initiator +
-            ", type=" + type +
-            ", item=" + item +
-            ", itemClass=" + itemClass +
-            '}';
+                "changeId=" + changeId +
+                ", initiator=" + initiator +
+                ", type=" + type +
+                ", predicate=" + predicate +
+                ", item=" + item +
+                ", itemClass=" + itemClass +
+                '}';
     }
 
     /**
@@ -171,6 +198,7 @@ public final class StorageItemChange<T extends Model> {
         private UUID changeId;
         private Initiator initiator;
         private Type type;
+        private QueryPredicate predicate;
         private T item;
         private Class<T> itemClass;
 
@@ -217,6 +245,16 @@ public final class StorageItemChange<T extends Model> {
         }
 
         /**
+         * Configures the predicate that was applied before making the change.
+         * @param predicate The predicate that was applied for this change.
+         * @return Current Builder instance for fluent configuration chainging
+         */
+        public Builder<T> predicate(@Nullable QueryPredicate predicate) {
+            this.predicate = predicate;
+            return this;
+        }
+
+        /**
          * Configures the item that changed.
          * For a save, this is the item after the save.
          * For a delete, this is the item before the delete.
@@ -249,6 +287,7 @@ public final class StorageItemChange<T extends Model> {
                 Objects.requireNonNull(usedId),
                 Objects.requireNonNull(initiator),
                 Objects.requireNonNull(type),
+                predicate, // Nullable
                 Objects.requireNonNull(item),
                 Objects.requireNonNull(itemClass)
             );

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
@@ -75,7 +75,8 @@ interface SQLCommandFactory {
      * @return the SQL command that encapsulates the UPDATE command
      */
     <T extends Model> SqlCommand updateFor(@NonNull ModelSchema modelSchema,
-                                           @NonNull T item);
+                                           @NonNull T item,
+                                           @NonNull QueryPredicate predicate) throws DataStoreException;
 
     /**
      * Generates the DELETE command in a raw string representation.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -300,19 +300,19 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     writeSuccess = saveModel(item, modelSchema, sqlCommand, ModelConflictStrategy.THROW_EXCEPTION);
                 }
 
-                // Do not publish item change if write did not go through.
+                final StorageItemChange.Record record = StorageItemChange.<T>builder()
+                        .item(item)
+                        .itemClass((Class<T>) item.getClass())
+                        .type(StorageItemChange.Type.SAVE)
+                        .predicate(predicate)
+                        .initiator(initiator)
+                        .build()
+                        .toRecord(storageItemChangeConverter);
                 if (writeSuccess) {
-                    final StorageItemChange.Record record = StorageItemChange.<T>builder()
-                            .item(item)
-                            .itemClass((Class<T>) item.getClass())
-                            .type(StorageItemChange.Type.SAVE)
-                            .predicate(predicate)
-                            .initiator(initiator)
-                            .build()
-                            .toRecord(storageItemChangeConverter);
+                    // Do not publish item change if write did not go through.
                     itemChangeSubject.onNext(record);
-                    itemSaveListener.onResult(record);
                 }
+                itemSaveListener.onResult(record);
             } catch (Exception exception) {
                 itemChangeSubject.onError(exception);
                 itemSaveListener.onError(new DataStoreException("Error in saving the model.", exception,

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -306,6 +306,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                             .item(item)
                             .itemClass((Class<T>) item.getClass())
                             .type(StorageItemChange.Type.SAVE)
+                            .predicate(predicate)
                             .initiator(initiator)
                             .build()
                             .toRecord(storageItemChangeConverter);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlCommand.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlCommand.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
+import com.amplifyframework.util.ArrayUtils;
 import com.amplifyframework.util.Immutable;
 
 import java.util.List;
@@ -157,7 +158,7 @@ final class SqlCommand {
         for (int index = 0; index < length; index++) {
             array[index] = selectionArgs.get(index).toString();
         }
-        return Immutable.of(array);
+        return ArrayUtils.copyOf(array);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlCommand.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlCommand.java
@@ -42,7 +42,7 @@ final class SqlCommand {
     private final SQLiteStatement compiledSqlStatement;
 
     // A list of arguments to be used as selection arguments
-    private final List<String> selectionArgs;
+    private final List<Object> selectionArgs;
 
     /**
      * Construct a SqlCommand object.
@@ -78,7 +78,7 @@ final class SqlCommand {
      */
     SqlCommand(@NonNull String tableName,
                @NonNull String sqlStatement,
-               @Nullable List<String> selectionArgs) {
+               @Nullable List<Object> selectionArgs) {
         this(tableName, sqlStatement, null, selectionArgs);
     }
 
@@ -94,7 +94,7 @@ final class SqlCommand {
     SqlCommand(@NonNull String tableName,
                @NonNull String sqlStatement,
                @Nullable SQLiteStatement compiledSqlStatement,
-               @Nullable List<String> selectionArgs) {
+               @Nullable List<Object> selectionArgs) {
         this.tableName = Objects.requireNonNull(tableName);
         this.sqlStatement = Objects.requireNonNull(sqlStatement);
         this.compiledSqlStatement = compiledSqlStatement;
@@ -131,7 +131,7 @@ final class SqlCommand {
      * Return the list of arguments for selection.
      * @return the list of arguments for selection
      */
-    List<String> getSelectionArgs() {
+    List<Object> getSelectionArgs() {
         return Immutable.of(selectionArgs);
     }
 
@@ -145,8 +145,19 @@ final class SqlCommand {
         if (!hasSelectionArgs()) {
             return null;
         }
+        /*
+         Potentially inefficient to do this per call, but
+         this should never need to be called more than once.
 
-        return selectionArgs.toArray(new String[0]);
+         Doing `Arrays.copyOf(selectionArgs.toArray(), selectionArgs.size(), String[].class);`
+         does NOT work because not every object (e.g. Integer) can be cast to string.
+         */
+        final int length = selectionArgs.size();
+        final String[] array = new String[length];
+        for (int index = 0; index < length; index++) {
+            array[index] = selectionArgs.get(index).toString();
+        }
+        return Immutable.of(array);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
@@ -82,6 +82,11 @@ public enum SqlKeyword {
     NOT("NOT"),
 
     /**
+     * SQL keyword to check if a value is in range of values.
+     */
+    BETWEEN("BEWTEEN"),
+
+    /**
      * SQL keyword to check if a string is contained in another.
      */
     IN("IN"),

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore.storage.sqlite.adapter;
 import com.amplifyframework.core.model.ModelAssociation;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.PrimaryKey;
 import com.amplifyframework.core.model.types.JavaFieldType;
 import com.amplifyframework.core.model.types.SqliteDataType;
 import com.amplifyframework.core.model.types.internal.TypeConverter;
@@ -137,6 +138,18 @@ public final class SQLiteTable {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns the column name of primary key.
+     * Return "id" if no column identifies as primary key.
+     * @return the column name of primary key
+     */
+    public String getPrimaryKeyColumnName() {
+        if (getPrimaryKey() == null) {
+            return PrimaryKey.fieldName();
+        }
+        return getPrimaryKey().getColumnName();
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -57,14 +57,17 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
 
     @Override
     public void initialize(
-            @NonNull Context context, @NonNull ResultListener<List<ModelSchema>> listener) {
+            @NonNull Context context,
+            @NonNull ResultListener<List<ModelSchema>> listener
+    ) {
     }
 
     @Override
     public <T extends Model> void save(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
-            @NonNull final ResultListener<StorageItemChange.Record> itemSaveListener) {
+            @NonNull final ResultListener<StorageItemChange.Record> itemSaveListener
+    ) {
         save(item, initiator, null, itemSaveListener);
     }
 
@@ -74,16 +77,17 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
             @Nullable final QueryPredicate predicate,
-            @NonNull final ResultListener<StorageItemChange.Record> itemSaveListener) {
-        //TODO: Implement conditional-write
+            @NonNull final ResultListener<StorageItemChange.Record> itemSaveListener
+    ) {
         items.add(item);
         StorageItemChange.Record save = StorageItemChange.<T>builder()
-            .item(item)
-            .itemClass((Class<T>) item.getClass())
-            .type(StorageItemChange.Type.SAVE)
-            .initiator(initiator)
-            .build()
-            .toRecord(storageItemChangeConverter);
+                .item(item)
+                .itemClass((Class<T>) item.getClass())
+                .type(StorageItemChange.Type.SAVE)
+                .predicate(predicate)
+                .initiator(initiator)
+                .build()
+                .toRecord(storageItemChangeConverter);
         changeRecordStream.onNext(save);
         itemSaveListener.onResult(save);
     }
@@ -91,8 +95,8 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     @Override
     public <T extends Model> void query(
             @NonNull final Class<T> itemClass,
-            @NonNull final ResultListener<Iterator<T>> queryResultsListener) {
-
+            @NonNull final ResultListener<Iterator<T>> queryResultsListener
+    ) {
         query(itemClass, null, queryResultsListener);
     }
 
@@ -101,8 +105,8 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     public <T extends Model> void query(
             @NonNull final Class<T> itemClass,
             @Nullable final QueryPredicate predicate,
-            @NonNull final ResultListener<Iterator<T>> queryResultsListener) {
-
+            @NonNull final ResultListener<Iterator<T>> queryResultsListener
+    ) {
         List<T> result = new ArrayList<>();
         for (Model item : items) {
             if (itemClass.isAssignableFrom((item.getClass()))) {
@@ -117,8 +121,8 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     public <T extends Model> void delete(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
-            @NonNull final ResultListener<StorageItemChange.Record> itemDeletionListener) {
-
+            @NonNull final ResultListener<StorageItemChange.Record> itemDeletionListener
+    ) {
         for (Model savedItem : items) {
             if (savedItem.getId().equals(item.getId())) {
                 items.remove(item);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -60,12 +60,22 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull Context context, @NonNull ResultListener<List<ModelSchema>> listener) {
     }
 
-    @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.
     @Override
     public <T extends Model> void save(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
             @NonNull final ResultListener<StorageItemChange.Record> itemSaveListener) {
+        save(item, initiator, null, itemSaveListener);
+    }
+
+    @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.
+    @Override
+    public <T extends Model> void save(
+            @NonNull final T item,
+            @NonNull final StorageItemChange.Initiator initiator,
+            @Nullable final QueryPredicate predicate,
+            @NonNull final ResultListener<StorageItemChange.Record> itemSaveListener) {
+        //TODO: Implement conditional-write
         items.add(item);
         StorageItemChange.Record save = StorageItemChange.<T>builder()
             .item(item)

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -16,7 +16,6 @@
 package com.amplifyframework.datastore;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.category.Category;
@@ -61,7 +60,7 @@ public class DataStoreCategory
      */
     @Override
     public <T extends Model> void save(@NonNull T object,
-                                       @Nullable QueryPredicate predicate,
+                                       @NonNull QueryPredicate predicate,
                                        @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
         getSelectedPlugin().save(object, predicate, saveItemListener);
     }
@@ -89,7 +88,7 @@ public class DataStoreCategory
      */
     @Override
     public <T extends Model> void query(@NonNull Class<T> itemClass,
-                                        @Nullable QueryPredicate predicate,
+                                        @NonNull QueryPredicate predicate,
                                         @NonNull ResultListener<Iterator<T>> queryResultsListener) {
         getSelectedPlugin().query(itemClass, predicate, queryResultsListener);
     }

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -50,28 +50,28 @@ public class DataStoreCategory
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void save(@NonNull T object,
+    public <T extends Model> void save(@NonNull T item,
                                        @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
-        getSelectedPlugin().save(object, saveItemListener);
+        getSelectedPlugin().save(item, saveItemListener);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void save(@NonNull T object,
+    public <T extends Model> void save(@NonNull T item,
                                        @NonNull QueryPredicate predicate,
                                        @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
-        getSelectedPlugin().save(object, predicate, saveItemListener);
+        getSelectedPlugin().save(item, predicate, saveItemListener);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void delete(@NonNull T object,
+    public <T extends Model> void delete(@NonNull T item,
                                          @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener) {
-        getSelectedPlugin().delete(object, deleteItemListener);
+        getSelectedPlugin().delete(item, deleteItemListener);
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -60,6 +60,16 @@ public class DataStoreCategory
      * {@inheritDoc}
      */
     @Override
+    public <T extends Model> void save(@NonNull T object,
+                                       @Nullable QueryPredicate predicate,
+                                       @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
+        getSelectedPlugin().save(object, predicate, saveItemListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public <T extends Model> void delete(@NonNull T object,
                                          @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener) {
         getSelectedPlugin().delete(object, deleteItemListener);

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -16,7 +16,6 @@
 package com.amplifyframework.datastore;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
@@ -60,7 +59,7 @@ public interface DataStoreCategoryBehavior {
      */
     <T extends Model> void save(
             @NonNull T item,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener);
 
     /**
@@ -97,7 +96,7 @@ public interface DataStoreCategoryBehavior {
      * @param <T> The type of items being queried
      */
     <T extends Model> void query(@NonNull Class<T> itemClass,
-                                 @Nullable QueryPredicate predicate,
+                                 @NonNull QueryPredicate predicate,
                                  @NonNull ResultListener<Iterator<T>> queryResultsListener);
 
 

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -49,6 +49,21 @@ public interface DataStoreCategoryBehavior {
             @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener);
 
     /**
+     * Saves an item into the DataStore if the data being overwritten meets
+     * the provided conditions. This is useful for making sure that no data
+     * is overwritten with an outdated/incorrect assumption.
+     * @param item An item to save
+     * @param predicate Predicate condition to apply for conditional write
+     * @param saveItemListener
+     *        An optional listener which will be callback'd when the save succeeds or fails
+     * @param <T> The time of item being saved
+     */
+    <T extends Model> void save(
+            @NonNull T item,
+            @Nullable QueryPredicate predicate,
+            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener);
+
+    /**
      * Deletes an item from the DataStore.
      * @param item An item to delete from the DataStore
      * @param deleteItemListener

--- a/core/src/main/java/com/amplifyframework/util/ArrayUtils.java
+++ b/core/src/main/java/com/amplifyframework/util/ArrayUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.util;
+
+import androidx.annotation.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * Utility for common Array operations.
+ */
+public final class ArrayUtils {
+
+    /**
+     * Dis-allows instantiation of this class.
+     */
+    private ArrayUtils() { }
+
+    /**
+     * Creates a copy of the provided source array.
+     * @param sourceArray A possibly null, possibly empty array
+     * @param <T> The type of items in the array
+     * @return A copy of the provided array
+     */
+    public static <T> T[] copyOf(@Nullable final T[] sourceArray) {
+        if (sourceArray == null) {
+            return null;
+        }
+
+        return Arrays.copyOf(sourceArray, sourceArray.length);
+    }
+}

--- a/core/src/main/java/com/amplifyframework/util/Immutable.java
+++ b/core/src/main/java/com/amplifyframework/util/Immutable.java
@@ -18,6 +18,7 @@ package com.amplifyframework.util;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -79,5 +80,19 @@ public final class Immutable {
         }
 
         return Collections.unmodifiableList(new ArrayList<>(mutableList));
+    }
+
+    /**
+     * Creates an immutable copy of the provided array.
+     * @param mutableArray A possibly null, possibly empty array
+     * @param <T> The type of items in the array
+     * @return An immutable copy of the provided array
+     */
+    public static <T> T[] of(final T[] mutableArray) {
+        if (mutableArray == null) {
+            return null;
+        }
+
+        return Arrays.copyOf(mutableArray, mutableArray.length);
     }
 }

--- a/core/src/main/java/com/amplifyframework/util/Immutable.java
+++ b/core/src/main/java/com/amplifyframework/util/Immutable.java
@@ -18,7 +18,6 @@ package com.amplifyframework.util;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -74,25 +73,11 @@ public final class Immutable {
      * @param <T> The type of items in the list
      * @return An immutable copy of the provided list
      */
-    public static <T> List<T> of(final List<T> mutableList) {
+    public static <T> List<T> of(@Nullable final List<T> mutableList) {
         if (mutableList == null) {
             return null;
         }
 
         return Collections.unmodifiableList(new ArrayList<>(mutableList));
-    }
-
-    /**
-     * Creates an immutable copy of the provided array.
-     * @param mutableArray A possibly null, possibly empty array
-     * @param <T> The type of items in the array
-     * @return An immutable copy of the provided array
-     */
-    public static <T> T[] of(final T[] mutableArray) {
-        if (mutableArray == null) {
-            return null;
-        }
-
-        return Arrays.copyOf(mutableArray, mutableArray.length);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Implemented conditional save on storage engine layer. Saving with predicate will only write to database if the data being overwritten meets the conditions.

* Overloaded `save` method in `LocalStorageAdapter`
  * predicate parameter is `@Nullable` (internal use-case)
  * inherited to `SQLiteStorageAdapter`, `InMemoryStorageAdapter`
* Overloaded `save` method in `DataStoreCategoryBehavior`
  * predicate parameter is `@NonNull`
  * inherited to `DataStoreCategory`, `AWSDataStorePlugin`
* Re-factored logic involved with binding values to pre-compiled SQL statement
  * De-coupled the processing of an object for fields and binding procedure. Field extraction from object is now a separate utility method, and binding of values is a separate utility method.
  * This way, additional values can be appended to `update` statement without being confined to precompiled `insert` statement
* Minor update to predicate parser
  * Store arguments as `Object` type to remember their data types
  * `BETWEEN` operator native to SQL is used

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
