### PR TITLE
Versions in datastore

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AWSDataStorePluginInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AWSDataStorePluginInstrumentedTest.java
@@ -70,12 +70,10 @@ public final class AWSDataStorePluginInstrumentedTest {
         context = ApplicationProvider.getApplicationContext();
         api = SynchronousApi.singleton();
         dataStore = SynchronousDataStore.singleton();
-        outboundModelEventAccumulator = HubAccumulator.create(HubChannel.DATASTORE, event ->
-            DataStoreChannelEventName.PUBLISHED_TO_CLOUD.toString().equals(event.getName())
-        );
-        inboundModelEventAccumulator = HubAccumulator.create(HubChannel.DATASTORE, event ->
-            DataStoreChannelEventName.RECEIVED_FROM_CLOUD.toString().equals(event.getName())
-        );
+        outboundModelEventAccumulator =
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD);
+        inboundModelEventAccumulator =
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.RECEIVED_FROM_CLOUD);
     }
 
     /**

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
@@ -32,7 +32,6 @@ import com.amplifyframework.testutils.Await;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -207,7 +206,6 @@ public final class StorageItemChangeRecordIntegrationTest {
      * will be a StorageItemChange.Record which itself contains a BlogOwner.
      * @throws DataStoreException from storage item change, or on failure to mainuplate I/O to DataStore
      */
-    @Ignore("update operations are not currently implemented! TODO: validate this, once available")
     @Test
     public void updatesAreObservedForChangeRecords() throws DataStoreException {
         // Establish a subscription to listen for storage change records
@@ -272,7 +270,6 @@ public final class StorageItemChangeRecordIntegrationTest {
      * {@link LocalStorageAdapter#observe(Consumer, Consumer, Action)} will be called.
      * @throws DataStoreException from storage item change, or on failure to mainuplate I/O to DataStore
      */
-    @Ignore("delete() is not currently implemented! Validate this test when it is.")
     @Test
     public void deletionIsObservedForChangeRecord() throws DataStoreException {
         // What we are really observing are items of type StorageItemChange.Record that contain

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
@@ -121,32 +121,31 @@ public final class StorageItemChangeRecordIntegrationTest {
             .name("Tony Daniels")
             .build();
 
-        final StorageItemChange<BlogOwner> originalSaveForTony = StorageItemChange.<BlogOwner>builder()
+        final StorageItemChange<BlogOwner> originalTonyCreation = StorageItemChange.<BlogOwner>builder()
             .item(tonyDaniels)
             .itemClass(BlogOwner.class)
-            .type(StorageItemChange.Type.SAVE)
+            .type(StorageItemChange.Type.CREATE)
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
             .build();
 
         // Save the creation mutation for Tony, as a Record object.
-        StorageItemChange.Record saveForTonyAsRecord =
-            originalSaveForTony.toRecord(storageItemChangeConverter);
-        save(saveForTonyAsRecord);
+        StorageItemChange.Record originalTonyCreationAsRecord =
+            originalTonyCreation.toRecord(storageItemChangeConverter);
+        save(originalTonyCreationAsRecord);
 
         // Now, lookup what records we have in the storage.
-        List<StorageItemChange.Record> foundRecords = query();
+        List<StorageItemChange.Record> recordsInStorage = query();
 
-        // There should be 1, the save for the insertionForTony.
-        // and it should be identical to the thing we tried to save.
-        assertEquals(1, foundRecords.size());
-        StorageItemChange.Record firstResultRecord = foundRecords.get(0);
-        assertEquals(saveForTonyAsRecord, firstResultRecord);
+        // There should be 1, and it should be the original creation for Tony.
+        assertEquals(1, recordsInStorage.size());
+        StorageItemChange.Record firstRecordFoundInStorage = recordsInStorage.get(0);
+        assertEquals(originalTonyCreationAsRecord, firstRecordFoundInStorage);
 
         // After we convert back from record, we should get back a copy of
         // what we created above
-        StorageItemChange<BlogOwner> reconstructedSaveForTony =
-            firstResultRecord.toStorageItemChange(storageItemChangeConverter);
-        assertEquals(originalSaveForTony, reconstructedSaveForTony);
+        StorageItemChange<BlogOwner> reconstructedCreationOfTony =
+            firstRecordFoundInStorage.toStorageItemChange(storageItemChangeConverter);
+        assertEquals(originalTonyCreation, reconstructedCreationOfTony);
     }
 
     /**
@@ -169,7 +168,7 @@ public final class StorageItemChangeRecordIntegrationTest {
                 .name("Juan Gonzales")
                 .build())
             .itemClass(BlogOwner.class)
-            .type(StorageItemChange.Type.SAVE)
+            .type(StorageItemChange.Type.CREATE)
             .build()
             .toRecord(storageItemChangeConverter);
 
@@ -212,59 +211,59 @@ public final class StorageItemChangeRecordIntegrationTest {
     @Test
     public void updatesAreObservedForChangeRecords() throws DataStoreException {
         // Establish a subscription to listen for storage change records
-        TestObserver<StorageItemChange.Record> saveAndUpdateObserver = TestObserver.create();
-        records().subscribe(saveAndUpdateObserver);
+        TestObserver<StorageItemChange.Record> storageObserver = TestObserver.create();
+        records().subscribe(storageObserver);
 
         // Create a record for Joe, and a change to save him into storage
         BlogOwner joeLastNameMispelled = BlogOwner.builder()
             .name("Joe Sweeneyy")
             .build();
-        StorageItemChange<BlogOwner> saveJoeWrongLastName = StorageItemChange.<BlogOwner>builder()
-            .type(StorageItemChange.Type.SAVE)
+        StorageItemChange<BlogOwner> createJoeWrongLastName = StorageItemChange.<BlogOwner>builder()
+            .type(StorageItemChange.Type.CREATE)
             .item(joeLastNameMispelled)
             .itemClass(BlogOwner.class)
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
             .build();
-        StorageItemChange.Record saveJoeWrongLastNameRecord =
-            saveJoeWrongLastName.toRecord(storageItemChangeConverter);
+        StorageItemChange.Record createJoeWrongLastNameAsRecord =
+            createJoeWrongLastName.toRecord(storageItemChangeConverter);
 
         // Save our saveJoeWrongLastName change item, as a record.
-        save(saveJoeWrongLastNameRecord);
+        save(createJoeWrongLastNameAsRecord);
 
         // Now, suppose we have to update that change object. Maybe it contained a bad item payload.
         BlogOwner joeWithLastNameFix = BlogOwner.builder()
             .name("Joe Sweeney")
             .build();
-        StorageItemChange<BlogOwner> saveJoeCorrectLastName = StorageItemChange.<BlogOwner>builder()
-            .changeId(saveJoeWrongLastName.changeId().toString()) // Same ID
+        StorageItemChange<BlogOwner> createJoeCorrectLastName = StorageItemChange.<BlogOwner>builder()
+            .changeId(createJoeWrongLastName.changeId().toString()) // Same ID
             .item(joeWithLastNameFix) // But with a patch to the item
             .itemClass(BlogOwner.class)
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
-            .type(StorageItemChange.Type.SAVE) // We're still saving Joe, we're updating this change.
+            .type(StorageItemChange.Type.UPDATE) // We're still *creating Joe*, we're *updating this change*.
             .build();
-        StorageItemChange.Record saveJoeCorrectLastNameRecord =
-            saveJoeCorrectLastName.toRecord(storageItemChangeConverter);
+        StorageItemChange.Record createJoeCorrectLastNameAsRecord =
+            createJoeCorrectLastName.toRecord(storageItemChangeConverter);
 
-        // Save an update (same model type, same unique ID) to the thing we saved before.
-        save(saveJoeCorrectLastNameRecord);
+        // Save an update (same model type, same unique ID) to the change we saved previously.
+        save(createJoeCorrectLastNameAsRecord);
 
         // Our observer got the records to save Joe with wrong age, and also to save joe with right age
-        List<StorageItemChange.Record> values = saveAndUpdateObserver.awaitCount(2).values();
+        List<StorageItemChange.Record> values = storageObserver.awaitCount(2).values();
         assertEquals(
-            saveJoeWrongLastNameRecord,
+            createJoeWrongLastNameAsRecord,
             values
                 .get(0)
                 .toStorageItemChange(storageItemChangeConverter)
                 .item()
         );
         assertEquals(
-            saveJoeCorrectLastNameRecord,
+            createJoeCorrectLastNameAsRecord,
             values
                 .get(1)
                 .toStorageItemChange(storageItemChangeConverter)
                 .item()
         );
-        saveAndUpdateObserver.dispose();
+        storageObserver.dispose();
     }
 
     /**
@@ -278,42 +277,42 @@ public final class StorageItemChangeRecordIntegrationTest {
     public void deletionIsObservedForChangeRecord() throws DataStoreException {
         // What we are really observing are items of type StorageItemChange.Record that contain
         // StorageItemChange.Record of BlogOwner
-        TestObserver<StorageItemChange.Record> saveObserver = TestObserver.create();
-        records().subscribe(saveObserver);
+        TestObserver<StorageItemChange.Record> storageObserver = TestObserver.create();
+        records().subscribe(storageObserver);
 
         BlogOwner beatrice = BlogOwner.builder()
             .name("Beatrice Stone")
             .build();
-        StorageItemChange<BlogOwner> saveBeatrice = StorageItemChange.<BlogOwner>builder()
+        StorageItemChange<BlogOwner> createBeatrice = StorageItemChange.<BlogOwner>builder()
             .item(beatrice)
             .itemClass(BlogOwner.class)
-            .type(StorageItemChange.Type.SAVE)
+            .type(StorageItemChange.Type.CREATE)
             .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
             .build();
-        StorageItemChange.Record saveBeatriceRecord =
-            saveBeatrice.toRecord(storageItemChangeConverter);
+        StorageItemChange.Record createBeatriceRecord =
+            createBeatrice.toRecord(storageItemChangeConverter);
 
-        save(saveBeatriceRecord);
+        save(createBeatriceRecord);
 
         // Assert that we do observe the record being saved ...
         assertEquals(
-            saveBeatriceRecord,
-            saveObserver.awaitCount(1)
+            createBeatriceRecord,
+            storageObserver.awaitCount(1)
                 .values()
                 .get(0)
                 .toStorageItemChange(storageItemChangeConverter)
                 .item()
         );
-        saveObserver.dispose();
+        storageObserver.dispose();
 
         TestObserver<StorageItemChange.Record> deletionObserver = TestObserver.create();
         records().subscribe(deletionObserver);
 
         // The mutation record doesn't change, but we want to delete it, itself.
-        delete(saveBeatriceRecord);
+        delete(createBeatriceRecord);
 
         assertEquals(
-            saveBeatriceRecord,
+            createBeatriceRecord,
             deletionObserver
                 .awaitCount(1)
                 .values()

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/TestStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/TestStorageAdapter.java
@@ -19,8 +19,10 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.datastore.DataStoreException;
 
 import java.util.Objects;
@@ -41,7 +43,16 @@ final class TestStorageAdapter {
      * @return An initialized instance of the {@link SynchronousStorageAdapter}
      */
     static SynchronousStorageAdapter create(ModelProvider modelProvider) {
-        SQLiteStorageAdapter sqLiteStorageAdapter = SQLiteStorageAdapter.forModels(modelProvider);
+        ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
+        modelSchemaRegistry.clear();
+        try {
+            modelSchemaRegistry.load(modelProvider.models());
+        } catch (AmplifyException modelSchemaLoadingFailure) {
+            throw new RuntimeException(modelSchemaLoadingFailure);
+        }
+        SQLiteStorageAdapter sqLiteStorageAdapter =
+            SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
+
         SynchronousStorageAdapter synchronousStorageAdapter =
             SynchronousStorageAdapter.instance(sqLiteStorageAdapter);
         Context context = ApplicationProvider.getApplicationContext();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -29,6 +29,7 @@ import com.amplifyframework.core.InitializationStatus;
 import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.appsync.AppSyncClient;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
@@ -66,15 +67,18 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     // Configuration for the plugin.
     private AWSDataStorePluginConfiguration pluginConfiguration;
 
-    private AWSDataStorePlugin(@NonNull final ModelProvider modelProvider) {
-        this.sqliteStorageAdapter = SQLiteStorageAdapter.forModels(modelProvider);
+    private AWSDataStorePlugin(
+            @NonNull ModelSchemaRegistry modelSchemaRegistry,
+            @NonNull ModelProvider modelProvider) {
+        this.sqliteStorageAdapter = SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
         this.storageItemChangeConverter = new GsonStorageItemChangeConverter();
-        this.orchestrator = createOrchestrator(modelProvider, sqliteStorageAdapter);
+        this.orchestrator = createOrchestrator(modelProvider, modelSchemaRegistry, sqliteStorageAdapter);
         this.categoryInitializationsPending = new CountDownLatch(1);
     }
 
-    private Orchestrator createOrchestrator(ModelProvider modelProvider, LocalStorageAdapter storageAdapter) {
-        return new Orchestrator(modelProvider, storageAdapter, AppSyncClient.instance());
+    private Orchestrator createOrchestrator(
+            ModelProvider modelProvider, ModelSchemaRegistry modelSchemaRegistry, LocalStorageAdapter storageAdapter) {
+        return new Orchestrator(modelProvider, modelSchemaRegistry, storageAdapter, AppSyncClient.instance());
     }
 
     /**
@@ -85,7 +89,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     @NonNull
     @SuppressWarnings("WeakerAccess")
     public static synchronized AWSDataStorePlugin forModels(@NonNull final ModelProvider modelProvider) {
-        return new AWSDataStorePlugin(modelProvider);
+        return new AWSDataStorePlugin(ModelSchemaRegistry.instance(), modelProvider);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -396,8 +396,11 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             case DELETE:
                 dataStoreItemChangeType = DataStoreItemChange.Type.DELETE;
                 break;
-            case SAVE:
-                dataStoreItemChangeType = DataStoreItemChange.Type.SAVE;
+            case UPDATE:
+                dataStoreItemChangeType = DataStoreItemChange.Type.UPDATE;
+                break;
+            case CREATE:
+                dataStoreItemChangeType = DataStoreItemChange.Type.CREATE;
                 break;
             default:
                 throw new DataStoreException(

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/ModelMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/ModelMetadata.java
@@ -35,9 +35,9 @@ import java.util.Objects;
 @SuppressWarnings({"MemberName", "ParameterName"})
 public final class ModelMetadata implements Model {
     private final @ModelField(targetType = "ID", isRequired = true) String id;
-    private final @ModelField(targetType = "Boolean", isRequired = true) Boolean _deleted;
-    private final @ModelField(targetType = "Int", isRequired = true) Integer _version;
-    private final @ModelField(targetType = "AWSTimestamp", isRequired = true) Long _lastChangedAt;
+    private final @ModelField(targetType = "Boolean") Boolean _deleted;
+    private final @ModelField(targetType = "Int") Integer _version;
+    private final @ModelField(targetType = "AWSTimestamp") Long _lastChangedAt;
 
     /**
      * Constructor for this metadata model.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/GsonStorageItemChangeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/GsonStorageItemChangeConverter.java
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.datastore.storage;
 
+import androidx.annotation.NonNull;
+
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryOperator;
@@ -51,8 +53,9 @@ public final class GsonStorageItemChangeConverter implements
                 .create();
     }
 
+    @NonNull
     @Override
-    public <T extends Model> StorageItemChange.Record toRecord(StorageItemChange<T> storageItemChange) {
+    public <T extends Model> StorageItemChange.Record toRecord(@NonNull StorageItemChange<T> storageItemChange) {
         return StorageItemChange.Record.builder()
                 .id(storageItemChange.changeId().toString())
                 .entry(gson.toJson(storageItemChange))
@@ -60,8 +63,9 @@ public final class GsonStorageItemChangeConverter implements
                 .build();
     }
 
+    @NonNull
     @Override
-    public <T extends Model> StorageItemChange<T> fromRecord(StorageItemChange.Record record)
+    public <T extends Model> StorageItemChange<T> fromRecord(@NonNull StorageItemChange.Record record)
             throws DataStoreException {
         Class<?> itemClass;
         try {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.datastore.storage;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
@@ -35,7 +36,6 @@ import java.util.UUID;
  * a stored item is changed.
  * @param <T> The type of the item that has changed
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
 public final class StorageItemChange<T extends Model> {
     private final UUID changeId;
     private final Initiator initiator;
@@ -45,21 +45,12 @@ public final class StorageItemChange<T extends Model> {
     private final Class<T> itemClass;
 
     private StorageItemChange(
-            @NonNull UUID changeId,
-            @NonNull Initiator initiator,
-            @NonNull Type type,
-            @NonNull T item,
-            @NonNull Class<T> itemClass) {
-        this(changeId, initiator, type, null, item, itemClass);
-    }
-
-    private StorageItemChange(
-            @NonNull UUID changeId,
-            @NonNull Initiator initiator,
-            @NonNull Type type,
-            @Nullable QueryPredicate predicate,
-            @NonNull T item,
-            @NonNull Class<T> itemClass) {
+            UUID changeId,
+            Initiator initiator,
+            Type type,
+            QueryPredicate predicate,
+            T item,
+            Class<T> itemClass) {
         this.changeId = changeId;
         this.initiator = initiator;
         this.type = type;
@@ -72,6 +63,7 @@ public final class StorageItemChange<T extends Model> {
      * Gets the ID of this change.
      * @return Unique ID for this change
      */
+    @NonNull
     public UUID changeId() {
         return changeId;
     }
@@ -80,6 +72,7 @@ public final class StorageItemChange<T extends Model> {
      * Gets an identification of the actor who initiated this change.
      * @return Identification of actor who initiated the change
      */
+    @NonNull
     public Initiator initiator() {
         return initiator;
     }
@@ -88,6 +81,7 @@ public final class StorageItemChange<T extends Model> {
      * Gets the type of change.
      * @return Type of change
      */
+    @NonNull
     public Type type() {
         return type;
     }
@@ -96,6 +90,7 @@ public final class StorageItemChange<T extends Model> {
      * Gets the predicate that was applied before this item change.
      * @return Predicate applied for this item change
      */
+    @Nullable
     public QueryPredicate predicate() {
         return predicate;
     }
@@ -106,6 +101,7 @@ public final class StorageItemChange<T extends Model> {
      * For deletions, this is the item as it was before the deletion.
      * @return Representation of item that changed
      */
+    @NonNull
     public T item() {
         return item;
     }
@@ -114,6 +110,7 @@ public final class StorageItemChange<T extends Model> {
      * Gets the class of the changed item.
      * @return Class of changed item
      */
+    @NonNull
     public Class<T> itemClass() {
         return itemClass;
     }
@@ -123,6 +120,7 @@ public final class StorageItemChange<T extends Model> {
      * @param <T> Type of item that has changed
      * @return A builder of StorageItemChange.
      */
+    @NonNull
     public static <T extends Model> Builder<T> builder() {
         return new Builder<>();
     }
@@ -133,12 +131,13 @@ public final class StorageItemChange<T extends Model> {
      * @param recordFactory A component capable of generating records.
      * @return A Record representation of this instance.
      */
+    @NonNull
     public Record toRecord(@NonNull RecordFactory recordFactory) {
         return Objects.requireNonNull(recordFactory).toRecord(this);
     }
 
     @Override
-    public boolean equals(Object thatObject) {
+    public boolean equals(@Nullable Object thatObject) {
         if (this == thatObject) {
             return true;
         }
@@ -178,6 +177,7 @@ public final class StorageItemChange<T extends Model> {
         return result;
     }
 
+    @NonNull
     @Override
     public String toString() {
         return "StorageItemChange{" +
@@ -194,7 +194,7 @@ public final class StorageItemChange<T extends Model> {
      * A utility for fluent construction of {@link StorageItemChange}.
      * @param <T> Type of item to be included in built StorageItemChanges.
      */
-    @SuppressWarnings("UnusedReturnValue")
+    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
     public static final class Builder<T extends Model> {
         private UUID changeId;
         private Initiator initiator;
@@ -210,6 +210,7 @@ public final class StorageItemChange<T extends Model> {
          * @param changeId A string representation of a Java UUID
          * @return Current Builder instance for fluent configuration chaining
          */
+        @NonNull
         public Builder<T> changeId(@NonNull String changeId) {
             this.changeId = UUID.fromString(Objects.requireNonNull(changeId));
             return this;
@@ -220,6 +221,7 @@ public final class StorageItemChange<T extends Model> {
          * each newly generated {@link StorageItemChange}.
          * @return Current Builder instance for fluent configuration chaining
          */
+        @NonNull
         public Builder<T> randomChangeId() {
             this.changeId = null;
             return this;
@@ -230,16 +232,18 @@ public final class StorageItemChange<T extends Model> {
          * @param initiator An identification of the initiator of this change
          * @return Current Builder instance for fluent configuration chaining
          */
+        @NonNull
         public Builder<T> initiator(@NonNull Initiator initiator) {
             this.initiator = Objects.requireNonNull(initiator);
             return this;
         }
 
         /**
-         * Configures the type of the change, e.g., {@link Type#SAVE}, etc.
+         * Configures the type of the change, e.g., {@link Type#CREATE}, etc.
          * @param type The type of change, e.g. {@link Type#DELETE}
          * @return Current Builder instance for fluent configuration chaining
          */
+        @NonNull
         public Builder<T> type(@NonNull Type type) {
             this.type = Objects.requireNonNull(type);
             return this;
@@ -250,6 +254,7 @@ public final class StorageItemChange<T extends Model> {
          * @param predicate The predicate that was applied for this change.
          * @return Current Builder instance for fluent configuration chainging
          */
+        @NonNull
         public Builder<T> predicate(@Nullable QueryPredicate predicate) {
             this.predicate = predicate;
             return this;
@@ -262,7 +267,8 @@ public final class StorageItemChange<T extends Model> {
          * @param item Representation of the item that changed
          * @return Current Builder instance for fluent configuration chaining
          */
-        public Builder<T> item(T item) {
+        @NonNull
+        public Builder<T> item(@NonNull T item) {
             this.item = Objects.requireNonNull(item);
             return this;
         }
@@ -272,7 +278,8 @@ public final class StorageItemChange<T extends Model> {
          * @param itemClass Class of the item that changed
          * @return Current Builder instance for fluent configuration chaining
          */
-        public Builder<T> itemClass(Class<T> itemClass) {
+        @NonNull
+        public Builder<T> itemClass(@NonNull Class<T> itemClass) {
             this.itemClass = Objects.requireNonNull(itemClass);
             return this;
         }
@@ -281,6 +288,8 @@ public final class StorageItemChange<T extends Model> {
          * Builds an instance of a StorageItemChange.
          * @return A new StorageItemChange instance.
          */
+        @SuppressLint("SyntheticAccessor")
+        @NonNull
         public StorageItemChange<T> build() {
             final UUID usedId = changeId == null ? UUID.randomUUID() : changeId;
             randomChangeId();
@@ -299,7 +308,7 @@ public final class StorageItemChange<T extends Model> {
      * A Record of a StorageItemChange is just a StorageItemChange in its serialized form.
      * This is the type which the {@link LocalStorageAdapter} deals with directly.
      */
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "WeakerAccess"})
     @ModelConfig(pluralName = "Records")
     @Index(fields = {"itemClass"}, name = "itemClassBasedIndex")
     public static final class Record implements Model {
@@ -400,6 +409,7 @@ public final class StorageItemChange<T extends Model> {
          * @return A StorageItemChange representation of the record
          * @throws DataStoreException If unable to perform the conversion
          */
+        @NonNull
         public <T extends Model> StorageItemChange<T> toStorageItemChange(
                 @NonNull StorageItemChangeFactory factory) throws DataStoreException {
             return Objects.requireNonNull(factory).fromRecord(this);
@@ -409,6 +419,7 @@ public final class StorageItemChange<T extends Model> {
          * Gets an instance of a {@link Record.Builder}.
          * @return A builder for Records
          */
+        @NonNull
         public static Builder builder() {
             return new Builder();
         }
@@ -419,6 +430,7 @@ public final class StorageItemChange<T extends Model> {
          * @param entry Record entry
          * @return A record containing the entry, and with random ID.
          */
+        @NonNull
         public static Record forEntry(@NonNull String entry) {
             return Record.builder().entry(entry).build();
         }
@@ -484,6 +496,7 @@ public final class StorageItemChange<T extends Model> {
              * Builds a Record using the configured properties.
              * @return A new instance of a {@link Record}.
              */
+            @SuppressLint("SyntheticAccessor")
             @NonNull
             public Record build() {
                 final UUID usedId = id == null ? UUID.randomUUID() : id;
@@ -515,15 +528,18 @@ public final class StorageItemChange<T extends Model> {
     }
 
     /**
-     * A type of change, e.g., one of the possible operations that can be
-     * invoked on {@link LocalStorageAdapter} to change a stored item.
+     * An outcome of one of the save/delete operations on the {@link LocalStorageAdapter}.
      */
     public enum Type {
         /**
-         * An item was saved into storage.
-         * This may have been an insert or an update ("upsert").
+         * A new item was created into storage.
          */
-        SAVE,
+        CREATE,
+
+        /**
+         * An existing item was updated.
+         */
+        UPDATE,
 
         /**
          * An item was deleted from storage.
@@ -542,7 +558,8 @@ public final class StorageItemChange<T extends Model> {
          * @return A Record corresponding to the storage item change.
          * @param <T> Type of item being kept in the StorageItemChange.
          */
-        <T extends Model> Record toRecord(StorageItemChange<T> storageItemChange);
+        @NonNull
+        <T extends Model> Record toRecord(@NonNull StorageItemChange<T> storageItemChange);
     }
 
     /**
@@ -559,6 +576,7 @@ public final class StorageItemChange<T extends Model> {
          * @return A {@link StorageItemChange} representation of provided record
          * @throws DataStoreException If unable to perform the conversion
          */
-        <T extends Model> StorageItemChange<T> fromRecord(Record record) throws DataStoreException;
+        @NonNull
+        <T extends Model> StorageItemChange<T> fromRecord(@NonNull Record record) throws DataStoreException;
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/SystemModelsProviderFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/SystemModelsProviderFactory.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.datastore.SimpleModelProvider;
+import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.storage.sqlite.PersistentModelVersion;
 
 /**
@@ -35,13 +36,19 @@ public final class SystemModelsProviderFactory {
         return SimpleModelProvider.instance(
             SYSTEM_MODELS_VERSION,
 
+            // PersistentModelVersion.class is stores the version of the data schema; that is,
+            // which models exist in the system, and what is their shape. When the structure of
+            // the data changes, this should see a version bump.
+            PersistentModelVersion.class,
+
+            // ModelMetadata.class stores the version of particular instances of a model. Unlike
+            // PersistentModelVersion, which details with the structure of data, ModelMetadata
+            // deals actually with individual records, and their states.
+            ModelMetadata.class,
+
             // StorageItemChange.Record.class is an internal system event
             // it is used to stage local storage changes for upload to cloud
-            StorageItemChange.Record.class,
-
-            // PersistentModelVersion.class is an internal system event
-            // it is used to store the version of the ModelProvider
-            PersistentModelVersion.class
+            StorageItemChange.Record.class
         );
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -301,8 +301,11 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 final String primaryKeyName = sqliteTable.getPrimaryKeyColumnName();
                 final SqlCommand sqlCommand;
                 final ModelConflictStrategy modelConflictStrategy;
+                final StorageItemChange.Type type;
 
                 if (dataExistsInSQLiteTable(sqliteTable.getName(), primaryKeyName, item.getId())) {
+                    type = StorageItemChange.Type.UPDATE;
+
                     // update model stored in SQLite
                     // update always checks for ID first
                     final QueryPredicateOperation<?> idCheck =
@@ -322,6 +325,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     modelConflictStrategy = ModelConflictStrategy.OVERWRITE_EXISTING;
                 } else {
                     // insert model in SQLite
+                    type = StorageItemChange.Type.CREATE;
+
                     sqlCommand = insertSqlPreparedStatements.get(modelSchema.getName());
                     if (sqlCommand == null || !sqlCommand.hasCompiledSqlStatement()) {
                         onError.accept(new DataStoreException(
@@ -339,7 +344,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 final StorageItemChange.Record record = StorageItemChange.<T>builder()
                     .item(item)
                     .itemClass((Class<T>) item.getClass())
-                    .type(StorageItemChange.Type.SAVE)
+                    .type(type)
                     .predicate(predicate)
                     .initiator(initiator)
                     .build()

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Action;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+import com.amplifyframework.datastore.appsync.ModelMetadata;
+import com.amplifyframework.datastore.appsync.ModelWithMetadata;
+import com.amplifyframework.datastore.storage.LocalStorageAdapter;
+import com.amplifyframework.datastore.storage.StorageItemChange;
+
+import java.util.Objects;
+
+import io.reactivex.Completable;
+
+/**
+ * The merger is responsible for merging cloud data back into the local store.
+ * Subscriptions, Mutations, and Syncs, all generate cloud-side data models.
+ * All of these sources must be rectified with the current state of the local storage.
+ * This is the purpose of the merger.
+ */
+@SuppressWarnings("CodeBlock2Expr")
+final class Merger {
+    private final LocalStorageAdapter localStorageAdapter;
+
+    /**
+     * Constructs a Merger.
+     * @param localStorageAdapter A local storage adapter
+     */
+    Merger(@NonNull LocalStorageAdapter localStorageAdapter) {
+        this.localStorageAdapter = Objects.requireNonNull(localStorageAdapter);
+    }
+
+    /**
+     * Merge an item back into the local store.
+     * TODO: check the state of the mutation outbox, before accessing the local storage.
+     * @param modelWithMetadata A model, combined with metadata about it
+     * @param <T> Type of model
+     * @return A completable operation to merge the item
+     */
+    <T extends Model> Completable merge(ModelWithMetadata<T> modelWithMetadata) {
+        ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
+        T model = modelWithMetadata.getModel();
+        if (Boolean.TRUE.equals(metadata.isDeleted())) {
+            return delete(model).andThen(save(metadata));
+        } else {
+            return save(model).andThen(save(metadata));
+        }
+    }
+
+    // Delete a model.
+    private <T extends Model> Completable delete(T model) {
+        return Completable.defer(() -> Completable.create(emitter -> {
+            // First, check if the thing exists.
+            // If we don't, we'll get an exception saying basically,
+            // "failed to delete a non-existing thing."
+            ifPresent(model.getClass(), model.getId(), () -> {
+                localStorageAdapter.delete(
+                    model,
+                    StorageItemChange.Initiator.SYNC_ENGINE,
+                    record -> emitter.onComplete(),
+                    emitter::onError
+                );
+            }, emitter::onComplete);
+        }));
+    }
+
+    // Create or update a model.
+    private <T extends Model> Completable save(T model) {
+        return Completable.defer(() -> Completable.create(emitter -> {
+            localStorageAdapter.save(
+                model,
+                StorageItemChange.Initiator.SYNC_ENGINE,
+                record -> emitter.onComplete(),
+                emitter::onError
+            );
+        }));
+    }
+
+    /**
+     * If the DataStore contains an item of the given class and with the given ID,
+     * then perform an action. Otherwise, perform some other action.
+     * @param clazz Search for this class in the DataStore
+     * @param modelId Search for an item with this ID in the DataStore
+     * @param onPresent If there is a match, perform this action
+     * @param onNotPresent If there is NOT a match, perform this action as a fallback
+     * @param <T> The type of item being searched
+     */
+    private <T extends Model> void ifPresent(
+            Class<T> clazz, String modelId, Action onPresent, Action onNotPresent) {
+        localStorageAdapter.query(clazz, QueryField.field("id").eq(modelId), iterator -> {
+            if (iterator.hasNext()) {
+                onPresent.call();
+            } else {
+                onNotPresent.call();
+            }
+        }, failure -> onNotPresent.call());
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Mutation.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Mutation.java
@@ -19,6 +19,7 @@ import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 
 import java.util.Objects;
 
@@ -27,22 +28,26 @@ import java.util.Objects;
  * A {@link Mutation} is a depiction of a GraphQL mutation _as received on a subscription_.
  * Subscriptions notify the client of mutations that have occurred on the backend.
  * Other GraphQL mutation data may be represented in additional/other data structures.
+ *
+ * TODO0: is this even needed? Can we just use {@link ModelWithMetadata} directly?
+ * TODO1: is this well named? Can it be called a SubscriptionEvent, instead?
+ *
  * @param <T> Type of data that has been mutated
  */
 final class Mutation<T extends Model> {
-    private final T model;
+    private final ModelWithMetadata<T> modelWithMetadata;
     private final Class<T> modelClass;
     private final Type type;
 
-    private Mutation(T model, Class<T> modelClass, Type type) {
-        this.model = model;
+    private Mutation(ModelWithMetadata<T> modelWithMetadata, Class<T> modelClass, Type type) {
+        this.modelWithMetadata = modelWithMetadata;
         this.modelClass = modelClass;
         this.type = type;
     }
 
     @NonNull
-    T model() {
-        return model;
+    ModelWithMetadata<T> modelWithMetadata() {
+        return modelWithMetadata;
     }
 
     @SuppressWarnings("unused")
@@ -51,6 +56,7 @@ final class Mutation<T extends Model> {
         return modelClass;
     }
 
+    @SuppressWarnings("unused")
     @NonNull
     Type type() {
         return type;
@@ -62,13 +68,13 @@ final class Mutation<T extends Model> {
     }
 
     static final class Builder<T extends Model> {
-        private T model;
+        private ModelWithMetadata<T> modelWithMetadata;
         private Class<T> modelClass;
         private Type type;
 
         @NonNull
-        Builder<T> model(@NonNull T model) {
-            this.model = Objects.requireNonNull(model);
+        Builder<T> modelWithMetadata(@NonNull ModelWithMetadata<T> modelWithMetadata) {
+            this.modelWithMetadata = Objects.requireNonNull(modelWithMetadata);
             return this;
         }
 
@@ -87,7 +93,7 @@ final class Mutation<T extends Model> {
         @SuppressLint("SyntheticAccessor")
         @NonNull
         Mutation<T> build() {
-            return new Mutation<>(model, modelClass, type);
+            return new Mutation<>(modelWithMetadata, modelClass, type);
         }
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -17,18 +17,28 @@ package com.amplifyframework.datastore.syncengine;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.AppSync;
+import com.amplifyframework.datastore.appsync.ModelMetadata;
+import com.amplifyframework.datastore.appsync.ModelWithMetadata;
+import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.logging.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
+import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
@@ -39,16 +49,20 @@ import io.reactivex.schedulers.Schedulers;
  *
  * The responses to these mutations are themselves forwarded to the Merger (TODO: write a merger.)
  */
+@SuppressWarnings("CodeBlock2Expr")
 final class MutationProcessor {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
+    private final LocalStorageAdapter localStorageAdapter;
     private final AppSync appSync;
     private final MutationOutbox mutationOutbox;
     private final CompositeDisposable disposable;
 
     MutationProcessor(
+            @NonNull LocalStorageAdapter localStorageAdapter,
             @NonNull MutationOutbox mutationOutbox,
             @NonNull AppSync appSync) {
+        this.localStorageAdapter = localStorageAdapter;
         this.appSync = Objects.requireNonNull(appSync);
         this.mutationOutbox = Objects.requireNonNull(mutationOutbox);
         this.disposable = new CompositeDisposable();
@@ -56,24 +70,66 @@ final class MutationProcessor {
 
     /**
      * Start observing the mutation outbox for locally-initiated changes.
+     *
+     * To process a StorageItemChange, we try to publish it to the remote GraphQL
+     * API. If that succeeds, then we can remove it from the outbox. Otherwise,
+     * we have to keep the mutation in the outbox, so that we can try to publish
+     * it again later, when network conditions become favorable again.
      */
     void startDrainingMutationOutbox() {
         disposable.add(
             mutationOutbox.observe()
                 .subscribeOn(Schedulers.io())
                 .observeOn(Schedulers.io())
-                .flatMapSingle(this::publishToNetwork)
-                .flatMapSingle(mutationOutbox::remove)
+                .flatMapSingle(this::processOutboxItem)
                 .subscribe(
-                    processedChange -> {
-                        LOG.info("Change processed successfully! " + processedChange);
-                        HubEvent<? extends Model> publishedToCloudEvent =
-                            HubEvent.create(DataStoreChannelEventName.PUBLISHED_TO_CLOUD, processedChange.item());
-                        Amplify.Hub.publish(HubChannel.DATASTORE, publishedToCloudEvent);
-                    },
+                    this::announceSuccessToHub,
                     error -> LOG.warn("Error ended observation of mutation outbox: ", error),
                     () -> LOG.warn("Observation of mutation outbox was completed.")
                 )
+        );
+    }
+
+    /**
+     * Process an item in the mutation outbox.
+     * @param mutationOutboxItem An item in the mutation outbox
+     * @param <T> Type of model
+     * @return A single echos back the processed change, upon success; emits failure, upon
+     */
+    private <T extends Model> Single<StorageItemChange<T>> processOutboxItem(StorageItemChange<T> mutationOutboxItem) {
+        // First, publish the change over the network.
+        return publishToNetwork(mutationOutboxItem)
+            .flatMapCompletable(modelWithMetadata -> {
+                // Then, save the RESPONSE of the network call, locally
+                return saveModel(modelWithMetadata.getModel())
+                    // If that succeeds, save the metadata, too.
+                    .andThen(saveModel(modelWithMetadata.getSyncMetadata()));
+            })
+            // Lastly, remove the item from the outbox, so we don't process it again.
+            .andThen(mutationOutbox.remove(mutationOutboxItem));
+    }
+
+    /**
+     * Publish a successfully processed storage item change to hub.
+     * @param processedChange A change that has been successfully processed and removed from outbox
+     * @param <T> Type of model
+     */
+    private <T extends Model> void announceSuccessToHub(StorageItemChange<T> processedChange) {
+        LOG.info("Change processed successfully! " + processedChange);
+        HubEvent<StorageItemChange<? extends Model>> publishedToCloudEvent =
+            HubEvent.create(DataStoreChannelEventName.PUBLISHED_TO_CLOUD, processedChange);
+        Amplify.Hub.publish(HubChannel.DATASTORE, publishedToCloudEvent);
+    }
+
+    // This should go through the Merger, not directly into storage.
+    private <T extends Model> Completable saveModel(T model) {
+        return Completable.create(emitter ->
+            localStorageAdapter.save(
+                model,
+                StorageItemChange.Initiator.SYNC_ENGINE,
+                record -> emitter.onComplete(),
+                emitter::onError
+            )
         );
     }
 
@@ -85,35 +141,127 @@ final class MutationProcessor {
     }
 
     /**
-     * To process a StorageItemChange, we try to publish it to the remote GraphQL
-     * API. If that succeeds, then we can remove it from the outbox. Otherwise,
-     * we have to keep the mutation in the outbox, so that we can try to publish
-     * it again later, when network conditions become favorable again.
+     * Attempt to publish a change (update, delete, creation) over the network.
      * @param storageItemChange A storage item change to be published to remote API
-     * @return A single which completes with the successfully published item, or errors
+     * @param <T> Type of model
+     * @return A single which completes with the successfully published item, or emits error
      *         if the publication fails
      */
-    @SuppressWarnings("checkstyle:MethodTypeParameterName") // The generics are complex, so use meaningful names
-    private <MODEL extends Model, SIC extends StorageItemChange<MODEL>> Single<SIC> publishToNetwork(
-        final SIC storageItemChange) {
-        //noinspection CodeBlock2Expr More readable as a block statement
+    private <T extends Model> Single<ModelWithMetadata<T>> publishToNetwork(StorageItemChange<T> storageItemChange) {
+        switch (storageItemChange.type()) {
+            case UPDATE:
+                return update(storageItemChange);
+            case CREATE:
+                return create(storageItemChange);
+            case DELETE:
+                return delete(storageItemChange);
+            default:
+                return Single.error(new DataStoreException(
+                   "Unknown change type in storage = " + storageItemChange.type(),
+                   "This is likely a bug. Please file a ticket with AWS."
+                ));
+        }
+    }
+
+    // For an item in the outbox, dispatch an update mutation
+    private <T extends Model> Single<ModelWithMetadata<T>> update(StorageItemChange<T> storageItemChange) {
+        return findModelVersion(storageItemChange.item()).flatMap(version -> {
+            return publishWithStrategy(storageItemChange, (model, onSuccess, onError) -> {
+                appSync.update(model, version, onSuccess, onError);
+            });
+        });
+    }
+
+    // For an item in the outbox, dispatch a create mutation
+    private <T extends Model> Single<ModelWithMetadata<T>> create(StorageItemChange<T> storageItemChange) {
+        return publishWithStrategy(storageItemChange, appSync::create);
+    }
+
+    // For an item in the outbox, dispatch a delete mutation
+    private <T extends Model> Single<ModelWithMetadata<T>> delete(StorageItemChange<T> storageItemChange) {
+        return findModelVersion(storageItemChange.item()).flatMap(version -> {
+            return publishWithStrategy(storageItemChange, (model, onSuccess, onError) -> {
+                final Class<T> modelClass = storageItemChange.itemClass();
+                final String modelId = storageItemChange.item().getId();
+                appSync.delete(modelClass, modelId, version, onSuccess, onError);
+            });
+        });
+    }
+
+    /**
+     * Find the current version of a model, that we have in the local store.
+     * @param model A model
+     * @param <T> Type of model
+     * @return Current version known locally
+     */
+    private <T extends Model> Single<Integer> findModelVersion(T model) {
+        // The ModelMetadata for the model uses the same ID as an identifier.
+        final QueryPredicate hasMatchingId = QueryField.field("id").eq(model.getId());
+        return Single.create(emitter -> {
+            localStorageAdapter.query(ModelMetadata.class, hasMatchingId, iterableResults -> {
+                // Extract the results into a list.
+                final List<ModelMetadata> results = new ArrayList<>();
+                while (iterableResults.hasNext()) {
+                    results.add(iterableResults.next());
+                }
+                // There should be only one metadata for the model....
+                if (results.size() == 1) {
+                    emitter.onSuccess(results.get(0).getVersion());
+                } else {
+                    emitter.onError(new DataStoreException(
+                        "Wanted 1 metadata for item with id = " + model.getId() + ", but had " + results.size() + ".",
+                        "This is likely a bug. please report to AWS."
+                    ));
+                }
+            }, emitter::onError);
+        });
+    }
+
+    /**
+     * For an item in storage that has changed, publish the changed item using a publication strategy.
+     * @param storageItemChange A change to an item in storage
+     * @param publicationStrategy A strategy to publish the changed item
+     * @param <T> The model type of the item
+     * @return A single which emits the original storage item change, upon success; emits
+     *         a failure, if publication does not succeed
+     */
+    private <T extends Model> Single<ModelWithMetadata<T>> publishWithStrategy(
+            StorageItemChange<T> storageItemChange, PublicationStrategy<T> publicationStrategy) {
         return Single.defer(() -> Single.create(subscriber -> {
-            appSync.create(
+            publicationStrategy.publish(
                 storageItemChange.item(),
                 result -> {
-                    if (result.hasErrors() || !result.hasData()) {
-                        subscriber.onError(new DataStoreException(
-                            "Failed to publish an item to the network. AppSync response contained errors: "
-                                + result.getErrors(),
-                            "Verify that your endpoint is configured to accept "
-                                + storageItemChange.itemClass().getSimpleName() + " models."
-                        ));
-                    } else {
-                        subscriber.onSuccess(storageItemChange);
+                    if (!result.hasErrors() && result.hasData()) {
+                        subscriber.onSuccess(result.getData());
+                        return;
                     }
+                    subscriber.onError(new DataStoreException(
+                        "Failed to publish an item to the network. AppSync response contained errors: "
+                            + result.getErrors(),
+                        "Verify that your endpoint is configured to accept "
+                            + storageItemChange.itemClass().getSimpleName() + " models."
+                    ));
                 },
                 subscriber::onError
             );
         }));
+    }
+
+    /**
+     * A strategy to publish an item over the network.
+     * @param <T> Type of model being published
+     */
+    interface PublicationStrategy<T extends Model> {
+        /**
+         * Publish a storage item change, over the network.
+         * @param item An item to publish
+         * @param onSuccess Called when publication succeeds
+         * @param onFailure Called when publication fails
+         */
+        void publish(
+            T item,
+            Consumer<GraphQLResponse<ModelWithMetadata<T>>> onSuccess,
+            Consumer<DataStoreException> onFailure
+        );
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -60,7 +60,7 @@ public final class Orchestrator {
         RemoteModelState remoteModelState = new RemoteModelState(appSync, modelProvider);
         MutationOutbox mutationOutbox = new MutationOutbox(localStorageAdapter);
 
-        this.mutationProcessor = new MutationProcessor(mutationOutbox, appSync);
+        this.mutationProcessor = new MutationProcessor(localStorageAdapter, mutationOutbox, appSync);
         this.syncProcessor =
             new SyncProcessor(remoteModelState, localStorageAdapter, modelProvider, modelSchemaRegistry);
         this.subscriptionProcessor = new SubscriptionProcessor(localStorageAdapter, appSync, modelProvider);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -57,13 +57,15 @@ public final class Orchestrator {
         Objects.requireNonNull(appSync);
         Objects.requireNonNull(localStorageAdapter);
 
+        RemoteModelMutations remoteModelMutations = new RemoteModelMutations(appSync, modelProvider);
         RemoteModelState remoteModelState = new RemoteModelState(appSync, modelProvider);
         MutationOutbox mutationOutbox = new MutationOutbox(localStorageAdapter);
+        Merger merger = new Merger(localStorageAdapter);
+        VersionRepository versionRepository = new VersionRepository(localStorageAdapter);
 
-        this.mutationProcessor = new MutationProcessor(localStorageAdapter, mutationOutbox, appSync);
-        this.syncProcessor =
-            new SyncProcessor(remoteModelState, localStorageAdapter, modelProvider, modelSchemaRegistry);
-        this.subscriptionProcessor = new SubscriptionProcessor(localStorageAdapter, appSync, modelProvider);
+        this.mutationProcessor = new MutationProcessor(merger, versionRepository, mutationOutbox, appSync);
+        this.syncProcessor = new SyncProcessor(remoteModelState, merger, modelProvider, modelSchemaRegistry);
+        this.subscriptionProcessor = new SubscriptionProcessor(remoteModelMutations, merger);
         this.storageObserver = new StorageObserver(localStorageAdapter, mutationOutbox);
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RemoteModelMutations.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RemoteModelMutations.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.datastore.syncengine;
 
 import android.annotation.SuppressLint;
+import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.AmplifyException;
@@ -33,6 +34,7 @@ import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.logging.Logger;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import io.reactivex.Emitter;
@@ -57,11 +59,16 @@ final class RemoteModelMutations {
     private final ModelProvider modelProvider;
     private final Set<Subscription> subscriptions;
 
+    /**
+     * Constructs a new RemoteModelMutations.
+     * @param appSync An interface to an AppSync endpoint
+     * @param modelProvider Provides the model classes managed by this system
+     */
     RemoteModelMutations(
-            AppSync appSync,
-            ModelProvider modelProvider) {
-        this.modelProvider = modelProvider;
-        this.appSync = appSync;
+            @NonNull AppSync appSync,
+            @NonNull ModelProvider modelProvider) {
+        this.appSync = Objects.requireNonNull(appSync);
+        this.modelProvider = Objects.requireNonNull(modelProvider);
         this.subscriptions = new HashSet<>();
     }
 
@@ -123,8 +130,7 @@ final class RemoteModelMutations {
                 return this;
             }
 
-            @SuppressWarnings("unchecked")
-                // TODO: can this be improved?
+            @SuppressWarnings("unchecked") // TODO: can this be improved?
             Request<T> modelClass(Class<? extends Model> modelClass) {
                 this.modelClass = (Class<T>) modelClass;
                 return this;
@@ -210,7 +216,7 @@ final class RemoteModelMutations {
                         ));
                     } else {
                         commonEmitter.onNext(Mutation.<T>builder()
-                            .model(response.getData().getModel())
+                            .modelWithMetadata(response.getData())
                             .modelClass(modelClazz)
                             .type(fromSubscriptionType(subscriptionType))
                             .build());

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/TopologicalOrdering.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/TopologicalOrdering.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import android.annotation.SuppressLint;
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelAssociation;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Stack;
+
+/**
+ * Maintains a topological ordering of a collection of ModelSchema.
+ * A ModelSchema A is "less than" ModelSchema B, if there is a dependency lineage
+ * from A to B. If a ModelSchema has no dependencies, than it is greater than or
+ * equal to all other ModelSchema.
+ *
+ * For example, if a Blog has n Posts, and each Post has n Comment:
+ *   input := [Comment, Post, Blog]
+ * than the topological ordering is:
+ *   output := [Blog, Post, Comment]
+ */
+@SuppressWarnings("unused")
+final class TopologicalOrdering {
+    private final List<ModelSchema> modelSchema;
+
+    private TopologicalOrdering(List<ModelSchema> modelSchema) {
+        this.modelSchema = modelSchema;
+    }
+
+    /**
+     * Gets a TopologicalOrdering of the ModelSchema in the ModelSchemaRegistry.
+     * The set of ModelSchema in that registry is not expected to change during runtime,
+     * so the results of this TopologicalOrdering should likewise be stable at runtime.
+     * @param modelSchemaRegistry A registry of ModelSchema
+     * @param modelProvider A ModelProvider
+     * @return A topological ordering of the model schema in the registry
+     */
+    @SuppressLint("SyntheticAccessor")
+    static TopologicalOrdering forRegisteredModels(
+            @NonNull ModelSchemaRegistry modelSchemaRegistry,
+            @NonNull ModelProvider modelProvider) {
+        Objects.requireNonNull(modelProvider);
+        final List<ModelSchema> schemaForModels = new ArrayList<>();
+        for (Class<? extends Model> modelClass : modelProvider.models()) {
+            final String modelClassName = modelClass.getSimpleName();
+            final ModelSchema schemaForModelClass = modelSchemaRegistry.getModelSchemaForModelClass(modelClassName);
+            schemaForModels.add(schemaForModelClass);
+        }
+        return new TopologicalOrdering(new TopologicalSort(schemaForModels).result());
+    }
+
+    /**
+     * Compares two ModelSchema to determine if one comes before the other.
+     * For example, compare(blogSchema, postSchema) == -2.
+     * @param one A ModelSchema
+     * @param two A ModelSchema
+     * @return A number less than 0 if one comes before two. A number greater than 0 is one comes
+     *         after two. Returns 0 in the case where one and two are the same schema.
+     */
+    int compare(@NonNull ModelSchema one, @NonNull ModelSchema two) {
+        Objects.requireNonNull(one);
+        Objects.requireNonNull(two);
+        int onePosition = -1;
+        int twoPosition = -1;
+        for (int index = 0; index < modelSchema.size(); index++) {
+            if (modelSchema.get(index).equals(one)) {
+                onePosition = index;
+            }
+            if (modelSchema.get(index).equals(two)) {
+                twoPosition = index;
+            }
+        }
+        return onePosition - twoPosition;
+    }
+
+    /**
+     * Check the ordering of a ModelSchema.
+     * @param modelSchema A model schema
+     * @return A collection of checks that can be made on the ordering of the schema
+     */
+    @SuppressWarnings("unused")
+    @NonNull
+    @SuppressLint("SyntheticAccessor")
+    OrderingCheck check(@NonNull ModelSchema modelSchema) {
+        Objects.requireNonNull(modelSchema);
+        if (!this.modelSchema.contains(modelSchema)) {
+            throw new NoSuchElementException("No model schema matching " + modelSchema.getName());
+        }
+        return new OrderingCheck(modelSchema);
+    }
+
+    /**
+     * Exercises a Topological Sort on a list of ModelSchema.
+     */
+    private static final class TopologicalSort {
+        private final Stack<ModelSchema> result;
+        private final Set<ModelSchema> unvisited;
+        private final List<ModelSchema> input;
+
+        private TopologicalSort(List<ModelSchema> modelSchema) {
+            this.input = modelSchema;
+            this.unvisited = new HashSet<>(modelSchema);
+            this.result = new Stack<>();
+        }
+
+        private List<ModelSchema> result() {
+            while (!unvisited.isEmpty()) { // While there are model schema we haven't visited,
+                ModelSchema randomlyPicked = unvisited.iterator().next(); // Pick one at random.
+                visit(randomlyPicked); // Visit it.
+            }
+            return result;
+        }
+
+        private void visit(ModelSchema node) {
+            unvisited.remove(node);
+            for (ModelSchema unvisitedAssociationOwner : findUnvisitedAssociationOwners(node)) {
+                visit(unvisitedAssociationOwner);
+            }
+            result.push(node);
+        }
+
+        private Set<ModelSchema> findUnvisitedAssociationOwners(ModelSchema node) {
+            final Set<ModelSchema> unvisitedAssociationOwners = new HashSet<>();
+            for (ModelSchema associationOwner : findAssociationOwners(node)) {
+                if (unvisited.contains(associationOwner)) {
+                    unvisitedAssociationOwners.add(associationOwner);
+                }
+            }
+            return unvisitedAssociationOwners;
+        }
+
+        private Set<ModelSchema> findAssociationOwners(ModelSchema node) {
+            final Set<ModelSchema> associationOwners = new HashSet<>();
+            for (ModelAssociation association : node.getAssociations().values()) {
+                if (association.isOwner()) {
+                    associationOwners.add(findInputSchemaByName(association.getAssociatedType()));
+                }
+            }
+            return associationOwners;
+        }
+
+        private ModelSchema findInputSchemaByName(String name) {
+            for (ModelSchema schema : input) {
+                if (schema.getName().equals(name)) {
+                    return schema;
+                }
+            }
+            throw new NoSuchElementException("No model schema provided with name = " + name);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    final class OrderingCheck {
+        private final ModelSchema modelSchema;
+
+        private OrderingCheck(@NonNull ModelSchema modelSchema) {
+            this.modelSchema = Objects.requireNonNull(modelSchema);
+        }
+
+        boolean isAfter(@NonNull ModelSchema someOther) {
+            Objects.requireNonNull(someOther);
+            return compare(someOther, modelSchema) < 0;
+        }
+
+        boolean isBefore(@NonNull ModelSchema someOther) {
+            Objects.requireNonNull(someOther);
+            return compare(someOther, modelSchema) > 0;
+        }
+    }
+
+    /**
+     * Any component which provides a means to create an instance of {@link TopologicalOrdering}.
+     */
+    interface Factory {
+        TopologicalOrdering create();
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.appsync.ModelMetadata;
+import com.amplifyframework.datastore.storage.LocalStorageAdapter;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import io.reactivex.Single;
+
+/**
+ * The VersionRepository provides a higher-level facade to lookup the version
+ * of the various models in the local storage.
+ */
+@SuppressWarnings("CodeBlock2Expr")
+final class VersionRepository {
+    private final LocalStorageAdapter localStorageAdapter;
+
+    /**
+     * Constructs a new VersionRepository.
+     * @param localStorageAdapter A local storage repository, where model metadata can be found
+     */
+    VersionRepository(@NonNull LocalStorageAdapter localStorageAdapter) {
+        this.localStorageAdapter = Objects.requireNonNull(localStorageAdapter);
+    }
+
+    /**
+     * Find the current version of a model, that we have in the local store.
+     * @param model A model
+     * @param <T> Type of model
+     * @return Current version known locally
+     */
+    <T extends Model> Single<Integer> findModelVersion(T model) {
+        // The ModelMetadata for the model uses the same ID as an identifier.
+        final QueryPredicate hasMatchingId = QueryField.field("id").eq(model.getId());
+        return Single.create(emitter -> {
+            localStorageAdapter.query(ModelMetadata.class, hasMatchingId, iterableResults -> {
+                try {
+                    emitter.onSuccess(extractVersion(model, iterableResults));
+                } catch (DataStoreException badVersionFailure) {
+                    emitter.onError(badVersionFailure);
+                }
+            }, emitter::onError);
+        });
+    }
+
+    /**
+     * Extract a model version from an metadata iterator.
+     * @param model The model for which metadata is being interrogated, used only for creating error messages.
+     * @param metadataIterator An iterator of ModelMetadata; the metadata is associated with the provided model
+     * @param <T> The type of model
+     * @return The version of the model, if available
+     * @throws DataStoreException If there is no version for the model, or if the version cannot be obtained
+     */
+    private <T extends Model> int extractVersion(T model, Iterator<ModelMetadata> metadataIterator)
+            throws DataStoreException {
+        final List<ModelMetadata> results = new ArrayList<>();
+        while (metadataIterator.hasNext()) {
+            results.add(metadataIterator.next());
+        }
+
+        // There should be only one metadata for the model....
+        if (results.size() != 1) {
+            throw new DataStoreException(
+                "Wanted 1 metadata for item with id = " + model.getId() + ", but had " + results.size() + ".",
+                "This is likely a bug. please report to AWS."
+            );
+        }
+        final Integer version = results.get(0).getVersion();
+        if (version == null) {
+            throw new DataStoreException(
+                "Metadata for item with id = " + model.getId() + " had null version.",
+                "This is likely a bug. Please report to AWS."
+            );
+        }
+
+        return version;
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
@@ -33,20 +34,153 @@ import static org.mockito.Mockito.eq;
 /**
  * A utility to mock behaviors of an {@link AppSync} from test code.
  */
+@SuppressWarnings({"unused", "UnusedReturnValue", "WeakerAccess"})
 public final class AppSyncMocking {
     @SuppressWarnings("checkstyle:all") private AppSyncMocking() {}
 
-    public static Configurator configure(AppSync mock) {
-        return new Configurator(mock);
+    /**
+     * Prepare mocks on AppSync, to occur when a sync() call is made.
+     * @param mock A mock of the AppSync interface
+     * @return A configurator for the sync() behavior.
+     */
+    @NonNull
+    public static SyncConfigurator onSync(AppSync mock) {
+        return new SyncConfigurator(mock);
+    }
+
+    /**
+     * Prepare mocks on AppSync, to occur when a delete() call is made.
+     * @param mock A mock of the AppSync interface
+     * @return A configurator for the delete() behavior.
+     */
+    @NonNull
+    public static DeleteConfigurator onDelete(AppSync mock) {
+        return new DeleteConfigurator(mock);
+    }
+
+    /**
+     * Prepare mocks on AppSync, to occur when a create() call is made.
+     * @param mock A mock of the AppSync interface
+     * @return A configurator for the create() behavior.
+     */
+    @NonNull
+    public static CreateConfigurator onCreate(AppSync mock) {
+        return new CreateConfigurator(mock);
+    }
+
+    /**
+     * Configures mock behaviors to occur when create() is invoked.
+     */
+    public static final class CreateConfigurator {
+        private AppSync appSync;
+
+        /**
+         * Constructs a CreateConfigurator, bound to a mock AppSync instance.
+         * @param appSync A mock of the AppSync interface
+         */
+        CreateConfigurator(AppSync appSync) {
+            this.appSync = appSync;
+        }
+
+        /**
+         * Mocks a response to the create() API. The mock will call back the the success consumer.
+         * The provided value is a ModelWithMetadata. The model is the one passed to the mock.
+         * The metadata simply echos the model ID and includes the current time.
+         * @param model When this model is received, mock is enacted. This model is passed back in response.
+         * @param <T> Type of model
+         * @return A create configurator
+         */
+        public <T extends Model> CreateConfigurator mockResponse(T model) {
+            doAnswer(invocation -> {
+                // Simulate a successful response callback from the create() method.
+                final int indexOfModelBeingCreated = 0;
+                final int indexOfResultConsumer = 1;
+                T capturedModel = invocation.getArgument(indexOfModelBeingCreated);
+
+                // Pass back a ModelWithMetadata. Model is the one provided.
+                ModelMetadata metadata =
+                    new ModelMetadata(capturedModel.getId(), false, 1, System.currentTimeMillis());
+                ModelWithMetadata<T> modelWithMetadata = new ModelWithMetadata<>(model, metadata);
+                Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResult =
+                    invocation.getArgument(indexOfResultConsumer);
+                onResult.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
+
+                // Technically, create() returns a Cancelable...
+                return new NoOpCancelable();
+            }).when(appSync).create(
+                eq(model),
+                any(), // onResponse
+                any() // onFailure
+            );
+            return CreateConfigurator.this;
+        }
+    }
+
+    /**
+     * Configures mocked behavior when the AppSync delete() API is exercised.
+     */
+    public static final class DeleteConfigurator {
+        private AppSync appSync;
+
+        /**
+         * Constructs a DeleteConfigurator.
+         * @param appSync A mock instance of AppSync.
+         */
+        DeleteConfigurator(AppSync appSync) {
+            this.appSync = appSync;
+        }
+
+        /**
+         * Mocks a response to the delete() API. The mock will call back the the success consumer.
+         * The provided value is a ModelWithMetadata. The model is the one passed to the mock.
+         * The metadata simply echos the model ID and includes the current time, and includes
+         * the _delete == true flag.
+         * @param model When this model is received, mock is enacted. This model is passed back in response.
+         * @param <T> Type of model
+         * @return A create configurator
+         */
+        @NonNull
+        public <T extends Model> DeleteConfigurator mockResponse(T model) {
+            doAnswer(invocation -> {
+                // Simulate a successful response callback from the delete() method.
+                final int indexOfModelId = 1;
+                final int indexOfVersion = 2;
+                final int indexOfResultConsumer = 3;
+                Consumer<GraphQLResponse<ModelWithMetadata<? extends Model>>> onResult =
+                    invocation.getArgument(indexOfResultConsumer);
+
+                String modelId = invocation.getArgument(indexOfModelId);
+                int version = invocation.getArgument(indexOfVersion);
+                long time = System.currentTimeMillis();
+                ModelMetadata metadata = new ModelMetadata(modelId, true, version, time);
+                ModelWithMetadata<? extends Model> modelWithMetadata = new ModelWithMetadata<>(model, metadata);
+
+                onResult.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
+
+                // Technically, delete() returns a Cancelable...
+                return new NoOpCancelable();
+            }).when(appSync).delete(
+                eq(model.getClass()), // Class of the model
+                eq(model.getId()), // model ID
+                anyInt(), // version
+                any(), // onResponse
+                any() // onFailure
+            );
+            return this;
+        }
     }
 
     /**
      * Configures mocking for a particular {@link AppSync} mock.
      */
-    public static final class Configurator {
+    public static final class SyncConfigurator {
         private AppSync appSync;
 
-        Configurator(AppSync appSync) {
+        /**
+         * Constructs a new SyncConfigurator.
+         * @param appSync A mock AppSync instance
+         */
+        SyncConfigurator(AppSync appSync) {
             this.appSync = appSync;
             this.mockSuccessResponses();
         }
@@ -55,9 +189,8 @@ public final class AppSyncMocking {
          * By default, return an empty list of items when attempting to sync any/all Model classes.
          * @return Configurator instance
          */
-        @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
         @NonNull
-        public Configurator mockSuccessResponses() {
+        public SyncConfigurator mockSuccessResponses() {
             doAnswer(invocation -> {
                 // Get a handle to the response consumer that is passed into the sync() method
                 // Response consumer is the third param, at index 2 (@0, @1, @2, @3).
@@ -81,7 +214,8 @@ public final class AppSyncMocking {
 
         /**
          * Creates an instance of an {@link AppSync}, which will provide a fake response when asked to
-         * to {@link AppSync#sync(Class, Long, Consumer, Consumer)}.
+         * to {@link AppSync#sync(Class, Long, Consumer, Consumer)}. The response callback will
+         * be invoked, and will contain the provided ModelWithMetadata in its response.
          * @param modelClass Class of models for which the endpoint should respond
          * @param responseItems The items that should be included in the mocked response, for the model class
          * @param <T> Type of models for which a response is mocked
@@ -89,7 +223,7 @@ public final class AppSyncMocking {
          */
         @SuppressWarnings("varargs")
         @SafeVarargs
-        public final <T extends Model> Configurator mockSuccessResponse(
+        public final <T extends Model> SyncConfigurator mockSuccessResponse(
                 Class<T> modelClass, ModelWithMetadata<T>... responseItems) {
             doAnswer(invocation -> {
                 // Get a handle to the response consumer that is passed into the sync() method
@@ -111,7 +245,7 @@ public final class AppSyncMocking {
                 any(), // Consumer<Iterable<ModelWithMetadata<T>>>
                 any() // Consumer<DataStoreException>
             );
-            return Configurator.this;
+            return SyncConfigurator.this;
         }
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/GsonStorageItemChangeConverterTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/GsonStorageItemChangeConverterTest.java
@@ -52,7 +52,7 @@ public class GsonStorageItemChangeConverterTest {
                     .build())
                 .build())
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
-            .type(StorageItemChange.Type.SAVE)
+            .type(StorageItemChange.Type.CREATE)
             .build();
 
         // Instantiate the object under test

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -21,6 +21,7 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelIndex;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 
 import org.junit.Before;
@@ -52,7 +53,8 @@ public class SqlCommandTest {
      */
     @Before
     public void createSqlCommandFactory() {
-        sqlCommandFactory = new SQLiteCommandFactory();
+        ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
+        sqlCommandFactory = new SQLiteCommandFactory(modelSchemaRegistry);
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.appsync.ModelMetadata;
+import com.amplifyframework.datastore.appsync.ModelWithMetadata;
+import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
+import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testutils.Await;
+import com.amplifyframework.testutils.Time;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import io.reactivex.observers.TestObserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link Merger}.
+ * NOTE: the tests show that the Merger is not currently working to spec.
+ * At the moment, Merger just applies changes into the local store, without
+ * any consideration to the {@link MutationOutbox}. TODO: fix this.
+ */
+public final class MergerTest {
+    private static final long REASONABLE_WAIT_TIME = TimeUnit.SECONDS.toMillis(2);
+
+    private InMemoryStorageAdapter inMemoryStorageAdapter;
+    private Merger merger;
+
+    @Before
+    public void setup() {
+        this.inMemoryStorageAdapter = InMemoryStorageAdapter.create();
+        this.merger = new Merger(inMemoryStorageAdapter);
+    }
+
+    /**
+     * Assume there is a record A in the store. Then, we try to merge
+     * a mutation to delete record A. This should succeed. After the
+     * merge, A should NOT be in the store anymore.
+     * @throws DataStoreException On failure to arrange test data into store
+     */
+    @Test
+    public void mergeDeletionForExistingRecord() throws DataStoreException {
+        // Arrange: A blog owner, and some metadata about it, are in the store.
+        BlogOwner blogOwner = BlogOwner.builder()
+            .name("Jameson")
+            .build();
+        ModelMetadata originalMetadata =
+            new ModelMetadata(blogOwner.getId(), false, 1, Time.now());
+        putInStore(blogOwner, originalMetadata);
+        // Just to be sure, our arrangement worked, and that thing is in there, right? Good.
+        assertEquals(Collections.singletonList(blogOwner), findModels(BlogOwner.class));
+
+        // Act: merge a deletion record against the model.
+        ModelMetadata deletionMetadata =
+            new ModelMetadata(blogOwner.getId(), true, 1, Time.now());
+        TestObserver<Void> observer =
+            merger.merge(new ModelWithMetadata<>(blogOwner, deletionMetadata)).test();
+        assertTrue(observer.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
+        observer.assertNoErrors().assertComplete();
+
+        // Assert: the blog owner is no longer in the store.
+        assertEquals(0, findModels(BlogOwner.class).size());
+    }
+
+    /**
+     * Assume there is NOT a record in the store. Then, we try to
+     * merge a mutation to delete record A. This should succeed, since
+     * there was no work to be performed (it was already deleted.) After
+     * the merge, there should STILL be no matching record in the store.
+     */
+    @Test
+    public void mergeDeletionForNotExistingRecord() {
+        // Arrange, to start, there are no records matching the incoming deletion request.
+        BlogOwner blogOwner = BlogOwner.builder()
+            .name("Jameson")
+            .build();
+        // Note that putInStore does NOT happen!
+        // putInStore(blogOwner, new ModelMetadata(blogOwner.getId(), false, 1, Time.now()));
+
+        // Act: merge a deletion record that refers to something not in the store
+        ModelMetadata deletionMetadata =
+            new ModelMetadata(blogOwner.getId(), true, 1, Time.now());
+        TestObserver<Void> observer =
+            merger.merge(new ModelWithMetadata<>(blogOwner, deletionMetadata)).test();
+        assertTrue(observer.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
+        observer.assertNoErrors().assertComplete();
+
+        // Assert: there is still nothing in the store.
+        assertEquals(0, findModels(BlogOwner.class).size());
+    }
+
+    /**
+     * Assume there is NO record A. Then, we try to merge a save for a
+     * record A. This should succeed, with A being in the store, at the end.
+     */
+    @Test
+    public void mergeSaveForNotExistingRecord() {
+        // Arrange: nothing in the store, to start.
+        BlogOwner blogOwner = BlogOwner.builder()
+            .name("Jameson")
+            .build();
+        ModelMetadata metadata = new ModelMetadata(blogOwner.getId(), false, 1, Time.now());
+        // Note that putInStore is NOT called!
+        // putInStore(blogOwner, metadata);
+
+        // Act: merge a creation record
+        TestObserver<Void> observer = merger.merge(new ModelWithMetadata<>(blogOwner, metadata)).test();
+        assertTrue(observer.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
+        observer.assertNoErrors().assertComplete();
+
+        // Assert: the record & its associated metadata are now in the store.
+        assertEquals(Collections.singletonList(blogOwner), findModels(BlogOwner.class));
+        assertEquals(Collections.singletonList(metadata), findModels(ModelMetadata.class));
+    }
+
+    /**
+     * Assume there is a record A in the store. We try to merge a save for A.
+     * This should succeed, and it should be treated as an update. After the merge,
+     * A should have the updates from the merge.
+     * @throws DataStoreException On failure to arrange data into store
+     */
+    @Test
+    public void mergeSaveForExistingRecord() throws DataStoreException {
+        // Arrange: a record is already in the store.
+        BlogOwner originalModel = BlogOwner.builder()
+            .name("Jameson The Original")
+            .build();
+        ModelMetadata originalMetadata =
+            new ModelMetadata(originalModel.getId(), false, 1, Time.now());
+        putInStore(originalModel, originalMetadata);
+
+        // Act: merge a save.
+        BlogOwner updatedModel = originalModel.copyOfBuilder()
+            .name("Jameson The New and Improved")
+            .build();
+        ModelMetadata updatedMetadata =
+            new ModelMetadata(originalMetadata.getId(), false, 2, Time.now());
+        TestObserver<Void> observer = merger.merge(new ModelWithMetadata<>(updatedModel, updatedMetadata)).test();
+        assertTrue(observer.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
+        observer.assertComplete().assertNoErrors();
+
+        // Assert: the *UPDATED* stuff is in the store, *only*.
+        assertEquals(Collections.singletonList(updatedModel), findModels(BlogOwner.class));
+        assertEquals(Collections.singletonList(updatedMetadata), findModels(ModelMetadata.class));
+    }
+
+    /**
+     * Saves a variable argument list of models into the {@link InMemoryStorageAdapter}.
+     * @param models Models to save
+     * @param <T> Type of models
+     * @throws DataStoreException On failure to save
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    private final <T extends Model> void putInStore(final T... models) throws DataStoreException {
+        for (T model : models) {
+            Await.<StorageItemChange.Record, DataStoreException>result((onResult, onError) ->
+                inMemoryStorageAdapter.save(model, StorageItemChange.Initiator.DATA_STORE_API, onResult, onError)
+            );
+        }
+    }
+
+    /**
+     * Find models in the {@link InMemoryStorageAdapter} of a given class.
+     * @param modelClass Class of model being looked up
+     * @return A list of matching records; empty, if there are no matches
+     */
+    @SuppressWarnings({"SameParameterValue", "unchecked"})
+    private <T extends Model> List<T> findModels(@NonNull Class<T> modelClass) {
+        Objects.requireNonNull(modelClass);
+        final List<T> results = new ArrayList<>();
+        for (Model model : inMemoryStorageAdapter.items()) {
+            if (model.getClass().isAssignableFrom(modelClass)) {
+                results.add((T) model);
+            }
+        }
+        return results;
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationOutboxTest.java
@@ -60,8 +60,8 @@ public class MutationOutboxTest {
         TestObserver<StorageItemChange<? extends Model>> queueObserver = TestObserver.create();
         mutationOutbox.observe().subscribe(queueObserver);
 
-        StorageItemChange<BlogOwner> saveJameson = StorageItemChange.<BlogOwner>builder()
-            .type(StorageItemChange.Type.SAVE)
+        StorageItemChange<BlogOwner> createJameson = StorageItemChange.<BlogOwner>builder()
+            .type(StorageItemChange.Type.CREATE)
             .itemClass(BlogOwner.class)
             .item(BlogOwner.builder()
                 .name("Jameson Williams")
@@ -72,19 +72,19 @@ public class MutationOutboxTest {
         // Enqueue an save for a Jameson BlogOwner object,
         // and make sure that it calls back onSuccess().
         TestObserver<StorageItemChange<BlogOwner>> saveObserver = TestObserver.create();
-        mutationOutbox.enqueue(saveJameson).subscribe(saveObserver);
+        mutationOutbox.enqueue(createJameson).subscribe(saveObserver);
         saveObserver.awaitTerminalEvent();
         saveObserver.dispose();
 
         // Expected to observe the mutation on the subject
         queueObserver.awaitCount(1);
-        queueObserver.assertValue(saveJameson);
+        queueObserver.assertValue(createJameson);
         queueObserver.dispose();
 
         // Assert that the storage contains the mutation
         assertEquals(1, inMemoryStorageAdapter.items().size());
         assertEquals(
-            saveJameson.toRecord(storageItemChangeConverter),
+            createJameson.toRecord(storageItemChangeConverter),
             inMemoryStorageAdapter.items().get(0)
         );
     }
@@ -105,7 +105,7 @@ public class MutationOutboxTest {
             .item(BlogOwner.builder()
                 .name("Tony Daniels")
                 .build())
-            .type(StorageItemChange.Type.SAVE)
+            .type(StorageItemChange.Type.CREATE)
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
             .build());
         // .subscribe() is NOT called.
@@ -129,7 +129,7 @@ public class MutationOutboxTest {
 
         // Arrange: some mutations.
         StorageItemChange<BlogOwner> updateTony = StorageItemChange.<BlogOwner>builder()
-            .type(StorageItemChange.Type.SAVE)
+            .type(StorageItemChange.Type.UPDATE)
             .item(BlogOwner.builder()
                 .name("Tony Daniels")
                 .build())
@@ -137,7 +137,7 @@ public class MutationOutboxTest {
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
             .build();
         StorageItemChange<BlogOwner> insertSam = StorageItemChange.<BlogOwner>builder()
-            .type(StorageItemChange.Type.SAVE)
+            .type(StorageItemChange.Type.CREATE)
             .item(BlogOwner.builder()
                 .name("Sam Watson")
                 .build())

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -102,11 +102,11 @@ public final class MutationProcessorTest {
                     .wea(RandomString.string())
                     .build())
                 .initiator(StorageItemChange.Initiator.DATA_STORE_API)
-                .type(StorageItemChange.Type.SAVE)
+                .type(StorageItemChange.Type.CREATE)
                 .build()
                 .toRecord(recordConverter),
             StorageItemChange.<Blog>builder()
-                .type(StorageItemChange.Type.SAVE)
+                .type(StorageItemChange.Type.CREATE)
                 .initiator(StorageItemChange.Initiator.DATA_STORE_API)
                 .itemClass(Blog.class)
                 .item(Blog.builder()

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -65,7 +65,9 @@ public final class MutationProcessorTest {
         this.appSync = mock(AppSync.class);
 
         MutationOutbox mutationOutbox = new MutationOutbox(inMemoryStorageAdapter);
-        this.mutationProcessor = new MutationProcessor(inMemoryStorageAdapter, mutationOutbox, appSync);
+        Merger merger = new Merger(inMemoryStorageAdapter);
+        VersionRepository versionRepository = new VersionRepository(inMemoryStorageAdapter);
+        this.mutationProcessor = new MutationProcessor(merger, versionRepository, mutationOutbox, appSync);
 
         this.publicationEventAccumulator =
             HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -15,128 +15,261 @@
 
 package com.amplifyframework.datastore.syncengine;
 
-import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.core.Consumer;
-import com.amplifyframework.core.async.NoOpCancelable;
+import androidx.annotation.NonNull;
+
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.AppSync;
+import com.amplifyframework.datastore.appsync.AppSyncMocking;
+import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
-import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testutils.Await;
+import com.amplifyframework.testutils.HubAccumulator;
 import com.amplifyframework.testutils.random.RandomString;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
 /**
  * Tests the {@link MutationProcessor}.
  */
-@SuppressWarnings("unchecked") // Mockito's argument matchers, i.e. any(Raw.class)
 @RunWith(RobolectricTestRunner.class)
 public final class MutationProcessorTest {
-    private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(1);
+    private static final GsonStorageItemChangeConverter RECORD_CONVERTER = new GsonStorageItemChangeConverter();
 
-    private LocalStorageAdapter localStorageAdapter;
+    private InMemoryStorageAdapter inMemoryStorageAdapter;
     private AppSync appSync;
     private MutationProcessor mutationProcessor;
-    private StorageItemChange.RecordFactory recordConverter;
+    private HubAccumulator publicationEventAccumulator;
 
     @Before
     public void setup() {
-        this.localStorageAdapter = InMemoryStorageAdapter.create();
+        this.inMemoryStorageAdapter = InMemoryStorageAdapter.create();
         this.appSync = mock(AppSync.class);
-        this.mutationProcessor = new MutationProcessor(new MutationOutbox(localStorageAdapter), appSync);
-        this.recordConverter = new GsonStorageItemChangeConverter();
+
+        MutationOutbox mutationOutbox = new MutationOutbox(inMemoryStorageAdapter);
+        this.mutationProcessor = new MutationProcessor(inMemoryStorageAdapter, mutationOutbox, appSync);
+
+        this.publicationEventAccumulator =
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD);
+        this.publicationEventAccumulator.clear().start();
+    }
+
+    /**
+     * Stop accumulating events, after the test completes.
+     */
+    @After
+    public void stopAccumulator() {
+        this.publicationEventAccumulator.stop().clear();
     }
 
     /**
      * Validates that the {@link MutationProcessor} will read form the {@link MutationOutbox},
      * and will publish any items there-in to the {@link AppSync}.
      * @throws DataStoreException On failure to arrange items in to the MutationOutbox
-     * @throws InterruptedException If the latch is interrupted while waiting for AppSync API to be invoked
      */
     @Test
-    public void canDrainMutationOutbox() throws DataStoreException, InterruptedException {
-        // Arrange a CountDownLatch, which will count down when the AppSync API is hit.
-        final CountDownLatch apiInvocationsPending = new CountDownLatch(2);
-        doAnswer(invocation -> {
-            // Count down our latch, to signal that the create() API was hit.
-            apiInvocationsPending.countDown();
+    public void canDrainMutationOutbox() throws DataStoreException {
+        // Arrange some local state, in the LocalStorageAdapter.
+        // The "outbox" has three changes pending: 1 deletions, 2 creations.
+        saveModels(
+            // Tony has been deleted locally, so is not present. But, he still has
+            // metadata, and there is a pending deletion record in the outbox, waiting
+            // to be sync'd remotely.
+            // Models.Tony.MODEL
+            Models.Tony.MODEL_METADATA,
+            Models.Tony.DELETION_RECORD,
 
-            // Simulate a successful response callback from the create() method.
-            final int indexOfModelBeingCreated = 0;
-            final int indexOfResultConsumer = 1;
-            Model result = invocation.getArgument(indexOfModelBeingCreated);
-            Consumer<GraphQLResponse<Model>> onResult = invocation.getArgument(indexOfResultConsumer);
-            onResult.accept(new GraphQLResponse<>(result, Collections.emptyList()));
+            // Joe has been created locally, and is present in the local store.
+            // There is a creation record for him, pending in the outbox, which
+            // needs to be processed.
+            Models.Joe.MODEL,
+            Models.Joe.MODEL_METADATA,
+            Models.Joe.CREATION_RECORD,
 
-            // Technically, create() returns a Cancelable...
-            return new NoOpCancelable();
-        }).when(appSync)
-            .create(any(Model.class), any(Consumer.class), any(Consumer.class));
+            // Joe's blog has also been created locally, and is present in the local store.
+            // There is a creation record for him, pending in the ourbox, which still
+            // needs to be processed.
+            Models.JoeBlog.MODEL,
+            Models.JoeBlog.MODEL_METADATA,
+            Models.JoeBlog.CREATION_RECORD
+        );
 
-        // Put some stuff in the mutation outbox.
-        // (Actually, we're directly putting records into the storage adapter.
-        // technically, this is an implementation detail of them mutation outbox, oops!.)
-        populateStorageItemChangeRecords(
-            StorageItemChange.<BlogOwner>builder()
+        // We expect that AppSync will be asked to create two models, and to delete one.
+        // Mock successful responses for these invocations.
+        AppSyncMocking.onCreate(appSync)
+            .mockResponse(Models.Joe.MODEL)
+            .mockResponse(Models.JoeBlog.MODEL);
+        AppSyncMocking.onDelete(appSync)
+            .mockResponse(Models.Tony.MODEL);
+
+        // ACT! Try to start the mutation processor, to process the mutations stored above.
+        mutationProcessor.startDrainingMutationOutbox();
+
+        // Validate that we got "success" notifications out on Hub.
+        final List<StorageItemChange.Record> changesWeExpectToProcessSuccessfully = Arrays.asList(
+            Models.Tony.DELETION_RECORD,
+            Models.Joe.CREATION_RECORD,
+            Models.JoeBlog.CREATION_RECORD
+        );
+        assertEquals(
+            // Expected change records
+            changesWeExpectToProcessSuccessfully,
+            // Look at the records we saw on the hub. Did we get all of them?
+            takeRecordsFromAccumulator(changesWeExpectToProcessSuccessfully.size())
+        );
+
+        // Finally, we expect the mutation outbox to be empty, now, that the mutation
+        // processor has drained it.
+        assertEquals(0, findInStorage(StorageItemChange.Record.class).size());
+    }
+
+    /**
+     * Find items in storage that are of the given class.
+     * @param itemClass Type of item to look for
+     * @param <T> Class of item to look for
+     * @return A list of matching items, possible empty, never null.
+     */
+    @SuppressWarnings({"SameParameterValue", "unchecked"})
+    @NonNull
+    private <T> List<T> findInStorage(Class<T> itemClass) {
+        final List<T> matches = new ArrayList<>();
+        for (Model item : inMemoryStorageAdapter.items()) {
+            if (itemClass.isAssignableFrom(item.getClass())) {
+                matches.add((T) item);
+            }
+        }
+        return matches;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private List<StorageItemChange.Record> takeRecordsFromAccumulator(int quantity) {
+        final List<StorageItemChange.Record> changeRecords = new ArrayList<>();
+        for (HubEvent<?> hubEvent : publicationEventAccumulator.take(quantity)) {
+            StorageItemChange<? extends Model> change = (StorageItemChange<? extends Model>) hubEvent.getData();
+            if (change == null) {
+                throw new IllegalStateException("Found null data in publication event: " + hubEvent);
+            }
+            StorageItemChange.Record record = change.toRecord(RECORD_CONVERTER);
+            changeRecords.add(record);
+        }
+        return changeRecords;
+    }
+
+    /**
+     * Save a list of models.
+     * @param models Various models
+     * @param <T> The type of the models
+     * @throws DataStoreException On failure to save models
+     */
+    @SafeVarargs
+    private final <T extends Model> void saveModels(T... models) throws DataStoreException {
+        for (T model : models) {
+            Await.<T, DataStoreException>result((onResult, onError) -> inMemoryStorageAdapter.save(
+                model,
+                StorageItemChange.Initiator.DATA_STORE_API,
+                record -> onResult.accept(model),
+                onError
+            ));
+        }
+    }
+
+    /**
+     * Some arranged data that can be used as expected data, in test.
+     */
+    static final class Models {
+        @SuppressWarnings("checkstyle:all") private Models() {}
+
+        /**
+         * Tony is a BlogOwner. Tony has been deleted locally, and the mutation processor
+         * is supposed to pick up the deletion change and act on it. Before that happens,
+         * the model metadata shows deleted == false, since it hasn't been updated, yet.
+         * {@link Tony#MODEL} is not expected to be in the local storage, at the time
+         * the change is processed.
+         */
+        static final class Tony {
+            static final BlogOwner MODEL = BlogOwner.builder()
+                .name("Tony")
+                .wea(RandomString.string())
+                .build();
+
+            static final ModelMetadata MODEL_METADATA =
+                new ModelMetadata(Tony.MODEL.getId(), false, 1, System.currentTimeMillis());
+
+            static final StorageItemChange.Record DELETION_RECORD = StorageItemChange.<BlogOwner>builder()
                 .itemClass(BlogOwner.class)
-                .item(BlogOwner.builder()
-                    .name("First")
-                    .wea(RandomString.string())
-                    .build())
+                .item(Tony.MODEL)
+                .initiator(StorageItemChange.Initiator.DATA_STORE_API)
+                .type(StorageItemChange.Type.DELETE)
+                .build()
+                .toRecord(RECORD_CONVERTER);
+
+            @SuppressWarnings("checkstyle:all") private Tony() {}
+        }
+
+        /**
+         * Joe is present in the local store, and there is a creation event for him in the
+         * mutation outbox, that still needs to be processed.
+         */
+        static final class Joe {
+            static final BlogOwner MODEL = BlogOwner.builder()
+                .name("Joe")
+                .build();
+
+            static final ModelMetadata MODEL_METADATA =
+                new ModelMetadata(Joe.MODEL.getId(), false, 1, System.currentTimeMillis());
+
+            static final StorageItemChange.Record CREATION_RECORD = StorageItemChange.<BlogOwner>builder()
+                .itemClass(BlogOwner.class)
+                .item(Joe.MODEL)
                 .initiator(StorageItemChange.Initiator.DATA_STORE_API)
                 .type(StorageItemChange.Type.CREATE)
                 .build()
-                .toRecord(recordConverter),
-            StorageItemChange.<Blog>builder()
+                .toRecord(RECORD_CONVERTER);
+
+            @SuppressWarnings("checkstyle:all") private Joe() {}
+        }
+
+        /**
+         * Joe also has a blog. Joe and his blog are expected to be found in the local
+         * storage. Both Joe and his blog have items in the mutation outbox, waiting to be sync'd
+         * with the cloud.
+         */
+        static final class JoeBlog {
+            static final Blog MODEL = Blog.builder()
+                .name("Joe's cool blog")
+                .owner(Joe.MODEL)
+                .build();
+
+            static final ModelMetadata MODEL_METADATA =
+                new ModelMetadata(JoeBlog.MODEL.getId(), false, 1, System.currentTimeMillis());
+
+            static final StorageItemChange.Record CREATION_RECORD = StorageItemChange.<Blog>builder()
                 .type(StorageItemChange.Type.CREATE)
                 .initiator(StorageItemChange.Initiator.DATA_STORE_API)
                 .itemClass(Blog.class)
-                .item(Blog.builder()
-                    .name("Cool blog")
-                    .owner(BlogOwner.builder()
-                        .name("Cool owner")
-                        .build())
-                    .build())
+                .item(JoeBlog.MODEL)
                 .build()
-                .toRecord(recordConverter)
-        );
+                .toRecord(RECORD_CONVERTER);
 
-        // Okay, neat. Now, try to start the mutation processor.
-        mutationProcessor.startDrainingMutationOutbox();
-
-        // Wait for the API to be invoked.
-        apiInvocationsPending.await(REASONABLE_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
-
-        // As a result, the mutation processor should try to dispatch them to the
-        // AppSync.
-        assertEquals(0, apiInvocationsPending.getCount());
-    }
-
-    private void populateStorageItemChangeRecords(StorageItemChange.Record... records) throws DataStoreException {
-        for (StorageItemChange.Record record : records) {
-            Await.<StorageItemChange.Record, DataStoreException>result((onResult, onError) ->
-                localStorageAdapter.save(
-                    record, StorageItemChange.Initiator.DATA_STORE_API, onResult, onError
-                )
-            );
+            @SuppressWarnings("checkstyle:all") private JoeBlog() {}
         }
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/RemoteModelStateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/RemoteModelStateTest.java
@@ -17,11 +17,11 @@ package com.amplifyframework.datastore.syncengine;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
-import com.amplifyframework.datastore.SimpleModelProvider;
 import com.amplifyframework.datastore.appsync.AppSync;
 import com.amplifyframework.datastore.appsync.AppSyncMocking;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances;
+import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testmodels.commentsblog.Post;
 
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import io.reactivex.observers.TestObserver;
 
@@ -36,6 +37,7 @@ import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstan
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.BLOGGER_JAMESON;
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.DELETED_DRUM_POST;
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.DRUM_POST;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -43,7 +45,9 @@ import static org.mockito.Mockito.mock;
  */
 @SuppressWarnings("checkstyle:MagicNumber") // Arranged data picked arbitrarily
 public final class RemoteModelStateTest {
-    private AppSync endpoint;
+    private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(2);
+
+    private AppSync appSync;
     private RemoteModelState remoteModelState;
 
     /**
@@ -54,9 +58,9 @@ public final class RemoteModelStateTest {
      */
     @Before
     public void setup() {
-        endpoint = mock(AppSync.class);
-        final ModelProvider modelProvider = SimpleModelProvider.withRandomVersion(Post.class, BlogOwner.class);
-        remoteModelState = new RemoteModelState(endpoint, modelProvider);
+        appSync = mock(AppSync.class);
+        ModelProvider modelProvider = AmplifyModelProvider.getInstance();
+        remoteModelState = new RemoteModelState(appSync, modelProvider);
     }
 
     /**
@@ -68,14 +72,14 @@ public final class RemoteModelStateTest {
     public void observeReceivesAllModelInstances() {
         // Arrange: the AppSync endpoint will give us some MetaData for items
         // having these types.
-        AppSyncMocking.configure(endpoint)
+        AppSyncMocking.configure(appSync)
             .mockSuccessResponse(Post.class, DRUM_POST, DELETED_DRUM_POST)
             .mockSuccessResponse(BlogOwner.class, BLOGGER_JAMESON, BLOGGER_ISLA);
 
         // Act: Observe the RemoteModelState via observe().
-        TestObserver<ModelWithMetadata<? extends Model>> observer = TestObserver.create();
-        remoteModelState.observe().subscribe(observer);
-        observer.awaitTerminalEvent();
+        TestObserver<ModelWithMetadata<? extends Model>> observer = remoteModelState.observe().test();
+
+        assertTrue(observer.awaitTerminalEvent(REASONABLE_WAIT_TIME_MS, TimeUnit.MILLISECONDS));
         observer.assertValueCount(4);
 
         // assertValueSet(..., varargs, ...) would be cleanest. But equals() is broken

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/RemoteModelStateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/RemoteModelStateTest.java
@@ -72,7 +72,7 @@ public final class RemoteModelStateTest {
     public void observeReceivesAllModelInstances() {
         // Arrange: the AppSync endpoint will give us some MetaData for items
         // having these types.
-        AppSyncMocking.configure(appSync)
+        AppSyncMocking.onSync(appSync)
             .mockSuccessResponse(Post.class, DRUM_POST, DELETED_DRUM_POST)
             .mockSuccessResponse(BlogOwner.class, BLOGGER_JAMESON, BLOGGER_ISLA);
 
@@ -91,4 +91,3 @@ public final class RemoteModelStateTest {
         observer.dispose();
     }
 }
-

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -79,9 +79,9 @@ public final class SyncProcessorTest {
 
         this.appSync = mock(AppSync.class);
         final RemoteModelState remoteModelState = new RemoteModelState(appSync, modelProvider);
+        final Merger merger = new Merger(inMemoryStorageAdapter);
 
-        this.syncProcessor =
-            new SyncProcessor(remoteModelState, inMemoryStorageAdapter, modelProvider, modelSchemaRegistry);
+        this.syncProcessor = new SyncProcessor(remoteModelState, merger, modelProvider, modelSchemaRegistry);
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -104,7 +104,7 @@ public final class SyncProcessorTest {
             .subscribe(adapterObserver);
 
         // Arrange: return some responses for the sync() call on the RemoteModelState
-        AppSyncMocking.configure(appSync)
+        AppSyncMocking.onSync(appSync)
             .mockSuccessResponse(Post.class, DELETED_DRUM_POST)
             .mockSuccessResponse(BlogOwner.class, BLOGGER_ISLA, BLOGGER_JAMESON);
 
@@ -172,7 +172,7 @@ public final class SyncProcessorTest {
         // inMemoryStorageAdapter.items().add(DRUM_POST.getModel());
 
         // Arrange some responses from AppSync
-        AppSyncMocking.configure(appSync)
+        AppSyncMocking.onSync(appSync)
             .mockSuccessResponse(Post.class, DELETED_DRUM_POST)
             .mockSuccessResponse(BlogOwner.class, BLOGGER_JAMESON);
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TopologicalOrderingTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TopologicalOrderingTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
+import com.amplifyframework.datastore.SimpleModelProvider;
+import com.amplifyframework.testmodels.commentsblog.Blog;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testmodels.commentsblog.Comment;
+import com.amplifyframework.testmodels.commentsblog.Post;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link TopologicalOrdering} utility.
+ */
+public final class TopologicalOrderingTest {
+    /**
+     * Checks the topological ordering of the Blog, Post, and Comment classes.
+     * @throws AmplifyException On failure to load models into registry
+     */
+    @Test
+    public void orderingOfBlogPostComment() throws AmplifyException {
+        // Load the models into the registry.
+        // They are provided intentionally out of topological order.
+        final SimpleModelProvider provider =
+            SimpleModelProvider.withRandomVersion(Comment.class, Blog.class, BlogOwner.class, Post.class);
+
+        final ModelSchemaRegistry registry = ModelSchemaRegistry.instance();
+        registry.clear();
+        registry.load(provider.models());
+
+        // Find the schema that the registry created for each of the models.
+        ModelSchema commentSchema = findSchema(registry, Comment.class);
+        ModelSchema postSchema = findSchema(registry, Post.class);
+        ModelSchema blogSchema = findSchema(registry, Blog.class);
+
+        // Act: get a topological ordering of the models.
+        TopologicalOrdering topologicalOrdering = TopologicalOrdering.forRegisteredModels(registry, provider);
+
+        // Assert: Blog comes before Post, and Post comes before Comment.
+        assertTrue(topologicalOrdering.check(blogSchema).isBefore(postSchema));
+        assertTrue(topologicalOrdering.check(postSchema).isBefore(commentSchema));
+
+        // Assert: in other words, Comment is after Post, and Post is after Blog.
+        assertTrue(topologicalOrdering.check(commentSchema).isAfter(postSchema));
+        assertTrue(topologicalOrdering.check(postSchema).isAfter(blogSchema));
+    }
+
+    /**
+     * Find a {@link ModelSchema} in an {@link ModelSchemaRegistry}, looking up by the
+     * model's {@link Class}.
+     * @param registry Model schema registry
+     * @param modelClass Class of model
+     * @param <T> Type of model
+     * @return The ModelSchema for the requested class
+     */
+    private <T extends Model> ModelSchema findSchema(ModelSchemaRegistry registry, Class<T> modelClass) {
+        return registry.getModelSchemaForModelClass(modelClass.getSimpleName());
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/VersionRepositoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/VersionRepositoryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.appsync.ModelMetadata;
+import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
+import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testutils.Await;
+import com.amplifyframework.testutils.Time;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.observers.TestObserver;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link VersionRepository}.
+ */
+public final class VersionRepositoryTest {
+    private static final long REASONABLE_WAIT_TIME = TimeUnit.SECONDS.toMillis(1);
+
+    private InMemoryStorageAdapter inMemoryStorageAdapter;
+    private VersionRepository versionRepository;
+
+    @Before
+    public void setup() {
+        this.inMemoryStorageAdapter = InMemoryStorageAdapter.create();
+        this.versionRepository = new VersionRepository(inMemoryStorageAdapter);
+    }
+
+    /**
+     * When you try to get a model version, but there's no metadata for that model,
+     * this should fail with an {@link DataStoreException}.
+     */
+    @Test
+    public void emitsErrorForNoMetadataInRepo() {
+        // Arrange: no metadata is in the repo.
+        BlogOwner blogOwner = BlogOwner.builder()
+            .name("Jameson Williams")
+            .build();
+        // Note that this line is NOT executed in arrangement.
+        // ModelMetadata metadata = new ModelMetadata(blogOwner.getId(), false, 1, Time.now());
+        // putInStore(blogOwner blogOwner);
+
+        // Act: try to lookup the metadata. Is it going to work? Duh.
+        TestObserver<Integer> observer = versionRepository.findModelVersion(blogOwner).test();
+        assertTrue(observer.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
+
+        // Assert: this failed. There was no version available.
+        String expectedMessage =
+            String.format(Locale.US, "Wanted 1 metadata for item with id = %s, but had 0.", blogOwner.getId());
+        observer
+            .assertError(DataStoreException.class)
+            .assertErrorMessage(expectedMessage);
+    }
+
+    /**
+     * When you try to get the version for a model, and there is metadata for the model
+     * in the DataStore, BUT the version info is not populated, this should return an
+     * {@link DataStoreException}.
+     * @throws DataStoreException
+     *         NOT EXPECTED. This happens on failure to arrange data before test action.
+     *         The expected DataStoreException is communicated via callback, not thrown
+     *         on the calling thread. It's a different thing than this.
+     */
+    @Test
+    public void emitsErrorWhenMetadataHasNullVersion() throws DataStoreException {
+        // Arrange a model an metadata into the store, but the metadtaa doesn't contain a valid version
+        BlogOwner blogOwner = BlogOwner.builder()
+            .name("Jameson")
+            .build();
+        ModelMetadata metadata = new ModelMetadata(blogOwner.getId(), null, null, null);
+        putInStore(blogOwner, metadata);
+
+        // Act: try to get the version.
+        TestObserver<Integer> observer = versionRepository.findModelVersion(blogOwner).test();
+        assertTrue(observer.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
+
+        // Assert: the single emitted a DataStoreException.
+        String expectedMessage =
+            String.format(Locale.US, "Metadata for item with id = %s had null version.", blogOwner.getId());
+        observer
+            .assertError(DataStoreException.class)
+            .assertErrorMessage(expectedMessage);
+    }
+
+    /**
+     * When there is metadata for a model in the store, and that metadata includes a version -
+     * for heaven's sake, man - do please emit the dang thing.
+     * @throws DataStoreException On failure to arrange data into store
+     */
+    @SuppressWarnings("checkstyle:MagicNumber") // 1_000 is magic. Big. Whooping. Deal.
+    @Test
+    public void emitsSuccessWithValueWhenVersionInStore() throws DataStoreException {
+        // Arrange versioning info into the store.
+        BlogOwner owner = BlogOwner.builder()
+            .name("Jameson")
+            .build();
+        int expectedVersion = new Random().nextInt(1_000);
+        putInStore(new ModelMetadata(owner.getId(), false, expectedVersion, Time.now()));
+
+        // Act! Try to obtain it via the Versioning Repository.
+        TestObserver<Integer> observer = versionRepository.findModelVersion(owner).test();
+        assertTrue(observer.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
+
+        // Assert: we got a version.
+        observer
+            .assertNoErrors()
+            .assertComplete()
+            .assertValue(expectedVersion);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final <T extends Model> void putInStore(@NonNull T... models) throws DataStoreException {
+        Objects.requireNonNull(models);
+        for (T model : models) {
+            Await.<StorageItemChange.Record, DataStoreException>result((onResult, onError) ->
+                inMemoryStorageAdapter.save(model, StorageItemChange.Initiator.DATA_STORE_API, onResult, onError)
+            );
+        }
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchemaRegistry.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchemaRegistry.java
@@ -28,9 +28,6 @@ import java.util.Set;
  * A utility that creates ModelSchema from Model classes.
  */
 public final class ModelSchemaRegistry {
-    // Singleton instance
-    private static ModelSchemaRegistry singleton;
-
     // Model ClassName => ModelSchema map
     private final Map<String, ModelSchema> modelSchemaMap;
 
@@ -75,19 +72,18 @@ public final class ModelSchemaRegistry {
      * Retrieve the map of Model ClassName => ModelSchema.
      * @return an immutable map of Model ClassName => ModelSchema
      */
+    @NonNull
     public Map<String, ModelSchema> getModelSchemaMap() {
         return Immutable.of(modelSchemaMap);
     }
 
     /**
-     * Returns the singleton instance.
-     * @return the singleton instance of the ModelSchemaRegistry.
+     * Creates a new instance.
+     * @return A new instance
      */
-    public static synchronized ModelSchemaRegistry singleton() {
-        if (singleton == null) {
-            singleton = new ModelSchemaRegistry();
-        }
-        return singleton;
+    @NonNull
+    public static synchronized ModelSchemaRegistry instance() {
+        return new ModelSchemaRegistry();
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreItemChange.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreItemChange.java
@@ -58,7 +58,7 @@ public final class DataStoreItemChange<T extends Model> {
     }
 
     /**
-     * Gets the type of change, e.g. {@link Type#SAVE} or {@link Type#DELETE}.
+     * Gets the type of change, e.g. {@link Type#CREATE} or {@link Type#UPDATE} or {@link Type#DELETE}.
      * @return Type of change
      */
     @NonNull
@@ -173,6 +173,7 @@ public final class DataStoreItemChange<T extends Model> {
          * @param uuid A UUID to assign in the next DataStoreChangeEvent that is generated
          * @return Current Builder instance, for fluent method chaining
          */
+        @NonNull
         public Builder<T> uuid(@NonNull final String uuid) {
             this.uuid = UUID.fromString(Objects.requireNonNull(uuid));
             return this;
@@ -182,6 +183,7 @@ public final class DataStoreItemChange<T extends Model> {
          * Configures the builder to use a random UUID for DataStoreItemChange instances.
          * @return The current instance of the Builder, for fluent method chaining
          */
+        @NonNull
         public Builder<T> randomUuid() {
             this.uuid = null;
             return this;
@@ -227,8 +229,9 @@ public final class DataStoreItemChange<T extends Model> {
          * @param initiator Initiator of change
          * @return Current builder instance for fluent chaining
          */
-        public Builder<T> initiator(final Initiator initiator) {
-            this.initiator = initiator;
+        @NonNull
+        public Builder<T> initiator(@NonNull Initiator initiator) {
+            this.initiator = Objects.requireNonNull(initiator);
             return this;
         }
 
@@ -238,6 +241,7 @@ public final class DataStoreItemChange<T extends Model> {
          * @return A new DataStoreItemChange instance
          */
         @SuppressLint("SyntheticAccessor")
+        @NonNull
         public DataStoreItemChange<T> build() {
             final UUID usedId = uuid == null ? UUID.randomUUID() : uuid;
             randomUuid();
@@ -259,9 +263,14 @@ public final class DataStoreItemChange<T extends Model> {
      */
     public enum Type {
         /**
-         * An item has been saved into the DataStore.
+         * An item with a new ID has been saved into the DataStore.
          */
-        SAVE,
+        CREATE,
+
+        /**
+         * An existing item was updated. The existing item was matched by its ID.
+         */
+        UPDATE,
 
         /**
          * An existing item has been deleted from the DataStore.

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxDataStoreBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxDataStoreBindingTest.java
@@ -93,7 +93,7 @@ public final class RxDataStoreBindingTest {
             Consumer<DataStoreItemChange<Model>> resultConsumer = invocation.getArgument(indexOfResultConsumer);
             resultConsumer.accept(DataStoreItemChange.builder()
                 .uuid(modelFromInvocation.getId())
-                .type(Type.SAVE)
+                .type(Type.CREATE)
                 .itemClass(Model.class)
                 .initiator(Initiator.LOCAL)
                 .item(modelFromInvocation)
@@ -241,7 +241,7 @@ public final class RxDataStoreBindingTest {
             .uuid(model.getId())
             .itemClass(Model.class)
             .item(model)
-            .type(Type.SAVE)
+            .type(Type.CREATE)
             .initiator(Initiator.LOCAL)
             .build();
         doAnswer(invocation -> {

--- a/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
@@ -18,6 +18,7 @@ package com.amplifyframework.testutils;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.hub.HubEventFilter;
@@ -71,6 +72,27 @@ public final class HubAccumulator {
         Objects.requireNonNull(channel);
         Objects.requireNonNull(filter);
         return new HubAccumulator(channel, filter);
+    }
+
+    /**
+     * Gets an {@link HubAccumulator} that accumulates events arriving on a particular channel,
+     * whose event name is the given enum value (as string). For example, an accumulator
+     * created in this way will match all events with name {@link DataStoreChannelEventName#PUBLISHED_TO_CLOUD}:
+     *
+     *   HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISH_TO_CLOUD);
+     *
+     * @param channel Channel on which to listen for events
+     * @param enumeratedEventName A enum value, the toString() of which is expected as the name of
+     *                             a hub event. Only events with this name will be accumualated.
+     * @param <E> The type of enumeration
+     * @return A HubAccumulator
+     */
+    @NonNull
+    public static <E extends Enum<E>> HubAccumulator create(
+            @NonNull HubChannel channel, @NonNull E enumeratedEventName) {
+        Objects.requireNonNull(channel);
+        Objects.requireNonNull(enumeratedEventName);
+        return new HubAccumulator(channel, event -> enumeratedEventName.toString().equals(event.getName()));
     }
 
     /**

--- a/testutils/src/main/java/com/amplifyframework/testutils/Time.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Time.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils;
+
+/**
+ * An almost-worthless wrapper to avoid writing {@link System#currentTimeMillis()} all
+ * over the place. Instead, what we mean is "the current time," or Time.now().
+ */
+public final class Time {
+    @SuppressWarnings("checkstyle:all") private Time() {}
+
+    /**
+     * Gets the current time, expressed in a duration of milliseconds since the epoch.
+     * @return Current time in ms since epoch
+     */
+    public static long now() {
+        return System.currentTimeMillis();
+    }
+}


### PR DESCRIPTION
1. Write model versions to a local store, while working over the results from a base sync.
2. Read and post model versions to AppSync when publishing updates/deleted to AppSync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.