### PR TITLE
Refactor storage options to abstract out common properties

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/utils/S3RequestUtils.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/utils/S3RequestUtils.java
@@ -18,8 +18,6 @@ package com.amplifyframework.storage.s3.utils;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.storage.StorageAccessLevel;
-import com.amplifyframework.storage.StorageException;
-import com.amplifyframework.storage.options.StorageOptions;
 
 import java.util.Locale;
 
@@ -61,22 +59,6 @@ public final class S3RequestUtils {
         return getAccessLevelPrefix(accessLevel, identityId) + BUCKET_SEPARATOR + key;
     }
 
-    /**
-     * See {@link S3RequestUtils#getServiceKey(StorageAccessLevel, String, String)}.
-     *
-     * @param options Storage options to specify accessor and access level
-     *                of the request
-     * @param key User-friendly key to access the item
-     * @return Formatted key to be used internally by S3 plugin
-     */
-    @NonNull
-    public static String getServiceKey(
-            @NonNull StorageOptions options,
-            @NonNull String key
-    ) {
-        return getAccessLevelPrefix(options) + BUCKET_SEPARATOR + key;
-    }
-
     @NonNull
     private static String getAccessLevelPrefix(
             @NonNull StorageAccessLevel accessLevel,
@@ -87,26 +69,5 @@ public final class S3RequestUtils {
         } else {
             return accessLevel.name().toLowerCase(Locale.US);
         }
-    }
-
-    @NonNull
-    private static String getAccessLevelPrefix(@NonNull StorageOptions options) {
-        StorageAccessLevel accessLevel = options.getAccessLevel();
-        if (accessLevel == null) {
-            throw new RuntimeException(new StorageException(
-                    "Storage access-level is null.",
-                    "Set the access-level value to PUBLIC | PROTECTED | PRIVATE."
-            ));
-        }
-
-        String identityId = options.getTargetIdentityId();
-        if (identityId == null) {
-            throw new RuntimeException(new StorageException(
-                    "The identity ID of storage accessor is null.",
-                    "Provide a valid identity ID to specify the accessor."
-            ));
-        }
-
-        return getAccessLevelPrefix(accessLevel, identityId);
     }
 }

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageDownloadFileOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageDownloadFileOptions.java
@@ -15,42 +15,16 @@
 
 package com.amplifyframework.storage.options;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import com.amplifyframework.core.async.Options;
-import com.amplifyframework.storage.StorageAccessLevel;
-
-import java.util.Objects;
 
 /**
  * Options to specify attributes of get API invocation.
  */
-public final class StorageDownloadFileOptions implements Options {
-    private final StorageAccessLevel accessLevel;
-    private final String targetIdentityId;
+public final class StorageDownloadFileOptions extends StorageOptions {
 
     private StorageDownloadFileOptions(final Builder builder) {
-        this.accessLevel = builder.getAccessLevel();
-        this.targetIdentityId = builder.getTargetIdentityId();
-    }
-
-    /**
-     * Gets the storage access level.
-     * @return Storage access level
-     */
-    @Nullable
-    public StorageAccessLevel getAccessLevel() {
-        return accessLevel;
-    }
-
-    /**
-     * Gets the target identity ID.
-     * @return target identity ID
-     */
-    @Nullable
-    public String getTargetIdentityId() {
-        return targetIdentityId;
+        super(builder.getAccessLevel(), builder.getTargetIdentityId());
     }
 
     /**
@@ -77,9 +51,8 @@ public final class StorageDownloadFileOptions implements Options {
      */
     @NonNull
     public static Builder from(@NonNull final StorageDownloadFileOptions options) {
-        return builder()
-            .accessLevel(options.getAccessLevel())
-            .targetIdentityId(options.getTargetIdentityId());
+        return builder().accessLevel(options.getAccessLevel())
+                .targetIdentityId(options.getTargetIdentityId());
     }
 
     /**
@@ -96,53 +69,12 @@ public final class StorageDownloadFileOptions implements Options {
      * instances of the {@link StorageDownloadFileOptions}, by chaining
      * fluent configuration method calls.
      */
-    public static final class Builder {
-        private StorageAccessLevel accessLevel;
-        private String targetIdentityId;
-
-        /**
-         * Configures the storage access level to set on new
-         * StorageDownloadFileOptions instances.
-         * @param accessLevel Storage access level for new StorageDownloadFileOptions instances
-         * @return Current Builder instance, for fluent method chaining
-         */
-        @NonNull
-        public Builder accessLevel(@NonNull StorageAccessLevel accessLevel) {
-            this.accessLevel = Objects.requireNonNull(accessLevel);
-            return this;
-        }
-
-        /**
-         * Configures the target identity ID that will be used on newly
-         * built StorageDownloadFileOptions.
-         * @param targetIdentityId Target identity ID for new StorageDownloadFileOptions instances
-         * @return Current Builder instance, for fluent method chaining
-         */
-        @NonNull
-        public Builder targetIdentityId(@NonNull String targetIdentityId) {
-            this.targetIdentityId = Objects.requireNonNull(targetIdentityId);
-            return this;
-        }
-
-        /**
-         * Constructs and returns a new immutable instance of the
-         * StorageDownloadFileOptions, using the configurations that
-         * have been provided the current instance of the Builder.
-         * @return A new immutable instance of StorageDownloadFileOptions
-         */
+    public static final class Builder extends StorageOptions.Builder<Builder, StorageDownloadFileOptions> {
+        @SuppressLint("SyntheticAccessor")
+        @Override
         @NonNull
         public StorageDownloadFileOptions build() {
             return new StorageDownloadFileOptions(this);
-        }
-
-        @Nullable
-        StorageAccessLevel getAccessLevel() {
-            return accessLevel;
-        }
-
-        @Nullable
-        String getTargetIdentityId() {
-            return targetIdentityId;
         }
     }
 }

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageListOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageListOptions.java
@@ -15,42 +15,16 @@
 
 package com.amplifyframework.storage.options;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import com.amplifyframework.core.async.Options;
-import com.amplifyframework.storage.StorageAccessLevel;
-
-import java.util.Objects;
 
 /**
  * Options to specify attributes of list API invocation.
  */
-public final class StorageListOptions implements Options {
-    private final StorageAccessLevel accessLevel;
-    private final String targetIdentityId;
+public final class StorageListOptions extends StorageOptions {
 
     private StorageListOptions(final Builder builder) {
-        this.accessLevel = builder.getAccessLevel();
-        this.targetIdentityId = builder.getTargetIdentityId();
-    }
-
-    /**
-     * Gets the storage access level.
-     * @return Storage access level
-     */
-    @Nullable
-    public StorageAccessLevel getAccessLevel() {
-        return accessLevel;
-    }
-
-    /**
-     * Gets the target identity id.
-     * @return target identity id
-     */
-    @Nullable
-    public String getTargetIdentityId() {
-        return targetIdentityId;
+        super(builder.getAccessLevel(), builder.getTargetIdentityId());
     }
 
     /**
@@ -75,8 +49,7 @@ public final class StorageListOptions implements Options {
      */
     @NonNull
     public static Builder from(@NonNull final StorageListOptions options) {
-        return builder()
-                .accessLevel(options.getAccessLevel())
+        return builder().accessLevel(options.getAccessLevel())
                 .targetIdentityId(options.getTargetIdentityId());
     }
 
@@ -94,51 +67,12 @@ public final class StorageListOptions implements Options {
      * Used to construct instance of StorageListOptions via
      * fluent configuration methods.
      */
-    public static final class Builder {
-        private StorageAccessLevel accessLevel;
-        private String targetIdentityId;
-
-        /**
-         * Configures the storage access level.
-         * @param accessLevel Storage access level
-         * @return Builder instance for fluent chaining
-         */
-        @NonNull
-        public Builder accessLevel(@NonNull StorageAccessLevel accessLevel) {
-            this.accessLevel = Objects.requireNonNull(accessLevel);
-            return this;
-        }
-
-        /**
-         * Configures the target identity ID.
-         * @param targetIdentityId target identity ID
-         * @return current Builder instance, for fluent chaining
-         */
-        @NonNull
-        public Builder targetIdentityId(@NonNull String targetIdentityId) {
-            this.targetIdentityId = Objects.requireNonNull(targetIdentityId);
-            return this;
-        }
-
-        /**
-         * Constructs a new immutable instance of the {@link StorageListOptions},
-         * using the values that have been configured on the current instance of this
-         * {@link StorageListOptions.Builder} instance, via prior method calls.
-         * @return A new immutable instance of {@link StorageListOptions}.
-         */
+    public static final class Builder extends StorageOptions.Builder<Builder, StorageListOptions> {
+        @SuppressLint("SyntheticAccessor")
+        @Override
         @NonNull
         public StorageListOptions build() {
             return new StorageListOptions(this);
-        }
-
-        @Nullable
-        StorageAccessLevel getAccessLevel() {
-            return accessLevel;
-        }
-
-        @Nullable
-        String getTargetIdentityId() {
-            return targetIdentityId;
         }
     }
 }

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageOptions.java
@@ -26,7 +26,7 @@ import com.amplifyframework.storage.StorageAccessLevel;
  * storage operation will inspect the provided options
  * instance for access level and target ID.
  */
-public abstract class StorageOptions implements Options {
+abstract class StorageOptions implements Options {
     private final StorageAccessLevel accessLevel;
     private final String targetIdentityId;
 

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageOptions.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.core.async.Options;
+import com.amplifyframework.storage.StorageAccessLevel;
+
+/**
+ * Storage options interface requires that every
+ * storage operation will inspect the provided options
+ * instance for access level and target ID.
+ */
+public abstract class StorageOptions implements Options {
+    private final StorageAccessLevel accessLevel;
+    private final String targetIdentityId;
+
+    StorageOptions(StorageAccessLevel accessLevel,
+                   String targetIdentityId) {
+        this.accessLevel = accessLevel;
+        this.targetIdentityId = targetIdentityId;
+    }
+
+    /**
+     * Gets the storage access level.
+     * @return Storage access level
+     */
+    @Nullable
+    public final StorageAccessLevel getAccessLevel() {
+        return accessLevel;
+    }
+
+    /**
+     * Gets the target identity id.
+     * @return target identity id
+     */
+    @Nullable
+    public final String getTargetIdentityId() {
+        return targetIdentityId;
+    }
+
+    /**
+     * Builds storage options.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    abstract static class Builder<B extends Builder, O extends StorageOptions> {
+        private StorageAccessLevel accessLevel;
+        private String targetIdentityId;
+
+        /**
+         * Configures the storage access level to set on new
+         * StorageOptions instances.
+         * @param accessLevel Storage access level for new StorageOptions instances
+         * @return Current Builder instance, for fluent method chaining
+         */
+        @NonNull
+        public final B accessLevel(@Nullable StorageAccessLevel accessLevel) {
+            this.accessLevel = accessLevel;
+            return (B) this;
+        }
+
+        /**
+         * Configures the target identity ID that will be used on newly
+         * built StorageOptions.
+         * @param targetIdentityId Target identity ID for new StorageOptions instances
+         * @return Current Builder instance, for fluent method chaining
+         */
+        @NonNull
+        public final B targetIdentityId(@Nullable String targetIdentityId) {
+            this.targetIdentityId = targetIdentityId;
+            return (B) this;
+        }
+
+        @Nullable
+        public final StorageAccessLevel getAccessLevel() {
+            return accessLevel;
+        }
+
+        @Nullable
+        public final String getTargetIdentityId() {
+            return targetIdentityId;
+        }
+
+        /**
+         * Constructs and returns a new immutable instance of the
+         * StorageOptions, using the configurations that
+         * have been provided the current instance of the Builder.
+         * @return A new immutable instance of StorageOptions
+         */
+        @NonNull
+        public abstract O build();
+    }
+}

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageRemoveOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageRemoveOptions.java
@@ -15,42 +15,16 @@
 
 package com.amplifyframework.storage.options;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import com.amplifyframework.core.async.Options;
-import com.amplifyframework.storage.StorageAccessLevel;
-
-import java.util.Objects;
 
 /**
  * Options to specify attributes of remove API invocation.
  */
-public final class StorageRemoveOptions implements Options {
-    private final StorageAccessLevel accessLevel;
-    private final String targetIdentityId;
+public final class StorageRemoveOptions extends StorageOptions {
 
     private StorageRemoveOptions(final Builder builder) {
-        this.accessLevel = builder.getAccessLevel();
-        this.targetIdentityId = builder.getTargetIdentityId();
-    }
-
-    /**
-     * Gets the storage access level.
-     * @return Storage access level
-     */
-    @Nullable
-    public StorageAccessLevel getAccessLevel() {
-        return accessLevel;
-    }
-
-    /**
-     * Gets the target identity ID.
-     * @return target identity ID
-     */
-    @Nullable
-    public String getTargetIdentityId() {
-        return targetIdentityId;
+        super(builder.getAccessLevel(), builder.getTargetIdentityId());
     }
 
     /**
@@ -77,8 +51,7 @@ public final class StorageRemoveOptions implements Options {
      */
     @NonNull
     public static Builder from(@NonNull final StorageRemoveOptions options) {
-        return builder()
-                .accessLevel(options.getAccessLevel())
+        return builder().accessLevel(options.getAccessLevel())
                 .targetIdentityId(options.getTargetIdentityId());
     }
 
@@ -96,53 +69,12 @@ public final class StorageRemoveOptions implements Options {
      * instances of the {@link StorageRemoveOptions}, by chaining
      * fluent configuration method calls.
      */
-    public static final class Builder {
-        private StorageAccessLevel accessLevel;
-        private String targetIdentityId;
-
-        /**
-         * Configures the storage access level to set on new
-         * StorageRemoveOptions instances.
-         * @param accessLevel Storage access level for new StorageRemoveOptions instances
-         * @return Current Builder instance, for fluent method chaining
-         */
-        @NonNull
-        public Builder accessLevel(@NonNull StorageAccessLevel accessLevel) {
-            this.accessLevel = Objects.requireNonNull(accessLevel);
-            return this;
-        }
-
-        /**
-         * Configures the target identity ID that will be used on newly
-         * built StorageRemoveOptions.
-         * @param targetIdentityId Target identity ID for new StorageRemoveOptions instances
-         * @return Current Builder instance, for fluent method chaining
-         */
-        @NonNull
-        public Builder targetIdentityId(@NonNull String targetIdentityId) {
-            this.targetIdentityId = Objects.requireNonNull(targetIdentityId);
-            return this;
-        }
-
-        /**
-         * Constructs and returns a new immutable instance of the
-         * StorageRemoveOptions, using the configurations that
-         * have been provided the current instance of the Builder.
-         * @return A new immutable instance of StorageRemoveOptions
-         */
+    public static final class Builder extends StorageOptions.Builder<Builder, StorageRemoveOptions> {
+        @SuppressLint("SyntheticAccessor")
+        @Override
         @NonNull
         public StorageRemoveOptions build() {
             return new StorageRemoveOptions(this);
-        }
-
-        @Nullable
-        StorageAccessLevel getAccessLevel() {
-            return accessLevel;
-        }
-
-        @Nullable
-        String getTargetIdentityId() {
-            return targetIdentityId;
         }
     }
 }

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageUploadFileOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageUploadFileOptions.java
@@ -15,11 +15,10 @@
 
 package com.amplifyframework.storage.options;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.amplifyframework.core.async.Options;
-import com.amplifyframework.storage.StorageAccessLevel;
 import com.amplifyframework.util.Immutable;
 
 import java.util.HashMap;
@@ -29,35 +28,14 @@ import java.util.Objects;
 /**
  * Options to specify attributes of put API invocation.
  */
-public final class StorageUploadFileOptions implements Options {
-    private final StorageAccessLevel accessLevel;
-    private final String targetIdentityId;
+public final class StorageUploadFileOptions extends StorageOptions {
     private final String contentType;
     private final Map<String, String> metadata;
 
-    private StorageUploadFileOptions(Builder builder) {
-        this.accessLevel = builder.getAccessLevel();
-        this.targetIdentityId = builder.getTargetIdentityId();
+    private StorageUploadFileOptions(final Builder builder) {
+        super(builder.getAccessLevel(), builder.getTargetIdentityId());
         this.contentType = builder.getContentType();
         this.metadata = builder.getMetadata();
-    }
-
-    /**
-     * Gets the storage access level.
-     * @return Storage access level
-     */
-    @Nullable
-    public StorageAccessLevel getAccessLevel() {
-        return accessLevel;
-    }
-
-    /**
-     * Target user to apply the action on.
-     * @return Target user's identity id
-     */
-    @Nullable
-    public String getTargetIdentityId() {
-        return targetIdentityId;
     }
 
     /**
@@ -73,7 +51,7 @@ public final class StorageUploadFileOptions implements Options {
      * Metadata for the object to store.
      * @return metadata
      */
-    @Nullable
+    @NonNull
     public Map<String, String> getMetadata() {
         return Immutable.of(metadata);
     }
@@ -83,6 +61,7 @@ public final class StorageUploadFileOptions implements Options {
      * and build a new immutable instance of StorageUploadFileOptions.
      * @return a new builder instance
      */
+    @SuppressLint("SyntheticAccessor")
     @NonNull
     public static Builder builder() {
         return new Builder();
@@ -100,8 +79,7 @@ public final class StorageUploadFileOptions implements Options {
      */
     @NonNull
     public static Builder from(@NonNull final StorageUploadFileOptions options) {
-        return builder()
-                .accessLevel(options.getAccessLevel())
+        return builder().accessLevel(options.getAccessLevel())
                 .targetIdentityId(options.getTargetIdentityId())
                 .contentType(options.getContentType())
                 .metadata(options.getMetadata());
@@ -121,33 +99,12 @@ public final class StorageUploadFileOptions implements Options {
      * StorageUploadFileOptions, using fluent of property configuration
      * methods.
      */
-    public static final class Builder {
-        private StorageAccessLevel accessLevel;
-        private String targetIdentityId;
+    public static final class Builder extends StorageOptions.Builder<Builder, StorageUploadFileOptions> {
         private String contentType;
         private Map<String, String> metadata;
 
-        /**
-         * Configures the storage access level for the new
-         * StorageUploadFileOptions instance.
-         * @param accessLevel Storage access level
-         * @return Current Builder instance for fluent chaining
-         */
-        @NonNull
-        public Builder accessLevel(@NonNull StorageAccessLevel accessLevel) {
-            this.accessLevel = Objects.requireNonNull(accessLevel);
-            return this;
-        }
-
-        /**
-         * Configures the target identity id for a new StorageUploadFileOptions instance.
-         * @param targetIdentityId Target user's identity id
-         * @return Current Builder instance for fluent chaining
-         */
-        @NonNull
-        public Builder targetIdentityId(@NonNull String targetIdentityId) {
-            this.targetIdentityId = Objects.requireNonNull(targetIdentityId);
-            return this;
+        private Builder() {
+            this.metadata = new HashMap<>();
         }
 
         /**
@@ -155,9 +112,10 @@ public final class StorageUploadFileOptions implements Options {
          * @param contentType Content type
          * @return Current Builder instance for fluent chaining
          */
+        @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
         @NonNull
-        public Builder contentType(@NonNull String contentType) {
-            this.contentType = Objects.requireNonNull(contentType);
+        public Builder contentType(@Nullable String contentType) {
+            this.contentType = contentType;
             return this;
         }
 
@@ -172,36 +130,27 @@ public final class StorageUploadFileOptions implements Options {
             return this;
         }
 
+        @SuppressWarnings("WeakerAccess")
+        @Nullable
+        public String getContentType() {
+            return contentType;
+        }
+
+        @NonNull
+        public Map<String, String> getMetadata() {
+            return Immutable.of(metadata);
+        }
+
         /**
          * Builds a new immutable StorageUploadFileOptions instance,
          * based on the configuration options that have been previously
          * set on this Builder instance.
          * @return A new immutable StorageUploadFileOptions instance
          */
+        @SuppressLint("SyntheticAccessor")
         @NonNull
         public StorageUploadFileOptions build() {
             return new StorageUploadFileOptions(this);
         }
-
-        @Nullable
-        StorageAccessLevel getAccessLevel() {
-            return accessLevel;
-        }
-
-        @Nullable
-        String getTargetIdentityId() {
-            return targetIdentityId;
-        }
-
-        @Nullable
-        String getContentType() {
-            return contentType;
-        }
-
-        @Nullable
-        Map<String, String> getMetadata() {
-            return Immutable.of(metadata);
-        }
     }
 }
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Portion of #259 that deals with `StorageOptions`.
- Abstracted out `StorageOptions` to reduce duplicate code
- ~~`StorageOptions` is now sufficient for building S3 service key, so added utility method in `S3RequestUtils` class~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
