### PR TITLE
[aws-datastore] Mutation outbox precedence over cloud content

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/PersistentModelVersion.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/PersistentModelVersion.java
@@ -43,7 +43,7 @@ public final class PersistentModelVersion implements Model {
     // 
     // Once the limitation is addressed, remove this static identifier and provide an appropriate
     // update strategy for the PersistentModelVersion to move to the new architecture.
-    private static final String STATIC_IDENTIFIER_FOR_VERSION = "version-in-local-storage";
+    private static final String STATIC_IDENTIFIER_FOR_VERSION = "1ae1b4d0-7894-4f23-831e-ccf6c8439e1c";
 
     @ModelField(targetType = "ID", isRequired = true)
     private final String id;
@@ -56,9 +56,8 @@ public final class PersistentModelVersion implements Model {
      * @param version version of the {@link com.amplifyframework.core.model.ModelProvider}
      */
     PersistentModelVersion(@NonNull String version) {
-        Objects.requireNonNull(version);
+        this.version = Objects.requireNonNull(version);
         this.id = STATIC_IDENTIFIER_FOR_VERSION;
-        this.version = version;
     }
 
     /**
@@ -108,6 +107,7 @@ public final class PersistentModelVersion implements Model {
      * Return the version of the models.
      * @return the version of the models.
      */
+    @NonNull
     public String getVersion() {
         return this.version;
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -336,6 +336,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 @SuppressWarnings("unchecked")
                 // item.getClass() is Class<? extends Model>, builder wants Class<T>.
                 final StorageItemChange.Record record = StorageItemChange.<T>builder()
+                    .changeId(item.getId())
                     .item(item)
                     .itemClass((Class<T>) item.getClass())
                     .type(type)
@@ -496,6 +497,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     }
                 }
                 final StorageItemChange.Record record = StorageItemChange.<T>builder()
+                    .changeId(item.getId())
                     .item(item)
                     .itemClass((Class<T>) item.getClass())
                     .type(StorageItemChange.Type.DELETE)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -62,7 +62,7 @@ public final class Orchestrator {
 
         RemoteModelMutations remoteModelMutations = new RemoteModelMutations(appSync, modelProvider);
         MutationOutbox mutationOutbox = new MutationOutbox(localStorageAdapter);
-        Merger merger = new Merger(localStorageAdapter);
+        Merger merger = new Merger(mutationOutbox, localStorageAdapter);
         VersionRepository versionRepository = new VersionRepository(localStorageAdapter);
         SyncTimeRegistry syncTimeRegistry = new SyncTimeRegistry(localStorageAdapter);
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -39,7 +39,6 @@ import io.reactivex.subjects.PublishSubject;
  * contract. This intended for use as a stub in test code.
  */
 public final class InMemoryStorageAdapter implements LocalStorageAdapter {
-
     private final List<Model> items;
     private final PublishSubject<StorageItemChange.Record> changeRecordStream;
     private final GsonStorageItemChangeConverter storageItemChangeConverter;

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
@@ -25,6 +25,7 @@ import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testutils.Await;
+import com.amplifyframework.testutils.random.RandomString;
 import com.amplifyframework.util.Time;
 
 import org.junit.Before;
@@ -51,12 +52,14 @@ public final class MergerTest {
     private static final long REASONABLE_WAIT_TIME = TimeUnit.SECONDS.toMillis(2);
 
     private InMemoryStorageAdapter inMemoryStorageAdapter;
+    private MutationOutbox mutationOutbox;
     private Merger merger;
 
     @Before
     public void setup() {
         this.inMemoryStorageAdapter = InMemoryStorageAdapter.create();
-        this.merger = new Merger(inMemoryStorageAdapter);
+        this.mutationOutbox = new MutationOutbox(inMemoryStorageAdapter);
+        this.merger = new Merger(mutationOutbox, inMemoryStorageAdapter);
     }
 
     /**
@@ -169,6 +172,46 @@ public final class MergerTest {
         // Assert: the *UPDATED* stuff is in the store, *only*.
         assertEquals(Collections.singletonList(updatedModel), findModels(BlogOwner.class));
         assertEquals(Collections.singletonList(updatedMetadata), findModels(ModelMetadata.class));
+    }
+
+    /**
+     * When a record comes into the merger to be merged,
+     * if there is a pending mutation in the outbox, for a model of the same ID,
+     * then that record shall NOT be merged.
+     * @throws DataStoreException On failure to arrange data into store
+     */
+    @Test
+    public void recordIsNotMergedWhenOutboxHasPendingMutation() throws DataStoreException {
+        // Arrange: some model with a well known ID exists on the system.
+        // We pretend that the user has recently updated it via the DataStore update() API.
+        String knownId = RandomString.string();
+        BlogOwner blogOwner = BlogOwner.builder()
+            .name("Jameson")
+            .id(knownId)
+            .build();
+        ModelMetadata localMetadata =
+            new ModelMetadata(blogOwner.getId(), false, 1, Time.now());
+        putInStore(blogOwner, localMetadata);
+        mutationOutbox.enqueue(StorageItemChange.<BlogOwner>builder()
+            .changeId(knownId)
+            .initiator(StorageItemChange.Initiator.DATA_STORE_API)
+            .item(blogOwner)
+            .itemClass(BlogOwner.class)
+            .type(StorageItemChange.Type.UPDATE)
+            .build());
+
+        // Act: now, cloud sync happens, and the sync engine tries to apply an update
+        // for the same model ID, into the store. According to the cloud, this same
+        // record should be DELETED.
+        ModelMetadata cloudMetadata = new ModelMetadata(knownId, true, 2, Time.now());
+        merger.merge(new ModelWithMetadata<>(blogOwner, cloudMetadata));
+
+        // Assert: the record is NOT deleted from the local store.
+        // The original is still there.
+        // Or in other words, the cloud data was NOT merged.
+        final List<BlogOwner> blogOwnersInStorage = findModels(BlogOwner.class);
+        assertEquals(1, blogOwnersInStorage.size());
+        assertEquals(blogOwner, blogOwnersInStorage.get(0));
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -66,7 +66,7 @@ public final class MutationProcessorTest {
         this.appSync = mock(AppSync.class);
 
         MutationOutbox mutationOutbox = new MutationOutbox(inMemoryStorageAdapter);
-        Merger merger = new Merger(inMemoryStorageAdapter);
+        Merger merger = new Merger(mutationOutbox, inMemoryStorageAdapter);
         VersionRepository versionRepository = new VersionRepository(inMemoryStorageAdapter);
         this.mutationProcessor = new MutationProcessor(merger, versionRepository, mutationOutbox, appSync);
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -89,8 +89,10 @@ public final class SyncProcessorTest {
         modelSchemaRegistry.load(modelProvider.models());
 
         this.appSync = mock(AppSync.class);
-        final Merger merger = new Merger(inMemoryStorageAdapter);
+
         final SyncTimeRegistry syncTimeRegistry = new SyncTimeRegistry(inMemoryStorageAdapter);
+        final MutationOutbox mutationOutbox = new MutationOutbox(inMemoryStorageAdapter);
+        final Merger merger = new Merger(mutationOutbox, inMemoryStorageAdapter);
 
         this.syncProcessor = SyncProcessor.builder()
             .modelProvider(modelProvider)


### PR DESCRIPTION
While applying cloud content back into the local storage, the Merger
must consider whether or not the Mutation Outbox has a change record
corresponding to a model with the same UUID.

If the Mutation Outbox has a pending change for a model of the same ID,
then the Merger shall NOT apply the cloud update. This is to prevent
loss of customer data on the client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
