### PR TITLE
Remove Retrolambda

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.1'
-        classpath 'me.tatarka:gradle-retrolambda:3.7.1'
     }
 }
 
@@ -86,9 +85,6 @@ subprojects { project ->
 }
 
 private void configureAndroidLibrary(Project project) {
-    project.apply plugin: 'me.tatarka.retrolambda'
-    project.retrolambda.jvmArgs += '-Dretrolambda.quiet=true'
-
     project.android {
         buildToolsVersion rootProject.ext.buildToolsVersion
         compileSdkVersion rootProject.ext.compileSdkVersion


### PR DESCRIPTION
This project will require Java 1.8 in its consumers, and will no longer
use Retrolambda to support older consumers.

Consumers will need to declare the following block in their
`build.gradle`:

```
android {
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_8
        targetCompatibility JavaVersion.VERSION_1_8
    }
}
```

Amplify and its consumers are expected to use only the first-party
Android tools to provide Java 1.8 features.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
