### PR TITLE
[aws-datastore] Perform base sync at startup and save model versions

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/TestStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/TestStorageAdapter.java
@@ -19,8 +19,10 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.datastore.DataStoreException;
 
 import java.util.Objects;
@@ -41,7 +43,16 @@ final class TestStorageAdapter {
      * @return An initialized instance of the {@link SynchronousStorageAdapter}
      */
     static SynchronousStorageAdapter create(ModelProvider modelProvider) {
-        SQLiteStorageAdapter sqLiteStorageAdapter = SQLiteStorageAdapter.forModels(modelProvider);
+        ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
+        modelSchemaRegistry.clear();
+        try {
+            modelSchemaRegistry.load(modelProvider.models());
+        } catch (AmplifyException modelSchemaLoadingFailure) {
+            throw new RuntimeException(modelSchemaLoadingFailure);
+        }
+        SQLiteStorageAdapter sqLiteStorageAdapter =
+            SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
+
         SynchronousStorageAdapter synchronousStorageAdapter =
             SynchronousStorageAdapter.instance(sqLiteStorageAdapter);
         Context context = ApplicationProvider.getApplicationContext();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -29,6 +29,7 @@ import com.amplifyframework.core.InitializationStatus;
 import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.appsync.AppSyncClient;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
@@ -66,15 +67,18 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     // Configuration for the plugin.
     private AWSDataStorePluginConfiguration pluginConfiguration;
 
-    private AWSDataStorePlugin(@NonNull final ModelProvider modelProvider) {
-        this.sqliteStorageAdapter = SQLiteStorageAdapter.forModels(modelProvider);
+    private AWSDataStorePlugin(
+            @NonNull ModelSchemaRegistry modelSchemaRegistry,
+            @NonNull ModelProvider modelProvider) {
+        this.sqliteStorageAdapter = SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
         this.storageItemChangeConverter = new GsonStorageItemChangeConverter();
-        this.orchestrator = createOrchestrator(modelProvider, sqliteStorageAdapter);
+        this.orchestrator = createOrchestrator(modelProvider, modelSchemaRegistry, sqliteStorageAdapter);
         this.categoryInitializationsPending = new CountDownLatch(1);
     }
 
-    private Orchestrator createOrchestrator(ModelProvider modelProvider, LocalStorageAdapter storageAdapter) {
-        return new Orchestrator(modelProvider, storageAdapter, AppSyncClient.instance());
+    private Orchestrator createOrchestrator(
+            ModelProvider modelProvider, ModelSchemaRegistry modelSchemaRegistry, LocalStorageAdapter storageAdapter) {
+        return new Orchestrator(modelProvider, modelSchemaRegistry, storageAdapter, AppSyncClient.instance());
     }
 
     /**
@@ -85,7 +89,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     @NonNull
     @SuppressWarnings("WeakerAccess")
     public static synchronized AWSDataStorePlugin forModels(@NonNull final ModelProvider modelProvider) {
-        return new AWSDataStorePlugin(modelProvider);
+        return new AWSDataStorePlugin(ModelSchemaRegistry.instance(), modelProvider);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/ModelMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/ModelMetadata.java
@@ -35,9 +35,9 @@ import java.util.Objects;
 @SuppressWarnings({"MemberName", "ParameterName"})
 public final class ModelMetadata implements Model {
     private final @ModelField(targetType = "ID", isRequired = true) String id;
-    private final @ModelField(targetType = "Boolean", isRequired = true) Boolean _deleted;
-    private final @ModelField(targetType = "Int", isRequired = true) Integer _version;
-    private final @ModelField(targetType = "AWSTimestamp", isRequired = true) Long _lastChangedAt;
+    private final @ModelField(targetType = "Boolean") Boolean _deleted;
+    private final @ModelField(targetType = "Int") Integer _version;
+    private final @ModelField(targetType = "AWSTimestamp") Long _lastChangedAt;
 
     /**
      * Constructor for this metadata model.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/SystemModelsProviderFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/SystemModelsProviderFactory.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.datastore.SimpleModelProvider;
+import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.storage.sqlite.PersistentModelVersion;
 
 /**
@@ -35,13 +36,19 @@ public final class SystemModelsProviderFactory {
         return SimpleModelProvider.instance(
             SYSTEM_MODELS_VERSION,
 
+            // PersistentModelVersion.class is stores the version of the data schema; that is,
+            // which models exist in the system, and what is their shape. When the structure of
+            // the data changes, this should see a version bump.
+            PersistentModelVersion.class,
+
+            // ModelMetadata.class stores the version of particular instances of a model. Unlike
+            // PersistentModelVersion, which details with the structure of data, ModelMetadata
+            // deals actually with individual records, and their states.
+            ModelMetadata.class,
+
             // StorageItemChange.Record.class is an internal system event
             // it is used to stage local storage changes for upload to cloud
-            StorageItemChange.Record.class,
-
-            // PersistentModelVersion.class is an internal system event
-            // it is used to store the version of the ModelProvider
-            PersistentModelVersion.class
+            StorageItemChange.Record.class
         );
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore.syncengine;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.datastore.appsync.AppSync;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 
@@ -40,6 +41,7 @@ public final class Orchestrator {
      * The Orchestrator will synchronize data between the {@link AppSync}
      * and the {@link LocalStorageAdapter}.
      * @param modelProvider A provider of the models to be synchronized
+     * @param modelSchemaRegistry A registry of model schema
      * @param localStorageAdapter Interface to local storage, used to
      *                       durably store offline changes until
      *                       then can be written to the network
@@ -47,13 +49,15 @@ public final class Orchestrator {
      */
     public Orchestrator(
             @NonNull final ModelProvider modelProvider,
+            @NonNull final ModelSchemaRegistry modelSchemaRegistry,
             @NonNull final LocalStorageAdapter localStorageAdapter,
             @NonNull final AppSync appSync) {
+        Objects.requireNonNull(modelSchemaRegistry);
         Objects.requireNonNull(modelProvider);
         Objects.requireNonNull(appSync);
         Objects.requireNonNull(localStorageAdapter);
 
-        RemoteModelState remoteModelState = new RemoteModelState(appSync, modelProvider);
+        RemoteModelState remoteModelState = new RemoteModelState(appSync, modelProvider, modelSchemaRegistry);
         MutationOutbox mutationOutbox = new MutationOutbox(localStorageAdapter);
 
         this.mutationProcessor = new MutationProcessor(mutationOutbox, appSync);
@@ -72,7 +76,7 @@ public final class Orchestrator {
         return Completable.fromAction(() -> {
             storageObserver.startObservingStorageChanges();
             subscriptionProcessor.startSubscriptions();
-            //syncProcessor.hydrate().blockingAwait(); This crashes right now ...
+            syncProcessor.hydrate().blockingAwait();
             mutationProcessor.startDrainingMutationOutbox();
             subscriptionProcessor.startDrainingMutationBuffer();
         });

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -15,11 +15,15 @@
 
 package com.amplifyframework.datastore.syncengine;
 
+import com.amplifyframework.core.Action;
+import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.logging.Logger;
 
 import io.reactivex.Completable;
 import io.reactivex.schedulers.Schedulers;
@@ -33,6 +37,7 @@ import io.reactivex.schedulers.Schedulers;
  * into the {@link LocalStorageAdapter} as it is currently.
  */
 final class SyncProcessor {
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
     private final RemoteModelState remoteModelState;
     private final LocalStorageAdapter localStorageAdapter;
 
@@ -54,11 +59,12 @@ final class SyncProcessor {
             .subscribeOn(Schedulers.io())
             .observeOn(Schedulers.io())
             // For each model state, provide it as an input to a completable operation
-            .flatMapCompletable(modelWithMetadata ->
+            .flatMapCompletable(modelWithMetadata -> {
                 // Save the metadata if the data save succeeds
-                saveItemToStorage(modelWithMetadata)
-                    .andThen(saveMetadataToStorage(modelWithMetadata))
-            );
+                LOG.info("Base sync, saving " + modelWithMetadata);
+                return saveItemToStorage(modelWithMetadata)
+                    .andThen(saveMetadataToStorage(modelWithMetadata));
+            });
     }
 
     private <T extends Model> Completable saveItemToStorage(ModelWithMetadata<T> modelWithMetadata) {
@@ -67,13 +73,36 @@ final class SyncProcessor {
             final ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
             final T item = modelWithMetadata.getModel();
             if (Boolean.TRUE.equals(metadata.isDeleted())) {
-                localStorageAdapter.delete(item, StorageItemChange.Initiator.SYNC_ENGINE,
-                    ignoredRecord -> emitter.onComplete(), emitter::onError);
+                ifPresent(item.getClass(), item.getId(), () ->
+                    localStorageAdapter.delete(item, StorageItemChange.Initiator.SYNC_ENGINE,
+                        ignoredRecord -> emitter.onComplete(), emitter::onError),
+                    emitter::onComplete
+                );
             } else {
                 localStorageAdapter.save(item, StorageItemChange.Initiator.SYNC_ENGINE,
                     ignoredRecord -> emitter.onComplete(), emitter::onError);
             }
         });
+    }
+
+    /**
+     * If the DataStore contains an item of the given class and with the given ID,
+     * then perform an action. Otherwise, perform some other action.
+     * @param clazz Search for this class in the DataStore
+     * @param modelId Search for an item with this ID in the DataStore
+     * @param onPresent If there is a match, perform this action
+     * @param onNotPresent If there is NOT a match, perform this action as a fallback
+     * @param <T> The type of item being searched
+     */
+    private <T extends Model> void ifPresent(
+            Class<T> clazz, String modelId, Action onPresent, Action onNotPresent) {
+        localStorageAdapter.query(clazz, QueryField.field("id").eq(modelId), iterator -> {
+            if (iterator.hasNext()) {
+                onPresent.call();
+            } else {
+                onNotPresent.call();
+            }
+        }, failure -> onNotPresent.call());
     }
 
     private <T extends Model> Completable saveMetadataToStorage(ModelWithMetadata<T> modelWithMetadata) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/TopologicalOrdering.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/TopologicalOrdering.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import android.annotation.SuppressLint;
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelAssociation;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Stack;
+
+/**
+ * Maintains a topological ordering of a collection of ModelSchema.
+ * A ModelSchema A is "less than" ModelSchema B, if there is a dependency lineage
+ * from A to B. If a ModelSchema has no dependencies, than it is greater than or
+ * equal to all other ModelSchema.
+ *
+ * For example, if a Blog has n Posts, and each Post has n Comment:
+ *   input := [Comment, Post, Blog]
+ * than the topological ordering is:
+ *   output := [Blog, Post, Comment]
+ */
+@SuppressWarnings("unused")
+final class TopologicalOrdering {
+    private final List<ModelSchema> modelSchema;
+
+    private TopologicalOrdering(List<ModelSchema> modelSchema) {
+        this.modelSchema = modelSchema;
+    }
+
+    /**
+     * Gets a TopologicalOrdering of the ModelSchema in the ModelSchemaRegistry.
+     * The set of ModelSchema in that registry is not expected to change during runtime,
+     * so the results of this TopologicalOrdering should likewise be stable at runtime.
+     * @param modelSchemaRegistry A registry of ModelSchema
+     * @param modelProvider A ModelProvider
+     * @return A topological ordering of the model schema in the registry
+     */
+    @SuppressLint("SyntheticAccessor")
+    static TopologicalOrdering forRegisteredModels(
+            @NonNull ModelSchemaRegistry modelSchemaRegistry,
+            @NonNull ModelProvider modelProvider) {
+        Objects.requireNonNull(modelProvider);
+        final List<ModelSchema> schemaForModels = new ArrayList<>();
+        for (Class<? extends Model> modelClass : modelProvider.models()) {
+            final String modelClassName = modelClass.getSimpleName();
+            final ModelSchema schemaForModelClass = modelSchemaRegistry.getModelSchemaForModelClass(modelClassName);
+            schemaForModels.add(schemaForModelClass);
+        }
+        return new TopologicalOrdering(new TopologicalSort(schemaForModels).result());
+    }
+
+    /**
+     * Compares two ModelSchema to determine if one comes before the other.
+     * For example, compare(blogSchema, postSchema) == -2.
+     * @param one A ModelSchema
+     * @param two A ModelSchema
+     * @return A number less than 0 if one comes before two. A number greater than 0 is one comes
+     *         after two. Returns 0 in the case where one and two are the same schema.
+     */
+    int compare(@NonNull ModelSchema one, @NonNull ModelSchema two) {
+        Objects.requireNonNull(one);
+        Objects.requireNonNull(two);
+        int onePosition = -1;
+        int twoPosition = -1;
+        for (int index = 0; index < modelSchema.size(); index++) {
+            if (modelSchema.get(index).equals(one)) {
+                onePosition = index;
+            }
+            if (modelSchema.get(index).equals(two)) {
+                twoPosition = index;
+            }
+        }
+        return onePosition - twoPosition;
+    }
+
+    /**
+     * Check the ordering of a ModelSchema.
+     * @param modelSchema A model schema
+     * @return A collection of checks that can be made on the ordering of the schema
+     */
+    @SuppressWarnings("unused")
+    @NonNull
+    @SuppressLint("SyntheticAccessor")
+    OrderingCheck check(@NonNull ModelSchema modelSchema) {
+        Objects.requireNonNull(modelSchema);
+        if (!this.modelSchema.contains(modelSchema)) {
+            throw new NoSuchElementException("No model schema matching " + modelSchema.getName());
+        }
+        return new OrderingCheck(modelSchema);
+    }
+
+    /**
+     * Exercises a Topological Sort on a list of ModelSchema.
+     */
+    private static final class TopologicalSort {
+        private final Stack<ModelSchema> result;
+        private final Set<ModelSchema> unvisited;
+        private final List<ModelSchema> input;
+
+        private TopologicalSort(List<ModelSchema> modelSchema) {
+            this.input = modelSchema;
+            this.unvisited = new HashSet<>(modelSchema);
+            this.result = new Stack<>();
+        }
+
+        private List<ModelSchema> result() {
+            while (!unvisited.isEmpty()) { // While there are model schema we haven't visited,
+                ModelSchema randomlyPicked = unvisited.iterator().next(); // Pick one at random.
+                visit(randomlyPicked); // Visit it.
+            }
+            return result;
+        }
+
+        private void visit(ModelSchema node) {
+            unvisited.remove(node);
+            for (ModelSchema unvisitedAssociationOwner : findUnvisitedAssociationOwners(node)) {
+                visit(unvisitedAssociationOwner);
+            }
+            result.push(node);
+        }
+
+        private Set<ModelSchema> findUnvisitedAssociationOwners(ModelSchema node) {
+            final Set<ModelSchema> unvisitedAssociationOwners = new HashSet<>();
+            for (ModelSchema associationOwner : findAssociationOwners(node)) {
+                if (unvisited.contains(associationOwner)) {
+                    unvisitedAssociationOwners.add(associationOwner);
+                }
+            }
+            return unvisitedAssociationOwners;
+        }
+
+        private Set<ModelSchema> findAssociationOwners(ModelSchema node) {
+            final Set<ModelSchema> associationOwners = new HashSet<>();
+            for (ModelAssociation association : node.getAssociations().values()) {
+                if (association.isOwner()) {
+                    associationOwners.add(findInputSchemaByName(association.getAssociatedType()));
+                }
+            }
+            return associationOwners;
+        }
+
+        private ModelSchema findInputSchemaByName(String name) {
+            for (ModelSchema schema : input) {
+                if (schema.getName().equals(name)) {
+                    return schema;
+                }
+            }
+            throw new NoSuchElementException("No model schema provided with name = " + name);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    final class OrderingCheck {
+        private final ModelSchema modelSchema;
+
+        private OrderingCheck(@NonNull ModelSchema modelSchema) {
+            this.modelSchema = Objects.requireNonNull(modelSchema);
+        }
+
+        boolean isAfter(@NonNull ModelSchema someOther) {
+            Objects.requireNonNull(someOther);
+            return compare(someOther, modelSchema) < 0;
+        }
+
+        boolean isBefore(@NonNull ModelSchema someOther) {
+            Objects.requireNonNull(someOther);
+            return compare(someOther, modelSchema) > 0;
+        }
+    }
+
+    /**
+     * Any component which provides a means to create an instance of {@link TopologicalOrdering}.
+     */
+    interface Factory {
+        TopologicalOrdering create();
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -21,6 +21,7 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelIndex;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 
 import org.junit.Before;
@@ -52,7 +53,8 @@ public class SqlCommandTest {
      */
     @Before
     public void createSqlCommandFactory() {
-        sqlCommandFactory = new SQLiteCommandFactory();
+        ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
+        sqlCommandFactory = new SQLiteCommandFactory(modelSchemaRegistry);
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -15,21 +15,26 @@
 
 package com.amplifyframework.datastore.syncengine;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
-import com.amplifyframework.datastore.SimpleModelProvider;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.datastore.appsync.AppSync;
 import com.amplifyframework.datastore.appsync.AppSyncMocking;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testmodels.commentsblog.Post;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Completable;
@@ -47,8 +52,10 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests the {@link SyncProcessor}.
  */
+@SuppressWarnings({"unchecked", "checkstyle:MagicNumber"})
+@RunWith(RobolectricTestRunner.class)
 public final class SyncProcessorTest {
-    private static final long OP_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);
+    private static final long OP_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(2);
 
     private StorageItemChange.StorageItemChangeFactory storageRecordDeserializer;
     private AppSync appSync;
@@ -58,15 +65,21 @@ public final class SyncProcessorTest {
 
     /**
      * Wire up dependencies for the SyncProcessor, and build one for testing.
+     * @throws AmplifyException On failure to load models into registry
      */
     @Before
-    public void setup() {
+    public void setup() throws AmplifyException {
         this.storageRecordDeserializer = new GsonStorageItemChangeConverter();
         this.inMemoryStorageAdapter = InMemoryStorageAdapter.create();
 
-        final ModelProvider modelProvider = SimpleModelProvider.withRandomVersion(Post.class, BlogOwner.class);
+        final ModelProvider modelProvider = AmplifyModelProvider.getInstance();
+        ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
+        modelSchemaRegistry.clear();
+        modelSchemaRegistry.load(modelProvider.models());
+
         this.appSync = mock(AppSync.class);
-        final RemoteModelState remoteModelState = new RemoteModelState(appSync, modelProvider);
+
+        final RemoteModelState remoteModelState = new RemoteModelState(appSync, modelProvider, modelSchemaRegistry);
 
         this.syncProcessor = new SyncProcessor(remoteModelState, inMemoryStorageAdapter);
     }
@@ -75,7 +88,6 @@ public final class SyncProcessorTest {
      * When {@link SyncProcessor#hydrate()}'s {@link Completable} completes,
      * then the local storage adapter should have all of the remote model state.
      */
-    @SuppressWarnings({"unchecked", "checkstyle:MagicNumber"})
     @Test
     public void localStorageAdapterIsHydratedFromRemoteModelState() {
         // Arrange: drum post is already in the adapter before hydration.
@@ -145,6 +157,50 @@ public final class SyncProcessorTest {
         );
 
         adapterObserver.dispose();
+        hydrationObserver.dispose();
+    }
+
+    /**
+     * Suppose that the remote AppSync endpoint has a deleted record, and tells the client to
+     * delete a record. But suppose the client is sync'ing for the first time. So, the client
+     * doesn't actually need to delete this record. The deletion attempt will fail. But, that's
+     * okay. Generally speaking, we want to do a "best effort" to apply the remote updates.
+     */
+    @Test
+    public void hydrationContinuesEvenIfOneItemFailsToSync() {
+        // The local store does NOT have the drum post to start (or, for that matter, any items.)
+        // inMemoryStorageAdapter.items().add(DRUM_POST.getModel());
+
+        // Arrange some responses from AppSync
+        AppSyncMocking.configure(appSync)
+            .mockSuccessResponse(Post.class, DELETED_DRUM_POST)
+            .mockSuccessResponse(BlogOwner.class, BLOGGER_JAMESON);
+
+        // Act: hydrate the local store.
+        TestObserver<Void> hydrationObserver = syncProcessor.hydrate().test();
+
+        // Assert that hydration completed without error.
+        assertTrue(hydrationObserver.awaitTerminalEvent(OP_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        hydrationObserver.assertNoErrors();
+        hydrationObserver.assertComplete();
+
+        // Local storage should have a metadata record for the deletion, but no entry for the drum
+        // post. There should be an entry and a metadata for Jameson the BlogOwner.
+        List<? extends Model> storageItems = inMemoryStorageAdapter.items();
+        assertEquals(3, storageItems.size());
+        assertEquals(
+            // Expect a metadata for Jameson & deleted drum post, and an entry for Jameson
+            Observable.fromArray(BLOGGER_JAMESON)
+                .flatMap(blogger -> Observable.fromArray(blogger.getModel(), blogger.getSyncMetadata()))
+                .startWith(DELETED_DRUM_POST.getSyncMetadata())
+                .toSortedList(SortByModelId::compare)
+                .blockingGet(),
+            Observable.fromIterable(storageItems)
+                .toSortedList(SortByModelId::compare)
+                .blockingGet()
+        );
+
+        // Cleanup!
         hydrationObserver.dispose();
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TopologicalOrderingTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TopologicalOrderingTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
+import com.amplifyframework.datastore.SimpleModelProvider;
+import com.amplifyframework.testmodels.commentsblog.Blog;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testmodels.commentsblog.Comment;
+import com.amplifyframework.testmodels.commentsblog.Post;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link TopologicalOrdering} utility.
+ */
+public final class TopologicalOrderingTest {
+    /**
+     * Checks the topological ordering of the Blog, Post, and Comment classes.
+     * @throws AmplifyException On failure to load models into registry
+     */
+    @Test
+    public void orderingOfBlogPostComment() throws AmplifyException {
+        // Load the models into the registry.
+        // They are provided intentionally out of topological order.
+        final SimpleModelProvider provider =
+            SimpleModelProvider.withRandomVersion(Comment.class, Blog.class, BlogOwner.class, Post.class);
+
+        final ModelSchemaRegistry registry = ModelSchemaRegistry.instance();
+        registry.clear();
+        registry.load(provider.models());
+
+        // Find the schema that the registry created for each of the models.
+        ModelSchema commentSchema = findSchema(registry, Comment.class);
+        ModelSchema postSchema = findSchema(registry, Post.class);
+        ModelSchema blogSchema = findSchema(registry, Blog.class);
+
+        // Act: get a topological ordering of the models.
+        TopologicalOrdering topologicalOrdering = TopologicalOrdering.forRegisteredModels(registry, provider);
+
+        // Assert: Blog comes before Post, and Post comes before Comment.
+        assertTrue(topologicalOrdering.check(blogSchema).isBefore(postSchema));
+        assertTrue(topologicalOrdering.check(postSchema).isBefore(commentSchema));
+
+        // Assert: in other words, Comment is after Post, and Post is after Blog.
+        assertTrue(topologicalOrdering.check(commentSchema).isAfter(postSchema));
+        assertTrue(topologicalOrdering.check(postSchema).isAfter(blogSchema));
+    }
+
+    /**
+     * Find a {@link ModelSchema} in an {@link ModelSchemaRegistry}, looking up by the
+     * model's {@link Class}.
+     * @param registry Model schema registry
+     * @param modelClass Class of model
+     * @param <T> Type of model
+     * @return The ModelSchema for the requested class
+     */
+    private <T extends Model> ModelSchema findSchema(ModelSchemaRegistry registry, Class<T> modelClass) {
+        return registry.getModelSchemaForModelClass(modelClass.getSimpleName());
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchemaRegistry.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchemaRegistry.java
@@ -22,15 +22,13 @@ import com.amplifyframework.util.Immutable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
  * A utility that creates ModelSchema from Model classes.
  */
 public final class ModelSchemaRegistry {
-    // Singleton instance
-    private static ModelSchemaRegistry singleton;
-
     // Model ClassName => ModelSchema map
     private final Map<String, ModelSchema> modelSchemaMap;
 
@@ -57,8 +55,10 @@ public final class ModelSchemaRegistry {
      *                        {@link Class#getSimpleName()} method.
      * @return the ModelSchema object for the given Model class.
      */
+    @NonNull
     public synchronized ModelSchema getModelSchemaForModelClass(@NonNull String classSimpleName) {
-        return modelSchemaMap.get(classSimpleName);
+        final ModelSchema result = modelSchemaMap.get(classSimpleName);
+        return Objects.requireNonNull(result);
     }
 
     /**
@@ -67,27 +67,28 @@ public final class ModelSchemaRegistry {
      * @param <T> type of the model instance
      * @return the ModelSchema object for the given Model instance.
      */
+    @NonNull
     public synchronized <T extends Model> ModelSchema getModelSchemaForModelInstance(@NonNull T modelInstance) {
-        return modelSchemaMap.get(modelInstance.getClass().getSimpleName());
+        final ModelSchema result = modelSchemaMap.get(modelInstance.getClass().getSimpleName());
+        return Objects.requireNonNull(result);
     }
 
     /**
      * Retrieve the map of Model ClassName => ModelSchema.
      * @return an immutable map of Model ClassName => ModelSchema
      */
+    @NonNull
     public Map<String, ModelSchema> getModelSchemaMap() {
         return Immutable.of(modelSchemaMap);
     }
 
     /**
-     * Returns the singleton instance.
-     * @return the singleton instance of the ModelSchemaRegistry.
+     * Creates a new instance.
+     * @return A new instance
      */
-    public static synchronized ModelSchemaRegistry singleton() {
-        if (singleton == null) {
-            singleton = new ModelSchemaRegistry();
-        }
-        return singleton;
+    @NonNull
+    public static synchronized ModelSchemaRegistry instance() {
+        return new ModelSchemaRegistry();
     }
 
     /**


### PR DESCRIPTION
Perform a base sync as part of starting up the DataStore.

ModelMetadata is used to record the version of particular models managed
by the DataStore. A table for this structure must be created while the
storage adapter is initializing.

Items coming back from the base sync must be applied with respect to the
topological ordering of their model classes. For example, given a
relationship:

 1 Blog - n Posts - n Comments

The blog must be created, so that a post can "belongsTo" it, and the
post must be created next, so that a comment can "belongsTo" that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
