### PR TITLE
Async configuration and release methods on Amplify facade

### DIFF
--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AmazonPinpointAnalyticsPlugin.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AmazonPinpointAnalyticsPlugin.java
@@ -17,7 +17,9 @@ package com.amplifyframework.analytics.pinpoint;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.analytics.AnalyticsEvent;
 import com.amplifyframework.analytics.AnalyticsException;
 import com.amplifyframework.analytics.AnalyticsPlugin;
@@ -175,6 +177,7 @@ public final class AmazonPinpointAnalyticsPlugin extends AnalyticsPlugin<Object>
     /**
      * {@inheritDoc}
      */
+    @WorkerThread
     @Override
     public void configure(@NonNull JSONObject pluginConfiguration, Context context) throws AnalyticsException {
 
@@ -224,6 +227,12 @@ public final class AmazonPinpointAnalyticsPlugin extends AnalyticsPlugin<Object>
         autoEventSubmitter = new AutoEventSubmitter(analyticsClient,
                 pinpointAnalyticsPluginConfiguration.getAutoFlushEventsInterval());
         autoEventSubmitter.start();
+    }
+
+    @WorkerThread
+    @Override
+    public void release(@NonNull Context context) throws AmplifyException {
+        // TODO: implement
     }
 
     /**

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -20,8 +20,10 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.annotation.WorkerThread;
 import androidx.core.util.ObjectsCompat;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiPlugin;
 import com.amplifyframework.api.aws.operation.AWSRestOperation;
@@ -99,6 +101,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         return "awsAPIPlugin";
     }
 
+    @WorkerThread
     @Override
     public void configure(@NonNull JSONObject pluginConfigurationJson, @Nullable Context context) throws ApiException {
         // Null-check for configuration is done inside readFrom method
@@ -127,6 +130,12 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             }
             apiDetails.put(apiName, new ClientDetails(apiConfiguration, okHttpClient, subscriptionEndpoint));
         }
+    }
+
+    @WorkerThread
+    @Override
+    public void release(@NonNull Context context) throws AmplifyException {
+        // TODO: implement
     }
 
     @NonNull

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -99,6 +99,7 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
      * {@inheritDoc}
      */
     @SuppressLint("CheckResult")
+    @WorkerThread
     @Override
     public void configure(
             @Nullable JSONObject pluginConfigurationJson,
@@ -121,6 +122,12 @@ public final class AWSDataStorePlugin implements DataStorePlugin<Void> {
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .blockingGet();
+    }
+
+    @WorkerThread
+    @Override
+    public void release(@NonNull Context context) throws AmplifyException {
+        // TODO: implement
     }
 
     private void startModelSynchronization(AWSDataStorePluginConfiguration.SyncMode syncMode) {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -17,7 +17,9 @@ package com.amplifyframework.storage.s3;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.storage.StorageAccessLevel;
 import com.amplifyframework.storage.StorageException;
@@ -77,6 +79,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         return AWS_S3_STORAGE_PLUGIN_KEY;
     }
 
+    @WorkerThread
     @Override
     public void configure(@NonNull JSONObject pluginConfiguration, @NonNull Context context) throws StorageException {
         String regionStr;
@@ -133,6 +136,12 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         }
 
         this.defaultAccessLevel = StorageAccessLevel.PUBLIC; // This will be passed in the config in the future
+    }
+
+    @WorkerThread
+    @Override
+    public void release(@NonNull Context context) throws AmplifyException {
+        // TODO: implement
     }
 
     @NonNull

--- a/core/src/main/java/com/amplifyframework/core/plugin/Plugin.java
+++ b/core/src/main/java/com/amplifyframework/core/plugin/Plugin.java
@@ -16,6 +16,8 @@
 package com.amplifyframework.core.plugin;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.category.CategoryTypeable;
@@ -41,7 +43,16 @@ public interface Plugin<E> extends CategoryTypeable {
      * @param context An Android Context
      * @throws AmplifyException an error is encountered during configuration.
      */
+    @WorkerThread
     void configure(JSONObject pluginConfiguration, Context context) throws AmplifyException;
+
+    /**
+     * Releases resources used by the plugin.
+     * @param context An Android Context
+     * @throws AmplifyException an error is encountered while releasing resources
+     */
+    @WorkerThread
+    void release(@NonNull Context context) throws AmplifyException;
 
     /**
      * Returns escape hatch for plugin to enable lower-level client use-cases.

--- a/core/src/main/java/com/amplifyframework/hub/AWSHubPlugin.java
+++ b/core/src/main/java/com/amplifyframework/hub/AWSHubPlugin.java
@@ -20,6 +20,9 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
+
+import com.amplifyframework.AmplifyException;
 
 import org.json.JSONObject;
 
@@ -127,9 +130,14 @@ public final class AWSHubPlugin extends HubPlugin<Void> {
         return "awsHubPlugin";
     }
 
+    @WorkerThread
     @Override
     public void configure(@NonNull JSONObject pluginConfiguration, Context context) {
+    }
 
+    @WorkerThread
+    @Override
+    public void release(@NonNull Context context) throws AmplifyException {
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/logging/AndroidLoggingPlugin.java
+++ b/core/src/main/java/com/amplifyframework/logging/AndroidLoggingPlugin.java
@@ -19,6 +19,9 @@ import android.content.Context;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
+
+import com.amplifyframework.AmplifyException;
 
 import org.json.JSONObject;
 
@@ -64,12 +67,19 @@ final class AndroidLoggingPlugin extends LoggingPlugin<Void> {
         return "AndroidLoggingPlugin";
     }
 
+    @WorkerThread
     @Override
     public void configure(
             @NonNull JSONObject pluginConfiguration,
             @NonNull Context context)
             throws LoggingException {
         // In the future, accept a log level configuration from JSON?
+    }
+
+    @WorkerThread
+    @Override
+    public void release(@NonNull Context context) throws AmplifyException {
+        // Nothing to be released?
     }
 
     @Nullable

--- a/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
+++ b/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.AmplifyException;
@@ -101,11 +102,18 @@ public class AmplifyTest {
             return uuid;
         }
 
+        @WorkerThread
         @Override
         public void configure(
                 @NonNull final JSONObject pluginConfiguration,
                 final Context context) {
             // No configuration for this one. Cool, huh?
+        }
+
+        @WorkerThread
+        @Override
+        public void release(@NonNull Context context) throws AmplifyException {
+            // No release for this one.
         }
 
         @Override


### PR DESCRIPTION
Async Configuration and Release

1. Amplify.configure(...) becomes an asynchronous method;
2. A new (also asynchronous) Amplify.release(...) is added as an
    optional cleanup hook.

See: https://github.com/aws-amplify/amplify-android/issues/215

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
