### PR TITLE
[Storage] Split success and error callbacks

### DIFF
--- a/aws-storage-s3/src/main/AndroidManifest.xml
+++ b/aws-storage-s3/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.amplifyframework.storage" >
+    package="com.amplifyframework.storage.s3" >
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application>

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -18,6 +18,7 @@ package com.amplifyframework.storage.s3;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.storage.StorageAccessLevel;
 import com.amplifyframework.storage.StorageException;
@@ -146,8 +147,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
-        return downloadFile(key, local, StorageDownloadFileOptions.defaultInstance(), resultListener);
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return downloadFile(key, local, StorageDownloadFileOptions.defaultInstance(), onSuccess, onError);
     }
 
     @NonNull
@@ -156,13 +158,17 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageDownloadFileOptions options,
-            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
         AWSS3StorageDownloadFileRequest request = new AWSS3StorageDownloadFileRequest(
                 key,
                 local,
                 options.getAccessLevel() != null ? options.getAccessLevel() : defaultAccessLevel,
                 options.getTargetIdentityId()
         );
+
+        ResultListener<StorageDownloadFileResult, StorageException> resultListener =
+                ResultListener.instance(onSuccess, onError);
 
         AWSS3StorageDownloadFileOperation operation =
                 new AWSS3StorageDownloadFileOperation(storageService, request, resultListener);
@@ -176,8 +182,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
-        return uploadFile(key, local, StorageUploadFileOptions.defaultInstance(), resultListener);
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return uploadFile(key, local, StorageUploadFileOptions.defaultInstance(), onSuccess, onError);
     }
 
     @NonNull
@@ -186,7 +193,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageUploadFileOptions options,
-            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+
         AWSS3StorageUploadFileRequest request = new AWSS3StorageUploadFileRequest(
                 key,
                 local,
@@ -195,6 +204,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                 options.getContentType(),
                 options.getMetadata()
         );
+
+        ResultListener<StorageUploadFileResult, StorageException> resultListener =
+                ResultListener.instance(onSuccess, onError);
 
         AWSS3StorageUploadFileOperation operation =
                 new AWSS3StorageUploadFileOperation(storageService, request, resultListener);
@@ -208,8 +220,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
-            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
-        return remove(key, StorageRemoveOptions.defaultInstance(), resultListener);
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return remove(key, StorageRemoveOptions.defaultInstance(), onSuccess, onError);
     }
 
     @NonNull
@@ -217,12 +230,16 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
             @NonNull StorageRemoveOptions options,
-            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
         AWSS3StorageRemoveRequest request = new AWSS3StorageRemoveRequest(
                 key,
                 options.getAccessLevel() != null ? options.getAccessLevel() : defaultAccessLevel,
                 options.getTargetIdentityId()
         );
+
+        ResultListener<StorageRemoveResult, StorageException> resultListener =
+                ResultListener.instance(onSuccess, onError);
 
         AWSS3StorageRemoveOperation operation =
                 new AWSS3StorageRemoveOperation(storageService, executorService, request, resultListener);
@@ -236,8 +253,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
-            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
-        return list(path, StorageListOptions.defaultInstance(), resultListener);
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return list(path, StorageListOptions.defaultInstance(), onSuccess, onError);
     }
 
     @NonNull
@@ -245,12 +263,16 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     public StorageListOperation<?> list(
             @NonNull String path,
             @NonNull StorageListOptions options,
-            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
         AWSS3StorageListRequest request = new AWSS3StorageListRequest(
                 path,
                 options.getAccessLevel() != null ? options.getAccessLevel() : defaultAccessLevel,
                 options.getTargetIdentityId()
         );
+
+        ResultListener<StorageListResult, StorageException> resultListener =
+                ResultListener.instance(onSuccess, onError);
 
         AWSS3StorageListOperation operation =
                 new AWSS3StorageListOperation(storageService, executorService, request, resultListener);
@@ -297,3 +319,4 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         }
     }
 }
+

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
@@ -17,7 +17,7 @@ package com.amplifyframework.storage;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.storage.operation.StorageDownloadFileOperation;
@@ -51,8 +51,9 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
-        return getSelectedPlugin().downloadFile(key, local, resultListener);
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return getSelectedPlugin().downloadFile(key, local, onSuccess, onError);
     }
 
     @NonNull
@@ -61,8 +62,9 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageDownloadFileOptions options,
-            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener) {
-        return getSelectedPlugin().downloadFile(key, local, options, resultListener);
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return getSelectedPlugin().downloadFile(key, local, options, onSuccess, onError);
     }
 
     @NonNull
@@ -70,8 +72,9 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
-        return getSelectedPlugin().uploadFile(key, local, resultListener);
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return getSelectedPlugin().uploadFile(key, local, onSuccess, onError);
     }
 
     @NonNull
@@ -80,16 +83,18 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageUploadFileOptions options,
-            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener) {
-        return getSelectedPlugin().uploadFile(key, local, options, resultListener);
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return getSelectedPlugin().uploadFile(key, local, options, onSuccess, onError);
     }
 
     @NonNull
     @Override
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
-            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
-        return getSelectedPlugin().remove(key, resultListener);
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return getSelectedPlugin().remove(key, onSuccess, onError);
     }
 
     @NonNull
@@ -97,16 +102,18 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
     public StorageRemoveOperation<?> remove(
             @NonNull String key,
             @NonNull StorageRemoveOptions options,
-            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener) {
-        return getSelectedPlugin().remove(key, options, resultListener);
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return getSelectedPlugin().remove(key, options, onSuccess, onError);
     }
 
     @NonNull
     @Override
     public StorageListOperation<?> list(
             @NonNull String path,
-            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
-        return getSelectedPlugin().list(path, resultListener);
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return getSelectedPlugin().list(path, onSuccess, onError);
     }
 
     @NonNull
@@ -114,8 +121,9 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
     public StorageListOperation<?> list(
             @NonNull String path,
             @NonNull StorageListOptions options,
-            @NonNull ResultListener<StorageListResult, StorageException> resultListener) {
-        return getSelectedPlugin().list(path, options, resultListener);
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<StorageException> onError) {
+        return getSelectedPlugin().list(path, options, onSuccess, onError);
     }
 }
 

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
@@ -17,7 +17,7 @@ package com.amplifyframework.storage;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.storage.operation.StorageDownloadFileOperation;
 import com.amplifyframework.storage.operation.StorageListOperation;
 import com.amplifyframework.storage.operation.StorageRemoveOperation;
@@ -34,14 +34,16 @@ import com.amplifyframework.storage.result.StorageUploadFileResult;
 /**
  * Defines the behavior of the Storage category that clients will use.
  */
+@SuppressWarnings("unused")
 public interface StorageCategoryBehavior {
 
     /**
      * Download object to file from storage.
-     * Register a listener to get the download results.
+     * Provide callbacks to obtain the download results.
      * @param key the unique identifier for the object in storage
      * @param local the path to a local file
-     * @param resultListener Listens for the results of the download
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
@@ -49,19 +51,20 @@ public interface StorageCategoryBehavior {
     StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener
-    );
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError);
 
     /**
      * Download object to memory from storage.
      * Set advanced options such as the access level of the object
      * you want to retrieve (you can have different objects with
      * the same name under different access levels).
-     * Register a listener to get the results of the download.
+     * Provide callbacks to obtain the results of the download.
      * @param key the unique identifier for the object in storage
      * @param local the path to a local file
      * @param options parameters specific to plugin behavior
-     * @param resultListener Listens for the results of the download
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
@@ -70,15 +73,16 @@ public interface StorageCategoryBehavior {
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageDownloadFileOptions options,
-            @NonNull ResultListener<StorageDownloadFileResult, StorageException> resultListener
-    );
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError);
 
     /**
      * Upload local file on given path to storage.
      * Register a listener to obtain the results of the upload.
      * @param key the unique identifier of the object in storage
      * @param local the path to a local file
-     * @param resultListener Listens for results of upload request
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
@@ -86,8 +90,8 @@ public interface StorageCategoryBehavior {
     StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull String local,
-            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener
-    );
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError);
 
     /**
      * Upload local file on given path to storage.
@@ -96,7 +100,8 @@ public interface StorageCategoryBehavior {
      * @param key the unique identifier of the object in storage
      * @param local the path to a local file
      * @param options parameters specific to plugin behavior
-     * @param resultListener Listens to results of upload request
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
@@ -105,29 +110,30 @@ public interface StorageCategoryBehavior {
             @NonNull String key,
             @NonNull String local,
             @NonNull StorageUploadFileOptions options,
-            @NonNull ResultListener<StorageUploadFileResult, StorageException> resultListener
-    );
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError);
 
     /**
      * Delete object from storage.
      * @param key the unique identifier of the object in storage
-     * @param resultListener Listens to results of remove operation
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *        actions related to the execution of the work
-     *
      */
     @NonNull
     StorageRemoveOperation<?> remove(
             @NonNull String key,
-            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener
-    );
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<StorageException> onError);
 
     /**
      * Delete object from storage.
      * Register a listener to get results of remove operation.
      * @param key the unique identifier of the object in storage
      * @param options parameters specific to plugin behavior
-     * @param resultListener Listens for results of remove request.
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *        actions related to the execution of the work
      */
@@ -135,22 +141,23 @@ public interface StorageCategoryBehavior {
     StorageRemoveOperation<?> remove(
             @NonNull String key,
             @NonNull StorageRemoveOptions options,
-            @NonNull ResultListener<StorageRemoveResult, StorageException> resultListener
-    );
+            @NonNull Consumer<StorageRemoveResult> onSuccess,
+            @NonNull Consumer<StorageException> onError);
 
     /**
      * List the object identifiers under the hierarchy specified
      * by the path, relative to access level, from storage.
      * @param path The path in storage to list items from
-     * @param resultListener Listens for results of list operation
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
     @NonNull
     StorageListOperation<?> list(
             @NonNull String path,
-            @NonNull ResultListener<StorageListResult, StorageException> resultListener
-    );
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<StorageException> onError);
 
     /**
      * List the object identifiers under the hierarchy specified
@@ -158,7 +165,8 @@ public interface StorageCategoryBehavior {
      * Register a listener to observe progress.
      * @param path The path in storage to list items from
      * @param options parameters specific to plugin behavior
-     * @param resultListener listens to results of list operation
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
      *         actions related to the execution of the work
      */
@@ -166,6 +174,7 @@ public interface StorageCategoryBehavior {
     StorageListOperation<?> list(
             @NonNull String path,
             @NonNull StorageListOptions options,
-            @NonNull ResultListener<StorageListResult, StorageException> resultListener
-    );
+            @NonNull Consumer<StorageListResult> onSuccess,
+            @NonNull Consumer<StorageException> onError);
 }
+


### PR DESCRIPTION
The APIs of the Storage category are reworked. Instead of accepting a
`ResultListener<SomeTypeOfStorageResult, StorageException>` as a single callback argument, all APIs will now accept
two "decomposed" functional interfaces, a
`Consumer<SomeTypeOfStorageResult>`, and a `Consumer<StorageException>`.

This change enables a simpler experience for the caller.

Instead of obtaining results like:

```
final StorageListOperation<?> operation =
    Amplify.Storage.list(path, new ResultListener() {
        @Override
        public void onResult(StorageListResult storageListResult) {
            Log.i(TAG, "Got a result! " + storageListResult);
        }

        @Override
        public void onError(StorageException error) {
            Log.e(TAG, "Listing storage items failed.", error);
        }
    });
```

The user may now more simply write:
```
final StorageListOperation<?> operation =
    Amplify.Storage.list(path,
        result -> Log.i(TAG, "Got a result! " + storageListResult),
        error -> Log.e(TAG, "Listing storage items failed.", error)
    );
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.