### PR TITLE
Use Retrolambda for broader consumer compatibility

### DIFF
--- a/aws-analytics-pinpoint/build.gradle
+++ b/aws-analytics-pinpoint/build.gradle
@@ -15,6 +15,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply from: rootProject.file("configuration/retrolambda.gradle")
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/android-lint.gradle")
 apply from: rootProject.file('gradle-mvn-push.gradle')

--- a/aws-api/build.gradle
+++ b/aws-api/build.gradle
@@ -15,6 +15,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply from: rootProject.file("configuration/retrolambda.gradle")
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/android-lint.gradle")
 apply from: rootProject.file('gradle-mvn-push.gradle')

--- a/aws-datastore/build.gradle
+++ b/aws-datastore/build.gradle
@@ -15,6 +15,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply from: rootProject.file("configuration/retrolambda.gradle")
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/android-lint.gradle")
 apply from: rootProject.file('gradle-mvn-push.gradle')

--- a/aws-storage-s3/build.gradle
+++ b/aws-storage-s3/build.gradle
@@ -15,6 +15,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply from: rootProject.file("configuration/retrolambda.gradle")
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/android-lint.gradle")
 apply from: rootProject.file('gradle-mvn-push.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.3'
+        classpath 'me.tatarka:gradle-retrolambda:3.7.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/configuration/retrolambda.gradle
+++ b/configuration/retrolambda.gradle
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+apply plugin: 'me.tatarka.retrolambda'
+
+retrolambda {
+    jvmArgs "-Dretrolambda.quiet=true"
+}
+

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,6 +15,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply from: rootProject.file("configuration/retrolambda.gradle")
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/android-lint.gradle")
 apply from: rootProject.file('gradle-mvn-push.gradle')

--- a/testmodels/build.gradle
+++ b/testmodels/build.gradle
@@ -14,6 +14,7 @@
  */
 
 apply plugin: 'com.android.library'
+apply from: rootProject.file("configuration/retrolambda.gradle")
 
 android {
     compileSdkVersion 29

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -14,6 +14,7 @@
  */
 
 apply plugin: 'com.android.library'
+apply from: rootProject.file("configuration/retrolambda.gradle")
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/android-lint.gradle")
 


### PR DESCRIPTION
To reduce friction in using the library, Retrolambda is used to convert
class files to Java class file version 50. before producing aars. This
prevents the need for the user to elect Java 1.8 source and target
compatibility in their consuming project. This configuration may also be
more compatible with older versions of the Android Studio and Android
Build Tools, that may be found in a user's environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
