### PR TITLE
[aws-datastore] Re-provision if system models change

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
@@ -22,8 +22,10 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
+import com.amplifyframework.datastore.CompoundModelProvider;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.StrictMode;
+import com.amplifyframework.datastore.storage.SystemModelsProviderFactory;
 import com.amplifyframework.testmodels.personcar.AmplifyCliGeneratedModelProvider;
 import com.amplifyframework.testmodels.personcar.RandomVersionModelProvider;
 import com.amplifyframework.testutils.Await;
@@ -104,7 +106,9 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
         assertFalse(CollectionUtils.isNullOrEmpty(firstResults));
 
         // Assert if version is stored correctly
-        String expectedVersion = modelProvider.version();
+        String expectedVersion =
+            CompoundModelProvider.of(modelProvider, SystemModelsProviderFactory.create())
+                .version();
         PersistentModelVersion persistentModelVersion =
                 PersistentModelVersion
                         .fromLocalStorage(sqliteStorageAdapter)
@@ -131,7 +135,9 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
         assertFalse(CollectionUtils.isNullOrEmpty(secondResults));
 
         // Check if the new version is stored in local storage.
-        expectedVersion = modelProviderThatUpgradesVersion.version();
+        expectedVersion =
+            CompoundModelProvider.of(modelProviderThatUpgradesVersion, SystemModelsProviderFactory.create())
+                .version();
         persistentModelVersion = PersistentModelVersion
                 .fromLocalStorage(sqliteStorageAdapter)
                 .blockingGet()

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/CompoundModelProvider.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/CompoundModelProvider.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * A ModelProvider which is created by composing together some other model providers.
+ *
+ * This is useful in the AWS DataStore implementation, as we have a user-provided
+ * ModelProvider (from the CLI tool), and an internal System models provider.
+ * When we initialize the DataStore, we don't distinguish between the two, we just need
+ * to prepare storage to accommodate all the models. At this time, we want an
+ * {@link CompoundModelProvider} to aggregate things.
+ *
+ * Buildings a stable {@link CompoundModelProvider#version()} is a key achievement of
+ * this class. For input versions A, B, C, we want to repeatably and reliably produce
+ * the same stable output value D, by means of some hashing function.
+ */
+public final class CompoundModelProvider implements ModelProvider {
+    private final SimpleModelProvider delegateProvider;
+
+    private CompoundModelProvider(SimpleModelProvider delegateProvider) {
+        this.delegateProvider = delegateProvider;
+    }
+
+    /**
+     * Gets an {@link CompoundModelProvider} that provides all of the same models as the
+     * constituent {@link ModelProvider} that are provided. The version of the returned
+     * {@link CompoundModelProvider} shall be stable UUID hash of the versions of all
+     * provided {@link ModelProvider}s.
+     * @param modelProviders model providers
+     * @return A compound provider, which provides the models of all of the input providers
+     */
+    @NonNull
+    public static CompoundModelProvider of(@NonNull ModelProvider... modelProviders) {
+        // We want to always add the versions to the string builder in the same order
+        // This helps to guarantee that of(A,B) == of(B,A).
+        final List<ModelProvider> sortedProviders = new ArrayList<>(Arrays.asList(modelProviders));
+        Collections.sort(sortedProviders, (one, two) -> one.version().compareTo(two.version()));
+
+        Set<Class<? extends Model>> modelClasses = new HashSet<>();
+        StringBuilder componentVersionBuffer = new StringBuilder();
+        for (ModelProvider componentProvider : sortedProviders) {
+            componentVersionBuffer.append(componentProvider.version());
+            modelClasses.addAll(componentProvider.models());
+        }
+        String version = UUID.nameUUIDFromBytes(componentVersionBuffer.toString().getBytes()).toString();
+        SimpleModelProvider delegateProvider = SimpleModelProvider.instance(version, modelClasses);
+        return new CompoundModelProvider(delegateProvider);
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Model>> models() {
+        return delegateProvider.models();
+    }
+
+    @NonNull
+    @Override
+    public String version() {
+        return delegateProvider.version();
+    }
+
+    @Override
+    public boolean equals(Object thatObject) {
+        if (!(thatObject instanceof ModelProvider)) {
+            return false;
+        }
+
+        ModelProvider thatProvider = (ModelProvider) thatObject;
+        return version().equals(thatProvider.version());
+    }
+
+    @Override
+    public int hashCode() {
+        return version().hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "CompoundModelsProvider{" +
+            "delegateProvider=" + delegateProvider +
+            '}';
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -39,6 +39,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
 import com.amplifyframework.core.model.types.JavaFieldType;
 import com.amplifyframework.core.model.types.internal.TypeConverter;
+import com.amplifyframework.datastore.CompoundModelProvider;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
@@ -89,10 +90,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     static final String DATABASE_NAME = "AmplifyDatastore.db";
 
     // Provider of the Models that will be warehouse-able by the DataStore
-    private final ModelProvider userModelsProvider;
-
-    // Provider of models that are used internally for DataStore to track metadata
-    private final ModelProvider systemModelsProvider;
+    // and models that are used internally for DataStore to track metadata
+    private final ModelProvider modelsProvider;
 
     // ModelSchemaRegistry instance that gives the ModelSchema and Model objects
     // based on Model class name lookup mechanism.
@@ -141,8 +140,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             ModelProvider userModelsProvider,
             ModelProvider systemModelsProvider) {
         this.modelSchemaRegistry = modelSchemaRegistry;
-        this.userModelsProvider = userModelsProvider;
-        this.systemModelsProvider = systemModelsProvider;
+        this.modelsProvider = CompoundModelProvider.of(userModelsProvider, systemModelsProvider);
         this.threadPool = Executors.newCachedThreadPool();
         this.insertSqlPreparedStatements = Collections.emptyMap();
         this.gson = new Gson();
@@ -182,10 +180,6 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
 
         threadPool.submit(() -> {
             try {
-                final Set<Class<? extends Model>> models = new HashSet<>();
-                models.addAll(systemModelsProvider.models());
-                models.addAll(userModelsProvider.models());
-
                 /*
                  * Start with a fresh registry.
                  */
@@ -195,7 +189,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                  * Any exception raised during this when inspecting the Model classes
                  * through reflection will be notified via the `onError` callback.
                  */
-                modelSchemaRegistry.load(models);
+                modelSchemaRegistry.load(modelsProvider.models());
 
                 /*
                  * Create the CREATE TABLE and CREATE INDEX commands for each of the
@@ -203,7 +197,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                  * create commands.
                  */
                 this.sqlCommandFactory = new SQLiteCommandFactory(modelSchemaRegistry);
-                CreateSqlCommands createSqlCommands = getCreateCommands(models);
+                CreateSqlCommands createSqlCommands = getCreateCommands(modelsProvider.models());
                 sqliteStorageHelper = SQLiteStorageHelper.getInstance(
                         context,
                         DATABASE_NAME,
@@ -928,7 +922,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                                 "Checking if the model version need to be updated...");
                         PersistentModelVersion persistentModelVersion = iterator.next();
                         String oldVersion = persistentModelVersion.getVersion();
-                        String newVersion = userModelsProvider.version();
+                        String newVersion = modelsProvider.version();
                         if (!ObjectsCompat.equals(oldVersion, newVersion)) {
                             LOG.debug("Updating version as it has changed from " +
                                     oldVersion + " to " + newVersion);
@@ -942,7 +936,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     }
                     return PersistentModelVersion.saveToLocalStorage(
                             this,
-                            new PersistentModelVersion(userModelsProvider.version()));
+                            new PersistentModelVersion(modelsProvider.version()));
                 }).ignoreElement();
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/CompoundModelProviderTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/CompoundModelProviderTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore;
+
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.testmodels.commentsblog.Author;
+import com.amplifyframework.testmodels.commentsblog.Blog;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link CompoundModelProvider}.
+ */
+public final class CompoundModelProviderTest {
+    /**
+     * It should be possible to create multiple instance of {@link CompoundModelProvider}
+     * from different component providers that have the same UUID. The compound versions
+     * should be repeatably the same.
+     */
+    @Test
+    public void compoundVersionIsStable() {
+        // Arrange three model providers.
+        // The first has one UUID
+        // The seconds and third share a UUID.
+        String uniqueVersion = UUID.randomUUID().toString();
+        ModelProvider first = SimpleModelProvider.instance(uniqueVersion, Blog.class);
+
+        String repeatedVersion = UUID.randomUUID().toString();
+        ModelProvider second = SimpleModelProvider.instance(repeatedVersion, BlogOwner.class);
+        ModelProvider third = SimpleModelProvider.instance(repeatedVersion, BlogOwner.class);
+
+        // Act: create a couple of compounds, one of (A + B), and another of (A + C).
+        CompoundModelProvider firstPlusSecond = CompoundModelProvider.of(first, second);
+        CompoundModelProvider firstPlusThird = CompoundModelProvider.of(first, third);
+
+        // Assert: both instances report the same version for the compound,
+        // on the basis that the ipnut versions were all the same.
+        assertEquals(firstPlusSecond.version(), firstPlusThird.version());
+    }
+
+    /**
+     * If a component provider A provides models 1, 2,
+     * and another provider B provides models 2, 3,
+     * The compound shall provide 1,2,3.
+     */
+    @Test
+    public void compoundProvidesAllComponentModels() {
+        SimpleModelProvider oneTwoProvider = SimpleModelProvider.withRandomVersion(Blog.class, BlogOwner.class);
+        SimpleModelProvider twoThreeProvider = SimpleModelProvider.withRandomVersion(BlogOwner.class, Author.class);
+        CompoundModelProvider compound = CompoundModelProvider.of(oneTwoProvider, twoThreeProvider);
+
+        assertEquals(
+            new HashSet<>(Arrays.asList(Blog.class, BlogOwner.class, Author.class)),
+            compound.models()
+        );
+    }
+
+    /**
+     * Check {@link CompoundModelProvider#equals(Object)} and {@link CompoundModelProvider#hashCode()} etc.,
+     * for two instances of {@link CompoundModelProvider} that contain the same logical contents.
+     */
+    @Test
+    public void differentInstancesOfSameContentAreEquals() {
+        SimpleModelProvider componentProvider = SimpleModelProvider.withRandomVersion(BlogOwner.class);
+        CompoundModelProvider first = CompoundModelProvider.of(componentProvider);
+        CompoundModelProvider second = CompoundModelProvider.of(componentProvider);
+
+        // The two providers had the same component, so they should have the same versions, too.
+        assertEquals(first.version(), second.version());
+        // The two providers are considered equals(), on the basis that they have the same version.
+        assertEquals(first, second);
+
+        // hashCode() works; adding different instances with same content into a set
+        // will result in only one copy.
+        Set<CompoundModelProvider> provider = new HashSet<>();
+        provider.add(first);
+        provider.add(second);
+        assertEquals(1, provider.size());
+    }
+
+    /**
+     * It's alright to have an {@link CompoundModelProvider} that provides no models.
+     */
+    @Test
+    public void possibleToHaveAnEmptyProvider() {
+        CompoundModelProvider compoundModelProvider = CompoundModelProvider.of();
+        assertTrue(compoundModelProvider.models().isEmpty());
+        String emptyStringUuid = UUID.nameUUIDFromBytes("".getBytes()).toString();
+        assertEquals(emptyStringUuid, compoundModelProvider.version());
+    }
+
+    /**
+     * A compound provider of A, B, should be the same as a compound provider of B, A.
+     */
+    @Test
+    public void parameterOrderDoesNotMatter() {
+        // Arrange two providers that have inputs provided out-of-order
+        SimpleModelProvider one = SimpleModelProvider.withRandomVersion(Blog.class);
+        SimpleModelProvider two = SimpleModelProvider.withRandomVersion(BlogOwner.class);
+        CompoundModelProvider oneAndTwo = CompoundModelProvider.of(one, two);
+        CompoundModelProvider twoAndOne = CompoundModelProvider.of(two, one);
+
+        // They should be equivalent.
+        assertEquals(oneAndTwo, twoAndOne);
+
+        // And hashCode() should also work, duh.
+        Set<CompoundModelProvider> providers = new HashSet<>();
+        providers.add(oneAndTwo);
+        providers.add(twoAndOne);
+        assertEquals(1, providers.size());
+        assertEquals(oneAndTwo, providers.iterator().next());
+        assertEquals(twoAndOne, providers.iterator().next());
+    }
+}


### PR DESCRIPTION
There was some exiting logic to blow away the SQL tables if the user's
model structure changes (as informed by the version in the model
provider).

However, no such logic existed for changes to the system models
provider.

To acommodate this, form a compound provider of both, and consider its
version, instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
