### PR TITLE
[aws-api] Install Consrypt Security provider before using OkHttp

### DIFF
--- a/aws-api/build.gradle
+++ b/aws-api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     implementation dependency.androidx.appcompat
     implementation dependency.okhttp
+    implementation dependency.conscrypt
     implementation dependency.gson
 
     implementation dependency.aws.authcore

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -106,6 +106,8 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         AWSApiPluginConfiguration pluginConfig =
                 AWSApiPluginConfigurationReader.readFrom(pluginConfigurationJson);
 
+        ConscryptLoader.load();
+
         final InterceptorFactory interceptorFactory =
                 new AppSyncSigV4SignerInterceptorFactory(authProvider);
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/ConscryptLoader.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/ConscryptLoader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.logging.Logger;
+
+import org.conscrypt.Conscrypt;
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Load Conscrypt Provider into Java Security system.
+ * https://github.com/square/okhttp#requirements
+ * https://github.com/google/conscrypt#android
+ */
+final class ConscryptLoader {
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-api");
+    private static boolean installed = false;
+
+    @SuppressWarnings("checkstyle:all") private ConscryptLoader() {}
+
+    static void load() {
+        if (!installed) {
+            synchronized (Security.class) {
+                synchronized (Conscrypt.class) {
+                    installConscrypt();
+                }
+            }
+        }
+    }
+
+    private static void installConscrypt() {
+        // If conscrypt isn't available, we're done. Nothing to install.
+        if (!Conscrypt.isAvailable()) {
+            return;
+        }
+        // Remove any existing installations.
+        for (Provider provider : findInstalledConscryptProviders()) {
+            Security.removeProvider(provider.getName());
+        }
+        // Now, install Conscrypt.
+        Security.insertProviderAt(Conscrypt.newProvider(), 1);
+        installed = true;
+        LOG.info("Installed Conscrypt security provider.");
+    }
+
+    @NonNull
+    private static List<Provider> findInstalledConscryptProviders() {
+        final List<Provider> conscrypts = new ArrayList<>();
+        for (Provider provider : Security.getProviders()) {
+            if (Conscrypt.isConscrypt(provider)) {
+                conscrypts.add(provider);
+            }
+        }
+        return conscrypts;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ ext {
             mobileclient: "com.amazonaws:aws-android-sdk-mobile-client:$awsSdkVersion"
         ],
         okhttp: 'com.squareup.okhttp3:okhttp:4.3.1',
+        conscrypt: 'org.conscrypt:conscrypt-android:2.2.1',
         gson: 'com.google.code.gson:gson:2.8.6',
         rxandroid: 'io.reactivex.rxjava2:rxandroid:2.1.1',
         rxjava: 'io.reactivex.rxjava2:rxjava:2.2.13',


### PR DESCRIPTION
OkHttp documentation suggests using Conscrypt. If you don't, OkHttp will
emit an informational stack trace into the logs.

Refer: https://github.com/square/okhttp#requirements
Refer: https://github.com/square/okhttp/issues/5760
Refer: https://stackoverflow.com/questions/58630667

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
