### PR TITLE
[DataStore] Use Hub notifications to communicate Sync Engine events

### DIFF
--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreChannelEventName.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreChannelEventName.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.hub.HubCategory;
+import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.hub.HubEvent;
+
+import java.util.Objects;
+
+/**
+ * An enumeration of the names of events relating the the {@link DataStoreCategory},
+ * that are published via {@link HubCategory#publish(HubChannel, HubEvent)} on the
+ * {@link HubChannel#DATASTORE} channel.
+ */
+public enum DataStoreChannelEventName {
+    /**
+     * An item in the local storage has been published to the cloud.
+     * An event that uses this value for {@link HubEvent#getName()} will contain a model object
+     * in the {@link HubEvent#getData()}.
+     */
+    PUBLISHED_TO_CLOUD("published_to_cloud"),
+
+    /**
+     * A model was updated locally, from a model version that was received from the cloud.
+     * An event that uses this value for {@link HubEvent#getName()} will contain a model object
+     * in the {@link HubEvent#getData()}.
+     */
+    RECEIVED_FROM_CLOUD("received_from_cloud");
+
+    private final String hubEventName;
+
+    /**
+     * Enumerate the name of an even that is published on Hub, on the {@link HubChannel#DATASTORE} channel.
+     * @param hubEventName The name of an event to use when creating an {@link HubEvent}
+     */
+    DataStoreChannelEventName(@NonNull String hubEventName) {
+        Objects.requireNonNull(hubEventName);
+        this.hubEventName = hubEventName;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return hubEventName;
+    }
+
+    /**
+     * Check if the provided string is one of the enumerated hub event names used by the
+     * DataStore category.
+     * @param possibleEventName Possibly, the name of a Hub event published by DataStore
+     * @return The enumerated event name, if found
+     * @throws IllegalArgumentException If the provided string is not a known event name
+     */
+    @NonNull
+    public static DataStoreChannelEventName fromString(@Nullable String possibleEventName) {
+        for (DataStoreChannelEventName value : values()) {
+            if (value.toString().equals(possibleEventName)) {
+                return value;
+            }
+        }
+        final String errorMessage =
+            "DataStore category does not publish any Hub event with name = " + possibleEventName;
+        throw new IllegalArgumentException(errorMessage);
+    }
+}

--- a/core/src/main/java/com/amplifyframework/hub/HubEvent.java
+++ b/core/src/main/java/com/amplifyframework/hub/HubEvent.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -54,6 +55,19 @@ public final class HubEvent<T> {
     }
 
     /**
+     * Create a Hub event from an enumerated value.
+     * The {@link Enum#toString()} method will be used to generate the event name.
+     * @param enumerated An enumerated value
+     * @param <E> Type of enumeration
+     * @return A Hub event with the enumerate value's string representation as the event name
+     */
+    @NonNull
+    public static <E extends Enum<E>> HubEvent<?> create(@NonNull E enumerated) {
+        Objects.requireNonNull(enumerated);
+        return new HubEvent<>(enumerated.toString(), null);
+    }
+
+    /**
      * Creates a Hub event with a name and associated data.
      * @param name Name for the event
      * @param data Data associated with the event
@@ -63,6 +77,21 @@ public final class HubEvent<T> {
     @NonNull
     public static <T> HubEvent<T> create(@NonNull String name, @NonNull T data) {
         return new HubEvent<>(name, data);
+    }
+
+    /**
+     * Creates a Hub event from an enum (to generate the event name) and a data item.
+     * @param enumerated An enumeration value
+     * @param data Data to populate in event
+     * @param <E> An enumeration type, {@link Enum#toString()} will be used to generate the event name
+     * @param <T> Type of event data
+     * @return A HubEvent
+     */
+    @NonNull
+    public static <T, E extends Enum<E>> HubEvent<T> create(@NonNull E enumerated, @NonNull T data) {
+        Objects.requireNonNull(enumerated);
+        Objects.requireNonNull(data);
+        return new HubEvent<>(enumerated.toString(), data);
     }
 
     /**

--- a/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.hub.HubEvent;
+import com.amplifyframework.hub.HubEventFilter;
+import com.amplifyframework.hub.HubEventFilters;
+import com.amplifyframework.hub.SubscriptionToken;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Accumulates {@link HubEvent}s received on a {@link HubChannel}, into an in-memory
+ * buffer. These may be queried by tests in a synchronous way to check if they have arrived.
+ */
+@SuppressWarnings({"unused", "UnusedReturnValue"})
+public final class HubAccumulator {
+    private final HubChannel channel;
+    private final HubEventFilter filter;
+    private final List<HubEvent<?>> events;
+    private SubscriptionToken token;
+    private CountDownLatch latch;
+
+    private HubAccumulator(@NonNull HubChannel channel, @NonNull HubEventFilter filter) {
+        this.channel = channel;
+        this.filter = filter;
+        this.events = new ArrayList<>();
+    }
+
+    /**
+     * Gets an {@link HubAccumulator} that accumulates events arriving
+     * on a particular channel.
+     * @param channel Events will be accumulated for this channel only
+     * @return A HubAccumulator for the requested channel
+     */
+    @NonNull
+    public static HubAccumulator create(@NonNull HubChannel channel) {
+        Objects.requireNonNull(channel);
+        return new HubAccumulator(channel, HubEventFilters.always());
+    }
+
+    @NonNull
+    public static HubAccumulator create(@NonNull HubChannel channel, @NonNull HubEventFilter filter) {
+        Objects.requireNonNull(channel);
+        Objects.requireNonNull(filter);
+        return new HubAccumulator(channel, filter);
+    }
+
+    /**
+     * Start accumulating events.
+     * @return HubAccumulator instance for fluent chaining
+     */
+    @NonNull
+    public HubAccumulator start() {
+        this.token = Amplify.Hub.subscribe(channel, filter, event -> {
+            events.add(event);
+            if (latch != null) {
+                latch.countDown();
+            }
+        });
+        return this;
+    }
+
+    /**
+     * Stop accumulating events.
+     * @return HubAccumulator instance for fluent chaining
+     */
+    @NonNull
+    public HubAccumulator stop() {
+        if (token != null) {
+            Amplify.Hub.unsubscribe(token);
+            token = null;
+        }
+        return this;
+    }
+
+    /**
+     * Clear all events from the accumulator.
+     * @return HubAccumulator instance for fluent chaining
+     */
+    @NonNull
+    public HubAccumulator clear() {
+        events.clear();
+        return this;
+    }
+
+    /**
+     * Wait for a quantity of events to be accumulated.
+     * If there are fewer than this many, right now, this method will
+     * block until the rest show up. If there are enough, they will
+     * be returned immediately. The returned items will be cleared from the
+     * accumulator.
+     * @param desiredQuantity Number of items being awaited
+     * @return A list of desiredQuantity many items
+     * @throws RuntimeException On failure to attain the requested number of events
+     *                          within a reasonable waiting period
+     */
+    @NonNull
+    public List<HubEvent<?>> take(int desiredQuantity) {
+        // If we haven't yet received the desired quantity of events on the subscription,
+        // setup a latch to await the desired quantity, less the number of existing events.
+        // For example: I desire 5, I already have 3, I wait for 2 more.
+        if (events.size() < desiredQuantity) {
+            latch = new CountDownLatch(desiredQuantity - events.size());
+            Latch.await(latch);
+            latch = null;
+        }
+
+        // If we already had the right number of events,
+        // or if our latch counted down as a result of receiving the remaining number of events,
+        // return the requested number of events.
+        List<HubEvent<?>> returning = new ArrayList<>(events.subList(0, desiredQuantity));
+
+        // Also, clear those events out of the events list so that next call to #take(int)
+        // returns (a) unique value(s).
+        Iterator<HubEvent<?>> iterator = events.iterator();
+        while (iterator.hasNext()) {
+            if (returning.contains(iterator.next())) {
+                iterator.remove();
+            }
+        }
+
+        return returning;
+    }
+
+    /**
+     * Wait for the next event to show up, or pull the first one
+     * in the accumulator, if there is one.
+     * @return A HubEvent, either the first in the accumulator list, or
+     *         the next one that shows up (in the future).
+     */
+    @NonNull
+    public HubEvent<?> takeOne() {
+        return take(1).get(0);
+    }
+}

--- a/testutils/src/main/java/com/amplifyframework/testutils/Latch.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Latch.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils;
+
+import androidx.annotation.NonNull;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A utility to count down a latch.
+ * This is done frequently enough in the test code that its best
+ * to centralize a single pattern for it.
+ */
+@SuppressWarnings({"SameParameterValue", "WeakerAccess"})
+final class Latch {
+    private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(5);
+
+    @SuppressWarnings("checkstyle:all") private Latch() {}
+
+    /**
+     * Await a latch to count down, for a given number of milliseconds.
+     * @param latch A latch on which to await count down
+     * @param waitTimeMs Time to wait before throwing an error
+     * @throws RuntimeException If the latch doesn't count down in the allotted timeout
+     */
+    static void await(@NonNull CountDownLatch latch, long waitTimeMs) {
+        try {
+            latch.await(waitTimeMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException interruptedException) {
+            // Will check regardless in a moment ...
+        }
+        if (latch.getCount() != 0) {
+            throw new RuntimeException("Failed to count down latch.");
+        }
+    }
+
+    /**
+     * Await a latch to count down, in a "reasonable" amount of time.
+     * We define "reasonable," not you. If you want to take a stab, instead, try
+     * {@link #await(CountDownLatch, long)}.
+     * @param latch A latch on which we will await count down
+     * @throws RuntimeException If the latch doesn't count down in the allotted time
+     */
+    static void await(@NonNull CountDownLatch latch) {
+        await(latch, REASONABLE_WAIT_TIME_MS);
+    }
+}

--- a/testutils/src/main/java/com/amplifyframework/testutils/Sleep.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Sleep.java
@@ -15,10 +15,25 @@
 
 package com.amplifyframework.testutils;
 
+import com.amplifyframework.hub.HubEvent;
+
 /**
  * A test utility to sleep the thread of execution.
  * This exists so that we don't have to catch {@link InterruptedException} all over the place,
  * cluttering our test code.
+ *
+ * Okay. Now, here's a rant about why you _almost certainly_ shouldn't use this class:
+ *
+ * Sleeping for the purpose of state synchronization is a code smell. Often, mechanisms like
+ * this will be used as a means to cross your fingers and hope that some components have reached a
+ * desired state after (some magic amount of) milliseconds. Well, what if the state is reached
+ * after (some magic amount of milliseconds) + 10ms?
+ *
+ * Instead, you should coordinate component state based on deterministic events. Instead of
+ * using this utility, consider publishing a {@link HubEvent} from one component, and listening
+ * for it in another.
+ *
+ * All of this considered, "When ya gotta sleep, ya gotta, sleep." Ya know?
  */
 public final class Sleep {
     @SuppressWarnings("checkstyle:all") private Sleep() {}


### PR DESCRIPTION
Previously, DataStore instrumentation tests were using Sleep to wait an
arbitrary amount of time for synchronization tasks to complete. See the
new statement in Sleep.java about why waiting for a random amount of
time is a bad strategy for synchronization. Instead, DataStore
synchronization events are now published to the Hub.

Some test utilities are added to help await Hub events, in tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
