### PR TITLE
[TestUtils] Recycle Synchronous Latching Code

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
@@ -18,10 +18,7 @@ package com.amplifyframework.api.aws;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.rest.RestOptions;
 import com.amplifyframework.api.rest.RestResponse;
-import com.amplifyframework.core.Amplify;
-import com.amplifyframework.core.ResultListener;
-import com.amplifyframework.testutils.EmptyConsumer;
-import com.amplifyframework.testutils.LatchedConsumer;
+import com.amplifyframework.testutils.SynchronousApi;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,6 +34,8 @@ import static org.junit.Assert.assertNotNull;
  */
 public final class RestApiInstrumentationTest {
 
+    private static SynchronousApi api;
+
     /**
      * Configure the Amplify framework, if that hasn't already happened in this process instance.
      * @throws AmplifyException Exception is thrown if configuration fails.
@@ -44,6 +43,7 @@ public final class RestApiInstrumentationTest {
     @BeforeClass
     public static void onceBeforeTests() throws AmplifyException {
         AmplifyTestConfigurator.configureIfNotConfigured();
+        api = SynchronousApi.singleton();
     }
 
     /**
@@ -52,16 +52,10 @@ public final class RestApiInstrumentationTest {
      */
     @Test
     public void getRequestWithNoAuth() throws JSONException {
-        final RestOptions options = new RestOptions("simplesuccess");
-        LatchedConsumer<RestResponse> responseConsumer = LatchedConsumer.instance();
-        ResultListener<RestResponse> resultListener =
-            ResultListener.instance(responseConsumer, EmptyConsumer.of(Throwable.class));
-        Amplify.API.get("nonAuthApi", options, resultListener);
-        RestResponse response = responseConsumer.awaitValue();
-        assertNotNull("Should return a non null data", response.getData());
+        RestResponse responseData =
+            api.get("nonAuthApi", new RestOptions("simplesuccess"));
 
-        final JSONObject resultJSON = response.getData().asJSONObject();
-        final JSONObject contextJSON = resultJSON.getJSONObject("context");
+        final JSONObject contextJSON = responseData.getData().asJSONObject().getJSONObject("context");
         assertNotNull("Should contain an object called context", contextJSON);
         assertEquals(
                 "Should return the right value",
@@ -80,12 +74,7 @@ public final class RestApiInstrumentationTest {
     @Test
     public void postRequestWithNoAuth() throws JSONException {
         final RestOptions options = new RestOptions("simplesuccess", "sample body".getBytes());
-        LatchedConsumer<RestResponse> responseConsumer = LatchedConsumer.instance();
-        ResultListener<RestResponse> responseListener =
-            ResultListener.instance(responseConsumer, EmptyConsumer.of(Throwable.class));
-        Amplify.API.post("nonAuthApi", options, responseListener);
-        RestResponse response = responseConsumer.awaitValue();
-        assertNotNull("Should return a non null data", response.getData());
+        final RestResponse response = api.post("nonAuthApi", options);
 
         final JSONObject resultJSON = response.getData().asJSONObject();
         final JSONObject contextJSON = resultJSON.getJSONObject("context");
@@ -106,16 +95,10 @@ public final class RestApiInstrumentationTest {
      */
     @Test
     public void getRequestWithApiKey() throws JSONException {
-        final RestOptions options = new RestOptions("simplesuccessapikey");
-        LatchedConsumer<RestResponse> responseConsumer = LatchedConsumer.instance();
-        ResultListener<RestResponse> responseListener =
-            ResultListener.instance(responseConsumer, EmptyConsumer.of(Throwable.class));
-        Amplify.API.get("apiKeyApi", options, responseListener);
-        RestResponse response = responseConsumer.awaitValue();
-        assertNotNull("Should return a non null data", response.getData());
+        final RestResponse response =
+            api.get("apiKeyApi", new RestOptions("simplesuccessapikey"));
 
-        final JSONObject resultJSON = response.getData().asJSONObject();
-        final JSONObject contextJSON = resultJSON.getJSONObject("context");
+        final JSONObject contextJSON = response.getData().asJSONObject().getJSONObject("context");
         assertNotNull("Should contain an object called context", contextJSON);
         assertEquals(
                 "Should return the right value",

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncApiInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncApiInstrumentationTest.java
@@ -15,20 +15,23 @@
 
 package com.amplifyframework.datastore;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.StreamListener;
 import com.amplifyframework.core.async.Cancelable;
+import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.network.AppSyncApi;
 import com.amplifyframework.datastore.network.ModelWithMetadata;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testmodels.commentsblog.Post;
 import com.amplifyframework.testmodels.commentsblog.PostStatus;
-import com.amplifyframework.testutils.EmptyAction;
 import com.amplifyframework.testutils.EmptyConsumer;
+import com.amplifyframework.testutils.LatchedAction;
 import com.amplifyframework.testutils.LatchedResponseConsumer;
 
 import org.junit.BeforeClass;
@@ -57,7 +60,7 @@ public class AppSyncApiInstrumentationTest {
     @BeforeClass
     public static void onceBeforeTests() throws AmplifyException {
         TestConfiguration.configureIfNotConfigured();
-        api = new AppSyncApi(Amplify.API);
+        api = AppSyncApi.instance();
     }
 
     /**
@@ -69,17 +72,11 @@ public class AppSyncApiInstrumentationTest {
         Long startTime = new Date().getTime();
 
         // Create simple model with no relationship
-        LatchedResponseConsumer<ModelWithMetadata<BlogOwner>> blogOwnerCreateConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<BlogOwner>>> blogOwnerCreateListener =
-            ResultListener.instance(blogOwnerCreateConsumer, EmptyConsumer.of(Throwable.class));
-
         BlogOwner owner = BlogOwner.builder()
             .name("David")
             .build();
-        api.create(owner, blogOwnerCreateListener);
+        ModelWithMetadata<BlogOwner> blogOwnerCreateResult = create(owner);
 
-        ModelWithMetadata<BlogOwner> blogOwnerCreateResult = blogOwnerCreateConsumer.awaitResponseData();
         assertEquals(owner, blogOwnerCreateResult.getModel());
         assertEquals(new Integer(1), blogOwnerCreateResult.getSyncMetadata().getVersion());
         // TODO: BE AWARE THAT THE DELETED PROPERTY RETURNS NULL INSTEAD OF FALSE
@@ -87,29 +84,17 @@ public class AppSyncApiInstrumentationTest {
         assertEquals(owner.getId(), blogOwnerCreateResult.getSyncMetadata().getId());
 
         // Subscribe to Blog creations
-        LatchedResponseConsumer<ModelWithMetadata<Blog>> blogCreateSubscriptionConsumer =
-            LatchedResponseConsumer.instance();
-        StreamListener<GraphQLResponse<ModelWithMetadata<Blog>>> blogCreateSubscriptionListener =
-            StreamListener.instance(
-                blogCreateSubscriptionConsumer, EmptyConsumer.of(Throwable.class), EmptyAction.instance()
-            );
-        Cancelable subscription = api.onCreate(Blog.class, blogCreateSubscriptionListener);
+        Subscription<Blog> subscription = Subscription.onCreate(Blog.class);
 
         // Now, actually create a Blog
-        LatchedResponseConsumer<ModelWithMetadata<Blog>> blogCreateConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<Blog>>> blogCreateListener =
-            ResultListener.instance(blogCreateConsumer, EmptyConsumer.of(Throwable.class));
-
         Blog blog = Blog.builder()
             .name("Create test")
             .owner(owner)
             .build();
-        api.create(blog, blogCreateListener);
+        ModelWithMetadata<Blog> blogCreateResult = create(blog);
 
         // Currently cannot do BlogOwner.justId because it will assign the id to the name field.
         // This is being fixed
-        ModelWithMetadata<Blog> blogCreateResult = blogCreateConsumer.awaitResponseData();
         assertEquals(blog.getId(), blogCreateResult.getModel().getId());
         assertEquals(blog.getName(), blogCreateResult.getModel().getName());
         assertEquals(blog.getOwner().getId(), blogCreateResult.getModel().getOwner().getId());
@@ -120,20 +105,11 @@ public class AppSyncApiInstrumentationTest {
 
         // Validate that subscription picked up the mutation
         // & End the subscription since we're done with.
-        assertEquals(blogCreateResult, blogCreateSubscriptionConsumer.awaitResponseData());
+        assertEquals(blogCreateResult, subscription.awaitNextItem());
         subscription.cancel();
+        subscription.awaitSubscriptionCompletion();
 
         // Create Posts which Blog hasMany of
-        LatchedResponseConsumer<ModelWithMetadata<Post>> post1CreateConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<Post>>> post1CreateListener =
-            ResultListener.instance(post1CreateConsumer, EmptyConsumer.of(Throwable.class));
-
-        LatchedResponseConsumer<ModelWithMetadata<Post>> post2CreateConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<Post>>> post2CreateListener =
-            ResultListener.instance(post2CreateConsumer, EmptyConsumer.of(Throwable.class));
-
         Post post1 = Post.builder()
             .title("Post 1")
             .status(PostStatus.ACTIVE)
@@ -146,12 +122,8 @@ public class AppSyncApiInstrumentationTest {
             .rating(-1)
             .blog(blog)
             .build();
-
-        api.create(post1, post1CreateListener);
-        api.create(post2, post2CreateListener);
-
-        Post post1ModelResult = post1CreateConsumer.awaitResponseData().getModel();
-        Post post2ModelResult = post2CreateConsumer.awaitResponseData().getModel();
+        Post post1ModelResult = create(post1).getModel();
+        Post post2ModelResult = create(post2).getModel();
 
         // Results only have blog ID so strip out other information from the original post blog
         assertEquals(
@@ -168,18 +140,13 @@ public class AppSyncApiInstrumentationTest {
         );
 
         // Update model
-        LatchedResponseConsumer<ModelWithMetadata<Blog>> blogUpdateConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<Blog>>> blogUpdateListener =
-            ResultListener.instance(blogUpdateConsumer, EmptyConsumer.of(Throwable.class));
         Blog updatedBlog = blog.copyOfBuilder()
             .name("Updated blog")
             .build();
         Long updateBlogStartTime = new Date().getTime();
 
-        api.update(updatedBlog, 1, blogUpdateListener);
+        ModelWithMetadata<Blog> blogUpdateResult = update(updatedBlog, 1);
 
-        ModelWithMetadata<Blog> blogUpdateResult = blogUpdateConsumer.awaitResponseData();
         assertEquals(updatedBlog.getName(), blogUpdateResult.getModel().getName());
         assertEquals(updatedBlog.getOwner().getId(), blogUpdateResult.getModel().getOwner().getId());
         assertEquals(updatedBlog.getId(), blogUpdateResult.getModel().getId());
@@ -189,14 +156,7 @@ public class AppSyncApiInstrumentationTest {
         assertTrue(blogUpdateResult.getSyncMetadata().getLastChangedAt() > updateBlogStartTime);
 
         // Delete one of the posts
-        LatchedResponseConsumer<ModelWithMetadata<Post>> post1DeleteConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<Post>>> post1DeleteListener =
-            ResultListener.instance(post1CreateConsumer, EmptyConsumer.of(Throwable.class));
-
-        api.delete(Post.class, post1.getId(), 1, post1DeleteListener);
-
-        ModelWithMetadata<Post> post1DeleteResult = post1DeleteConsumer.awaitResponseData();
+        ModelWithMetadata<Post> post1DeleteResult = delete(Post.class, post1.getId(), 1);
         assertEquals(
             post1.copyOfBuilder()
                 .blog(Blog.justId(blog.getId()))
@@ -206,41 +166,165 @@ public class AppSyncApiInstrumentationTest {
         assertTrue(post1DeleteResult.getSyncMetadata().isDeleted());
 
         // Try to delete a post with a bad version number
-        LatchedResponseConsumer<ModelWithMetadata<Post>> post2DeleteConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<ModelWithMetadata<Post>>> post2DeleteListener =
-            ResultListener.instance(post2CreateConsumer, EmptyConsumer.of(Throwable.class));
-
-        api.delete(Post.class, post2.getId(), 0, post2DeleteListener);
-
-        List<GraphQLResponse.Error> post2DeleteErrors = post2DeleteConsumer.awaitErrorsInNextResponse();
+        List<GraphQLResponse.Error> post2DeleteErrors = deleteExpectingErrors(Post.class, post2.getId(), 0);
         assertEquals("Conflict resolver rejects mutation.", post2DeleteErrors.get(0).getMessage());
 
         // Run sync on Blogs
         // TODO: This is currently a pretty worthless test - mainly for setting a debug point and manually inspecting
-        LatchedResponseConsumer<Iterable<ModelWithMetadata<Blog>>> blogSyncConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<Blog>>>> blogSyncListener =
-            ResultListener.instance(blogSyncConsumer, EmptyConsumer.of(Throwable.class));
-
         // When you call sync with a null lastSync it gives only one entry per object (the latest state)
-        api.sync(Blog.class, null, blogSyncListener);
-
-        Iterable<ModelWithMetadata<Blog>> blogSyncResult = blogSyncConsumer.awaitResponseData();
+        Iterable<ModelWithMetadata<Blog>> blogSyncResult = sync(Blog.class, null);
         assertTrue(blogSyncResult.iterator().hasNext());
 
         // Run sync on Posts
         // TODO: This is currently a pretty worthless test - mainly for setting a debug point and manually inspecting
-        LatchedResponseConsumer<Iterable<ModelWithMetadata<Post>>> postSyncConsumer =
-            LatchedResponseConsumer.instance();
-        ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<Post>>>> postSyncListener =
-            ResultListener.instance(postSyncConsumer, EmptyConsumer.of(Throwable.class));
-
         // When you call sync with a lastSyncTime it gives you one entry per version of that object which was created
         // since that time.
-        api.sync(Post.class, startTime, postSyncListener);
-
-        Iterable<ModelWithMetadata<Post>> postSyncResult = postSyncConsumer.awaitResponseData();
+        Iterable<ModelWithMetadata<Post>> postSyncResult = sync(Post.class, startTime);
         assertTrue(postSyncResult.iterator().hasNext());
+    }
+
+    /**
+     * Create a model via the App Sync API, and return the App Sync API's
+     * understood version of that model, along with server's metadata for the model.
+     * @param model Model to create in remote App Sync API
+     * @param <T> Type of model being created
+     * @return Endpoint's version of the model, along with metadata about the model
+     */
+    @NonNull
+    private <T extends Model> ModelWithMetadata<T> create(@NonNull T model) {
+        LatchedResponseConsumer<ModelWithMetadata<T>> createdItemConsumer =
+            LatchedResponseConsumer.instance();
+        ResultListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
+            ResultListener.instance(createdItemConsumer, EmptyConsumer.of(Throwable.class));
+        api.create(model, listener);
+        return createdItemConsumer.awaitResponseData();
+    }
+
+    /**
+     * Updates an existing item in the App Sync API, whose remote version is the expected value.
+     * @param model Updated model, to persist remotely
+     * @param version Current version of the model that we (the client) know about
+     * @param <T> The type of model being updated
+     * @return Server's version of the model after update, along with new metadata
+     */
+    @SuppressWarnings("SameParameterValue") // Keep details in the actual test.
+    @NonNull
+    private <T extends Model> ModelWithMetadata<T> update(@NonNull T model, int version) {
+        LatchedResponseConsumer<ModelWithMetadata<T>> updatedItemConsumer =
+            LatchedResponseConsumer.instance();
+        ResultListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
+            ResultListener.instance(updatedItemConsumer, EmptyConsumer.of(Throwable.class));
+        api.update(model, version, listener);
+        return updatedItemConsumer.awaitResponseData();
+    }
+
+    /**
+     * Deletes an instance of a model.
+     * @param clazz The class of model being deleted
+     * @param modelId The ID of the model instance to delete
+     * @param version The version of the model being deleted as understood by client
+     * @param <T> Type of model being deleted
+     * @return A record of the item that was deleted from endpoint, along with metadata about the deletion
+     */
+    @SuppressWarnings("SameParameterValue") // Reads better with details in one place
+    private <T extends Model> ModelWithMetadata<T> delete(
+            @NonNull Class<T> clazz, String modelId, int version) {
+        LatchedResponseConsumer<ModelWithMetadata<T>> deleteResultConsumer =
+            LatchedResponseConsumer.instance();
+        ResultListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
+            ResultListener.instance(deleteResultConsumer, EmptyConsumer.of(Throwable.class));
+        api.delete(clazz, modelId, version, listener);
+        return deleteResultConsumer.awaitResponseData();
+    }
+
+    /**
+     * Try to delete an item, but expect it to error.
+     * Return the errors that were contained in the GraphQLResponse returned from endpoint.
+     * @param clazz Class of item for which a delete is attempted
+     * @param modelId ID of item for which delete is attempted
+     * @param version Version of item for which deleted is attempted
+     * @param <T> Type of item for which delete is attempted
+     * @return List of GraphQLResponse.Error which explain why delete failed
+     */
+    @SuppressWarnings("SameParameterValue") // It'll read better if we keep details in the call line
+    private <T extends Model> List<GraphQLResponse.Error> deleteExpectingErrors(
+            @NonNull Class<T> clazz, String modelId, int version) {
+        LatchedResponseConsumer<ModelWithMetadata<T>> deleteResultConsumer =
+            LatchedResponseConsumer.instance();
+        ResultListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
+            ResultListener.instance(deleteResultConsumer, EmptyConsumer.of(Throwable.class));
+        api.delete(clazz, modelId, version, listener);
+        return deleteResultConsumer.awaitErrorsInNextResponse();
+    }
+
+    /**
+     * Sync models of a given class, that have been updated since the provided last sync time.
+     * @param clazz Class of models being sync'd
+     * @param lastSyncTime Last time a sync occurred
+     * @param <T> Type of models
+     * @return An iterable collection of models with metadata describing models state on remote endpoint
+     */
+    private <T extends Model> Iterable<ModelWithMetadata<T>> sync(
+            @NonNull Class<T> clazz, @Nullable Long lastSyncTime) {
+        LatchedResponseConsumer<Iterable<ModelWithMetadata<T>>> syncConsumer =
+            LatchedResponseConsumer.instance();
+        ResultListener<GraphQLResponse<Iterable<ModelWithMetadata<T>>>> syncListener =
+            ResultListener.instance(syncConsumer, EmptyConsumer.of(Throwable.class));
+        api.sync(clazz, lastSyncTime, syncListener);
+        return syncConsumer.awaitResponseData();
+    }
+
+    static final class Subscription<T extends Model> {
+        private final Cancelable cancelable;
+        private final LatchedResponseConsumer<ModelWithMetadata<T>> responseConsumer;
+        private final LatchedAction completionAction;
+
+        private Subscription(
+                Cancelable cancelable,
+                LatchedResponseConsumer<ModelWithMetadata<T>> responseConsumer,
+                LatchedAction completionAction) {
+            this.cancelable = cancelable;
+            this.responseConsumer = responseConsumer;
+            this.completionAction = completionAction;
+        }
+
+        /**
+         * Being a new subscription to model creations.
+         * @param <T> Type of model being monitored
+         * @param clazz Class of model being monitored
+         * @return A subscription for the model class
+         */
+        @SuppressWarnings("SameParameterValue") // Keep details in the @Test method
+        @NonNull
+        static <T extends Model> Subscription<T> onCreate(Class<T> clazz) {
+            LatchedResponseConsumer<ModelWithMetadata<T>> itemConsumer = LatchedResponseConsumer.instance();
+            LatchedAction completionAction = LatchedAction.instance();
+            StreamListener<GraphQLResponse<ModelWithMetadata<T>>> listener =
+                StreamListener.instance(itemConsumer, EmptyConsumer.of(Throwable.class), completionAction);
+            Cancelable cancelable = api.onCreate(clazz, listener);
+            return new Subscription<>(cancelable, itemConsumer, completionAction);
+        }
+
+        /**
+         * Cancel the subscription.
+         */
+        void cancel() {
+            cancelable.cancel();
+        }
+
+        /**
+         * Await the next item that arrives on the subscription.
+         * @return Next item on subscription
+         */
+        ModelWithMetadata<T> awaitNextItem() {
+            return responseConsumer.awaitResponseData();
+        }
+
+        /**
+         * Wait for the subscription to complete.
+         */
+        void awaitSubscriptionCompletion() {
+            completionAction.awaitCall();
+        }
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -22,7 +22,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.AmplifyException;
-import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.category.CategoryType;
@@ -73,7 +72,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
     }
 
     private SyncEngine createSyncEngine(ModelProvider modelProvider, LocalStorageAdapter storageAdapter) {
-        return new SyncEngine(modelProvider, storageAdapter, new AppSyncApi(Amplify.API));
+        return new SyncEngine(modelProvider, storageAdapter, AppSyncApi.instance());
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/network/AppSyncApi.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/network/AppSyncApi.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.network;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategoryBehavior;
@@ -56,10 +57,21 @@ public final class AppSyncApi implements AppSyncEndpoint {
      * Constructs a new AppSyncApi.
      * @param api The API Category, configured with a DataStore API
      */
-    public AppSyncApi(@NonNull final GraphQlBehavior api) {
+    @VisibleForTesting
+    AppSyncApi(@NonNull final GraphQlBehavior api) {
         this.api = Objects.requireNonNull(api);
         this.variablesSerializer = new GsonVariablesSerializer();
         this.responseDeserializer = new GsonResponseDeserializer();
+    }
+
+    /**
+     * Obtain an instance of the AppSyncAPI, which uses the Amplify API category
+     * as its backing implementation for GraphQL behaviors.
+     * @return An App Sync API instance
+     */
+    @NonNull
+    public static AppSyncApi instance() {
+        return new AppSyncApi(Amplify.API);
     }
 
     @NonNull

--- a/testutils/src/main/java/com/amplifyframework/testutils/SynchronousApi.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/SynchronousApi.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.api.ApiCategory;
+import com.amplifyframework.api.graphql.GraphQLRequest;
+import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.api.graphql.MutationType;
+import com.amplifyframework.api.graphql.SubscriptionType;
+import com.amplifyframework.api.rest.RestOptions;
+import com.amplifyframework.api.rest.RestResponse;
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.StreamListener;
+import com.amplifyframework.core.async.Cancelable;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.util.Immutable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A utility to perform synchronous calls to the {@link ApiCategory}.
+ * This code is not well suited for production use, but is useful in test
+ * code, where we want to make a series of sequential assertions after
+ * performing various operations.
+ */
+public final class SynchronousApi {
+    private static SynchronousApi singleton = null;
+
+    @SuppressWarnings("checkstyle:all") private SynchronousApi() {}
+
+    /**
+     * Gets a singleton instance of the Synchronous API utility.
+     * @return Singleton instance of Synchronous API
+     */
+    @NonNull
+    public static synchronized SynchronousApi singleton() {
+        if (SynchronousApi.singleton == null) {
+            SynchronousApi.singleton = new SynchronousApi();
+        }
+        return SynchronousApi.singleton;
+    }
+
+    /**
+     * Create a model via API.
+     * @param apiName One of the configured, available APIs that expects type T
+     * @param model A model to be created on API
+     * @param <T> The type of model
+     * @return The instance of the model as created on endpoint
+     */
+    @NonNull
+    public <T extends Model> T create(@NonNull String apiName, @NonNull T model) {
+        return awaitResponseData(listener ->
+            Amplify.API.mutate(apiName, model, MutationType.CREATE, listener));
+    }
+
+    /**
+     * Create a model via API. Assumes there is exactly one configured API endpoint.
+     * @param model Model to create in remote API
+     * @param <T> The type of the model
+     * @return The endpoint's understanding of what was created
+     */
+    @NonNull
+    public <T extends Model> T create(@NonNull T model) {
+        return awaitResponseData(listener -> Amplify.API.mutate(model, MutationType.CREATE, listener));
+    }
+
+    /**
+     * Create an object at the remote endpoint using a raw request.
+     * @param apiName One of the configured APIs
+     * @param request A GraphQL creation request
+     * @param <T> Type of object being created
+     * @return The endpoint's understanding of the thing that was created
+     */
+    @NonNull
+    public <T> T create(@NonNull String apiName, @NonNull GraphQLRequest<T> request) {
+        return awaitResponseData(listener -> Amplify.API.mutate(apiName, request, listener));
+    }
+
+    /**
+     * Update a model.
+     * @param apiName One of the configured API endpoints, that knows about the model type
+     * @param model A model whose ID is already known to endpoint, but that has other changes
+     * @param predicate Conditions to check on existing model in endpoint, before applying updates
+     * @param <T> The type of model being updated
+     * @return The server's understanding of the model, after the update
+     */
+    @NonNull
+    public <T extends Model> T update(
+            @NonNull String apiName, @NonNull T model, @NonNull QueryPredicate predicate) {
+        return awaitResponseData(listener ->
+            Amplify.API.mutate(apiName, model, predicate, MutationType.UPDATE, listener));
+    }
+
+    /**
+     * Update a model, without any conditional predicate.
+     * Assume there is exactly one well-configured API endpoint.
+     * @param model Updated copy of model
+     * @param <T> The type of model being updated
+     * @return The updated item as understood by the API endpoint
+     */
+    @NonNull
+    public <T extends Model> T update(@NonNull T model) {
+        return awaitResponseData(listener -> Amplify.API.mutate(model, MutationType.UPDATE, listener));
+    }
+
+    /**
+     * Attempt to update a model, but expect it not to succeed.
+     * Obtain and return the GraphQL errors from the endpoint's response.
+     * @param apiName One of the configure API endpoints, that knows about this model type
+     * @param model Model that we will attempt to update
+     * @param predicate Only update the model if these conditions are met on existing data
+     * @param <T> The type of model being updated
+     * @return Errors contained in the endpoint's response, detailing why the update didn't succeed
+     */
+    @NonNull
+    public <T extends Model> List<GraphQLResponse.Error> updateExpectingErrors(
+            @NonNull String apiName, @NonNull T model, @NonNull QueryPredicate predicate) {
+        return this.<T>awaitResponseErrors(listener ->
+            Amplify.API.mutate(apiName, model, predicate, MutationType.UPDATE, listener));
+    }
+
+    /**
+     * Gets an instance of a model by its model class and model ID.
+     * @param apiName One of the configured API endpoints
+     * @param clazz The class of model being searched at the endpoint
+     * @param modelId The ID of the model being searched
+     * @param <T> The type of the model being searched
+     * @return A result, if available
+     */
+    @NonNull
+    public <T extends Model> T get(
+            @NonNull final String apiName, @NonNull Class<T> clazz, @NonNull String modelId) {
+        return awaitResponseData(listener -> Amplify.API.query(apiName, clazz, modelId, listener));
+    }
+
+    /**
+     * Gets an instance of a model by its model class and model ID.
+     * Assumes a single endpoint is properly configured in API category.
+     * @param clazz The class of the model being queried
+     * @param modelId The ID of the specific model instance being queried
+     * @param <T> Type of model being queried
+     * @return If available, an exact match for the queried class and ID
+     */
+    @NonNull
+    public <T extends Model> T get(@NonNull Class<T> clazz, @NonNull String modelId) {
+        return awaitResponseData(listener -> Amplify.API.query(clazz, modelId, listener));
+    }
+
+    /**
+     * Peform a blocking REST GET.
+     * @param apiName A configured REST API
+     * @param options REST options for GET
+     * @return REST Response
+     */
+    @NonNull
+    public RestResponse get(@NonNull String apiName, @NonNull RestOptions options) {
+        LatchedConsumer<RestResponse> responseConsumer = LatchedConsumer.instance();
+        ResultListener<RestResponse> resultListener =
+            ResultListener.instance(responseConsumer, EmptyConsumer.of(Throwable.class));
+        Amplify.API.get(apiName, options, resultListener);
+        return responseConsumer.awaitValue();
+    }
+
+    /**
+     * Perform a REST POST.
+     * @param apiName One of the configured endpoints APIs
+     * @param options POST options
+     * @return REST Response
+     */
+    @NonNull
+    public RestResponse post(@NonNull String apiName, @NonNull RestOptions options) {
+        LatchedConsumer<RestResponse> responseConsumer = LatchedConsumer.instance();
+        ResultListener<RestResponse> responseListener =
+            ResultListener.instance(responseConsumer, EmptyConsumer.of(Throwable.class));
+        Amplify.API.post(apiName, options, responseListener);
+        return responseConsumer.awaitValue();
+    }
+
+    /**
+     * Gets a list of models of certain class and that match a querying predicate.
+     * @param apiName One of the configured API endpoints
+     * @param clazz The class of models being listed
+     * @param predicate A querying predicate to match against models of the requested class
+     * @param <T> The type of models being listed
+     * @return A list of models of the requested type, that match the predicate
+     */
+    @NonNull
+    public <T extends Model> List<T> list(
+            @NonNull String apiName,
+            @NonNull Class<T> clazz,
+            @SuppressWarnings("NullableProblems") @NonNull QueryPredicate predicate) {
+        final Iterable<T> queryResults =
+            awaitResponseData(listener -> Amplify.API.query(apiName, clazz, predicate, listener));
+        final List<T> results = new ArrayList<>();
+        for (T item : queryResults) {
+            results.add(item);
+        }
+        return Immutable.of(results);
+    }
+
+    /**
+     * Lists all remote instances of a model, by model class.
+     * @param apiName One of the configured API endpoints
+     * @param clazz The class of models being queried
+     * @param <T> The type of models being queried
+     * @return A list of all models of the requested class
+     */
+    @NonNull
+    public <T extends Model> List<T> list(@NonNull String apiName, @NonNull Class<T> clazz) {
+        //noinspection ConstantConditions To save boiler plate, we do this internally.
+        return list(apiName, clazz, null);
+    }
+
+    /**
+     * Deletes a model from the remote endpoint.
+     * @param apiName One of the configured API endpoints
+     * @param modelToDelete Model to be deleted from endpoint
+     * @param <T> Type of model being deleted
+     * @return The endpoint's view of the model that was deleted
+     */
+    @NonNull
+    public <T extends Model> T delete(@NonNull String apiName, @NonNull T modelToDelete) {
+        return awaitResponseData(listener ->
+            Amplify.API.mutate(apiName, modelToDelete, MutationType.DELETE, listener));
+    }
+
+    /**
+     * Subscribe to model creations.
+     * @param apiName One of the configured API endpoints
+     * @param clazz Class of model for which you want notifications when they're created
+     * @param <T> The type of model for which creation notifications will be dispatched
+     * @return A Cancelable interface that can be used to end the subscription
+     */
+    @NonNull
+    public <T extends Model> Subscription<T> onCreate(@NonNull String apiName, @NonNull Class<T> clazz) {
+        return createSubscription(streamListener ->
+            Amplify.API.subscribe(apiName, clazz, SubscriptionType.ON_CREATE, streamListener));
+    }
+
+    /**
+     * Subscribe to create mutations, by forming a GraphQL subscription request.
+     * @param apiName One of the configured APIs
+     * @param request A GraphQL subscription request
+     * @param <T> Type of object for which creation notifications are generated
+     * @return A subscription object representing this ongoing subscription
+     */
+    @NonNull
+    public <T> Subscription<T> onCreate(@NonNull String apiName, @NonNull GraphQLRequest<T> request) {
+        return createSubscription(streamListener -> Amplify.API.subscribe(apiName, request, streamListener));
+    }
+
+    private <T> Subscription<T> createSubscription(SubscriptionCreationMethod<T> method) {
+        LatchedResponseConsumer<T> streamItemConsumer = LatchedResponseConsumer.instance();
+        LatchedAction streamCompletionAction = LatchedAction.instance();
+        LatchedConsumer<Throwable> errorConsumer = LatchedConsumer.instance();
+        StreamListener<GraphQLResponse<T>> streamListener =
+            StreamListener.instance(streamItemConsumer, errorConsumer, streamCompletionAction);
+
+        final Cancelable cancelable = method.streamTo(streamListener);
+        if (cancelable == null) {
+            throw new RuntimeException("Got a null operation back from API subscribe.");
+        }
+
+        return new Subscription<>(
+            streamItemConsumer,
+            errorConsumer,
+            streamCompletionAction,
+            cancelable
+        );
+    }
+
+    private <T> T awaitResponseData(AsyncOperation<T> operation) {
+        LatchedResponseConsumer<T> responseConsumer = LatchedResponseConsumer.instance();
+        ResultListener<GraphQLResponse<T>> responseListener =
+            ResultListener.instance(responseConsumer, EmptyConsumer.of(Throwable.class));
+        operation.respondWith(responseListener);
+        return responseConsumer.awaitResponseData();
+    }
+
+    private <T> List<GraphQLResponse.Error> awaitResponseErrors(AsyncOperation<T> operation) {
+        LatchedResponseConsumer<T> responseConsumer = LatchedResponseConsumer.instance();
+        ResultListener<GraphQLResponse<T>> responseListener =
+            ResultListener.instance(responseConsumer, EmptyConsumer.of(Throwable.class));
+        operation.respondWith(responseListener);
+        return responseConsumer.awaitErrorsInNextResponse();
+    }
+
+    interface AsyncOperation<T> {
+        void respondWith(ResultListener<GraphQLResponse<T>> responseListener);
+    }
+
+    interface SubscriptionCreationMethod<T> {
+        Cancelable streamTo(StreamListener<GraphQLResponse<T>> streamListener);
+    }
+
+    /**
+     * A subscription instance provides synchronous methods to interact
+     * with an ongoing background subscription.
+     * @param <T> Type of data that is subscribed
+     */
+    @SuppressWarnings("unused")
+    public static final class Subscription<T> {
+        private final LatchedResponseConsumer<T> itemConsumer;
+        private final LatchedConsumer<Throwable> errorConsumer;
+        private final LatchedAction completionAction;
+        private final Cancelable cancellationMethod;
+
+        Subscription(
+                @NonNull LatchedResponseConsumer<T> itemConsumer,
+                @NonNull LatchedConsumer<Throwable> errorConsumer,
+                @NonNull LatchedAction completionAction,
+                @NonNull Cancelable cancellationMethod) {
+            this.itemConsumer = itemConsumer;
+            this.errorConsumer = errorConsumer;
+            this.completionAction = completionAction;
+            this.cancellationMethod = cancellationMethod;
+        }
+
+        /**
+         * Await the first value that arrives on the subscription.
+         * Its response envelope must not contain any errors.
+         * @return The first value received on the subscription
+         */
+        @NonNull
+        public T awaitFirstValue() {
+            return itemConsumer.awaitResponseData();
+        }
+
+        /**
+         * Await values to arrive in responses. Respones must not contain errors.
+         * @param count Number of values to await
+         * @return The values
+         */
+        @NonNull
+        public List<T> awaitValues(int count) {
+            return Immutable.of(itemConsumer.awaitResponseData(count));
+        }
+
+        /**
+         * Await the next response, and validate that it contains errors,
+         * and return them.
+         * @return The errors in the next response
+         */
+        @NonNull
+        public List<GraphQLResponse.Error> awaitNextResponseErrors() {
+            return Immutable.of(itemConsumer.awaitErrorsInNextResponse());
+        }
+
+        /**
+         * Wait for the subscription to commplete.
+         */
+        public void awaitSubscriptionCompletion() {
+            completionAction.awaitCall();
+        }
+
+        /**
+         * Await a failure of the subscription.
+         * @return The failure
+         */
+        @NonNull
+        public Throwable awaitSubscriptionFailure() {
+            return errorConsumer.awaitValue();
+        }
+
+        /**
+         * Cancel the subscription.
+         */
+        public void cancel() {
+            cancellationMethod.cancel();
+        }
+    }
+}

--- a/testutils/src/main/java/com/amplifyframework/testutils/SynchronousDataStore.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/SynchronousDataStore.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreItemChange;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * A utility to facilitate synchronous calls to the Amplify DataStore category.
+ * This is not appropriate for production use, but is valuable in test code.
+ * Test code wants to perform a series of sequential verifications, with the assumption
+ * that a DataStore operation has completed with some kind of terminal result.
+ */
+public final class SynchronousDataStore {
+    private static SynchronousDataStore singleton;
+
+    @SuppressWarnings("checkstyle:all") private SynchronousDataStore() {}
+
+    /**
+     * Gets a singleton instance of the SynchronousDataStore.
+     * @return Singleton instance of Synchronous DataStore
+     */
+    @NonNull
+    public static synchronized SynchronousDataStore singleton() {
+        if (SynchronousDataStore.singleton == null) {
+            SynchronousDataStore.singleton = new SynchronousDataStore();
+        }
+        return SynchronousDataStore.singleton;
+    }
+
+    /**
+     * Saves an item into the DataStore.
+     * @param item Item to save
+     * @param <T> The type of item being saved
+     */
+    public <T extends Model> void save(@NonNull T item) {
+        LatchedConsumer<DataStoreItemChange<T>> saveConsumer = LatchedConsumer.instance();
+        ResultListener<DataStoreItemChange<T>> resultListener =
+            ResultListener.instance(saveConsumer, EmptyConsumer.of(Throwable.class));
+        Amplify.DataStore.save(item, resultListener);
+        saveConsumer.awaitValue();
+    }
+
+    /**
+     * Search for an item in the DataStore by its class type and ID.
+     * @param clazz Class of item being accessed
+     * @param itemId Unique ID of the item being accessed
+     * @param <T> The type of item being accessed
+     * @return An item with the provided class and ID, if present in DataStore
+     * @throws NoSuchElementException If there is no matching item in the DataStore
+     */
+    @NonNull
+    public <T extends Model> T get(@NonNull Class<T> clazz, @NonNull String itemId) {
+        LatchedConsumer<Iterator<T>> queryConsumer = LatchedConsumer.instance();
+        ResultListener<Iterator<T>> resultListener =
+            ResultListener.instance(queryConsumer, EmptyConsumer.of(Throwable.class));
+        Amplify.DataStore.query(clazz, resultListener);
+
+        final Iterator<T> iterator = queryConsumer.awaitValue();
+        while (iterator.hasNext()) {
+            T value = iterator.next();
+            if (value.getId().equals(itemId)) {
+                return value;
+            }
+        }
+
+        throw new NoSuchElementException("No item in DataStore with class = " + clazz + " and id = " + itemId);
+    }
+}


### PR DESCRIPTION
Centralizes use of latches into test utility methods/classes. Declutters
test code to help focus on the meaning of the tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
