### PR TITLE
[Analytics] Make builder methods public accessible

### DIFF
--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/PinpointProperties.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/PinpointProperties.java
@@ -57,17 +57,17 @@ public final class PinpointProperties extends Properties {
             metrics = new HashMap<>();
         }
 
-        Builder add(String key, String value) {
+        public Builder add(String key, String value) {
             attributes.put(key, value);
             return this;
         }
 
-        Builder add(String key, Double value) {
+        public Builder add(String key, Double value) {
             metrics.put(key, value);
             return this;
         }
 
-        PinpointProperties build() {
+        public PinpointProperties build() {
             return new PinpointProperties(this);
         }
     }


### PR DESCRIPTION
* Patch for issue: https://github.com/aws-amplify/amplify-android/issues/256

*Issue #, if available:*
#256

*Description of changes:*
Make `PinpointProperties.Builder#add()` public access

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
