### PR TITLE
[Storage] Split success and error callbacks

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -18,6 +18,7 @@ package com.amplifyframework.storage.s3;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.storage.StorageAccessLevel;
 import com.amplifyframework.storage.StorageException;
@@ -70,6 +71,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         this.executorService = Executors.newCachedThreadPool();
     }
 
+    @NonNull
     @Override
     public String getPluginKey() {
         return AWS_S3_STORAGE_PLUGIN_KEY;
@@ -138,28 +140,33 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         return storageService.getClient();
     }
 
+    @NonNull
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageDownloadFileResult> resultListener
-    ) {
-        return downloadFile(key, local, StorageDownloadFileOptions.defaultInstance(), resultListener);
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return downloadFile(key, local, StorageDownloadFileOptions.defaultInstance(), onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageDownloadFileOptions options,
-            @NonNull ResultListener<StorageDownloadFileResult> resultListener
-    ) {
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+
         AWSS3StorageDownloadFileRequest request = new AWSS3StorageDownloadFileRequest(
                 key,
                 local,
                 options.getAccessLevel() != null ? options.getAccessLevel() : defaultAccessLevel,
                 options.getTargetIdentityId()
         );
+
+        ResultListener<StorageDownloadFileResult> resultListener = ResultListener.instance(onSuccess, onError);
 
         AWSS3StorageDownloadFileOperation operation =
                 new AWSS3StorageDownloadFileOperation(storageService, request, resultListener);
@@ -168,22 +175,25 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         return operation;
     }
 
+    @NonNull
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageUploadFileResult> resultListener
-    ) {
-        return uploadFile(key, local, StorageUploadFileOptions.defaultInstance(), resultListener);
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return uploadFile(key, local, StorageUploadFileOptions.defaultInstance(), onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageUploadFileOptions options,
-            @NonNull ResultListener<StorageUploadFileResult> resultListener
-    ) {
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+
         AWSS3StorageUploadFileRequest request = new AWSS3StorageUploadFileRequest(
                 key,
                 local,
@@ -193,6 +203,8 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                 options.getMetadata()
         );
 
+        ResultListener<StorageUploadFileResult> resultListener = ResultListener.instance(onSuccess, onError);
+
         AWSS3StorageUploadFileOperation operation =
                 new AWSS3StorageUploadFileOperation(storageService, request, resultListener);
 
@@ -201,25 +213,30 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         return operation;
     }
 
+    @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
-            @NonNull ResultListener<StorageRemoveResult> resultListener
-    ) {
-        return remove(key, StorageRemoveOptions.defaultInstance(), resultListener);
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return remove(key, StorageRemoveOptions.defaultInstance(), onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
             @NonNull StorageRemoveOptions options,
-            @NonNull ResultListener<StorageRemoveResult> resultListener
-    ) {
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+
         AWSS3StorageRemoveRequest request = new AWSS3StorageRemoveRequest(
                 key,
                 options.getAccessLevel() != null ? options.getAccessLevel() : defaultAccessLevel,
                 options.getTargetIdentityId()
         );
+
+        ResultListener<StorageRemoveResult> resultListener = ResultListener.instance(onSuccess, onError);
 
         AWSS3StorageRemoveOperation operation =
                 new AWSS3StorageRemoveOperation(storageService, executorService, request, resultListener);
@@ -229,25 +246,30 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         return operation;
     }
 
+    @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
-            @NonNull ResultListener<StorageListResult> resultListener
-    ) {
-        return list(path, StorageListOptions.defaultInstance(), resultListener);
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return list(path, StorageListOptions.defaultInstance(), onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
             @NonNull StorageListOptions options,
-            @NonNull ResultListener<StorageListResult> resultListener
-    ) {
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+
         AWSS3StorageListRequest request = new AWSS3StorageListRequest(
                 path,
                 options.getAccessLevel() != null ? options.getAccessLevel() : defaultAccessLevel,
                 options.getTargetIdentityId()
         );
+
+        ResultListener<StorageListResult> resultListener = ResultListener.instance(onSuccess, onError);
 
         AWSS3StorageListOperation operation =
                 new AWSS3StorageListOperation(storageService, executorService, request, resultListener);
@@ -288,6 +310,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
          * Returns the key this property is listed under in the config JSON.
          * @return The key as a string
          */
+        @NonNull
         public String getConfigurationKey() {
             return configurationKey;
         }

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
@@ -17,7 +17,7 @@ package com.amplifyframework.storage;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.storage.operation.StorageDownloadFileOperation;
@@ -40,80 +40,89 @@ import com.amplifyframework.storage.result.StorageUploadFileResult;
  */
 public final class StorageCategory extends Category<StoragePlugin<?>> implements StorageCategoryBehavior {
 
+    @NonNull
     @Override
     public CategoryType getCategoryType() {
         return CategoryType.STORAGE;
     }
 
+    @NonNull
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageDownloadFileResult> resultListener
-    ) {
-        return getSelectedPlugin().downloadFile(key, local, resultListener);
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return getSelectedPlugin().downloadFile(key, local, onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageDownloadFileOptions options,
-            @NonNull ResultListener<StorageDownloadFileResult> resultListener
-    ) {
-        return getSelectedPlugin().downloadFile(key, local, options, resultListener);
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return getSelectedPlugin().downloadFile(key, local, options, onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageUploadFileResult> resultListener
-    ) {
-        return getSelectedPlugin().uploadFile(key, local, resultListener);
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return getSelectedPlugin().uploadFile(key, local, onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageUploadFileOptions options,
-            @NonNull ResultListener<StorageUploadFileResult> resultListener
-    ) {
-        return getSelectedPlugin().uploadFile(key, local, options, resultListener);
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return getSelectedPlugin().uploadFile(key, local, options, onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
-            @NonNull ResultListener<StorageRemoveResult> resultListener
-    ) {
-        return getSelectedPlugin().remove(key, resultListener);
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return getSelectedPlugin().remove(key, onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
             @NonNull StorageRemoveOptions options,
-            @NonNull ResultListener<StorageRemoveResult> resultListener) {
-        return getSelectedPlugin().remove(key, options, resultListener);
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return getSelectedPlugin().remove(key, options, onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
-            @NonNull ResultListener<StorageListResult> resultListener
-    ) {
-        return getSelectedPlugin().list(path, resultListener);
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return getSelectedPlugin().list(path, onSuccess, onError);
     }
 
+    @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
             @NonNull StorageListOptions options,
-            @NonNull ResultListener<StorageListResult> resultListener
-    ) {
-        return getSelectedPlugin().list(path, options, resultListener);
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<Throwable> onError) {
+        return getSelectedPlugin().list(path, options, onSuccess, onError);
     }
 }
-

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
@@ -17,7 +17,7 @@ package com.amplifyframework.storage;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.storage.operation.StorageDownloadFileOperation;
 import com.amplifyframework.storage.operation.StorageListOperation;
 import com.amplifyframework.storage.operation.StorageRemoveOperation;
@@ -34,51 +34,64 @@ import com.amplifyframework.storage.result.StorageUploadFileResult;
 /**
  * Defines the behavior of the Storage category that clients will use.
  */
+@SuppressWarnings("unused")
 public interface StorageCategoryBehavior {
 
     /**
      * Download object to file from storage.
-     * Register a listener to get the download results.
+     * Provide callbacks to obtain the download results.
      * @param key the unique identifier for the object in storage
      * @param local the path to a local file
-     * @param resultListener Listens for the results of the download
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageDownloadFileOperation<?> downloadFile(@NonNull String key,
-                                  @NonNull String local,
-                                  @NonNull ResultListener<StorageDownloadFileResult> resultListener);
+    @NonNull
+    StorageDownloadFileOperation<?> downloadFile(
+            @NonNull String key,
+            @NonNull String local,
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError);
 
     /**
      * Download object to memory from storage.
      * Set advanced options such as the access level of the object
      * you want to retrieve (you can have different objects with
      * the same name under different access levels).
-     * Register a listener to get the results of the download.
+     * Provide callbacks to obtain the results of the download.
      * @param key the unique identifier for the object in storage
      * @param local the path to a local file
      * @param options parameters specific to plugin behavior
-     * @param resultListener Listens for the results of the download
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageDownloadFileOperation<?> downloadFile(@NonNull String key,
-                                  @NonNull String local,
-                                  @NonNull StorageDownloadFileOptions options,
-                                  @NonNull ResultListener<StorageDownloadFileResult> resultListener);
+    @NonNull
+    StorageDownloadFileOperation<?> downloadFile(
+            @NonNull String key,
+            @NonNull String local,
+            @NonNull StorageDownloadFileOptions options,
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError);
 
     /**
      * Upload local file on given path to storage.
      * Register a listener to obtain the results of the upload.
      * @param key the unique identifier of the object in storage
      * @param local the path to a local file
-     * @param resultListener Listens for results of upload request
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageUploadFileOperation<?> uploadFile(@NonNull String key,
-                                @NonNull String local,
-                                @NonNull ResultListener<StorageUploadFileResult> resultListener);
+    @NonNull
+    StorageUploadFileOperation<?> uploadFile(
+            @NonNull String key,
+            @NonNull String local,
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError);
 
     /**
      * Upload local file on given path to storage.
@@ -87,49 +100,64 @@ public interface StorageCategoryBehavior {
      * @param key the unique identifier of the object in storage
      * @param local the path to a local file
      * @param options parameters specific to plugin behavior
-     * @param resultListener Listens to results of upload request
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageUploadFileOperation<?> uploadFile(@NonNull String key,
-                                @NonNull String local,
-                                @NonNull StorageUploadFileOptions options,
-                                @NonNull ResultListener<StorageUploadFileResult> resultListener);
+    @NonNull
+    StorageUploadFileOperation<?> uploadFile(
+            @NonNull String key,
+            @NonNull String local,
+            @NonNull StorageUploadFileOptions options,
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<Throwable> onError);
 
     /**
      * Delete object from storage.
      * @param key the unique identifier of the object in storage
-     * @param resultListener Listens to results of remove operation
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *        actions related to the execution of the work
-     *
      */
-    StorageRemoveOperation<?> remove(@NonNull String key,
-                            @NonNull ResultListener<StorageRemoveResult> resultListener);
+    @NonNull
+    StorageRemoveOperation<?> remove(
+            @NonNull String key,
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<Throwable> onError);
 
     /**
      * Delete object from storage.
      * Register a listener to get results of remove operation.
      * @param key the unique identifier of the object in storage
      * @param options parameters specific to plugin behavior
-     * @param resultListener Listens for results of remove request.
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *        actions related to the execution of the work
      */
-    StorageRemoveOperation<?> remove(@NonNull String key,
-                            @NonNull StorageRemoveOptions options,
-                            @NonNull ResultListener<StorageRemoveResult> resultListener);
+    @NonNull
+    StorageRemoveOperation<?> remove(
+            @NonNull String key,
+            @NonNull StorageRemoveOptions options,
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<Throwable> onError);
 
     /**
      * List the object identifiers under the hierarchy specified
      * by the path, relative to access level, from storage.
      * @param path The path in storage to list items from
-     * @param resultListener Listens for results of list operation
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageListOperation<?> list(@NonNull String path,
-                            @NonNull ResultListener<StorageListResult> resultListener);
+    @NonNull
+    StorageListOperation<?> list(
+            @NonNull String path,
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<Throwable> onError);
 
     /**
      * List the object identifiers under the hierarchy specified
@@ -137,11 +165,15 @@ public interface StorageCategoryBehavior {
      * Register a listener to observe progress.
      * @param path The path in storage to list items from
      * @param options parameters specific to plugin behavior
-     * @param resultListener listens to results of list operation
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageListOperation<?> list(@NonNull String path,
-                            @NonNull StorageListOptions options,
-                            @NonNull ResultListener<StorageListResult> resultListener);
+    @NonNull
+    StorageListOperation<?> list(
+            @NonNull String path,
+            @NonNull StorageListOptions options,
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<Throwable> onError);
 }


### PR DESCRIPTION
The APIs of the Storage category are reworked. Instead of accepting a
ResultListener as a single callback argument, all APIs will now accept
two "decomposed" functional interfaces, a Consumer<SomeTypeOfResult>,
and a Consumer<Throwable>.

Instead of obtaining results like:

```
final StorageListOperation<?> operation =
    Amplify.Storage.list(path, new ResultListener() {
        @Override
        public void onResult(StorageListResult storageListResult) {
            Log.i(TAG, "Got a result! " + storageListResult);
        }

        @Override
        public void onError(Throwable error) {
            Log.e(TAG, "Listing storage items failed.", error);
        }
    });
```

The user can now more simply write this as:
```
final StorageListOperation<?> operation =
    Amplify.Storage.list(path,
        result -> Log.i(TAG, "Got a result! " + storageListResult),
        error -> Log.e(TAG, "Listing storage items failed.", error)
    );
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
