### PR TITLE
Fix the error that caused configuration to fail unless mobile client …

### DIFF
--- a/aws-storage-s3/build.gradle
+++ b/aws-storage-s3/build.gradle
@@ -26,10 +26,9 @@ dependencies {
     }
 
     testImplementation project(path: ':testutils')
-    testImplementation dependency.androidx.test.core
     testImplementation dependency.junit
     testImplementation dependency.mockito
     testImplementation dependency.robolectric
-    testImplementation dependency.aws.mobileclient
+    testImplementation dependency.androidx.test.core
 }
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -69,7 +69,6 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     private final ExecutorService executorService;
 
     private StorageService storageService;
-    private String userIdentityId;
     private StorageAccessLevel defaultAccessLevel;
 
     /**
@@ -141,7 +140,6 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         }
 
         try {
-            this.userIdentityId = identityIdProvider.getIdentityId();
             this.storageService = storageServiceFactory.create(
                     context,
                     region,
@@ -192,7 +190,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId() != null
                         ? options.getTargetIdentityId()
-                        : userIdentityId
+                        : getUserIdentityId()
         );
 
         AWSS3StorageDownloadFileOperation operation =
@@ -230,7 +228,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId() != null
                         ? options.getTargetIdentityId()
-                        : userIdentityId,
+                        : getUserIdentityId(),
                 options.getContentType(),
                 options.getMetadata()
         );
@@ -268,7 +266,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId() != null
                         ? options.getTargetIdentityId()
-                        : userIdentityId
+                        : getUserIdentityId()
         );
 
         AWSS3StorageRemoveOperation operation =
@@ -304,7 +302,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId() != null
                         ? options.getTargetIdentityId()
-                        : userIdentityId
+                        : getUserIdentityId()
         );
 
         AWSS3StorageListOperation operation =
@@ -313,6 +311,10 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         operation.start();
 
         return operation;
+    }
+
+    private String getUserIdentityId() {
+        return identityIdProvider.getIdentityId();
     }
 
     /**


### PR DESCRIPTION
…was initialized

*Issue #, if available:*

*Description of changes:*
In the last PR, I cached `identityId` in the configuration step. This required obtaining it from `AWSMobileClient`, which may not always be initialized at the time of plugin configuration. 

I reverted my change so that it is obtained each time a method is invoked rather than at configuration step. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
