### PR TITLE
[API] Accept Lambdas for REST Behaviors

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -35,6 +35,7 @@ import com.amplifyframework.api.rest.RestOperation;
 import com.amplifyframework.api.rest.RestOperationRequest;
 import com.amplifyframework.api.rest.RestOptions;
 import com.amplifyframework.api.rest.RestResponse;
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.StreamListener;
 import com.amplifyframework.core.model.Model;
@@ -448,15 +449,16 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     @Override
     public RestOperation get(
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         final String apiName;
         try {
             apiName = getSelectedApiName(EndpointType.REST);
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
-        return get(apiName, options, responseListener);
+        return get(apiName, options, onResponse, onFailure);
     }
 
     @Nullable
@@ -464,15 +466,17 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     public RestOperation get(
             @NonNull String apiName,
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         try {
             return createRestOperation(
                     apiName,
                     HttpMethod.GET,
                     options,
-                    responseListener);
+                    ResultListener.instance(onResponse, onFailure)
+            );
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
     }
@@ -481,15 +485,16 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     @Override
     public RestOperation put(
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         final String apiName;
         try {
             apiName = getSelectedApiName(EndpointType.REST);
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
-        return put(apiName, options, responseListener);
+        return put(apiName, options, onResponse, onFailure);
     }
 
     @Nullable
@@ -497,15 +502,17 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     public RestOperation put(
             @NonNull String apiName,
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         try {
             return createRestOperation(
                     apiName,
                     HttpMethod.PUT,
                     options,
-                    responseListener);
+                    ResultListener.instance(onResponse, onFailure)
+            );
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
     }
@@ -514,15 +521,16 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     @Override
     public RestOperation post(
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         final String apiName;
         try {
             apiName = getSelectedApiName(EndpointType.REST);
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
-        return post(apiName, options, responseListener);
+        return post(apiName, options, onResponse, onFailure);
     }
 
     @Nullable
@@ -530,15 +538,17 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     public RestOperation post(
             @NonNull String apiName,
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         try {
             return createRestOperation(
                     apiName,
                     HttpMethod.POST,
                     options,
-                    responseListener);
+                    ResultListener.instance(onResponse, onFailure)
+            );
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
     }
@@ -547,15 +557,16 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     @Override
     public RestOperation delete(
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         final String apiName;
         try {
             apiName = getSelectedApiName(EndpointType.REST);
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
-        return delete(apiName, options, responseListener);
+        return delete(apiName, options, onResponse, onFailure);
     }
 
     @Nullable
@@ -563,15 +574,17 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     public RestOperation delete(
             @NonNull String apiName,
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         try {
             return createRestOperation(
                     apiName,
                     HttpMethod.DELETE,
                     options,
-                    responseListener);
+                    ResultListener.instance(onResponse, onFailure)
+            );
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
     }
@@ -580,15 +593,16 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     @Override
     public RestOperation head(
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         final String apiName;
         try {
             apiName = getSelectedApiName(EndpointType.REST);
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
-        return head(apiName, options, responseListener);
+        return head(apiName, options, onResponse, onFailure);
     }
 
     @Nullable
@@ -596,15 +610,17 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     public RestOperation head(
             @NonNull String apiName,
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         try {
             return createRestOperation(
                     apiName,
                     HttpMethod.HEAD,
                     options,
-                    responseListener);
+                    ResultListener.instance(onResponse, onFailure)
+            );
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
     }
@@ -613,15 +629,16 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     @Override
     public RestOperation patch(
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         final String apiName;
         try {
             apiName = getSelectedApiName(EndpointType.REST);
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
-        return patch(apiName, options, responseListener);
+        return patch(apiName, options, onResponse, onFailure);
     }
 
     @Nullable
@@ -629,15 +646,17 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     public RestOperation patch(
             @NonNull String apiName,
             @NonNull RestOptions options,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
         try {
             return createRestOperation(
                     apiName,
                     HttpMethod.PATCH,
                     options,
-                    responseListener);
+                    ResultListener.instance(onResponse, onFailure)
+            );
         } catch (ApiException exception) {
-            responseListener.onError(exception);
+            onFailure.accept(exception);
             return null;
         }
     }

--- a/core/src/main/java/com/amplifyframework/api/ApiCategory.java
+++ b/core/src/main/java/com/amplifyframework/api/ApiCategory.java
@@ -26,6 +26,7 @@ import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.api.rest.RestOperation;
 import com.amplifyframework.api.rest.RestOptions;
 import com.amplifyframework.api.rest.RestResponse;
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.StreamListener;
 import com.amplifyframework.core.category.Category;
@@ -215,8 +216,9 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     @Override
     public RestOperation get(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().get(request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().get(request, onResponse, onFailure);
     }
 
     @Nullable
@@ -224,16 +226,18 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation get(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().get(apiName, request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().get(apiName, request, onResponse, onFailure);
     }
 
     @Nullable
     @Override
     public RestOperation put(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().put(request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().put(request, onResponse, onFailure);
     }
 
     @Nullable
@@ -241,16 +245,18 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation put(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().put(apiName, request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().put(apiName, request, onResponse, onFailure);
     }
 
     @Nullable
     @Override
     public RestOperation post(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().post(request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().post(request, onResponse, onFailure);
     }
 
     @Nullable
@@ -258,16 +264,18 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation post(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().post(apiName, request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().post(apiName, request, onResponse, onFailure);
     }
 
     @Nullable
     @Override
     public RestOperation delete(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().delete(request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().delete(request, onResponse, onFailure);
     }
 
     @Nullable
@@ -275,16 +283,18 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation delete(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().delete(apiName, request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().delete(apiName, request, onResponse, onFailure);
     }
 
     @Nullable
     @Override
     public RestOperation head(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().head(request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().head(request, onResponse, onFailure);
     }
 
     @Nullable
@@ -292,16 +302,18 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation head(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().head(apiName, request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().head(apiName, request, onResponse, onFailure);
     }
 
     @Nullable
     @Override
     public RestOperation patch(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().patch(request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().patch(request, onResponse, onFailure);
     }
 
     @Nullable
@@ -309,8 +321,9 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public RestOperation patch(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener) {
-        return getSelectedPlugin().patch(apiName, request, responseListener);
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().patch(apiName, request, onResponse, onFailure);
     }
 }
 

--- a/core/src/main/java/com/amplifyframework/api/RestBehavior.java
+++ b/core/src/main/java/com/amplifyframework/api/RestBehavior.java
@@ -21,7 +21,7 @@ import androidx.annotation.Nullable;
 import com.amplifyframework.api.rest.RestOperation;
 import com.amplifyframework.api.rest.RestOptions;
 import com.amplifyframework.api.rest.RestResponse;
-import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.Consumer;
 
 /**
  * REST behaviors which include the family of HTTP verbs (GET, POST, etc.).
@@ -31,20 +31,23 @@ public interface RestBehavior {
     /**
      * This is a helper method for easily invoking GET HTTP request.
      * Requires that only one API is configured in your
-     * `amplifyconfiguration.json`. Otherwise, emits an ApiException
-     * to the provided `ResultListener`.
+     * `amplifyconfiguration.json`. Otherwise, emits an {@link ApiException}
+     * to the provided `onFailure` callback.
      *
      * @param request GET request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
     @Nullable
     RestOperation get(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
@@ -52,9 +55,11 @@ public interface RestBehavior {
      *
      * @param apiName The name of a configured API.
      * @param request GET request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
@@ -62,26 +67,30 @@ public interface RestBehavior {
     RestOperation get(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
      * This is a helper method for easily invoking PUT HTTP request.
      * Requires that only one API is configured in your
-     * `amplifyconfiguration.json`. Otherwise, emits an ApiException
-     * to the provided `ResultListener`.
+     * `amplifyconfiguration.json`. Otherwise, emits an {@link ApiException}
+     * to the provided `onFailure` callback.
      *
      * @param request PUT request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
     @Nullable
     RestOperation put(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
@@ -89,9 +98,11 @@ public interface RestBehavior {
      *
      * @param apiName The name of a configured API.
      * @param request PUT request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
@@ -99,26 +110,30 @@ public interface RestBehavior {
     RestOperation put(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
      * This is a helper method for easily invoking POST HTTP request.
      * Requires that only one API is configured in your
-     * `amplifyconfiguration.json`. Otherwise, emits an ApiException
-     * to the provided `ResultListener`.
+     * `amplifyconfiguration.json`. Otherwise, emits an {@link ApiException}
+     * to the provided `onFailure` callback.
      *
      * @param request POST request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
     @Nullable
     RestOperation post(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
@@ -126,9 +141,11 @@ public interface RestBehavior {
      *
      * @param apiName The name of a configured API.
      * @param request POST request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
@@ -136,26 +153,30 @@ public interface RestBehavior {
     RestOperation post(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
      * This is a helper method for easily invoking DELETE HTTP request.
      * Requires that only one API is configured in your
-     * `amplifyconfiguration.json`. Otherwise, emits an ApiException
-     * to the provided `ResultListener`.
+     * `amplifyconfiguration.json`. Otherwise, emits an {@link ApiException}
+     * to the provided `onFailure` callback.
      *
      * @param request DELETE request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
     @Nullable
     RestOperation delete(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
@@ -163,9 +184,11 @@ public interface RestBehavior {
      *
      * @param apiName The name of a configured API.
      * @param request DELETE request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
@@ -173,26 +196,30 @@ public interface RestBehavior {
     RestOperation delete(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
      * This is a helper method for easily invoking HEAD HTTP request.
      * Requires that only one API is configured in your
-     * `amplifyconfiguration.json`. Otherwise, emits an ApiException
-     * to the provided `ResultListener`.
+     * `amplifyconfiguration.json`. Otherwise, emits an {@link ApiException}
+     * to the provided `onFailure` callback.
      *
      * @param request HEAD request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
     @Nullable
     RestOperation head(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
@@ -200,9 +227,11 @@ public interface RestBehavior {
      *
      * @param apiName The name of a configured API.
      * @param request HEAD request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
@@ -210,26 +239,30 @@ public interface RestBehavior {
     RestOperation head(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
      * This is a helper method for easily invoking PATCH HTTP request.
      * Requires that only one API is configured in your
-     * `amplifyconfiguration.json`. Otherwise, emits an ApiException
-     * to the provided `ResultListener`.
+     * `amplifyconfiguration.json`. Otherwise, emits an {@link ApiException}
+     * to the provided `onFailure` callback.
      *
      * @param request PATCH request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
     @Nullable
     RestOperation patch(
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 
     /**
@@ -237,9 +270,11 @@ public interface RestBehavior {
      *
      * @param apiName The name of a configured API.
      * @param request PATCH request object.
-     * @param responseListener
-     *      Invoked when response data/errors are available. If null,
-     *      response can still be obtained via Hub.
+     * @param onResponse
+     *        Invoked when a response is available from the REST endpoint.
+     *        A response may contain a non-200 error code from the endpoint.
+     * @param onFailure
+     *        Invoked upon failure to obtain a response from the REST endpoint
      * @return An {@link ApiOperation} to track progress and provide
      * a means to cancel the asynchronous operation
      */
@@ -247,6 +282,7 @@ public interface RestBehavior {
     RestOperation patch(
             @NonNull String apiName,
             @NonNull RestOptions request,
-            @NonNull ResultListener<RestResponse, ApiException> responseListener
+            @NonNull Consumer<RestResponse> onResponse,
+            @NonNull Consumer<ApiException> onFailure
     );
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/SynchronousApi.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/SynchronousApi.java
@@ -174,9 +174,7 @@ public final class SynchronousApi {
     @NonNull
     public RestResponse get(@NonNull String apiName, @NonNull RestOptions options) {
         LatchedConsumer<RestResponse> responseConsumer = LatchedConsumer.instance();
-        ResultListener<RestResponse, ApiException> resultListener =
-            ResultListener.instance(responseConsumer, EmptyConsumer.of(ApiException.class));
-        Amplify.API.get(apiName, options, resultListener);
+        Amplify.API.get(apiName, options, responseConsumer, EmptyConsumer.of(ApiException.class));
         return responseConsumer.awaitValue();
     }
 
@@ -189,9 +187,7 @@ public final class SynchronousApi {
     @NonNull
     public RestResponse post(@NonNull String apiName, @NonNull RestOptions options) {
         LatchedConsumer<RestResponse> responseConsumer = LatchedConsumer.instance();
-        ResultListener<RestResponse, ApiException> responseListener =
-            ResultListener.instance(responseConsumer, EmptyConsumer.of(ApiException.class));
-        Amplify.API.post(apiName, options, responseListener);
+        Amplify.API.post(apiName, options, responseConsumer, EmptyConsumer.of(ApiException.class));
         return responseConsumer.awaitValue();
     }
 


### PR DESCRIPTION
The `ResultListener` callback is removed from the public contract.
Previously, the syntax to perform a REST behavior was verbose:
```
Amplify.API.post(request, new ResultListener<RestResponse, ApiException>() {
    @Override
    public void onResult(RestResponse response) {
        Log.i("API", "POST response: " + response),
    }

    @Override
    public void onError(ApiException failure) {
        Log.e("API", "No response for POST.", failure);
    }
});
```
By splitting the callbacks into the `Consumer<RestResponse>` and
`Consumer<ApiException>`, the behavior may accept lambas:

```
Amplify.API.post(request,
    response -> Log.i("API", "POST response: " + response),
    failure -> Log.e("API", "No response for POST.", failure)
);
```

See GitHub issue: https://github.com/aws-amplify/amplify-android/issues/212

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
