### PR TITLE
Fix language code -> enum conversion

### DIFF
--- a/core/src/main/java/com/amplifyframework/predictions/models/LanguageType.java
+++ b/core/src/main/java/com/amplifyframework/predictions/models/LanguageType.java
@@ -15,6 +15,9 @@
 
 package com.amplifyframework.predictions.models;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Enum of different types of language. These are the languages
  * that are recognized and supported by Amazon Translate Service
@@ -131,7 +134,17 @@ public enum LanguageType {
     YORUBA("yo"),
     UNKNOWN("unknown");
 
+    private static final Map<String, LanguageType> CODES;
+
     private final String languageCode;
+
+    // Reverse look-up table
+    static {
+        CODES = new HashMap<>();
+        for (LanguageType language : LanguageType.values()) {
+            CODES.put(language.getLanguageCode(), language);
+        }
+    }
 
     LanguageType(String languageCode) {
         this.languageCode = languageCode;
@@ -145,11 +158,10 @@ public enum LanguageType {
      * @return An enum value of matching language code
      */
     public static LanguageType from(String languageCode) {
-        try {
-            return LanguageType.valueOf(languageCode);
-        } catch (IllegalArgumentException noMatchError) {
+        if (!CODES.containsKey(languageCode)) {
             return UNKNOWN;
         }
+        return CODES.get(languageCode);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I introduced a bug that fails to convert language code to language type enum. The issue is fixed in this PR by creating a static look-up map in the enum class.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
