### PR TITLE
[Core] Tighten Type Bounds on Error Consumers

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SingleArrayResultOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SingleArrayResultOperation.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.api.aws;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
@@ -49,7 +50,7 @@ public final class SingleArrayResultOperation<T> extends GraphQLOperation<T> {
 
     private final String endpoint;
     private final OkHttpClient client;
-    private final ResultListener<GraphQLResponse<Iterable<T>>> responseListener;
+    private final ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener;
 
     private Call ongoingCall;
 
@@ -67,7 +68,7 @@ public final class SingleArrayResultOperation<T> extends GraphQLOperation<T> {
             @NonNull OkHttpClient client,
             @NonNull GraphQLRequest<T> request,
             @NonNull GraphQLResponse.Factory responseFactory,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener) {
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener) {
         super(request, responseFactory);
         this.endpoint = endpoint;
         this.client = client;
@@ -116,6 +117,7 @@ public final class SingleArrayResultOperation<T> extends GraphQLOperation<T> {
         return new Builder<>();
     }
 
+    @SuppressLint("SyntheticAccessor")
     class OkHttpCallback implements Callback {
         @Override
         public void onResponse(@NonNull Call call,
@@ -161,7 +163,7 @@ public final class SingleArrayResultOperation<T> extends GraphQLOperation<T> {
         private OkHttpClient client;
         private GraphQLRequest<T> request;
         private GraphQLResponse.Factory responseFactory;
-        private ResultListener<GraphQLResponse<Iterable<T>>> responseListener;
+        private ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener;
 
         Builder<T> endpoint(final String endpoint) {
             this.endpoint = endpoint;
@@ -183,11 +185,12 @@ public final class SingleArrayResultOperation<T> extends GraphQLOperation<T> {
             return this;
         }
 
-        Builder<T> responseListener(final ResultListener<GraphQLResponse<Iterable<T>>> responseListener) {
+        Builder<T> responseListener(final ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener) {
             this.responseListener = responseListener;
             return this;
         }
 
+        @SuppressLint("SyntheticAccessor")
         SingleArrayResultOperation<T> build() {
             return new SingleArrayResultOperation<>(
                     endpoint,

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SingleItemResultOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SingleItemResultOperation.java
@@ -51,7 +51,7 @@ public final class SingleItemResultOperation<T> extends GraphQLOperation<T> {
 
     private final String endpoint;
     private final OkHttpClient client;
-    private final ResultListener<GraphQLResponse<T>> responseListener;
+    private final ResultListener<GraphQLResponse<T>, ApiException> responseListener;
 
     private Call ongoingCall;
 
@@ -69,7 +69,7 @@ public final class SingleItemResultOperation<T> extends GraphQLOperation<T> {
             @NonNull OkHttpClient client,
             @NonNull GraphQLRequest<T> request,
             @NonNull GraphQLResponse.Factory responseFactory,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         super(request, responseFactory);
         this.endpoint = endpoint;
         this.client = client;
@@ -168,7 +168,7 @@ public final class SingleItemResultOperation<T> extends GraphQLOperation<T> {
         private OkHttpClient client;
         private GraphQLRequest<T> request;
         private GraphQLResponse.Factory responseFactory;
-        private ResultListener<GraphQLResponse<T>> responseListener;
+        private ResultListener<GraphQLResponse<T>, ApiException> responseListener;
 
         Builder<T> endpoint(final String endpoint) {
             this.endpoint = endpoint;
@@ -190,7 +190,7 @@ public final class SingleItemResultOperation<T> extends GraphQLOperation<T> {
             return this;
         }
 
-        Builder<T> responseListener(final ResultListener<GraphQLResponse<T>> responseListener) {
+        Builder<T> responseListener(final ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
             this.responseListener = responseListener;
             return this;
         }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.api.aws;
 
+import android.annotation.SuppressLint;
 import android.net.Uri;
 import android.util.Base64;
 import androidx.annotation.NonNull;
@@ -72,7 +73,7 @@ final class SubscriptionEndpoint {
 
     synchronized <T> String requestSubscription(
             @NonNull GraphQLRequest<T> request,
-            @NonNull StreamListener<GraphQLResponse<T>> responseListener) {
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> responseListener) {
 
         if (webSocket == null) {
             try {
@@ -122,6 +123,7 @@ final class SubscriptionEndpoint {
         return subscriptionId;
     }
 
+    @SuppressLint("SyntheticAccessor")
     private WebSocket createWebSocket() throws ApiException {
         Request request = new Request.Builder()
             .url(buildConnectionRequestUrl())
@@ -342,14 +344,14 @@ final class SubscriptionEndpoint {
     static final class Subscription<T> {
         private static final int ACKNOWLEDGEMENT_TIMEOUT = 10 /* seconds */;
 
-        private final StreamListener<GraphQLResponse<T>> responseListener;
+        private final StreamListener<GraphQLResponse<T>, ApiException> responseListener;
         private final GraphQLResponse.Factory responseFactory;
         private final Class<T> classToCast;
         private final CountDownLatch subscriptionReadyAcknowledgment;
         private final CountDownLatch subscriptionCompletionAcknowledgement;
 
         Subscription(
-                StreamListener<GraphQLResponse<T>> responseListener,
+                StreamListener<GraphQLResponse<T>, ApiException> responseListener,
                 GraphQLResponse.Factory responseFactory,
                 Class<T> classToCast) {
             this.responseListener = responseListener;
@@ -410,7 +412,7 @@ final class SubscriptionEndpoint {
             }
         }
 
-        void dispatchError(Throwable error) {
+        void dispatchError(ApiException error) {
             responseListener.onError(error);
         }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionOperation.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.api.aws;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.api.ApiException;
@@ -29,13 +30,14 @@ import java.util.Objects;
 
 import okhttp3.OkHttpClient;
 
+@SuppressWarnings("unused")
 final class SubscriptionOperation<T> extends GraphQLOperation<T> {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-api");
 
     private final String endpoint;
     private final OkHttpClient client;
     private final SubscriptionEndpoint subscriptionEndpoint;
-    private final StreamListener<GraphQLResponse<T>> subscriptionListener;
+    private final StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener;
 
     private String subscriptionId;
 
@@ -45,7 +47,7 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
             @NonNull final OkHttpClient client,
             @NonNull final GraphQLRequest<T> graphQLRequest,
             @NonNull final GraphQLResponse.Factory responseFactory,
-            @NonNull final StreamListener<GraphQLResponse<T>> subscriptionListener) {
+            @NonNull final StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener) {
         super(graphQLRequest, responseFactory);
         this.endpoint = endpoint;
         this.client = client;
@@ -69,7 +71,7 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
     }
 
     @NonNull
-    StreamListener<GraphQLResponse<T>> subscriptionListener() {
+    StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener() {
         return subscriptionListener;
     }
 
@@ -107,7 +109,7 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
         private OkHttpClient client;
         private GraphQLRequest<T> graphQLRequest;
         private GraphQLResponse.Factory responseFactory;
-        private StreamListener<GraphQLResponse<T>> streamListener;
+        private StreamListener<GraphQLResponse<T>, ApiException> streamListener;
 
         @NonNull
         @Override
@@ -146,11 +148,13 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
 
         @NonNull
         @Override
-        public BuilderStep<T> streamListener(@NonNull final StreamListener<GraphQLResponse<T>> streamListener) {
+        public BuilderStep<T> streamListener(
+                @NonNull final StreamListener<GraphQLResponse<T>, ApiException> streamListener) {
             this.streamListener = Objects.requireNonNull(streamListener);
             return this;
         }
 
+        @SuppressLint("SyntheticAccessor")
         @NonNull
         @Override
         public SubscriptionOperation<T> build() {
@@ -192,7 +196,7 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
 
     interface StreamListenerStep<T> {
         @NonNull
-        BuilderStep<T> streamListener(@NonNull StreamListener<GraphQLResponse<T>> streamListener);
+        BuilderStep<T> streamListener(@NonNull StreamListener<GraphQLResponse<T>, ApiException> streamListener);
     }
 
     interface BuilderStep<T> {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
@@ -42,7 +42,7 @@ public final class AWSRestOperation extends RestOperation {
 
     private final String endpoint;
     private final OkHttpClient client;
-    private final ResultListener<RestResponse> responseListener;
+    private final ResultListener<RestResponse, ApiException> responseListener;
 
     private Call ongoingCall;
 
@@ -57,7 +57,7 @@ public final class AWSRestOperation extends RestOperation {
             RestOperationRequest request,
             String endpoint,
             OkHttpClient client,
-            ResultListener<RestResponse> responseListener) {
+            ResultListener<RestResponse, ApiException> responseListener) {
         super(request);
         this.endpoint = endpoint;
         this.client = client;

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncApiInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncApiInstrumentationTest.java
@@ -194,8 +194,8 @@ public class AppSyncApiInstrumentationTest {
     private <T extends Model> ModelWithMetadata<T> create(@NonNull T model) {
         LatchedResponseConsumer<ModelWithMetadata<T>> createdItemConsumer =
             LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
-            ResultListener.instance(createdItemConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> listener =
+            ResultListener.instance(createdItemConsumer, EmptyConsumer.of(DataStoreException.class));
         api.create(model, listener);
         return createdItemConsumer.awaitResponseData();
     }
@@ -212,8 +212,8 @@ public class AppSyncApiInstrumentationTest {
     private <T extends Model> ModelWithMetadata<T> update(@NonNull T model, int version) {
         LatchedResponseConsumer<ModelWithMetadata<T>> updatedItemConsumer =
             LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
-            ResultListener.instance(updatedItemConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> listener =
+            ResultListener.instance(updatedItemConsumer, EmptyConsumer.of(DataStoreException.class));
         api.update(model, version, listener);
         return updatedItemConsumer.awaitResponseData();
     }
@@ -231,8 +231,8 @@ public class AppSyncApiInstrumentationTest {
             @NonNull Class<T> clazz, String modelId, int version) {
         LatchedResponseConsumer<ModelWithMetadata<T>> deleteResultConsumer =
             LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
-            ResultListener.instance(deleteResultConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> listener =
+            ResultListener.instance(deleteResultConsumer, EmptyConsumer.of(DataStoreException.class));
         api.delete(clazz, modelId, version, listener);
         return deleteResultConsumer.awaitResponseData();
     }
@@ -251,8 +251,8 @@ public class AppSyncApiInstrumentationTest {
             @NonNull Class<T> clazz, String modelId, int version) {
         LatchedResponseConsumer<ModelWithMetadata<T>> deleteResultConsumer =
             LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
-            ResultListener.instance(deleteResultConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> listener =
+            ResultListener.instance(deleteResultConsumer, EmptyConsumer.of(DataStoreException.class));
         api.delete(clazz, modelId, version, listener);
         return deleteResultConsumer.awaitErrorsInNextResponse();
     }
@@ -268,8 +268,8 @@ public class AppSyncApiInstrumentationTest {
             @NonNull Class<T> clazz, @Nullable Long lastSyncTime) {
         LatchedResponseConsumer<Iterable<ModelWithMetadata<T>>> syncConsumer =
             LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> syncListener =
-            ResultListener.instance(syncConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>, DataStoreException> syncListener =
+            ResultListener.instance(syncConsumer, EmptyConsumer.of(DataStoreException.class));
         api.sync(clazz, lastSyncTime, syncListener);
         return syncConsumer.awaitResponseData();
     }
@@ -299,8 +299,8 @@ public class AppSyncApiInstrumentationTest {
         static <T extends Model> Subscription<T> onCreate(Class<T> clazz) {
             LatchedResponseConsumer<ModelWithMetadata<T>> itemConsumer = LatchedResponseConsumer.instance();
             LatchedAction completionAction = LatchedAction.instance();
-            StreamListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
-                StreamListener.instance(itemConsumer, EmptyConsumer.of(Throwable.class), completionAction);
+            StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> listener =
+                StreamListener.instance(itemConsumer, EmptyConsumer.of(DataStoreException.class), completionAction);
             Cancelable cancelable = api.onCreate(clazz, listener);
             return new Subscription<>(cancelable, itemConsumer, completionAction);
         }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
@@ -67,8 +67,8 @@ public final class StorageItemChangeRecordIntegrationTest {
         ApplicationProvider.getApplicationContext().deleteDatabase(DATABASE_NAME);
 
         LatchedConsumer<List<ModelSchema>> resultConsumer = LatchedConsumer.instance();
-        ResultListener<List<ModelSchema>> resultListener =
-            ResultListener.instance(resultConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<List<ModelSchema>, DataStoreException> resultListener =
+            ResultListener.instance(resultConsumer, EmptyConsumer.of(DataStoreException.class));
         ModelProvider modelProvider = ModelProviderFactory.createProviderOf(BlogOwner.class);
         this.localStorageAdapter = SQLiteStorageAdapter.forModels(modelProvider);
         localStorageAdapter.initialize(ApplicationProvider.getApplicationContext(), resultListener);
@@ -164,8 +164,8 @@ public final class StorageItemChangeRecordIntegrationTest {
 
         // Wait for it to save...
         LatchedConsumer<StorageItemChange.Record> consumer = LatchedConsumer.instance();
-        ResultListener<StorageItemChange.Record> listener =
-            ResultListener.instance(consumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<StorageItemChange.Record, DataStoreException> listener =
+            ResultListener.instance(consumer, EmptyConsumer.of(DataStoreException.class));
         localStorageAdapter.save(record, StorageItemChange.Initiator.SYNC_ENGINE, listener);
         consumer.awaitValue();
 
@@ -293,8 +293,8 @@ public final class StorageItemChangeRecordIntegrationTest {
         // The fact that it is getting saved means it gets wrapped into another
         // StorageItemChange.Record, which itself contains the original StorageItemChange.Record.
         LatchedConsumer<StorageItemChange.Record> consumerOfSaveResult = LatchedConsumer.instance();
-        ResultListener<StorageItemChange.Record> saveResultListener =
-            ResultListener.instance(consumerOfSaveResult, EmptyConsumer.of(Throwable.class));
+        ResultListener<StorageItemChange.Record, DataStoreException> saveResultListener =
+            ResultListener.instance(consumerOfSaveResult, EmptyConsumer.of(DataStoreException.class));
 
         localStorageAdapter.save(storageItemChangeRecord,
             StorageItemChange.Initiator.SYNC_ENGINE, saveResultListener);
@@ -312,8 +312,8 @@ public final class StorageItemChangeRecordIntegrationTest {
         // Okay, now we're going to do a query, then await & stash the query results.
         LatchedConsumer<Iterator<StorageItemChange.Record>> consumerOfQueryResults =
             LatchedConsumer.instance();
-        ResultListener<Iterator<StorageItemChange.Record>> queryResultsListener =
-            ResultListener.instance(consumerOfQueryResults, EmptyConsumer.of(Throwable.class));
+        ResultListener<Iterator<StorageItemChange.Record>, DataStoreException> queryResultsListener =
+            ResultListener.instance(consumerOfQueryResults, EmptyConsumer.of(DataStoreException.class));
 
         // TODO: if/when there is a form of query() which shall accept QueryPredicate, use that instead.
         localStorageAdapter.query(StorageItemChange.Record.class, queryResultsListener);
@@ -330,8 +330,8 @@ public final class StorageItemChangeRecordIntegrationTest {
         // The thing we are deleting is a StorageItemChange.Record, which is wrapping
         // a StorageItemChange.Record, which is wrapping an item.
         LatchedConsumer<StorageItemChange.Record> consumerOfRecordDeletionResult = LatchedConsumer.instance();
-        ResultListener<StorageItemChange.Record> recordDeletionListener =
-            ResultListener.instance(consumerOfRecordDeletionResult, EmptyConsumer.of(Throwable.class));
+        ResultListener<StorageItemChange.Record, DataStoreException> recordDeletionListener =
+            ResultListener.instance(consumerOfRecordDeletionResult, EmptyConsumer.of(DataStoreException.class));
 
         localStorageAdapter.delete(record, StorageItemChange.Initiator.SYNC_ENGINE, recordDeletionListener);
 

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
@@ -95,8 +95,8 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
         // Initialize StorageAdapter with models
         LatchedConsumer<List<ModelSchema>> firstInitializationConsumer =
                 LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
-        ResultListener<List<ModelSchema>> firstResultListener =
-                ResultListener.instance(firstInitializationConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<List<ModelSchema>, DataStoreException> firstResultListener =
+                ResultListener.instance(firstInitializationConsumer, EmptyConsumer.of(DataStoreException.class));
 
         sqliteStorageAdapter = SQLiteStorageAdapter.forModels(modelProvider);
         sqliteStorageAdapter.initialize(context, firstResultListener);
@@ -125,8 +125,8 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
         // Now, initialize storage adapter with the new models
         LatchedConsumer<List<ModelSchema>> secondInitializationConsumer =
             LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
-        ResultListener<List<ModelSchema>> secondResultListener =
-            ResultListener.instance(secondInitializationConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<List<ModelSchema>, DataStoreException> secondResultListener =
+            ResultListener.instance(secondInitializationConsumer, EmptyConsumer.of(DataStoreException.class));
         sqliteStorageAdapter.initialize(context, secondResultListener);
         assertFalse(CollectionUtils.isNullOrEmpty(secondInitializationConsumer.awaitValue()));
 

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterInstrumentedTest.java
@@ -99,8 +99,8 @@ public final class SQLiteStorageAdapterInstrumentedTest {
 
         LatchedConsumer<List<ModelSchema>> setupResultConsumer =
             LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
-        ResultListener<List<ModelSchema>> setupResultListener =
-            ResultListener.instance(setupResultConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<List<ModelSchema>, DataStoreException> setupResultListener =
+            ResultListener.instance(setupResultConsumer, EmptyConsumer.of(DataStoreException.class));
 
         sqliteStorageAdapter.initialize(context, setupResultListener);
 
@@ -243,8 +243,8 @@ public final class SQLiteStorageAdapterInstrumentedTest {
             .build();
         saveModel(blogOwner);
 
-        LatchedConsumer<Throwable> errorConsumer = LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
-        ResultListener<StorageItemChange.Record> saveResultListener =
+        LatchedConsumer<DataStoreException> errorConsumer = LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
+        ResultListener<StorageItemChange.Record, DataStoreException> saveResultListener =
             ResultListener.instance(EmptyConsumer.of(StorageItemChange.Record.class), errorConsumer);
 
         final Blog blog = Blog.builder()
@@ -583,8 +583,8 @@ public final class SQLiteStorageAdapterInstrumentedTest {
             @NonNull T model, @Nullable QueryPredicate predicate) {
         LatchedConsumer<StorageItemChange.Record> consumerOfSaveResult =
             LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
-        ResultListener<StorageItemChange.Record> saveListener =
-            ResultListener.instance(consumerOfSaveResult, EmptyConsumer.of(Throwable.class));
+        ResultListener<StorageItemChange.Record, DataStoreException> saveListener =
+            ResultListener.instance(consumerOfSaveResult, EmptyConsumer.of(DataStoreException.class));
 
         sqliteStorageAdapter.save(
             model,
@@ -597,9 +597,9 @@ public final class SQLiteStorageAdapterInstrumentedTest {
     }
 
     private <T extends Model> void saveModelExpectingError(@NonNull T model, @NonNull QueryPredicate predicate) {
-        LatchedConsumer<Throwable> consumerOfError =
+        LatchedConsumer<DataStoreException> consumerOfError =
             LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
-        ResultListener<StorageItemChange.Record> saveListener =
+        ResultListener<StorageItemChange.Record, DataStoreException> saveListener =
             ResultListener.instance(EmptyConsumer.of(StorageItemChange.Record.class), consumerOfError);
 
         sqliteStorageAdapter.save(
@@ -619,8 +619,8 @@ public final class SQLiteStorageAdapterInstrumentedTest {
             @NonNull Class<T> modelClass, @Nullable QueryPredicate predicate) {
         LatchedConsumer<Iterator<T>> queryResultConsumer =
             LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
-        ResultListener<Iterator<T>> resultListener =
-            ResultListener.instance(queryResultConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<Iterator<T>, DataStoreException> resultListener =
+            ResultListener.instance(queryResultConsumer, EmptyConsumer.of(DataStoreException.class));
         sqliteStorageAdapter.query(modelClass, predicate, resultListener);
         return queryResultConsumer.awaitValue();
     }
@@ -629,8 +629,8 @@ public final class SQLiteStorageAdapterInstrumentedTest {
     private <T extends Model> void deleteModel(@NonNull T model) {
         LatchedConsumer<StorageItemChange.Record> deleteConsumer =
             LatchedConsumer.instance(SQLITE_OPERATION_TIMEOUT_MS);
-        ResultListener<StorageItemChange.Record> deleteListener =
-            ResultListener.instance(deleteConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<StorageItemChange.Record, DataStoreException> deleteListener =
+            ResultListener.instance(deleteConsumer, EmptyConsumer.of(DataStoreException.class));
         sqliteStorageAdapter.delete(model, StorageItemChange.Initiator.DATA_STORE_API, deleteListener);
         deleteConsumer.awaitValue();
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -176,8 +176,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> void save(
             @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener
-    ) {
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> saveItemListener) {
         sqliteStorageAdapter.save(item, StorageItemChange.Initiator.DATA_STORE_API,
             ResultConversionListener.instance(saveItemListener, this::toDataStoreItemChange));
     }
@@ -189,8 +188,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     public <T extends Model> void save(
             @NonNull T item,
             @NonNull QueryPredicate predicate,
-            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener
-    ) {
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> saveItemListener) {
         sqliteStorageAdapter.save(item, StorageItemChange.Initiator.DATA_STORE_API, predicate,
             ResultConversionListener.instance(saveItemListener, this::toDataStoreItemChange));
     }
@@ -201,8 +199,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> void delete(
             @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener
-    ) {
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> deleteItemListener) {
         sqliteStorageAdapter.delete(item, StorageItemChange.Initiator.DATA_STORE_API,
             ResultConversionListener.instance(deleteItemListener, this::toDataStoreItemChange));
     }
@@ -213,8 +210,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> void query(
             @NonNull Class<T> itemClass,
-            @NonNull ResultListener<Iterator<T>> queryResultsListener
-    ) {
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
         sqliteStorageAdapter.query(itemClass, queryResultsListener);
     }
 
@@ -225,8 +221,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     public <T extends Model> void query(
             @NonNull Class<T> itemClass,
             @NonNull QueryPredicate predicate,
-            @NonNull ResultListener<Iterator<T>> queryResultsListener
-    ) {
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
         sqliteStorageAdapter.query(itemClass, predicate, queryResultsListener);
     }
 
@@ -258,8 +253,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> Observable<DataStoreItemChange<T>> observe(
             @NonNull Class<T> itemClass,
-            @NonNull String uniqueId
-    ) {
+            @NonNull String uniqueId) {
         return observe(itemClass)
             .filter(dataStoreItemChange -> uniqueId.equals(dataStoreItemChange.item().getId()));
     }
@@ -271,8 +265,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     @Override
     public <T extends Model> Observable<DataStoreItemChange<T>> observe(
             @NonNull Class<T> itemClass,
-            @NonNull QueryPredicate selectionCriteria
-    ) {
+            @NonNull QueryPredicate selectionCriteria) {
         return Observable.error(new DataStoreException("Not implemented yet, buster!", "Check back later!"));
     }
 
@@ -352,12 +345,12 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
          * @param dataStoreListener listener object of the public DataStore API
          * @param conversionStrategy A strategy to convert between storage adapter and data store api types
          */
-        static <T extends Model> ResultListener<StorageItemChange.Record> instance(
-                ResultListener<DataStoreItemChange<T>> dataStoreListener,
+        static <T extends Model> ResultListener<StorageItemChange.Record, DataStoreException> instance(
+                ResultListener<DataStoreItemChange<T>, DataStoreException> dataStoreListener,
                 ConversionStrategy conversionStrategy) {
 
             @SuppressWarnings("CodeBlock2Expr") // More readable as block
-            final Consumer<Throwable> errorConsumer = error -> {
+            final Consumer<DataStoreException> errorConsumer = error -> {
                 dataStoreListener.onError(new DataStoreException(
                     "Oof, something went wrong.", error, "Check the attached error for details."
                 ));

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/AppSyncApi.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/AppSyncApi.java
@@ -74,12 +74,13 @@ public final class AppSyncApi implements AppSyncEndpoint {
         return new AppSyncApi(Amplify.API);
     }
 
+    @SuppressWarnings("checkstyle:LineLength")
     @NonNull
     @Override
     public <T extends Model> Cancelable sync(
             @NonNull Class<T> modelClass,
             @Nullable Long lastSync,
-            @NonNull ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> responseListener) {
+            @NonNull ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>, DataStoreException> responseListener) {
 
         final String queryDoc;
         try {
@@ -104,7 +105,7 @@ public final class AppSyncApi implements AppSyncEndpoint {
     @Override
     public <T extends Model> Cancelable create(
             @NonNull T model,
-            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>> responseListener) {
+            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> responseListener) {
         final String doc;
         try {
             doc = AppSyncRequestFactory.buildCreationDoc(model.getClass());
@@ -137,7 +138,7 @@ public final class AppSyncApi implements AppSyncEndpoint {
     public <T extends Model> Cancelable update(
             @NonNull T model,
             @NonNull Integer version,
-            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>> responseListener) {
+            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> responseListener) {
         final String doc;
         try {
             doc = AppSyncRequestFactory.buildUpdateDoc(model.getClass());
@@ -173,7 +174,7 @@ public final class AppSyncApi implements AppSyncEndpoint {
             @NonNull Class<T> clazz,
             @NonNull String objectId,
             @NonNull Integer version,
-            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>> responseListener) {
+            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> responseListener) {
         final String doc;
         try {
             doc = AppSyncRequestFactory.buildDeletionDoc(clazz);
@@ -199,7 +200,7 @@ public final class AppSyncApi implements AppSyncEndpoint {
     @Override
     public <T extends Model> Cancelable onCreate(
             @NonNull Class<T> modelClass,
-            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>> subscriptionListener) {
+            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> subscriptionListener) {
         return subscription(modelClass, subscriptionListener, SubscriptionType.ON_CREATE);
     }
 
@@ -207,7 +208,7 @@ public final class AppSyncApi implements AppSyncEndpoint {
     @Override
     public <T extends Model> Cancelable onUpdate(
             @NonNull Class<T> modelClass,
-            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>> subscriptionListener) {
+            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> subscriptionListener) {
         return subscription(modelClass, subscriptionListener, SubscriptionType.ON_UPDATE);
     }
 
@@ -215,13 +216,13 @@ public final class AppSyncApi implements AppSyncEndpoint {
     @Override
     public <T extends Model> Cancelable onDelete(
             @NonNull Class<T> modelClass,
-            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>> subscriptionListener) {
+            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> subscriptionListener) {
         return subscription(modelClass, subscriptionListener, SubscriptionType.ON_DELETE);
     }
 
     private <T extends Model> Cancelable subscription(
             Class<T> clazz,
-            StreamListener<GraphQLResponse<ModelWithMetadata<T>>> subscriptionListener,
+            StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> subscriptionListener,
             SubscriptionType subscriptionType) {
         final String document;
         try {
@@ -244,7 +245,7 @@ public final class AppSyncApi implements AppSyncEndpoint {
             final String document,
             final Map<String, Object> variables,
             final Class<T> itemClass,
-            final ResultListener<GraphQLResponse<ModelWithMetadata<T>>> responseListener) {
+            final ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> responseListener) {
         final GraphQLRequest<String> request =
             new GraphQLRequest<>(document, variables, String.class, variablesSerializer);
         final Cancelable cancelable =

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/AppSyncEndpoint.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/AppSyncEndpoint.java
@@ -23,6 +23,7 @@ import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.StreamListener;
 import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreException;
 
 /**
  * Convenience class to call API in a way that supports versioning and retrieving sync metadata.
@@ -37,11 +38,13 @@ public interface AppSyncEndpoint {
      * @param responseListener Invoked when response data/errors are available.
      * @return A {@link Cancelable} to provide a means to cancel the asynchronous operation
      */
+    @SuppressWarnings("checkstyle:LineLength") // Long bounds for ResultListener
     @NonNull
     <T extends Model> Cancelable sync(
             @NonNull Class<T> modelClass,
             @Nullable Long lastSync,
-            @NonNull ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>, DataStoreException> responseListener
+    );
 
     /**
      * Uses Amplify API to make a mutation which will only apply if the version sent matches the server version.
@@ -53,7 +56,8 @@ public interface AppSyncEndpoint {
     @NonNull
     <T extends Model> Cancelable create(
             @NonNull T model,
-            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> responseListener
+    );
 
     /**
      * Uses Amplify API to make a mutation which will only apply if the version sent matches the server version.
@@ -67,7 +71,8 @@ public interface AppSyncEndpoint {
     <T extends Model> Cancelable update(
             @NonNull T model,
             @NonNull Integer version,
-            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> responseListener
+    );
 
     /**
      * Uses Amplify API to make a mutation which will only apply if the version sent matches the server version.
@@ -83,7 +88,8 @@ public interface AppSyncEndpoint {
             @NonNull Class<T> clazz,
             @NonNull String objectId,
             @NonNull Integer version,
-            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> responseListener
+    );
 
     /**
      * Get notified when a create event happens on a given class.
@@ -96,7 +102,8 @@ public interface AppSyncEndpoint {
     @NonNull
     <T extends Model> Cancelable onCreate(
             @NonNull Class<T> modelClass,
-            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>> subscriptionListener);
+            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> subscriptionListener
+    );
 
     /**
      * Get notified when an update event happens on a given class.
@@ -109,7 +116,8 @@ public interface AppSyncEndpoint {
     @NonNull
     <T extends Model> Cancelable onUpdate(
             @NonNull Class<T> modelClass,
-            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>> subscriptionListener);
+            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> subscriptionListener
+    );
 
     /**
      * Get notified when a delete event happens on a given class.
@@ -122,5 +130,6 @@ public interface AppSyncEndpoint {
     @NonNull
     <T extends Model> Cancelable onDelete(
             @NonNull Class<T> modelClass,
-            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>> subscriptionListener);
+            @NonNull StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> subscriptionListener
+    );
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/DataHydration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/DataHydration.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.network;
 
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 
@@ -63,7 +64,7 @@ final class DataHydration {
             // Save the model portion
             final ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
             final T item = modelWithMetadata.getModel();
-            final ResultListener<StorageItemChange.Record> listener =
+            final ResultListener<StorageItemChange.Record, DataStoreException> listener =
                 ResultListener.instance(ignoredRecord -> emitter.onComplete(), emitter::onError);
             if (Boolean.TRUE.equals(metadata.isDeleted())) {
                 localStorageAdapter.delete(item, StorageItemChange.Initiator.SYNC_ENGINE, listener);
@@ -78,7 +79,7 @@ final class DataHydration {
             // Save the metadata portion
             // This is separate from the model save since they have two distinct completions.
             final ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
-            final ResultListener<StorageItemChange.Record> metadataSaveListener =
+            final ResultListener<StorageItemChange.Record, DataStoreException> metadataSaveListener =
                 ResultListener.instance(ignoredRecord -> emitter.onComplete(), emitter::onError);
             localStorageAdapter.save(metadata, StorageItemChange.Initiator.SYNC_ENGINE, metadataSaveListener);
         });

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/MutationAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/MutationAdapter.java
@@ -15,16 +15,18 @@
 
 package com.amplifyframework.datastore.network;
 
+import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreException;
 
 final class MutationAdapter {
     @SuppressWarnings("checkstyle:all") private MutationAdapter() {}
 
-    static <T extends Model> ResultListener<GraphQLResponse<String>> instance(
-            ResultListener<GraphQLResponse<ModelWithMetadata<T>>> responseListener,
+    static <T extends Model> ResultListener<GraphQLResponse<String>, ApiException> instance(
+            ResultListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> responseListener,
             Class<T> itemClass,
             ResponseDeserializer responseDeserializer) {
 
@@ -36,6 +38,9 @@ final class MutationAdapter {
             responseListener.onResult(responseDeserializer.deserialize(result.getData(), itemClass));
         };
 
-        return ResultListener.instance(resultConsumer, responseListener::onError);
+        //noinspection CodeBlock2Expr Keep down line length a bit
+        return ResultListener.instance(resultConsumer, error -> {
+            responseListener.onError(new DataStoreException("Error during mutation.", error, "Check details."));
+        });
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelMutations.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelMutations.java
@@ -126,7 +126,7 @@ final class RemoteModelMutations {
             }
 
             Subscription begin() throws DataStoreException {
-                StreamListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
+                StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> listener =
                     SubscriptionFunnel.instance(commonEmitter, modelClass, subscriptionType);
 
                 final Cancelable cancelable;
@@ -175,7 +175,7 @@ final class RemoteModelMutations {
             }
 
             @SuppressLint("SyntheticAccessor")
-            static <T extends Model> StreamListener<GraphQLResponse<ModelWithMetadata<T>>> instance(
+            static <T extends Model> StreamListener<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException> instance(
                     Emitter<Mutation<? extends Model>> commonEmitter,
                     Class<T> modelClazz,
                     SubscriptionType subscriptionType) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelState.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/RemoteModelState.java
@@ -103,8 +103,10 @@ final class RemoteModelState {
     static final class MetadataEmitter {
         @SuppressWarnings("checkstyle:all") MetadataEmitter() {}
 
-        static <T extends Model> ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> instance(
-            final SingleEmitter<Iterable<ModelWithMetadata<T>>> emitter) {
+        @SuppressWarnings("checkstyle:Indentation") // Long template types require line breaks
+        static <T extends Model>
+        ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>, DataStoreException>
+        instance(final SingleEmitter<Iterable<ModelWithMetadata<T>>> emitter) {
             //noinspection CodeBlock2Expr
             return ResultListener.instance(
                 resultFromEndpoint -> {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/SyncAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/SyncAdapter.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.network;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategoryBehavior;
+import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.ResultListener;
@@ -31,8 +32,8 @@ import com.amplifyframework.datastore.DataStoreException;
 final class SyncAdapter {
     @SuppressWarnings("checkstyle:all") private SyncAdapter() {}
 
-    static <T extends Model> ResultListener<GraphQLResponse<Iterable<String>>> instance(
-            ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> responseListener,
+    static <T extends Model> ResultListener<GraphQLResponse<Iterable<String>>, ApiException> instance(
+            ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>, DataStoreException> responseListener,
             Class<T> itemClass,
             ResponseDeserializer responseDeserializer) {
         final Consumer<GraphQLResponse<Iterable<String>>> resultConsumer = resultFromApiQuery -> {
@@ -46,7 +47,7 @@ final class SyncAdapter {
             }
         };
         @SuppressWarnings("CodeBlock2Expr") // Block is more readable
-        final Consumer<Throwable> errorConsumer = error -> {
+        final Consumer<ApiException> errorConsumer = error -> {
             responseListener.onError(new DataStoreException(
                 "Failure performing sync query to AppSync.",
                 error, AmplifyException.TODO_RECOVERY_SUGGESTION

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/SyncEngine.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/SyncEngine.java
@@ -118,7 +118,7 @@ public final class SyncEngine {
     private Single<Mutation<? extends Model>> applyMutationToLocalStorage(Mutation<? extends Model> mutation) {
         final StorageItemChange.Initiator initiator = StorageItemChange.Initiator.SYNC_ENGINE;
         return Single.defer(() -> Single.create(emitter -> {
-            final ResultListener<StorageItemChange.Record> storageResultListener =
+            final ResultListener<StorageItemChange.Record, DataStoreException> storageResultListener =
                 ResultListener.instance(result -> emitter.onSuccess(mutation), emitter::onError);
 
             switch (mutation.type()) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -60,7 +60,8 @@ public interface LocalStorageAdapter {
      */
     void initialize(
             @NonNull Context context,
-            @NonNull ResultListener<List<ModelSchema>> listener);
+            @NonNull ResultListener<List<ModelSchema>, DataStoreException> listener
+    );
 
     /**
      * Save an item into local storage. The {@link ResultListener} will be invoked when the
@@ -73,7 +74,8 @@ public interface LocalStorageAdapter {
     <T extends Model> void save(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @NonNull ResultListener<StorageItemChange.Record> itemSaveListener);
+            @NonNull ResultListener<StorageItemChange.Record, DataStoreException> itemSaveListener
+    );
 
     /**
      * Save an item into local storage only if the data being overwritten meets the
@@ -89,7 +91,8 @@ public interface LocalStorageAdapter {
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
             @Nullable QueryPredicate predicate,
-            @NonNull ResultListener<StorageItemChange.Record> itemSaveListener);
+            @NonNull ResultListener<StorageItemChange.Record, DataStoreException> itemSaveListener
+    );
 
     /**
      * Query the storage for items of a given type.
@@ -99,7 +102,8 @@ public interface LocalStorageAdapter {
      */
     <T extends Model> void query(
             @NonNull Class<T> itemClass,
-            @NonNull ResultListener<Iterator<T>> queryResultsListener);
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener
+    );
 
     /**
      * Query the storage for items of a given type with specific conditions.
@@ -111,7 +115,8 @@ public interface LocalStorageAdapter {
     <T extends Model> void query(
             @NonNull Class<T> itemClass,
             @Nullable QueryPredicate predicate,
-            @NonNull ResultListener<Iterator<T>> queryResultsListener);
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener
+    );
 
     /**
      * Deletes an item from storage.
@@ -123,13 +128,14 @@ public interface LocalStorageAdapter {
     <T extends Model> void delete(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @NonNull ResultListener<StorageItemChange.Record> itemDeletionListener);
+            @NonNull ResultListener<StorageItemChange.Record, DataStoreException> itemDeletionListener);
 
     /**
      * Observe all changes to that occur to any/all objects in the storage.
      * @return An observable which emits an {@link StorageItemChange} notification every time
      *         any object managed by the storage adapter is changed in any way.
      */
+    @NonNull
     Observable<StorageItemChange.Record> observe();
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -127,6 +127,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
      * Construct the SQLiteStorageAdapter object.
      * @param modelProvider Provides the models that will be usable by the DataStore
      */
+    @SuppressWarnings("WeakerAccess") // Must be public so user can access from their app package(s)
     public SQLiteStorageAdapter(@NonNull ModelProvider modelProvider) {
         this.modelProvider = Objects.requireNonNull(modelProvider);
         this.modelSchemaRegistry = ModelSchemaRegistry.singleton();
@@ -143,8 +144,9 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
      * @param modelProvider A provider of models that will be represented in SQL
      * @return A SQLiteStorageAdapter that will host the provided models in SQL tables
      */
-    public static SQLiteStorageAdapter forModels(ModelProvider modelProvider) {
-        return new SQLiteStorageAdapter(modelProvider);
+    @NonNull
+    public static SQLiteStorageAdapter forModels(@NonNull ModelProvider modelProvider) {
+        return new SQLiteStorageAdapter(Objects.requireNonNull(modelProvider));
     }
 
     /**
@@ -153,7 +155,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     @Override
     public synchronized void initialize(
             @NonNull Context context,
-            @NonNull final ResultListener<List<ModelSchema>> listener) {
+            @NonNull final ResultListener<List<ModelSchema>, DataStoreException> listener) {
         threadPool.submit(() -> {
             try {
                 final Set<Class<? extends Model>> models = new HashSet<>();
@@ -244,8 +246,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     public <T extends Model> void save(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @NonNull ResultListener<StorageItemChange.Record> itemSaveListener
-    ) {
+            @NonNull ResultListener<StorageItemChange.Record, DataStoreException> itemSaveListener) {
         save(item, initiator, null, itemSaveListener);
     }
 
@@ -258,8 +259,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
             @Nullable QueryPredicate predicate,
-            @NonNull ResultListener<StorageItemChange.Record> itemSaveListener
-    ) {
+            @NonNull ResultListener<StorageItemChange.Record, DataStoreException> itemSaveListener) {
         threadPool.submit(() -> {
             try {
                 final ModelSchema modelSchema =
@@ -331,8 +331,9 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void query(@NonNull Class<T> itemClass,
-                                        @NonNull ResultListener<Iterator<T>> queryResultsListener) {
+    public <T extends Model> void query(
+            @NonNull Class<T> itemClass,
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
         query(itemClass, null, queryResultsListener);
     }
 
@@ -340,9 +341,10 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void query(@NonNull Class<T> itemClass,
-                                        @Nullable QueryPredicate predicate,
-                                        @NonNull ResultListener<Iterator<T>> queryResultsListener) {
+    public <T extends Model> void query(
+            @NonNull Class<T> itemClass,
+            @Nullable QueryPredicate predicate,
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
         threadPool.submit(() -> {
             try {
                 LOG.debug("Querying item for: " + itemClass.getSimpleName());
@@ -388,7 +390,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     public <T extends Model> void delete(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @NonNull ResultListener<StorageItemChange.Record> itemDeleteListener) {
+            @NonNull ResultListener<StorageItemChange.Record, DataStoreException> itemDeleteListener) {
         threadPool.submit(() -> {
             try {
                 final ModelSchema modelSchema =
@@ -433,6 +435,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public Observable<StorageItemChange.Record> observe() {
         return itemChangeSubject;
@@ -559,8 +562,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     private void bindPreCompiledStatementWithFieldValue(
             @NonNull SQLiteStatement preCompiledStatement,
             @Nullable Object fieldValue,
-            int columnIndex
-    ) throws DataStoreException {
+            int columnIndex)
+            throws DataStoreException {
 
         if (fieldValue == null) {
             preCompiledStatement.bindNull(columnIndex);
@@ -622,8 +625,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     private <T extends Model> Map<String, Object> buildMapForModel(
             @NonNull Class<T> modelClass,
             @NonNull ModelSchema modelSchema,
-            @NonNull Cursor cursor
-    ) throws DataStoreException {
+            @NonNull Cursor cursor) {
         final Map<String, Object> mapForModel = new HashMap<>();
         final SQLiteTable sqliteTable = SQLiteTable.fromSchema(modelSchema);
         final Map<String, SQLiteColumn> columns = sqliteTable.getColumns();
@@ -725,8 +727,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
             @NonNull SqlCommand sqlCommand,
-            ModelConflictStrategy modelConflictStrategy
-    ) throws IllegalAccessException, DataStoreException {
+            ModelConflictStrategy modelConflictStrategy)
+            throws IllegalAccessException, DataStoreException {
         Objects.requireNonNull(model);
         Objects.requireNonNull(modelSchema);
         Objects.requireNonNull(sqlCommand);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/AppSyncApiTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/AppSyncApiTest.java
@@ -20,6 +20,7 @@ import com.amplifyframework.api.graphql.GraphQLOperation;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testutils.EmptyConsumer;
 import com.amplifyframework.testutils.LatchedConsumer;
@@ -76,8 +77,8 @@ public final class AppSyncApiTest {
         // Request a sync. Await its completion using a test latch.
         final LatchedConsumer<GraphQLResponse<Iterable<ModelWithMetadata<BlogOwner>>>> syncConsumer =
             LatchedConsumer.instance();
-        final ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<BlogOwner>>>> listener =
-            ResultListener.instance(syncConsumer, EmptyConsumer.of(Throwable.class));
+        final ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<BlogOwner>>>, DataStoreException> listener =
+            ResultListener.instance(syncConsumer, EmptyConsumer.of(DataStoreException.class));
         endpoint.sync(BlogOwner.class, null, listener);
         syncConsumer.awaitValue();
 
@@ -107,7 +108,7 @@ public final class AppSyncApiTest {
     private void mockApiResponse(GraphQLResponse<Iterable<String>> arrangedApiResponse) {
         doAnswer(invocation -> {
             final int argPositionOfResultListener = 1; // second and final arg, starting from arg 0
-            ResultListener<GraphQLResponse<Iterable<String>>> listener =
+            ResultListener<GraphQLResponse<Iterable<String>>, DataStoreException> listener =
                 invocation.getArgument(argPositionOfResultListener);
             listener.onResult(arrangedApiResponse);
             return mock(GraphQLOperation.class);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/MockAppSyncEndpoint.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/MockAppSyncEndpoint.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore.network;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,7 +66,7 @@ final class MockAppSyncEndpoint {
                 // Get a handle to the listener that is passed into the sync() method
                 // ResultListener is the third and final param at index 2 (@0, @1, @2).
                 final int argumentPositionForResultListener = 2;
-                final ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> listener =
+                final ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>, DataStoreException> listener =
                     invocation.getArgument(argumentPositionForResultListener);
 
                 // Call its onResult(), and pass the mocked items inside of a GraphQLResponse wrapper

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/SyncEngineTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/SyncEngineTest.java
@@ -20,6 +20,7 @@ import android.os.Build;
 import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
@@ -81,8 +82,8 @@ public class SyncEngineTest {
 
         // Act: Put BlogOwner into storage, and wait for it to complete.
         LatchedConsumer<StorageItemChange.Record> saveConsumer = LatchedConsumer.instance(OPERATIONS_TIMEOUT_MS);
-        ResultListener<StorageItemChange.Record> listener =
-            ResultListener.instance(saveConsumer::accept, EmptyConsumer.of(Throwable.class));
+        ResultListener<StorageItemChange.Record, DataStoreException> listener =
+            ResultListener.instance(saveConsumer, EmptyConsumer.of(DataStoreException.class));
         localStorageAdapter.save(susan, StorageItemChange.Initiator.DATA_STORE_API, listener);
         saveConsumer.awaitValue();
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -23,6 +23,7 @@ import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.datastore.DataStoreException;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -58,16 +59,14 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     @Override
     public void initialize(
             @NonNull Context context,
-            @NonNull ResultListener<List<ModelSchema>> listener
-    ) {
+            @NonNull ResultListener<List<ModelSchema>, DataStoreException> listener) {
     }
 
     @Override
     public <T extends Model> void save(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
-            @NonNull final ResultListener<StorageItemChange.Record> itemSaveListener
-    ) {
+            @NonNull final ResultListener<StorageItemChange.Record, DataStoreException> itemSaveListener) {
         save(item, initiator, null, itemSaveListener);
     }
 
@@ -77,8 +76,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
             @Nullable final QueryPredicate predicate,
-            @NonNull final ResultListener<StorageItemChange.Record> itemSaveListener
-    ) {
+            @NonNull final ResultListener<StorageItemChange.Record, DataStoreException> itemSaveListener) {
         items.add(item);
         StorageItemChange.Record save = StorageItemChange.<T>builder()
                 .item(item)
@@ -95,8 +93,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     @Override
     public <T extends Model> void query(
             @NonNull final Class<T> itemClass,
-            @NonNull final ResultListener<Iterator<T>> queryResultsListener
-    ) {
+            @NonNull final ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
         query(itemClass, null, queryResultsListener);
     }
 
@@ -105,8 +102,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     public <T extends Model> void query(
             @NonNull final Class<T> itemClass,
             @Nullable final QueryPredicate predicate,
-            @NonNull final ResultListener<Iterator<T>> queryResultsListener
-    ) {
+            @NonNull final ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
         List<T> result = new ArrayList<>();
         for (Model item : items) {
             if (itemClass.isAssignableFrom((item.getClass()))) {
@@ -121,8 +117,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     public <T extends Model> void delete(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
-            @NonNull final ResultListener<StorageItemChange.Record> itemDeletionListener
-    ) {
+            @NonNull final ResultListener<StorageItemChange.Record, DataStoreException> itemDeletionListener) {
         for (Model savedItem : items) {
             if (savedItem.getId().equals(item.getId())) {
                 items.remove(item);
@@ -140,6 +135,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
         }
     }
 
+    @NonNull
     @Override
     public Observable<StorageItemChange.Record> observe() {
         return changeRecordStream;

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -56,6 +56,7 @@ import java.util.concurrent.Executors;
  * A plugin for the storage category which uses S3 as a storage
  * repository.
  */
+@SuppressWarnings("unused") // Revisit this suppression after tests are created
 public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     private static final String AWS_S3_STORAGE_PLUGIN_KEY = "awsS3StoragePlugin";
     private AWSS3StorageService storageService;
@@ -70,13 +71,14 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         this.executorService = Executors.newCachedThreadPool();
     }
 
+    @NonNull
     @Override
     public String getPluginKey() {
         return AWS_S3_STORAGE_PLUGIN_KEY;
     }
 
     @Override
-    public void configure(@NonNull JSONObject pluginConfiguration, Context context) throws StorageException {
+    public void configure(@NonNull JSONObject pluginConfiguration, @NonNull Context context) throws StorageException {
         String regionStr;
         String bucket;
 
@@ -133,27 +135,28 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         this.defaultAccessLevel = StorageAccessLevel.PUBLIC; // This will be passed in the config in the future
     }
 
+    @NonNull
     @Override
     public AmazonS3Client getEscapeHatch() {
         return storageService.getClient();
     }
 
+    @NonNull
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageDownloadFileResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
         return downloadFile(key, local, StorageDownloadFileOptions.defaultInstance(), resultListener);
     }
 
+    @NonNull
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageDownloadFileOptions options,
-            @NonNull ResultListener<StorageDownloadFileResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
         AWSS3StorageDownloadFileRequest request = new AWSS3StorageDownloadFileRequest(
                 key,
                 local,
@@ -168,22 +171,22 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         return operation;
     }
 
+    @NonNull
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageUploadFileResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
         return uploadFile(key, local, StorageUploadFileOptions.defaultInstance(), resultListener);
     }
 
+    @NonNull
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageUploadFileOptions options,
-            @NonNull ResultListener<StorageUploadFileResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
         AWSS3StorageUploadFileRequest request = new AWSS3StorageUploadFileRequest(
                 key,
                 local,
@@ -201,20 +204,20 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         return operation;
     }
 
+    @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
-            @NonNull ResultListener<StorageRemoveResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
         return remove(key, StorageRemoveOptions.defaultInstance(), resultListener);
     }
 
+    @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
             @NonNull StorageRemoveOptions options,
-            @NonNull ResultListener<StorageRemoveResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
         AWSS3StorageRemoveRequest request = new AWSS3StorageRemoveRequest(
                 key,
                 options.getAccessLevel() != null ? options.getAccessLevel() : defaultAccessLevel,
@@ -229,20 +232,20 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         return operation;
     }
 
+    @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
-            @NonNull ResultListener<StorageListResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
         return list(path, StorageListOptions.defaultInstance(), resultListener);
     }
 
+    @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
             @NonNull StorageListOptions options,
-            @NonNull ResultListener<StorageListResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
         AWSS3StorageListRequest request = new AWSS3StorageListRequest(
                 path,
                 options.getAccessLevel() != null ? options.getAccessLevel() : defaultAccessLevel,
@@ -288,6 +291,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
          * Returns the key this property is listed under in the config JSON.
          * @return The key as a string
          */
+        @NonNull
         public String getConfigurationKey() {
             return configurationKey;
         }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.storage.s3.operation;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.ResultListener;
@@ -38,7 +39,7 @@ import java.io.File;
 public final class AWSS3StorageDownloadFileOperation
         extends StorageDownloadFileOperation<AWSS3StorageDownloadFileRequest> {
     private final AWSS3StorageService storageService;
-    private final ResultListener<StorageDownloadFileResult> resultListener;
+    private final ResultListener<StorageDownloadFileResult, StorageException> resultListener;
     private TransferObserver transferObserver;
     private File file;
 
@@ -48,9 +49,10 @@ public final class AWSS3StorageDownloadFileOperation
      * @param request download request parameters
      * @param resultListener Notified when download results are available
      */
-    public AWSS3StorageDownloadFileOperation(@NonNull AWSS3StorageService storageService,
-                                             @NonNull AWSS3StorageDownloadFileRequest request,
-                                             @NonNull ResultListener<StorageDownloadFileResult> resultListener) {
+    public AWSS3StorageDownloadFileOperation(
+            @NonNull AWSS3StorageService storageService,
+            @NonNull AWSS3StorageDownloadFileRequest request,
+            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
         super(request);
         this.storageService = storageService;
         this.resultListener = resultListener;
@@ -58,6 +60,7 @@ public final class AWSS3StorageDownloadFileOperation
         this.file = null;
     }
 
+    @SuppressLint("SyntheticAccessor")
     @Override
     public void start() {
         // Only start if it hasn't already been started

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperation.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ExecutorService;
 public final class AWSS3StorageListOperation extends StorageListOperation<AWSS3StorageListRequest> {
     private final AWSS3StorageService storageService;
     private final ExecutorService executorService;
-    private final ResultListener<StorageListResult> resultListener;
+    private final ResultListener<StorageListResult, StorageException> resultListener;
 
     /**
      * Constructs a new AWSS3StorageListOperation.
@@ -45,16 +45,18 @@ public final class AWSS3StorageListOperation extends StorageListOperation<AWSS3S
      * @param request list request parameters
      * @param resultListener notified when list operation results are available
      */
-    public AWSS3StorageListOperation(@NonNull AWSS3StorageService storageService,
-                                     @NonNull ExecutorService executorService,
-                                     @NonNull AWSS3StorageListRequest request,
-                                     @NonNull ResultListener<StorageListResult> resultListener) {
+    public AWSS3StorageListOperation(
+            @NonNull AWSS3StorageService storageService,
+            @NonNull ExecutorService executorService,
+            @NonNull AWSS3StorageListRequest request,
+            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
         super(request);
         this.storageService = storageService;
         this.executorService = executorService;
         this.resultListener = resultListener;
     }
 
+    @SuppressWarnings("SyntheticAccessor")
     @Override
     public void start() {
         executorService.submit(() -> {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageRemoveOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageRemoveOperation.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ExecutorService;
  */
 public final class AWSS3StorageRemoveOperation extends StorageRemoveOperation<AWSS3StorageRemoveRequest> {
     private final AWSS3StorageService storageService;
-    private final ResultListener<StorageRemoveResult> resultListener;
+    private final ResultListener<StorageRemoveResult, StorageException> resultListener;
     private final ExecutorService executorService;
 
     /**
@@ -44,16 +44,18 @@ public final class AWSS3StorageRemoveOperation extends StorageRemoveOperation<AW
      * @param request remove request parameters
      * @param resultListener notified when remove operation results available
      */
-    public AWSS3StorageRemoveOperation(@NonNull AWSS3StorageService storageService,
-                                       @NonNull ExecutorService executorService,
-                                       @NonNull AWSS3StorageRemoveRequest request,
-                                       @NonNull ResultListener<StorageRemoveResult> resultListener) {
+    public AWSS3StorageRemoveOperation(
+            @NonNull AWSS3StorageService storageService,
+            @NonNull ExecutorService executorService,
+            @NonNull AWSS3StorageRemoveRequest request,
+            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
         super(request);
         this.storageService = storageService;
         this.executorService = executorService;
         this.resultListener = resultListener;
     }
 
+    @SuppressWarnings("SyntheticAccessor")
     @Override
     public void start() {
         executorService.submit(() -> {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.storage.s3.operation;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.ResultListener;
@@ -37,7 +38,7 @@ import java.io.File;
  */
 public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOperation<AWSS3StorageUploadFileRequest> {
     private final AWSS3StorageService storageService;
-    private final ResultListener<StorageUploadFileResult> resultListener;
+    private final ResultListener<StorageUploadFileResult, StorageException> resultListener;
     private TransferObserver transferObserver;
     private File file;
 
@@ -47,9 +48,10 @@ public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOper
      * @param request upload request parameters
      * @param resultListener Will be notified when results of upload are available
      */
-    public AWSS3StorageUploadFileOperation(@NonNull AWSS3StorageService storageService,
-                                           @NonNull AWSS3StorageUploadFileRequest request,
-                                           @NonNull ResultListener<StorageUploadFileResult> resultListener) {
+    public AWSS3StorageUploadFileOperation(
+            @NonNull AWSS3StorageService storageService,
+            @NonNull AWSS3StorageUploadFileRequest request,
+            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
         super(request);
         this.storageService = storageService;
         this.resultListener = resultListener;
@@ -57,6 +59,7 @@ public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOper
         this.file = null;
     }
 
+    @SuppressLint("SyntheticAccessor")
     @Override
     public void start() {
         // Only start if it hasn't already been started

--- a/core/src/main/java/com/amplifyframework/api/ApiCategory.java
+++ b/core/src/main/java/com/amplifyframework/api/ApiCategory.java
@@ -40,6 +40,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicate;
  * category are defined in the {@link ApiCategoryBehavior}.
  */
 public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCategoryBehavior {
+    @NonNull
     @Override
     public CategoryType getCategoryType() {
         return CategoryType.API;
@@ -49,8 +50,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public <T extends Model> GraphQLOperation<T> query(
             @NonNull Class<T> modelClass,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener) {
         return getSelectedPlugin().query(modelClass, responseListener);
     }
 
@@ -59,8 +59,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T extends Model> GraphQLOperation<T> query(
             @NonNull Class<T> modelClass,
             @NonNull String objectId,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         return getSelectedPlugin().query(modelClass, objectId, responseListener);
     }
 
@@ -68,9 +67,8 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public <T extends Model> GraphQLOperation<T> query(
             @NonNull Class<T> modelClass,
-            QueryPredicate predicate,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener
-    ) {
+            @NonNull QueryPredicate predicate,
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener) {
         return getSelectedPlugin().query(modelClass, predicate, responseListener);
     }
 
@@ -78,8 +76,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public <T> GraphQLOperation<T> query(
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener) {
         return getSelectedPlugin().query(graphQlRequest, responseListener);
     }
 
@@ -88,8 +85,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T extends Model> GraphQLOperation<T> query(
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener) {
         return getSelectedPlugin().query(apiName, modelClass, responseListener);
     }
 
@@ -99,8 +95,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
             @NonNull String objectId,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         return getSelectedPlugin().query(apiName, modelClass, objectId, responseListener);
     }
 
@@ -109,9 +104,8 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T extends Model> GraphQLOperation<T> query(
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
-            QueryPredicate predicate,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener
-    ) {
+            @NonNull QueryPredicate predicate,
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener) {
         return getSelectedPlugin().query(apiName, modelClass, predicate, responseListener);
     }
 
@@ -120,8 +114,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T> GraphQLOperation<T> query(
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener) {
         return getSelectedPlugin().query(apiName, graphQlRequest, responseListener);
     }
 
@@ -130,8 +123,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T extends Model> GraphQLOperation<T> mutate(
             @NonNull T model,
             @NonNull MutationType mutationType,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         return getSelectedPlugin().mutate(model, mutationType, responseListener);
     }
 
@@ -139,10 +131,9 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public <T extends Model> GraphQLOperation<T> mutate(
             @NonNull T model,
-            QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull MutationType mutationType,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         return getSelectedPlugin().mutate(model, predicate, mutationType, responseListener);
     }
 
@@ -150,8 +141,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public <T> GraphQLOperation<T> mutate(
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         return getSelectedPlugin().mutate(graphQlRequest, responseListener);
     }
 
@@ -161,8 +151,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
             @NonNull String apiName,
             @NonNull T model,
             @NonNull MutationType mutationType,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         return getSelectedPlugin().mutate(apiName, model, mutationType, responseListener);
     }
 
@@ -171,10 +160,9 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T extends Model> GraphQLOperation<T> mutate(
             @NonNull String apiName,
             @NonNull T model,
-            QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull MutationType mutationType,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         return getSelectedPlugin().mutate(apiName, model, predicate, mutationType, responseListener);
     }
 
@@ -183,8 +171,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T> GraphQLOperation<T> mutate(
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener
-    ) {
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener) {
         return getSelectedPlugin().mutate(apiName, graphQlRequest, responseListener);
     }
 
@@ -193,7 +180,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T extends Model> GraphQLOperation<T> subscribe(
             @NonNull Class<T> modelClass,
             @NonNull SubscriptionType subscriptionType,
-            @NonNull StreamListener<GraphQLResponse<T>> subscriptionListener) {
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener) {
         return getSelectedPlugin().subscribe(modelClass, subscriptionType, subscriptionListener);
     }
 
@@ -201,8 +188,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public <T> GraphQLOperation<T> subscribe(
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull StreamListener<GraphQLResponse<T>> subscriptionListener
-    ) {
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener) {
         return getSelectedPlugin().subscribe(graphQlRequest, subscriptionListener);
     }
 
@@ -212,7 +198,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
             @NonNull SubscriptionType subscriptionType,
-            @NonNull StreamListener<GraphQLResponse<T>> subscriptionListener) {
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener) {
         return getSelectedPlugin().subscribe(apiName, modelClass, subscriptionType, subscriptionListener);
     }
 
@@ -221,8 +207,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T> GraphQLOperation<T> subscribe(
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull StreamListener<GraphQLResponse<T>> subscriptionListener
-    ) {
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener) {
         return getSelectedPlugin().subscribe(apiName, graphQlRequest, subscriptionListener);
     }
 
@@ -230,8 +215,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public RestOperation get(
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().get(request, responseListener);
     }
 
@@ -240,8 +224,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation get(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().get(apiName, request, responseListener);
     }
 
@@ -249,8 +232,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public RestOperation put(
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().put(request, responseListener);
     }
 
@@ -259,8 +241,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation put(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().put(apiName, request, responseListener);
     }
 
@@ -268,8 +249,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public RestOperation post(
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().post(request, responseListener);
     }
 
@@ -278,8 +258,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation post(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().post(apiName, request, responseListener);
     }
 
@@ -287,8 +266,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public RestOperation delete(
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().delete(request, responseListener);
     }
 
@@ -297,8 +275,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation delete(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().delete(apiName, request, responseListener);
     }
 
@@ -306,8 +283,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public RestOperation head(
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().head(request, responseListener);
     }
 
@@ -316,8 +292,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation head(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().head(apiName, request, responseListener);
     }
 
@@ -325,8 +300,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public RestOperation patch(
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().patch(request, responseListener);
     }
 
@@ -335,8 +309,7 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation patch(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @Nullable ResultListener<RestResponse> responseListener
-    ) {
+            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
         return getSelectedPlugin().patch(apiName, request, responseListener);
     }
 }

--- a/core/src/main/java/com/amplifyframework/api/GraphQlBehavior.java
+++ b/core/src/main/java/com/amplifyframework/api/GraphQlBehavior.java
@@ -55,7 +55,8 @@ public interface GraphQlBehavior {
     @Nullable
     <T extends Model> GraphQLOperation<T> query(
             @NonNull Class<T> modelClass,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily performing GET Queries
@@ -80,7 +81,8 @@ public interface GraphQlBehavior {
     <T extends Model> GraphQLOperation<T> query(
             @NonNull Class<T> modelClass,
             @NonNull String objectId,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily performing LIST Queries
@@ -104,8 +106,9 @@ public interface GraphQlBehavior {
     @Nullable
     <T extends Model> GraphQLOperation<T> query(
             @NonNull Class<T> modelClass,
-            QueryPredicate predicate,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener);
+            @NonNull QueryPredicate predicate,
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener
+    );
 
     /**
      * Perform a GraphQL query against a configured GraphQL endpoint.
@@ -125,7 +128,8 @@ public interface GraphQlBehavior {
     @Nullable
     <T> GraphQLOperation<T> query(
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily calling a list query for
@@ -147,7 +151,8 @@ public interface GraphQlBehavior {
     <T extends Model> GraphQLOperation<T> query(
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily performing GET Queries
@@ -171,7 +176,8 @@ public interface GraphQlBehavior {
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
             @NonNull String objectId,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily performing LIST Queries
@@ -194,8 +200,9 @@ public interface GraphQlBehavior {
     <T extends Model> GraphQLOperation<T> query(
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
-            QueryPredicate predicate,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener);
+            @NonNull QueryPredicate predicate,
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener
+    );
 
     /**
      * Perform a GraphQL query against a configured GraphQL endpoint.
@@ -214,7 +221,8 @@ public interface GraphQlBehavior {
     <T> GraphQLOperation<T> query(
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull ResultListener<GraphQLResponse<Iterable<T>>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<Iterable<T>>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily performing Mutations
@@ -239,7 +247,8 @@ public interface GraphQlBehavior {
     <T extends Model> GraphQLOperation<T> mutate(
             @NonNull T model,
             @NonNull MutationType mutationType,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily performing Mutations
@@ -265,9 +274,10 @@ public interface GraphQlBehavior {
     @Nullable
     <T extends Model> GraphQLOperation<T> mutate(
             @NonNull T model,
-            QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull MutationType mutationType,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener
+    );
 
     /**
      * Perform a GraphQL mutation against a configured GraphQL endpoint.
@@ -287,7 +297,8 @@ public interface GraphQlBehavior {
     @Nullable
     <T> GraphQLOperation<T> mutate(
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily performing Mutations
@@ -312,7 +323,8 @@ public interface GraphQlBehavior {
             @NonNull String apiName,
             @NonNull T model,
             @NonNull MutationType mutationType,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily performing Mutations
@@ -338,9 +350,10 @@ public interface GraphQlBehavior {
     <T extends Model> GraphQLOperation<T> mutate(
             @NonNull String apiName,
             @NonNull T model,
-            QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull MutationType mutationType,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener
+    );
 
     /**
      * Perform a GraphQL mutation against a configured GraphQL endpoint.
@@ -360,7 +373,8 @@ public interface GraphQlBehavior {
     <T> GraphQLOperation<T> mutate(
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull ResultListener<GraphQLResponse<T>> responseListener);
+            @NonNull ResultListener<GraphQLResponse<T>, ApiException> responseListener
+    );
 
     /**
      * This is a special helper method for easily subscribing to events
@@ -386,7 +400,8 @@ public interface GraphQlBehavior {
     <T extends Model> GraphQLOperation<T> subscribe(
             @NonNull Class<T> modelClass,
             @NonNull SubscriptionType subscriptionType,
-            @NonNull StreamListener<GraphQLResponse<T>> subscriptionListener);
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener
+    );
 
     /**
      * Initiates a GraphQL subscription against a configured GraphQL
@@ -407,7 +422,8 @@ public interface GraphQlBehavior {
     @Nullable
     <T> GraphQLOperation<T> subscribe(
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull StreamListener<GraphQLResponse<T>> subscriptionListener);
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener
+    );
 
     /**
      * This is a special helper method for easily subscribing to events
@@ -432,7 +448,8 @@ public interface GraphQlBehavior {
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
             @NonNull SubscriptionType subscriptionType,
-            @NonNull StreamListener<GraphQLResponse<T>> subscriptionListener);
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener
+    );
 
     /**
      * Initiates a GraphQL subscription against a configured GraphQL
@@ -452,5 +469,6 @@ public interface GraphQlBehavior {
     <T> GraphQLOperation<T> subscribe(
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull StreamListener<GraphQLResponse<T>> subscriptionListener);
+            @NonNull StreamListener<GraphQLResponse<T>, ApiException> subscriptionListener
+    );
 }

--- a/core/src/main/java/com/amplifyframework/api/RestBehavior.java
+++ b/core/src/main/java/com/amplifyframework/api/RestBehavior.java
@@ -44,7 +44,7 @@ public interface RestBehavior {
     @Nullable
     RestOperation get(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -62,7 +62,7 @@ public interface RestBehavior {
     RestOperation get(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -81,7 +81,7 @@ public interface RestBehavior {
     @Nullable
     RestOperation put(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -99,7 +99,7 @@ public interface RestBehavior {
     RestOperation put(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -118,7 +118,7 @@ public interface RestBehavior {
     @Nullable
     RestOperation post(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -136,7 +136,7 @@ public interface RestBehavior {
     RestOperation post(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -155,7 +155,7 @@ public interface RestBehavior {
     @Nullable
     RestOperation delete(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -173,7 +173,7 @@ public interface RestBehavior {
     RestOperation delete(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -192,7 +192,7 @@ public interface RestBehavior {
     @Nullable
     RestOperation head(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -210,7 +210,7 @@ public interface RestBehavior {
     RestOperation head(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -229,7 +229,7 @@ public interface RestBehavior {
     @Nullable
     RestOperation patch(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 
     /**
@@ -247,6 +247,6 @@ public interface RestBehavior {
     RestOperation patch(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse> responseListener
+            @NonNull ResultListener<RestResponse, ApiException> responseListener
     );
 }

--- a/core/src/main/java/com/amplifyframework/core/ResultListener.java
+++ b/core/src/main/java/com/amplifyframework/core/ResultListener.java
@@ -17,6 +17,8 @@ package com.amplifyframework.core;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.AmplifyException;
+
 import java.util.Objects;
 
 /**
@@ -34,14 +36,15 @@ import java.util.Objects;
  * An {@link ResultListener} is modeled after an RxJava2 {@link io.reactivex.SingleObserver}.
  *
  * @param <R> The type of result being returned to the listener
+ * @param <E> The type of error expected instead of a result
  */
-public final class ResultListener<R> {
+public final class ResultListener<R, E extends AmplifyException> {
     private final Consumer<R> resultConsumer;
-    private final Consumer<Throwable> errorConsumer;
+    private final Consumer<E> errorConsumer;
 
     private ResultListener(
             @NonNull final Consumer<R> resultConsumer,
-            @NonNull final Consumer<Throwable> errorConsumer) {
+            @NonNull final Consumer<E> errorConsumer) {
         this.resultConsumer = resultConsumer;
         this.errorConsumer = errorConsumer;
     }
@@ -51,12 +54,13 @@ public final class ResultListener<R> {
      * @param resultConsumer Consumer of result
      * @param errorConsumer Consumer of error
      * @param <R> The result type
+     * @param <E> The expected type of error
      * @return A result listener
      */
     @NonNull
-    public static <R> ResultListener<R> instance(
+    public static <R, E extends AmplifyException> ResultListener<R, E> instance(
             @NonNull final Consumer<R> resultConsumer,
-            @NonNull final Consumer<Throwable> errorConsumer) {
+            @NonNull final Consumer<E> errorConsumer) {
         return new ResultListener<>(
             Objects.requireNonNull(resultConsumer),
             Objects.requireNonNull(errorConsumer)
@@ -76,7 +80,7 @@ public final class ResultListener<R> {
      * error has occurred.
      * @param error An error that prevents determination of a result.
      */
-    public void onError(@NonNull Throwable error) {
+    public void onError(@NonNull E error) {
         errorConsumer.accept(error);
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/StreamListener.java
+++ b/core/src/main/java/com/amplifyframework/core/StreamListener.java
@@ -17,6 +17,8 @@ package com.amplifyframework.core;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.AmplifyException;
+
 /**
  * A utility to combine a collection of {@link Consumer}s - for stream data, and
  * terminating completion/error events.
@@ -32,16 +34,17 @@ import androidx.annotation.NonNull;
  * The StreamListener is modeled after the RxJava2 {@link io.reactivex.Observer}.
  *
  * @param <T> The type of item(s) that can be emitted via {@link #onNext(Object)}
+ * @param <E> The type of error(s) that can be emitted via {@link #onError(E)}.
  * @see <a href="http://reactivex.io/documentation/contract.html">The Rx Observable Contract</a>
  */
-public final class StreamListener<T> {
+public final class StreamListener<T, E extends AmplifyException> {
     private final Consumer<T> itemConsumer;
-    private final Consumer<Throwable> errorConsumer;
+    private final Consumer<E> errorConsumer;
     private final Action completionAction;
 
     private StreamListener(
             @NonNull Consumer<T> itemConsumer,
-            @NonNull Consumer<Throwable> errorConsumer,
+            @NonNull Consumer<E> errorConsumer,
             @NonNull Action completionAction) {
         this.itemConsumer = itemConsumer;
         this.errorConsumer = errorConsumer;
@@ -54,12 +57,13 @@ public final class StreamListener<T> {
      * @param errorConsumer Consumer of terminating errors
      * @param completionAction Action to perform on end of stream
      * @param <T> Type of items found in stream
+     * @param <E> Type of error that terminates the stream
      * @return A stream listener
      */
     @NonNull
-    public static <T> StreamListener<T> instance(
+    public static <T, E extends AmplifyException> StreamListener<T, E> instance(
             @NonNull Consumer<T> itemConsumer,
-            @NonNull Consumer<Throwable> errorConsumer,
+            @NonNull Consumer<E> errorConsumer,
             @NonNull Action completionAction) {
         return new StreamListener<>(itemConsumer, errorConsumer, completionAction);
     }
@@ -89,7 +93,7 @@ public final class StreamListener<T> {
      * this is invoked.
      * @param error An error encountered while evaluating a stream
      */
-    public void onError(@NonNull Throwable error) {
+    public void onError(@NonNull E error) {
         errorConsumer.accept(error);
     }
 }

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -41,6 +41,7 @@ public class DataStoreCategory
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public CategoryType getCategoryType() {
         return CategoryType.DATASTORE;
@@ -50,8 +51,9 @@ public class DataStoreCategory
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void save(@NonNull T item,
-                                       @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
+    public <T extends Model> void save(
+            @NonNull T item,
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> saveItemListener) {
         getSelectedPlugin().save(item, saveItemListener);
     }
 
@@ -59,9 +61,10 @@ public class DataStoreCategory
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void save(@NonNull T item,
-                                       @NonNull QueryPredicate predicate,
-                                       @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener) {
+    public <T extends Model> void save(
+            @NonNull T item,
+            @NonNull QueryPredicate predicate,
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> saveItemListener) {
         getSelectedPlugin().save(item, predicate, saveItemListener);
     }
 
@@ -69,8 +72,9 @@ public class DataStoreCategory
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void delete(@NonNull T item,
-                                         @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener) {
+    public <T extends Model> void delete(
+            @NonNull T item,
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> deleteItemListener) {
         getSelectedPlugin().delete(item, deleteItemListener);
     }
 
@@ -78,8 +82,9 @@ public class DataStoreCategory
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void query(@NonNull Class<T> itemClass,
-                                        @NonNull ResultListener<Iterator<T>> queryResultsListener) {
+    public <T extends Model> void query(
+            @NonNull Class<T> itemClass,
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
         getSelectedPlugin().query(itemClass, queryResultsListener);
     }
 
@@ -87,9 +92,10 @@ public class DataStoreCategory
      * {@inheritDoc}
      */
     @Override
-    public <T extends Model> void query(@NonNull Class<T> itemClass,
-                                        @NonNull QueryPredicate predicate,
-                                        @NonNull ResultListener<Iterator<T>> queryResultsListener) {
+    public <T extends Model> void query(
+            @NonNull Class<T> itemClass,
+            @NonNull QueryPredicate predicate,
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
         getSelectedPlugin().query(itemClass, predicate, queryResultsListener);
     }
 

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -45,7 +45,8 @@ public interface DataStoreCategoryBehavior {
      */
     <T extends Model> void save(
             @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener);
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> saveItemListener
+    );
 
     /**
      * Saves an item into the DataStore if the data being overwritten meets
@@ -60,7 +61,8 @@ public interface DataStoreCategoryBehavior {
     <T extends Model> void save(
             @NonNull T item,
             @NonNull QueryPredicate predicate,
-            @NonNull ResultListener<DataStoreItemChange<T>> saveItemListener);
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> saveItemListener
+    );
 
     /**
      * Deletes an item from the DataStore.
@@ -71,7 +73,8 @@ public interface DataStoreCategoryBehavior {
      */
     <T extends Model> void delete(
             @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>> deleteItemListener);
+            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> deleteItemListener
+    );
 
     /**
      * Query the DataStore to find all items of the requested Java class.
@@ -83,7 +86,8 @@ public interface DataStoreCategoryBehavior {
      */
     <T extends Model> void query(
             @NonNull Class<T> itemClass,
-            @NonNull ResultListener<Iterator<T>> queryResultsListener);
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener
+    );
 
     /**
      * Query the DataStore to find all items of the requested Java class that fulfills the
@@ -95,10 +99,11 @@ public interface DataStoreCategoryBehavior {
      *        results, or if there is a failure to query
      * @param <T> The type of items being queried
      */
-    <T extends Model> void query(@NonNull Class<T> itemClass,
-                                 @NonNull QueryPredicate predicate,
-                                 @NonNull ResultListener<Iterator<T>> queryResultsListener);
-
+    <T extends Model> void query(
+            @NonNull Class<T> itemClass,
+            @NonNull QueryPredicate predicate,
+            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener
+    );
 
     /**
      * Observe all changes to any/all item(s) in the DataStore.

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
@@ -40,79 +40,81 @@ import com.amplifyframework.storage.result.StorageUploadFileResult;
  */
 public final class StorageCategory extends Category<StoragePlugin<?>> implements StorageCategoryBehavior {
 
+    @NonNull
     @Override
     public CategoryType getCategoryType() {
         return CategoryType.STORAGE;
     }
 
+    @NonNull
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageDownloadFileResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
         return getSelectedPlugin().downloadFile(key, local, resultListener);
     }
 
+    @NonNull
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageDownloadFileOptions options,
-            @NonNull ResultListener<StorageDownloadFileResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
         return getSelectedPlugin().downloadFile(key, local, options, resultListener);
     }
 
+    @NonNull
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageUploadFileResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
         return getSelectedPlugin().uploadFile(key, local, resultListener);
     }
 
+    @NonNull
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageUploadFileOptions options,
-            @NonNull ResultListener<StorageUploadFileResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
         return getSelectedPlugin().uploadFile(key, local, options, resultListener);
     }
 
+    @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
-            @NonNull ResultListener<StorageRemoveResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
         return getSelectedPlugin().remove(key, resultListener);
     }
 
+    @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
             @NonNull StorageRemoveOptions options,
-            @NonNull ResultListener<StorageRemoveResult> resultListener) {
+            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
         return getSelectedPlugin().remove(key, options, resultListener);
     }
 
+    @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
-            @NonNull ResultListener<StorageListResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
         return getSelectedPlugin().list(path, resultListener);
     }
 
+    @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
             @NonNull StorageListOptions options,
-            @NonNull ResultListener<StorageListResult> resultListener
-    ) {
+            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
         return getSelectedPlugin().list(path, options, resultListener);
     }
 }

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
@@ -45,9 +45,12 @@ public interface StorageCategoryBehavior {
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageDownloadFileOperation<?> downloadFile(@NonNull String key,
-                                  @NonNull String local,
-                                  @NonNull ResultListener<StorageDownloadFileResult> resultListener);
+    @NonNull
+    StorageDownloadFileOperation<?> downloadFile(
+            @NonNull String key,
+            @NonNull String local,
+            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener
+    );
 
     /**
      * Download object to memory from storage.
@@ -62,10 +65,13 @@ public interface StorageCategoryBehavior {
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageDownloadFileOperation<?> downloadFile(@NonNull String key,
-                                  @NonNull String local,
-                                  @NonNull StorageDownloadFileOptions options,
-                                  @NonNull ResultListener<StorageDownloadFileResult> resultListener);
+    @NonNull
+    StorageDownloadFileOperation<?> downloadFile(
+            @NonNull String key,
+            @NonNull String local,
+            @NonNull StorageDownloadFileOptions options,
+            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener
+    );
 
     /**
      * Upload local file on given path to storage.
@@ -76,9 +82,12 @@ public interface StorageCategoryBehavior {
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageUploadFileOperation<?> uploadFile(@NonNull String key,
-                                @NonNull String local,
-                                @NonNull ResultListener<StorageUploadFileResult> resultListener);
+    @NonNull
+    StorageUploadFileOperation<?> uploadFile(
+            @NonNull String key,
+            @NonNull String local,
+            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener
+    );
 
     /**
      * Upload local file on given path to storage.
@@ -91,10 +100,13 @@ public interface StorageCategoryBehavior {
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageUploadFileOperation<?> uploadFile(@NonNull String key,
-                                @NonNull String local,
-                                @NonNull StorageUploadFileOptions options,
-                                @NonNull ResultListener<StorageUploadFileResult> resultListener);
+    @NonNull
+    StorageUploadFileOperation<?> uploadFile(
+            @NonNull String key,
+            @NonNull String local,
+            @NonNull StorageUploadFileOptions options,
+            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener
+    );
 
     /**
      * Delete object from storage.
@@ -104,8 +116,11 @@ public interface StorageCategoryBehavior {
      *        actions related to the execution of the work
      *
      */
-    StorageRemoveOperation<?> remove(@NonNull String key,
-                            @NonNull ResultListener<StorageRemoveResult> resultListener);
+    @NonNull
+    StorageRemoveOperation<?> remove(
+            @NonNull String key,
+            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener
+    );
 
     /**
      * Delete object from storage.
@@ -116,9 +131,12 @@ public interface StorageCategoryBehavior {
      * @return an operation object that provides notifications and
      *        actions related to the execution of the work
      */
-    StorageRemoveOperation<?> remove(@NonNull String key,
-                            @NonNull StorageRemoveOptions options,
-                            @NonNull ResultListener<StorageRemoveResult> resultListener);
+    @NonNull
+    StorageRemoveOperation<?> remove(
+            @NonNull String key,
+            @NonNull StorageRemoveOptions options,
+            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener
+    );
 
     /**
      * List the object identifiers under the hierarchy specified
@@ -128,8 +146,11 @@ public interface StorageCategoryBehavior {
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageListOperation<?> list(@NonNull String path,
-                            @NonNull ResultListener<StorageListResult> resultListener);
+    @NonNull
+    StorageListOperation<?> list(
+            @NonNull String path,
+            @NonNull ResultListener<StorageListResult, StorageException> resultListener
+    );
 
     /**
      * List the object identifiers under the hierarchy specified
@@ -141,7 +162,10 @@ public interface StorageCategoryBehavior {
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
-    StorageListOperation<?> list(@NonNull String path,
-                            @NonNull StorageListOptions options,
-                            @NonNull ResultListener<StorageListResult> resultListener);
+    @NonNull
+    StorageListOperation<?> list(
+            @NonNull String path,
+            @NonNull StorageListOptions options,
+            @NonNull ResultListener<StorageListResult, StorageException> resultListener
+    );
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/SynchronousDataStore.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/SynchronousDataStore.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.DataStoreItemChange;
 
 import java.util.Iterator;
@@ -55,8 +56,8 @@ public final class SynchronousDataStore {
      */
     public <T extends Model> void save(@NonNull T item) {
         LatchedConsumer<DataStoreItemChange<T>> saveConsumer = LatchedConsumer.instance();
-        ResultListener<DataStoreItemChange<T>> resultListener =
-            ResultListener.instance(saveConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<DataStoreItemChange<T>, DataStoreException> resultListener =
+            ResultListener.instance(saveConsumer, EmptyConsumer.of(DataStoreException.class));
         Amplify.DataStore.save(item, resultListener);
         saveConsumer.awaitValue();
     }
@@ -72,8 +73,8 @@ public final class SynchronousDataStore {
     @NonNull
     public <T extends Model> T get(@NonNull Class<T> clazz, @NonNull String itemId) {
         LatchedConsumer<Iterator<T>> queryConsumer = LatchedConsumer.instance();
-        ResultListener<Iterator<T>> resultListener =
-            ResultListener.instance(queryConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<Iterator<T>, DataStoreException> resultListener =
+            ResultListener.instance(queryConsumer, EmptyConsumer.of(DataStoreException.class));
         Amplify.DataStore.query(clazz, resultListener);
 
         final Iterator<T> iterator = queryConsumer.awaitValue();

--- a/testutils/src/test/java/com/amplifyframework/testutils/LatchedResponseConsumerTest.java
+++ b/testutils/src/test/java/com/amplifyframework/testutils/LatchedResponseConsumerTest.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.testutils;
 
+import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.ResultListener;
@@ -46,8 +47,8 @@ public final class LatchedResponseConsumerTest {
     @Test
     public void valuesAreConsumedThroughResultListener() {
         LatchedResponseConsumer<String> resultConsumer = LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<String>> resultListener =
-            ResultListener.instance(resultConsumer, EmptyConsumer.of(Throwable.class));
+        ResultListener<GraphQLResponse<String>, ApiException> resultListener =
+            ResultListener.instance(resultConsumer, EmptyConsumer.of(ApiException.class));
 
         String expectedResponseData = "Hello, World.";
         resultListener.onResult(new GraphQLResponse<>(expectedResponseData, Collections.emptyList()));


### PR DESCRIPTION
The error callbacks had been left as Consumer&lt;Throwable&gt;. But, each
category is meant to return a category-specific exception type, e.g.
ApiException. So, the error callback should be a Consumer&lt;ApiException&gt;.

To achieve this, the ResultListener and StreamListener are reworked so
that the error consumer accepts Consumer&lt;E&gt; where &lt;E extends AmplifyException&gt;.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
