### PR TITLE
Use "master" as the default version name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx3g
 org.gradle.parallel=true
 
 GROUP=com.amplifyframework
-VERSION_NAME=0.9.0
+VERSION_NAME=master
 VERSION_CODE=1
 
 POM_URL=https://github.com/aws-amplify/amplify-android


### PR DESCRIPTION
During development, it is useful to publish development versions of the libraries to a local maven repository, via `publishToMavenLocal`. In the `master` branch, the library version is currently `0.9.0`.

As a result, it can be confusing to know what version of the library is getting consumed, from a consuming application that uses both `mavenLocal()` and `jcenter()`. Both could provide a `0.9.0`.

To avoid confusion, the version name in the master branch is changed to `master`. Development consumers may access the development version of the library through the local maven repository using:

    implementation 'com.amplifyframework:core:master'

etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
