### PR TITLE
Raise minSdkVersion to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ List<Bucket> buckets = s3Client.listBuckets();
 
 ## Platform Support
 
-Amplify SDK supports Android API level 15 (Android 4.0.3) and above.
+Amplify SDK supports Android API level 16 (Android 4.1) and above.
 
 ## Installation
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ task clean(type: Delete) {
 ext {
     buildToolsVersion = "29.0.2"
     compileSdkVersion = 29
-    minSdkVersion = 15
+    minSdkVersion = 16
     targetSdkVersion = 29
 
     awsSdkVersion = '2.16.8'


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Given the vanishingly small number of ICS users according to Google's [Distribution Dashboard](https://developer.android.com/about/dashboards) and our own log analysis and industry trends ([Google Play Services supports API Level 16+](https://android-developers.googleblog.com/2018/12/google-play-services-discontinuing.html), for example), we are dropping support for API Level 15.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
