### PR TITLE
[DataStore] Refactor in-memory storage adapter

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -165,6 +165,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
                     "This item was not found in the datastore: " + item.toString(),
                     "Use save() function to create models to store."
             ));
+            return;
         }
         Model savedItem = items.remove(index);
 


### PR DESCRIPTION
*Description of changes:*
In-memory storage adapter's current implementation does not behave as it should (e.g. it does not update/overwrite existing models).

* ~~Refactored it to store models in a HashMap for better performance~~
  * Reverted this change to not mess up data hydration test
* Distinguished update and insert
* Invoke error on conditional check failure

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
