### PR TITLE
Refactor storage operations and service

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -59,7 +59,6 @@ import java.util.concurrent.Executors;
  * A plugin for the storage category which uses S3 as a storage
  * repository.
  */
-@SuppressWarnings("unused") // Revisit this suppression after tests are created
 public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
 
     private static final String AWS_S3_STORAGE_PLUGIN_KEY = "awsS3StoragePlugin";
@@ -190,7 +189,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId() != null
                         ? options.getTargetIdentityId()
-                        : getUserIdentityId()
+                        : identityIdProvider.getIdentityId()
         );
 
         AWSS3StorageDownloadFileOperation operation =
@@ -228,7 +227,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId() != null
                         ? options.getTargetIdentityId()
-                        : getUserIdentityId(),
+                        : identityIdProvider.getIdentityId(),
                 options.getContentType(),
                 options.getMetadata()
         );
@@ -266,7 +265,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId() != null
                         ? options.getTargetIdentityId()
-                        : getUserIdentityId()
+                        : identityIdProvider.getIdentityId()
         );
 
         AWSS3StorageRemoveOperation operation =
@@ -302,7 +301,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId() != null
                         ? options.getTargetIdentityId()
-                        : getUserIdentityId()
+                        : identityIdProvider.getIdentityId()
         );
 
         AWSS3StorageListOperation operation =
@@ -311,10 +310,6 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         operation.start();
 
         return operation;
-    }
-
-    private String getUserIdentityId() {
-        return identityIdProvider.getIdentityId();
     }
 
     /**

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.java
@@ -18,7 +18,11 @@ package com.amplifyframework.storage.s3.operation;
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.Consumer;
+import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.hub.HubEvent;
+import com.amplifyframework.storage.StorageChannelEventName;
 import com.amplifyframework.storage.StorageException;
 import com.amplifyframework.storage.operation.StorageDownloadFileOperation;
 import com.amplifyframework.storage.result.StorageDownloadFileResult;
@@ -38,7 +42,7 @@ import java.io.File;
 public final class AWSS3StorageDownloadFileOperation
         extends StorageDownloadFileOperation<AWSS3StorageDownloadFileRequest> {
     private final StorageService storageService;
-    private final Consumer<StorageDownloadFileResult> onResult;
+    private final Consumer<StorageDownloadFileResult> onSuccess;
     private final Consumer<StorageException> onError;
     private TransferObserver transferObserver;
     private File file;
@@ -58,7 +62,7 @@ public final class AWSS3StorageDownloadFileOperation
     ) {
         super(request);
         this.storageService = storageService;
-        this.onResult = onSuccess;
+        this.onSuccess = onSuccess;
         this.onError = onError;
         this.transferObserver = null;
         this.file = null;
@@ -68,51 +72,27 @@ public final class AWSS3StorageDownloadFileOperation
     @Override
     public void start() {
         // Only start if it hasn't already been started
-        if (transferObserver == null) {
-            String serviceKey = S3RequestUtils.getServiceKey(
-                    getRequest().getAccessLevel(),
-                    getRequest().getTargetIdentityId(),
-                    getRequest().getKey()
-            );
+        if (transferObserver != null) {
+            return;
+        }
 
-            this.file = new File(getRequest().getLocal()); //TODO: Add error handling if path is invalid
-
-            try {
-                transferObserver = storageService.downloadToFile(serviceKey, file);
-            } catch (Exception exception) {
-                onError.accept(new StorageException(
-                        "Issue downloading file",
-                        exception,
-                        "See included exception for more details and suggestions to fix."
-                ));
-                return;
-            }
-
-            transferObserver.setTransferListener(new TransferListener() {
-                @Override
-                public void onStateChanged(int transferId, TransferState state) {
-                    if (TransferState.COMPLETED == state) {
-                        onResult.accept(StorageDownloadFileResult.fromFile(file));
-                    }
-                }
-
-                @SuppressWarnings("checkstyle:MagicNumber")
-                @Override
-                public void onProgressChanged(int transferId, long bytesCurrent, long bytesTotal) {
-                    @SuppressWarnings("unused")
-                    int percentage = (int) (bytesCurrent / bytesTotal * 100);
-                    // TODO: dispatch event to hub
-                }
-
-                @Override
-                public void onError(int transferId, Exception exception) {
-                    onError.accept(new StorageException(
-                        "Something went wrong with your AWS S3 Storage download file operation",
-                        exception,
-                        "See attached exception for more information and suggestions"
-                    ));
-                }
-            });
+        String serviceKey = S3RequestUtils.getServiceKey(
+                getRequest().getAccessLevel(),
+                getRequest().getTargetIdentityId(),
+                getRequest().getKey()
+        );
+      
+        this.file = new File(getRequest().getLocal());
+      
+        try {
+            transferObserver = storageService.downloadToFile(serviceKey, file);
+            transferObserver.setTransferListener(new DownloadTransferListener());
+        } catch (Exception exception) {
+            onError.accept(new StorageException(
+                    "Issue downloading file",
+                    exception,
+                    "See included exception for more details and suggestions to fix."
+            ));
         }
     }
 
@@ -158,6 +138,51 @@ public final class AWSS3StorageDownloadFileOperation
                     "See attached exception for more information and suggestions"
                 ));
             }
+        }
+    }
+
+    @SuppressLint("SyntheticAccessor")
+    private final class DownloadTransferListener implements TransferListener {
+        @Override
+        public void onStateChanged(int transferId, TransferState state) {
+            Amplify.Hub.publish(HubChannel.STORAGE,
+                    HubEvent.create(StorageChannelEventName.DOWNLOAD_STATE, state.name()));
+            switch (state) {
+                case COMPLETED:
+                    onSuccess.accept(StorageDownloadFileResult.fromFile(file));
+                    return;
+                case FAILED:
+                    onError.accept(new StorageException(
+                            "Storage download operation was interrupted.",
+                            "Please verify that you have a stable internet connection."
+                    ));
+                    return;
+                default:
+                    // no-op;
+            }
+        }
+
+        @Override
+        public void onProgressChanged(int transferId, long bytesCurrent, long bytesTotal) {
+            final float progress;
+            if (bytesTotal != 0) {
+                progress = (float) bytesCurrent / bytesTotal;
+            } else {
+                progress = 1f;
+            }
+            Amplify.Hub.publish(HubChannel.STORAGE,
+                    HubEvent.create(StorageChannelEventName.DOWNLOAD_PROGRESS, progress));
+        }
+
+        @Override
+        public void onError(int transferId, Exception exception) {
+            Amplify.Hub.publish(HubChannel.STORAGE,
+                    HubEvent.create(StorageChannelEventName.DOWNLOAD_ERROR, exception));
+            onError.accept(new StorageException(
+                    "Something went wrong with your AWS S3 Storage download file operation",
+                    exception,
+                    "See attached exception for more information and suggestions"
+            ));
         }
     }
 }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/service/AWSS3StorageService.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/service/AWSS3StorageService.java
@@ -39,7 +39,6 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * A representation of an S3 backend service endpoint.
@@ -72,13 +71,16 @@ public final class AWSS3StorageService implements StorageService {
         this.client = createS3Client(region);
 
         if (transferAcceleration) {
-            client.setS3ClientOptions(S3ClientOptions.builder().setAccelerateModeEnabled(true).build());
+            client.setS3ClientOptions(S3ClientOptions.builder()
+                    .setAccelerateModeEnabled(true)
+                    .build()
+            );
         }
 
         this.transferUtility = TransferUtility.builder()
-                                .context(this.context)
-                                .s3Client(client)
-                                .build();
+                .context(this.context)
+                .s3Client(client)
+                .build();
     }
 
     private AmazonS3Client createS3Client(@NonNull Region region) {
@@ -107,21 +109,6 @@ public final class AWSS3StorageService implements StorageService {
      * Begin uploading a file.
      * @param serviceKey S3 service key
      * @param file Target file
-     * @return A transfer observer
-     */
-    @NonNull
-    public TransferObserver uploadFile(
-            @NonNull String serviceKey,
-            @NonNull File file
-    ) {
-        startServiceIfNotAlreadyStarted();
-        return transferUtility.upload(bucket, serviceKey, file);
-    }
-
-    /**
-     * Begin uploading a file.
-     * @param serviceKey S3 service key
-     * @param file Target file
      * @param metadata Object metadata to associate with upload
      * @return A transfer observer
      */
@@ -129,12 +116,10 @@ public final class AWSS3StorageService implements StorageService {
     public TransferObserver uploadFile(
             @NonNull String serviceKey,
             @NonNull File file,
-            @NonNull Map<String, String> metadata
+            @NonNull ObjectMetadata metadata
     ) {
         startServiceIfNotAlreadyStarted();
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setUserMetadata(metadata);
-        return transferUtility.upload(bucket, serviceKey, file, objectMetadata);
+        return transferUtility.upload(bucket, serviceKey, file, metadata);
     }
 
     /**

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/service/StorageService.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/service/StorageService.java
@@ -22,10 +22,10 @@ import com.amplifyframework.storage.StorageItem;
 
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferObserver;
 import com.amazonaws.regions.Region;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 
 import java.io.File;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Interface to manage file transfer to and from a registered S3 bucket.
@@ -44,26 +44,16 @@ public interface StorageService {
 
     /**
      * Begin uploading a file to a key in storage and return an observer
-     * to monitor upload progress.
-     * @param serviceKey key to uniquely label item in storage
-     * @param file file to upload
-     * @return An instance of {@link TransferObserver} to monitor upload
-     */
-    TransferObserver uploadFile(@NonNull String serviceKey,
-                                @NonNull File file);
-
-    /**
-     * Begin uploading a file to a key in storage and return an observer
      * to monitor upload progress. This item will be stored with specified
      * metadata.
      * @param serviceKey key to uniquely label item in storage
      * @param file file to upload
-     * @param metadata map of metadata to attach to uploaded item
+     * @param metadata metadata to attach to uploaded item
      * @return An instance of {@link TransferObserver} to monitor upload
      */
     TransferObserver uploadFile(@NonNull String serviceKey,
                                 @NonNull File file,
-                                @NonNull Map<String, String> metadata);
+                                @NonNull ObjectMetadata metadata);
 
     /**
      * Returns a list of items from provided path inside the storage.

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
@@ -33,6 +33,7 @@ import com.amplifyframework.testutils.RandomString;
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferListener;
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferObserver;
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferState;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -183,7 +184,7 @@ public final class StorageComponentTest {
         final String fromLocalPath = RandomString.string();
 
         TransferObserver observer = mock(TransferObserver.class);
-        when(storageService.uploadFile(anyString(), any(File.class)))
+        when(storageService.uploadFile(anyString(), any(File.class), any(ObjectMetadata.class)))
                 .thenReturn(observer);
 
         doAnswer(invocation -> {
@@ -221,7 +222,7 @@ public final class StorageComponentTest {
         final String fromLocalPath = RandomString.string();
 
         TransferObserver observer = mock(TransferObserver.class);
-        when(storageService.uploadFile(anyString(), any(File.class)))
+        when(storageService.uploadFile(anyString(), any(File.class), any(ObjectMetadata.class)))
                 .thenReturn(observer);
 
         doAnswer(invocation -> {

--- a/core/src/main/java/com/amplifyframework/storage/StorageChannelEventName.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageChannelEventName.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.hub.HubCategory;
+import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.hub.HubEvent;
+
+import java.util.Objects;
+
+/**
+ * An enumeration of the names of events relating the the {@link StorageCategory},
+ * that are published via {@link HubCategory#publish(HubChannel, HubEvent)} on the
+ * {@link HubChannel#DATASTORE} channel.
+ */
+public enum StorageChannelEventName {
+
+    /**
+     * An error occurred while uploading a file.
+     */
+    UPLOAD_ERROR("upload_error"),
+
+    /**
+     * The state of an upload has changed.
+     */
+    UPLOAD_STATE("upload_state"),
+
+    /**
+     * Progress has been made on an upload.
+     */
+    UPLOAD_PROGRESS("upload_progress"),
+
+    /**
+     * A download has erred out.
+     */
+    DOWNLOAD_ERROR("download_error"),
+
+    /**
+     * A download has undergone a state change.
+     */
+    DOWNLOAD_STATE("download_state"),
+
+    /**
+     * A download has made some progress.
+     */
+    DOWNLOAD_PROGRESS("download_progress");
+
+    private final String hubEventName;
+
+    /**
+     * Enumerate the name of an even that is published on Hub, on the {@link HubChannel#STORAGE} channel.
+     * @param hubEventName The name of an event to use when creating an {@link HubEvent}
+     */
+    StorageChannelEventName(@NonNull String hubEventName) {
+        this.hubEventName = Objects.requireNonNull(hubEventName);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return hubEventName;
+    }
+
+    /**
+     * Check if the provided string is one of the enumerated hub event names used by the
+     * {@link StorageCategory}.
+     * @param possiblyMatchingEventName Possibly, the name of a Hub event published by Storage
+     * @return The enumerated event name, if found
+     * @throws IllegalArgumentException If the provided string is not a known event name
+     */
+    @NonNull
+    public static StorageChannelEventName fromString(@Nullable String possiblyMatchingEventName) {
+        for (StorageChannelEventName possibleMatch : StorageChannelEventName.values()) {
+            if (possibleMatch.toString().equals(possiblyMatchingEventName)) {
+                return possibleMatch;
+            }
+        }
+        final String errorMessage =
+            "Storage category does not publish any Hub event with name = " + possiblyMatchingEventName;
+        throw new IllegalArgumentException(errorMessage);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Portion of PR #259

Refactor storage operations for file transfers:
- Clean up `start()` method by implementing `TransferListener` elsewhere
- Emit Hub event on transfer state/progress update
- Upload operation now builds `ObjectMetadata` before invoking storage service
- Upload operation now accounts for `content-type` (and passes it to metadata)

Refactor storage service for upload:
- Remove `uploadFile` overload for optionally not passing in metadata
- Now requires `ObjectMetadata` rather than `Map<String, Object>`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
