### PR TITLE
Make HubAccumulator more reliable

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AWSDataStorePluginInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AWSDataStorePluginInstrumentedTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests the functions of {@link com.amplifyframework.datastore.AWSDataStorePlugin}.
+ * Tests the functions of {@link AWSDataStorePlugin}.
  * This test expects a backend API that has support for the {@link Blog} family of models,
  * which were defined by the schema in:
  * testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/schema.graphql.

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AWSDataStorePluginInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AWSDataStorePluginInstrumentedTest.java
@@ -16,7 +16,6 @@
 package com.amplifyframework.datastore;
 
 import android.content.Context;
-import android.os.StrictMode;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.amplifyframework.AmplifyException;
@@ -57,12 +56,7 @@ public final class AWSDataStorePluginInstrumentedTest {
      */
     @BeforeClass
     public static void enableStrictMode() {
-        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-            .detectLeakedSqlLiteObjects()
-            .detectLeakedClosableObjects()
-            .penaltyLog()
-            .penaltyDeath()
-            .build());
+        StrictMode.enable();
     }
 
     /**

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
@@ -54,7 +54,7 @@ import static org.junit.Assert.assertEquals;
  */
 public final class StorageItemChangeRecordIntegrationTest {
     private static final String DATABASE_NAME = "AmplifyDatastore.db";
-    private static final long OPERATION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);
+    private static final long OPERATION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(2);
 
     private GsonStorageItemChangeConverter storageItemChangeConverter;
     private LocalStorageAdapter localStorageAdapter;

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StrictMode.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StrictMode.java
@@ -13,20 +13,21 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.datastore.storage.sqlite;
+package com.amplifyframework.datastore;
 
 /**
  * Utility class to easily manipulate strict mode policies
  * for testing purposes.
  */
-final class StrictMode {
+public final class StrictMode {
     @SuppressWarnings("WhitespaceAround")
     private StrictMode() {}
 
     /**
-     * Enable strict mode for testing SQLite operations.
+     * Enable strict mode for testing SQLite operations to make
+     * sure that there are no leaks.
      */
-    static void enable() {
+    public static void enable() {
         android.os.StrictMode.setVmPolicy(strictModePolicy());
     }
 

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.storage.sqlite;
 
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.StrictMode;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore.storage.sqlite;
 import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.StrictMode;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterSaveTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterSaveTest.java
@@ -19,6 +19,7 @@ import android.util.Log;
 
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.StrictMode;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelperInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelperInstrumentedTest.java
@@ -17,10 +17,10 @@ package com.amplifyframework.datastore.storage.sqlite;
 
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.os.StrictMode;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.datastore.StrictMode;
 import com.amplifyframework.logging.Logger;
 
 import org.junit.After;
@@ -52,12 +52,7 @@ public class SQLiteStorageHelperInstrumentedTest {
      */
     @BeforeClass
     public static void enableStrictMode() {
-        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-                .detectLeakedSqlLiteObjects()
-                .detectLeakedClosableObjects()
-                .penaltyLog()
-                .penaltyDeath()
-                .build());
+        StrictMode.enable();
     }
 
     /**

--- a/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
@@ -56,10 +56,16 @@ public final class HubAccumulator {
      */
     @NonNull
     public static HubAccumulator create(@NonNull HubChannel channel) {
-        Objects.requireNonNull(channel);
-        return new HubAccumulator(channel, HubEventFilters.always());
+        return create(channel, HubEventFilters.always());
     }
 
+    /**
+     * Gets an {@link HubAccumulator} that accumulates events arriving
+     * on a particular channel.
+     * @param channel Events will be accumulated for this channel only
+     * @param filter Filter to apply to accumulating events
+     * @return A HubAccumulator for the requested channel
+     */
     @NonNull
     public static HubAccumulator create(@NonNull HubChannel channel, @NonNull HubEventFilter filter) {
         Objects.requireNonNull(channel);
@@ -121,9 +127,21 @@ public final class HubAccumulator {
         // If we haven't yet received the desired quantity of events on the subscription,
         // setup a latch to await the desired quantity, less the number of existing events.
         // For example: I desire 5, I already have 3, I wait for 2 more.
-        if (events.size() < desiredQuantity) {
-            latch = new CountDownLatch(desiredQuantity - events.size());
-            Latch.await(latch);
+        int waitCount = desiredQuantity - events.size();
+        if (waitCount > 0) {
+            latch = new CountDownLatch(waitCount);
+            try {
+                // Wait for proportionally as long as the number of missing events
+                long waitTimeMs = waitCount * Latch.REASONABLE_WAIT_TIME_MS;
+                Latch.await(latch, waitTimeMs);
+            } catch (RuntimeException exception) {
+                // Did not count down but wait! It's possible for a race condition to have occurred.
+                // What if the event was emitted right before latch was instantiated?
+                // Do one more check before throwing!
+                if (events.size() < desiredQuantity) {
+                    throw new RuntimeException("Not enough events were accumulated.");
+                }
+            }
             latch = null;
         }
 

--- a/testutils/src/main/java/com/amplifyframework/testutils/Latch.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Latch.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
  */
 @SuppressWarnings({"SameParameterValue", "WeakerAccess"})
 final class Latch {
-    private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(5);
+    static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(5);
 
     @SuppressWarnings("checkstyle:all") private Latch() {}
 

--- a/testutils/src/main/java/com/amplifyframework/testutils/SynchronousApi.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/SynchronousApi.java
@@ -46,10 +46,7 @@ import io.reactivex.disposables.Disposables;
  * performing various operations.
  */
 public final class SynchronousApi {
-
-    private static final long EXTENDED_TIMEOUT_IN_MILLISECONDS =
-            TimeUnit.SECONDS.toMillis(10); // 5 seconds is insufficient
-
+    private static final long OPERATION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
     private static SynchronousApi singleton = null;
 
     @SuppressWarnings("checkstyle:all") private SynchronousApi() {}
@@ -274,8 +271,7 @@ public final class SynchronousApi {
         return Observable.create(emitter -> {
             CompositeDisposable disposable = new CompositeDisposable();
             emitter.setDisposable(disposable);
-            Await.<String, ApiException>result(
-                EXTENDED_TIMEOUT_IN_MILLISECONDS,
+            Await.<String, ApiException>result(OPERATION_TIMEOUT_MS,
                 (onSubscriptionStarted, onError) -> {
                     Cancelable cancelable = Amplify.API.subscribe(
                         apiName,
@@ -306,8 +302,7 @@ public final class SynchronousApi {
         return Observable.create(emitter -> {
             CompositeDisposable disposable = new CompositeDisposable();
             emitter.setDisposable(disposable);
-            Await.<String, ApiException>result(
-                EXTENDED_TIMEOUT_IN_MILLISECONDS,
+            Await.<String, ApiException>result(OPERATION_TIMEOUT_MS,
                 (onSubscriptionStarted, onError) -> {
                     Cancelable cancelable = Amplify.API.subscribe(
                         apiName,
@@ -329,8 +324,7 @@ public final class SynchronousApi {
     private <T> T awaitResponseData(
             Await.ResultErrorEmitter<GraphQLResponse<T>, ApiException> resultErrorEmitter)
             throws ApiException {
-        final GraphQLResponse<T> response = Await.result(EXTENDED_TIMEOUT_IN_MILLISECONDS,
-                resultErrorEmitter);
+        final GraphQLResponse<T> response = Await.result(OPERATION_TIMEOUT_MS, resultErrorEmitter);
         if (response.hasErrors()) {
             String firstErrorMessage = response.getErrors().get(0).getMessage();
             throw new RuntimeException("Response has error:" + firstErrorMessage);
@@ -344,8 +338,7 @@ public final class SynchronousApi {
     private <T> List<GraphQLResponse.Error> awaitResponseErrors(
             Await.ResultErrorEmitter<GraphQLResponse<T>, ApiException> resultErrorEmitter)
             throws ApiException {
-        final GraphQLResponse<T> response = Await.result(EXTENDED_TIMEOUT_IN_MILLISECONDS,
-                resultErrorEmitter);
+        final GraphQLResponse<T> response = Await.result(OPERATION_TIMEOUT_MS, resultErrorEmitter);
         if (!response.hasErrors()) {
             throw new RuntimeException("No errors in response.");
         }
@@ -356,7 +349,6 @@ public final class SynchronousApi {
     private RestResponse awaitRestResponse(
             Await.ResultErrorEmitter<RestResponse, ApiException> resultErrorEmitter)
             throws ApiException {
-        return Await.result(EXTENDED_TIMEOUT_IN_MILLISECONDS,
-                resultErrorEmitter);
+        return Await.result(OPERATION_TIMEOUT_MS, resultErrorEmitter);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- `HubAccumulator` now waits proportionally as long as the number of events it is waiting on.
- Potentially resolve a race-condition in `HubAccumulator`
- Use consistent 2 seconds timeout duration throughout datastore instrumented tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
