### PR TITLE
[DataStore] Repair build failure from pull sequencing

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/ModelProviderFactory.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/ModelProviderFactory.java
@@ -15,9 +15,9 @@
 
 package com.amplifyframework.datastore.network;
 
-import com.amplifyframework.core.Immutable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.util.Immutable;
 
 import java.util.Arrays;
 import java.util.HashSet;


### PR DESCRIPTION
com.amplifyframework.core.Immutable has been moved to
com.amplifyframework.util.Immutable. However,
d462bfeb1a024a36f03a2324dbefabc0430d247f had been developed before
this change was made. The incompatibility was not detected prior to
including this commit into master.

This current commit updates import for the Immutable utility, to use the
current correct one (util, not core.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.