### PR TITLE
[aws-api] User wants to provide multiple path segments

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
@@ -20,7 +20,7 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
-import com.amplifyframework.api.aws.utils.RestOperationRequestUtils;
+import com.amplifyframework.api.aws.utils.RestRequestFactory;
 import com.amplifyframework.api.rest.RestOperation;
 import com.amplifyframework.api.rest.RestOperationRequest;
 import com.amplifyframework.api.rest.RestResponse;
@@ -78,10 +78,10 @@ public final class AWSRestOperation extends RestOperation {
             return;
         }
         try {
-            URL url = RestOperationRequestUtils.constructURL(endpoint,
+            URL url = RestRequestFactory.createURL(endpoint,
                     getRequest().getPath(),
                     getRequest().getQueryParameters());
-            Request request = RestOperationRequestUtils.constructOKHTTPRequest(url,
+            Request request = RestRequestFactory.createRequest(url,
                     getRequest().getData(),
                     getRequest().getHeaders(),
                     getRequest().getHttpMethod());

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
@@ -15,11 +15,15 @@
 
 package com.amplifyframework.api.aws.utils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.amplifyframework.api.rest.HttpMethod;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
+import java.util.Objects;
 
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -27,66 +31,58 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 
 /**
- * Util class to handle Rest url request.
+ * Factory to create {@link URL}s and OkHttp {@link Request}s for REST-ful behaviors.
  */
-public final class RestOperationRequestUtils {
-
-    private static final String CONTENT_TYPE = "application/json";
-
-    /**
-     * Private constructor since this is a utility class.
-     */
-    private RestOperationRequestUtils() {
-        //not called
-    }
+public final class RestRequestFactory {
+    @SuppressWarnings("checkstyle:all") private RestRequestFactory() {}
 
     /**
      * Create an URL by appending the path and queries.
-     * <p>
      * Throws exception if the url is malformed.
-     *
      * @param endpoint        A valid endpoint
      * @param path            path to be appended.
      * @param queryParameters query parameters
      * @return Valid URL
      * @throws MalformedURLException Throw when the exception is not valid
      */
-    public static URL constructURL(String endpoint,
-                                   String path,
-                                   Map<String, String> queryParameters)
+    @NonNull
+    public static URL createURL(
+            @NonNull String endpoint,
+            @Nullable String path,
+            @Nullable Map<String, String> queryParameters)
             throws MalformedURLException {
-        String urlPath = "";
-        if (path != null) {
-            urlPath = path;
-        }
         URL url = new URL(endpoint);
         HttpUrl.Builder builder = new HttpUrl.Builder()
-                .scheme(url.getProtocol())
-                .host(url.getHost())
-                .addPathSegment(url.getPath().replaceFirst("/", ""))
-                .addPathSegment(urlPath);
+            .scheme(url.getProtocol())
+            .host(url.getHost())
+            .addPathSegment(url.getPath().replaceFirst("/", ""))
+            .addPathSegments(path == null ? "" : path);
 
         if (queryParameters != null) {
             for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
                 builder.addQueryParameter(entry.getKey(), entry.getValue());
             }
         }
+
         return builder.build().url();
     }
 
     /**
      * Constructs the ok http request.
-     *
      * @param url         URL endpoint to make the request
      * @param requestData Data for the request
      * @param headers     Header map for th request
      * @param type        Rest operation type
      * @return Returns the request
      */
-    public static Request constructOKHTTPRequest(final URL url,
-                                                 final byte[] requestData,
-                                                 final Map<String, String> headers,
-                                                 final HttpMethod type) {
+    @NonNull
+    public static Request createRequest(
+            @NonNull URL url,
+            @Nullable byte[] requestData,
+            @Nullable Map<String, String> headers,
+            @NonNull HttpMethod type) {
+        Objects.requireNonNull(url);
+        Objects.requireNonNull(type);
         Request.Builder requestBuilder = new Request.Builder()
                 .url(url);
         switch (type) {
@@ -126,9 +122,10 @@ public final class RestOperationRequestUtils {
         return requestBuilder.build();
     }
 
-    private static void populateBody(final Request.Builder builder,
-                                     final byte[] data,
-                                     BodyCreationStrategy strategy) {
+    private static void populateBody(
+            Request.Builder builder,
+            byte[] data,
+            BodyCreationStrategy strategy) {
         if (data != null) {
             strategy.buildRequest(builder, data);
         }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
@@ -30,84 +30,75 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Rest the RestOperationRequestUtils.
+ * Tests the {@link RestRequestFactory}.
  */
-public final class RestOperationRequestUtilsTest {
-
+public final class RestRequestFactoryTest {
     /**
      * Test if we can create a valid URL.
-     *
      * @throws MalformedURLException Throws if the URL is invalid.
      */
     @Test
     public void createValidURL() throws MalformedURLException {
-
-        URL url = RestOperationRequestUtils.constructURL("http://amplify-android.com",
+        URL url = RestRequestFactory.createURL("http://amplify-android.com",
                 "path/to/path",
                 null);
         assertEquals("The url generated should match",
-                "http://amplify-android.com/path%2Fto%2Fpath",
+                "http://amplify-android.com/path/to/path",
                 url.toString());
     }
 
     /**
      * Test if we can create a valid URL with already existing path.
-     *
      * @throws MalformedURLException Throws if the URL is invalid.
      */
     @Test
     public void createValidURLWithPath() throws MalformedURLException {
-
-        URL url = RestOperationRequestUtils.constructURL("http://amplify-android.com/beta",
+        URL url = RestRequestFactory.createURL("http://amplify-android.com/beta",
                 "path/to/path",
                 null);
         assertEquals("The url generated should match",
-                "http://amplify-android.com/beta/path%2Fto%2Fpath",
+                "http://amplify-android.com/beta/path/to/path",
                 url.toString());
     }
 
     /**
      * Test creating a valid URL with queries.
-     *
      * @throws MalformedURLException Throws when the url is invalid.
      */
     @Test
     public void createValidURLWithQuery() throws MalformedURLException {
-
-        HashMap<String, String> queries = new HashMap<String, String>();
+        Map<String, String> queries = new HashMap<>();
         queries.put("key1", "value1");
         queries.put("key2", "value2");
-        URL url = RestOperationRequestUtils.constructURL("http://amplify-android.com",
+        URL url = RestRequestFactory.createURL("http://amplify-android.com",
                 "path/to/path",
                 queries);
         assertEquals("The url generated should match",
-                "http://amplify-android.com/path%2Fto%2Fpath?key1=value1&key2=value2",
+                "http://amplify-android.com/path/to/path?key1=value1&key2=value2",
                 url.toString());
     }
 
     /**
      * Test if exception is thrown on invalid URL.
-     *
      * @throws MalformedURLException Should throw since the URL is invalid.
      */
     @Test(expected = MalformedURLException.class)
     public void createInValidURL() throws MalformedURLException {
-        RestOperationRequestUtils.constructURL("asd.com",
+        RestRequestFactory.createURL("asd.com",
                 "path/to/path",
                 null);
     }
 
     /**
-     * Test creates a Get request.
-     *
+     * Test creates a GET request.
      * @throws MalformedURLException Throws when the URL is invalid.
      */
     @Test
     public void createGetRequest() throws MalformedURLException {
-        URL url = RestOperationRequestUtils.constructURL("http://amplify-android.com",
+        URL url = RestRequestFactory.createURL("http://amplify-android.com",
                 "path/to/path",
                 null);
-        Request request = RestOperationRequestUtils.constructOKHTTPRequest(url,
+        Request request = RestRequestFactory.createRequest(url,
                 null,
                 null,
                 HttpMethod.GET);
@@ -115,16 +106,15 @@ public final class RestOperationRequestUtilsTest {
     }
 
     /**
-     * Test creates a Post request.
-     *
+     * Test creates a POST request.
      * @throws MalformedURLException Throws when the URL is invalid.
      */
     @Test
     public void createPostRequest() throws MalformedURLException {
-        URL url = RestOperationRequestUtils.constructURL("http://amplify-android.com",
+        URL url = RestRequestFactory.createURL("http://amplify-android.com",
                 "path/to/path",
                 null);
-        Request request = RestOperationRequestUtils.constructOKHTTPRequest(url,
+        Request request = RestRequestFactory.createRequest(url,
                 null,
                 null,
                 HttpMethod.POST);
@@ -132,19 +122,18 @@ public final class RestOperationRequestUtilsTest {
     }
 
     /**
-     * Test creates a Post request with headers.
-     *
+     * Test creates a POST request with headers.
      * @throws MalformedURLException Throws when the URL is invalid.
      */
     @Test
     public void createPostRequestWithHeaders() throws MalformedURLException {
-        URL url = RestOperationRequestUtils.constructURL("http://amplify-android.com",
+        URL url = RestRequestFactory.createURL("http://amplify-android.com",
                 "path/to/path",
                 null);
 
-        final Map<String, String> headers = new HashMap<>();
+        Map<String, String> headers = new HashMap<>();
         headers.put("key1", "value1");
-        Request request = RestOperationRequestUtils.constructOKHTTPRequest(url,
+        Request request = RestRequestFactory.createRequest(url,
                 null,
                 headers,
                 HttpMethod.POST);


### PR DESCRIPTION
Previously, when a user passed multiple path segments via the
RestOptions path string:
```
Amplify.API.get(new RestOptions("path1/path2"), ok -> {}, fail -> {});
```
The forward-slash character (`/`) in the path string would be changed
into the string "`%2F`". So, if the endpoint were `https://domain.tld/api`, you'd end
up making a request to `https://domain.tld/api/path1%2Fpath2`.

After this change, the `/` characters in the provide path are preserved.
The system would end up making a request, instead, to
`https://domain.tld/api/path1/path2`.

Resolves: https://github.com/aws-amplify/amplify-android/issues/304

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
