### PR TITLE
Fixes Date fields being converted to current date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 A declarative library for application development using cloud services.
 
-## 0.10.0
+## 0.10.1
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 A declarative library for application development using cloud services.
 
+## 0.10.0
+
+### Bug Fixes
+
+- **API**
+  - Fixed Date fields being converted to the current date instead of their original value
+
 ## 0.9.0
 
 Initial release! Includes Core features, plus support for these categories:

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
@@ -37,6 +37,8 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.List;
 
@@ -72,15 +74,17 @@ public final class CodeGenerationInstrumentationTest {
      * This tests our ability to generate GraphQL queries at runtime, from model primitives,
      * for both queries and mutations. The query also tests functionality of the QueryPredicate filter.
      * @throws ApiException On failure to obtain valid response from endpoint
+     * @throws ParseException If we specify the wrong value for the date String in the test object
      */
     @SuppressWarnings("checkstyle:MagicNumber")
     @Test
-    public void queryMatchesMutationResult() throws ApiException {
+    public void queryMatchesMutationResult() throws ApiException, ParseException {
         // Create a Person
         Person david = Person.builder()
             .firstName("David")
             .lastName("Daudelin")
             .age(29)
+            .dob(new SimpleDateFormat("MM/dd/yyyy").parse("07/25/1990"))
             .relationship(MaritalStatus.married)
             .build();
         Person createdPerson = api.create(PERSON_API_NAME, david);

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonVariablesSerializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonVariablesSerializer.java
@@ -45,7 +45,7 @@ public final class GsonVariablesSerializer implements GraphQLRequest.VariablesSe
     class DateSerializer implements JsonSerializer<Date> {
         public JsonElement serialize(Date date, Type typeOfSrc, JsonSerializationContext context) {
             DateFormat df = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
-            return new JsonPrimitive(df.format(new Date()));
+            return new JsonPrimitive(df.format(date));
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Not the main topic but was reported on issue #216 

*Description of changes:*
Currently when serializing a Date field we have a horrible bug (my bad!) where it ignores the actual value the user provided and sets it to the current date 🤦‍♂️

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
