### PR TITLE
Use Android Test Orchestrator to isolate test runs

### DIFF
--- a/aws-analytics-pinpoint/build.gradle
+++ b/aws-analytics-pinpoint/build.gradle
@@ -35,5 +35,6 @@ dependencies {
     androidTestImplementation dependency.androidx.test.core
     androidTestImplementation dependency.androidx.test.runner
     androidTestImplementation dependency.androidx.test.junit
+    androidTestUtil dependency.androidx.test.orchestrator
 }
 

--- a/aws-api/build.gradle
+++ b/aws-api/build.gradle
@@ -44,5 +44,6 @@ dependencies {
     androidTestImplementation dependency.androidx.test.runner
     androidTestImplementation dependency.androidx.test.junit
     androidTestImplementation dependency.rxjava
+    androidTestUtil dependency.androidx.test.orchestrator
 }
 

--- a/aws-datastore/build.gradle
+++ b/aws-datastore/build.gradle
@@ -42,5 +42,6 @@ dependencies {
     androidTestImplementation dependency.androidx.test.runner
     androidTestImplementation dependency.androidx.test.junit
     androidTestImplementation dependency.rxjava
+    androidTestUtil dependency.androidx.test.orchestrator
 }
 

--- a/aws-storage-s3/build.gradle
+++ b/aws-storage-s3/build.gradle
@@ -38,5 +38,6 @@ dependencies {
     androidTestImplementation dependency.androidx.annotation
     androidTestImplementation dependency.androidx.test.runner
     androidTestImplementation dependency.androidx.test.junit
+    androidTestUtil dependency.androidx.test.orchestrator
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,8 @@ ext {
             test: [
                 core: 'androidx.test:core:1.2.0',
                 runner: 'androidx.test:runner:1.2.0',
-                junit: 'androidx.test.ext:junit:1.1.1'
+                junit: 'androidx.test.ext:junit:1.1.1',
+                orchestrator: 'androidx.test:orchestrator:1.1.0'
             ]
         ],
         aws: [
@@ -99,9 +100,11 @@ private void configureAndroidLibrary(Project project) {
             versionCode rootProject.findProperty('VERSION_CODE').toInteger()
             versionName rootProject.findProperty('VERSION_NAME')
             testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+            testInstrumentationRunnerArguments clearPackageData: 'true'
             consumerProguardFiles 'proguard-rules.pro'
 
             testOptions {
+                execution 'ANDROIDX_TEST_ORCHESTRATOR'
                 unitTests {
                     includeAndroidResources = true
                 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,5 +40,6 @@ dependencies {
     androidTestImplementation dependency.androidx.test.core
     androidTestImplementation dependency.androidx.test.runner
     androidTestImplementation dependency.androidx.test.junit
+    androidTestUtil dependency.androidx.test.orchestrator
 }
 


### PR DESCRIPTION
In an effort to minimize how one instrumentation test effects another,
onboard the Android Test Orchestrator.

Refer: https://developer.android.com/training/testing/junit-runner.html#ato-gradle

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
