### PR TITLE
[aws-storage-s3] Suppress autovalue warning from Robolectric

### DIFF
--- a/aws-storage-s3/build.gradle
+++ b/aws-storage-s3/build.gradle
@@ -28,7 +28,10 @@ dependencies {
     testImplementation project(path: ':testutils')
     testImplementation dependency.junit
     testImplementation dependency.mockito
-    testImplementation dependency.robolectric
+    testImplementation (dependency.robolectric) {
+        // https://github.com/robolectric/robolectric/issues/5245
+        exclude group: 'com.google.auto.service', module: 'auto-service'
+    }
     testImplementation dependency.androidx.test.core
 }
 


### PR DESCRIPTION
While building the S3 plugin, there's a new warning about annotation
processors. This is from the new dependency on Robolectric. Currently a
work-around is needed to suppress this warning, which is to exclude the
transitive autovalue dependency.

Refer: https://github.com/robolectric/robolectric/issues/5245

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
