### PR TITLE
[aws-datastore] CRUD type mapping is backwards

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -371,10 +371,10 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         final DataStoreItemChange.Type dataStoreItemChangeType;
         switch (storageItemChange.type()) {
             case DELETE:
-                dataStoreItemChangeType = DataStoreItemChange.Type.SAVE;
+                dataStoreItemChangeType = DataStoreItemChange.Type.DELETE;
                 break;
             case SAVE:
-                dataStoreItemChangeType = DataStoreItemChange.Type.DELETE;
+                dataStoreItemChangeType = DataStoreItemChange.Type.SAVE;
                 break;
             default:
                 throw new DataStoreException(


### PR DESCRIPTION
A SAVE in the storage adapter should be mapped to a SAVE in the
DataStore API, and a DELETE in the storage adapter should be mapped to a
DELETE in the DataStore API. However, these were backwards.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
