### PR TITLE
[DataStore] Always close SQLiteCursor in instrumentation test

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelperInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelperInstrumentedTest.java
@@ -141,6 +141,7 @@ public class SQLiteStorageHelperInstrumentedTest {
                 cursor.moveToNext();
             }
         }
+        cursor.close();
         return tableNamesFromDatabase;
     }
 


### PR DESCRIPTION
An instrumentation test was using a SQLiteCursor, but was not closing
the cursor when it was done using it. This would sometimes cause a
Strict Mode violation to kill the test process, before tests could
complete execution. So, even though all of the executed tests passed,
the process still crashes, leading a failure being reported for the
suite as a whole.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.