### PR TITLE
[DataStore] Pure Lambda API for DataStore

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -20,6 +20,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.StreamListener;
+import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchema;
@@ -28,8 +30,6 @@ import com.amplifyframework.datastore.DataStoreException;
 
 import java.util.Iterator;
 import java.util.List;
-
-import io.reactivex.Observable;
 
 /**
  * A LocalStorageAdapter provides a simple set of interactions to
@@ -132,11 +132,16 @@ public interface LocalStorageAdapter {
 
     /**
      * Observe all changes to that occur to any/all objects in the storage.
-     * @return An observable which emits an {@link StorageItemChange} notification every time
-     *         any object managed by the storage adapter is changed in any way.
+     * @param itemChangeListener
+     *        Receives a {@link StorageItemChange} notification every time
+     *        any object managed by the storage adapter is changed in any way. Terminates
+     *        with error or successful completion action.
+     * @return A Cancelable with which this observation may be terminated
      */
     @NonNull
-    Observable<StorageItemChange.Record> observe();
+    Cancelable observe(
+            @NonNull StreamListener<StorageItemChange.Record, DataStoreException> itemChangeListener
+    );
 
     /**
      * Terminate use of the local storage.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -27,6 +27,8 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.StreamListener;
+import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelProvider;
@@ -68,8 +70,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import io.reactivex.Completable;
-import io.reactivex.Observable;
 import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
 
 /**
@@ -437,8 +439,24 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
      */
     @NonNull
     @Override
-    public Observable<StorageItemChange.Record> observe() {
-        return itemChangeSubject;
+    public Cancelable observe(
+            @NonNull StreamListener<StorageItemChange.Record, DataStoreException> itemChangeListener) {
+        Disposable disposable = itemChangeSubject.subscribe(
+            itemChangeListener::onNext,
+            failure -> {
+                if (failure instanceof DataStoreException) {
+                    itemChangeListener.onError((DataStoreException) failure);
+                    return;
+                }
+                itemChangeListener.onError(new DataStoreException(
+                    "Failed to observe items in storage adapter.",
+                    failure,
+                    "Inspect the failure details."
+                ));
+            },
+            itemChangeListener::onComplete
+        );
+        return disposable::dispose;
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/network/DataHydrationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/network/DataHydrationTest.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.datastore.network;
 
+import com.amplifyframework.core.StreamListener;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
@@ -80,7 +81,10 @@ public final class DataHydrationTest {
         // Arrange a subscription to the storage adapter. We're going to watch for changes.
         // We expect to see content here as a result of the DataHydration applying updates.
         final TestObserver<StorageItemChange<? extends Model>> adapterObserver = TestObserver.create();
-        inMemoryStorageAdapter.observe()
+        Observable.<StorageItemChange.Record>create(emitter ->
+            inMemoryStorageAdapter.observe(
+                StreamListener.instance(emitter::onNext, emitter::onError, emitter::onComplete)
+            ))
             .map(record -> record.toStorageItemChange(storageRecordDeserializer))
             .subscribe(adapterObserver);
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -20,6 +20,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.StreamListener;
+import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
@@ -29,7 +31,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
 
 /**
@@ -137,8 +139,23 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
 
     @NonNull
     @Override
-    public Observable<StorageItemChange.Record> observe() {
-        return changeRecordStream;
+    public Cancelable observe(
+            StreamListener<StorageItemChange.Record, DataStoreException> itemChangeListener) {
+        Disposable disposable = changeRecordStream.subscribe(
+            itemChangeListener::onNext,
+            failure -> {
+                if (failure instanceof DataStoreException) {
+                    itemChangeListener.onError((DataStoreException) failure);
+                } else {
+                    itemChangeListener.onError(new DataStoreException(
+                        "Failed to observe changes to in-memory storage adapter.",
+                        failure, "Inspect the details."
+                    ));
+                }
+            },
+            itemChangeListener::onComplete
+        );
+        return disposable::dispose;
     }
 
     @Override

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -52,19 +52,6 @@ android {
 }
 
 dependencies {
-    // Rx is part of our API signature for the DataStore category.  If a
-    // consumer of Amplify will use the Rx-based DataStore APIs, RxJava2
-    // must be available at runtime.
-    //
-    // As a corollary, a plugin should declare an `implementation`
-    // dependency on Rx, so that it can implement the needed API:
-    //
-    //   implementation 'io.reactivex.rxjava2:rxjava:2.2.13'
-    //
-    // Without this, any use of Observable will raise a runtime
-    // exception.
-    compileOnly "io.reactivex.rxjava2:rxjava:$rxJava2Version"
-
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.annotation:annotation:1.1.0'
 

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -17,15 +17,15 @@ package com.amplifyframework.datastore;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.ResultListener;
+import com.amplifyframework.core.Action;
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 
 import java.util.Iterator;
-
-import io.reactivex.Observable;
 
 /**
  * DataStore simplifies local storage of your application data on the
@@ -53,8 +53,9 @@ public class DataStoreCategory
     @Override
     public <T extends Model> void save(
             @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> saveItemListener) {
-        getSelectedPlugin().save(item, saveItemListener);
+            @NonNull Consumer<DataStoreItemChange<T>> onItemSaved,
+            @NonNull Consumer<DataStoreException> onFailureToSave) {
+        getSelectedPlugin().save(item, onItemSaved, onFailureToSave);
     }
 
     /**
@@ -64,8 +65,9 @@ public class DataStoreCategory
     public <T extends Model> void save(
             @NonNull T item,
             @NonNull QueryPredicate predicate,
-            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> saveItemListener) {
-        getSelectedPlugin().save(item, predicate, saveItemListener);
+            @NonNull Consumer<DataStoreItemChange<T>> onItemSaved,
+            @NonNull Consumer<DataStoreException> onFailureToSave) {
+        getSelectedPlugin().save(item, predicate, onItemSaved, onFailureToSave);
     }
 
     /**
@@ -74,8 +76,9 @@ public class DataStoreCategory
     @Override
     public <T extends Model> void delete(
             @NonNull T item,
-            @NonNull ResultListener<DataStoreItemChange<T>, DataStoreException> deleteItemListener) {
-        getSelectedPlugin().delete(item, deleteItemListener);
+            @NonNull Consumer<DataStoreItemChange<T>> onItemDeleted,
+            @NonNull Consumer<DataStoreException> onFailureToDelete) {
+        getSelectedPlugin().delete(item, onItemDeleted, onFailureToDelete);
     }
 
     /**
@@ -84,8 +87,9 @@ public class DataStoreCategory
     @Override
     public <T extends Model> void query(
             @NonNull Class<T> itemClass,
-            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
-        getSelectedPlugin().query(itemClass, queryResultsListener);
+            @NonNull Consumer<Iterator<T>> onQueryResults,
+            @NonNull Consumer<DataStoreException> onQueryFailure) {
+        getSelectedPlugin().query(itemClass, onQueryResults, onQueryFailure);
     }
 
     /**
@@ -95,8 +99,9 @@ public class DataStoreCategory
     public <T extends Model> void query(
             @NonNull Class<T> itemClass,
             @NonNull QueryPredicate predicate,
-            @NonNull ResultListener<Iterator<T>, DataStoreException> queryResultsListener) {
-        getSelectedPlugin().query(itemClass, predicate, queryResultsListener);
+            @NonNull Consumer<Iterator<T>> onQueryResults,
+            @NonNull Consumer<DataStoreException> onQueryFailure) {
+        getSelectedPlugin().query(itemClass, predicate, onQueryResults, onQueryFailure);
     }
 
     /**
@@ -104,8 +109,12 @@ public class DataStoreCategory
      */
     @NonNull
     @Override
-    public Observable<DataStoreItemChange<? extends Model>> observe() {
-        return getSelectedPlugin().observe();
+    public Cancelable observe(
+            @NonNull Consumer<DataStoreItemChange<? extends Model>> onDataStoreItemChange,
+            @NonNull Consumer<DataStoreException> onObservationFailure,
+            @NonNull Action onObservationCompleted) {
+        return getSelectedPlugin().observe(
+            onDataStoreItemChange, onObservationFailure, onObservationCompleted);
     }
 
     /**
@@ -113,19 +122,13 @@ public class DataStoreCategory
      */
     @NonNull
     @Override
-    public <T extends Model> Observable<DataStoreItemChange<T>> observe(@NonNull Class<T> itemClass) {
-        return getSelectedPlugin().observe(itemClass);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public <T extends Model> Observable<DataStoreItemChange<T>> observe(
+    public <T extends Model> Cancelable observe(
             @NonNull Class<T> itemClass,
-            @NonNull String uniqueId) {
-        return getSelectedPlugin().observe(itemClass, uniqueId);
+            @NonNull Consumer<DataStoreItemChange<T>> onDataStoreItemChange,
+            @NonNull Consumer<DataStoreException> onObservationFailure,
+            @NonNull Action onObservationCompleted) {
+        return getSelectedPlugin().observe(itemClass,
+            onDataStoreItemChange, onObservationFailure, onObservationCompleted);
     }
 
     /**
@@ -133,9 +136,28 @@ public class DataStoreCategory
      */
     @NonNull
     @Override
-    public <T extends Model> Observable<DataStoreItemChange<T>> observe(
+    public <T extends Model> Cancelable observe(
             @NonNull Class<T> itemClass,
-            @NonNull QueryPredicate selectionCriteria) {
-        return getSelectedPlugin().observe(itemClass, selectionCriteria);
+            @NonNull String uniqueId,
+            @NonNull Consumer<DataStoreItemChange<T>> onDataStoreItemChange,
+            @NonNull Consumer<DataStoreException> onObservationFailure,
+            @NonNull Action onObservationCompleted) {
+        return getSelectedPlugin().observe(itemClass, uniqueId,
+            onDataStoreItemChange, onObservationFailure, onObservationCompleted);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public <T extends Model> Cancelable observe(
+            @NonNull Class<T> itemClass,
+            @NonNull QueryPredicate selectionCriteria,
+            @NonNull Consumer<DataStoreItemChange<T>> onDataStoreItemChange,
+            @NonNull Consumer<DataStoreException> onObservationFailure,
+            @NonNull Action onObservationCompleted) {
+        return getSelectedPlugin().observe(itemClass, selectionCriteria,
+            onDataStoreItemChange, onObservationFailure, onObservationCompleted);
     }
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/SynchronousDataStore.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/SynchronousDataStore.java
@@ -18,7 +18,6 @@ package com.amplifyframework.testutils;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.Amplify;
-import com.amplifyframework.core.ResultListener;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.DataStoreItemChange;
@@ -56,9 +55,7 @@ public final class SynchronousDataStore {
      */
     public <T extends Model> void save(@NonNull T item) {
         LatchedConsumer<DataStoreItemChange<T>> saveConsumer = LatchedConsumer.instance();
-        ResultListener<DataStoreItemChange<T>, DataStoreException> resultListener =
-            ResultListener.instance(saveConsumer, EmptyConsumer.of(DataStoreException.class));
-        Amplify.DataStore.save(item, resultListener);
+        Amplify.DataStore.save(item, saveConsumer, EmptyConsumer.of(DataStoreException.class));
         saveConsumer.awaitValue();
     }
 
@@ -73,9 +70,7 @@ public final class SynchronousDataStore {
     @NonNull
     public <T extends Model> T get(@NonNull Class<T> clazz, @NonNull String itemId) {
         LatchedConsumer<Iterator<T>> queryConsumer = LatchedConsumer.instance();
-        ResultListener<Iterator<T>, DataStoreException> resultListener =
-            ResultListener.instance(queryConsumer, EmptyConsumer.of(DataStoreException.class));
-        Amplify.DataStore.query(clazz, resultListener);
+        Amplify.DataStore.query(clazz, queryConsumer, EmptyConsumer.of(DataStoreException.class));
 
         final Iterator<T> iterator = queryConsumer.awaitValue();
         while (iterator.hasNext()) {


### PR DESCRIPTION
1. Remove Rx from the vanilla DataStore contract. It will be made
   available via the forthcoming RxBindings wrapper module, instead.
2. Accept only functional interfaces for callbacks in DataStore APIs.
   The `ResultListener` and `StreamListener` are removed from public APIs.

Previously, operations on DataStore were verbose:
```
Amplify.DataStore.save(post, new ResultListener<DataStoreItemChange<Post>>() {
    @Override
    public void onResult(DataStoreItemChange<Post> saveResult) {
    }

    @Override
    public void onError(DataStoreException error) {
    }
});
```
Such calls have been changed to:
```
Amplify.DataStore.save(post, new Consumer<DataStoreItemChange<Post>>() {
    @Override
    public void accept(DataStoreItemChange<Post> saveResult) {
    }
}, new Consumer<DataStoreException>() {
    @Override
    public void accept(DataStoreException error) {
    }
});
```
Which may be simplified to the following, with lambda expressions:
```
Amplify.DataStore.save(post, result -> {}, failure -> {});
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
