### PR TITLE
[aws-datastore] Single responsibility for SynchronousStorageAdapter

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StorageItemChangeRecordIntegrationTest.java
@@ -18,7 +18,6 @@ package com.amplifyframework.datastore;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
-import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchema;
@@ -26,10 +25,10 @@ import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
 import com.amplifyframework.datastore.storage.SystemModelsProviderFactory;
 import com.amplifyframework.datastore.storage.sqlite.SQLiteStorageAdapter;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
-import com.amplifyframework.testutils.Await;
 
 import org.junit.After;
 import org.junit.Before;
@@ -37,14 +36,10 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Observable;
-import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposables;
 import io.reactivex.observers.TestObserver;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
@@ -56,10 +51,9 @@ import static org.junit.Assert.assertEquals;
  */
 public final class StorageItemChangeRecordIntegrationTest {
     private static final String DATABASE_NAME = "AmplifyDatastore.db";
-    private static final long OPERATION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(2);
 
     private GsonStorageItemChangeConverter storageItemChangeConverter;
-    private LocalStorageAdapter localStorageAdapter;
+    private SynchronousStorageAdapter storageAdapter;
 
     /**
      * Prepare an instance of {@link LocalStorageAdapter}, and ensure that it will
@@ -78,12 +72,11 @@ public final class StorageItemChangeRecordIntegrationTest {
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.clear();
         modelSchemaRegistry.load(modelProvider.models());
-        this.localStorageAdapter = SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
-        List<ModelSchema> initializationResults = Await.result(
-            OPERATION_TIMEOUT_MS,
-            (Consumer<List<ModelSchema>> onResult, Consumer<DataStoreException> onError) ->
-                localStorageAdapter.initialize(getApplicationContext(), onResult, onError)
-        );
+
+        LocalStorageAdapter localStorageAdapter =
+            SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
+        this.storageAdapter = SynchronousStorageAdapter.delegatingTo(localStorageAdapter);
+        List<ModelSchema> initializationResults = storageAdapter.initialize(getApplicationContext());
 
         // Evaluate the returned set of ModelSchema. Make sure that there is one
         // for the StorageItemChange.Record system class, and one for
@@ -110,7 +103,7 @@ public final class StorageItemChangeRecordIntegrationTest {
      */
     @After
     public void terminateLocalStorageAdapter() throws DataStoreException {
-        localStorageAdapter.terminate();
+        storageAdapter.terminate();
         getApplicationContext().deleteDatabase(DATABASE_NAME);
     }
 
@@ -136,10 +129,11 @@ public final class StorageItemChangeRecordIntegrationTest {
         // Save the creation mutation for Tony, as a Record object.
         StorageItemChange.Record originalTonyCreationAsRecord =
             originalTonyCreation.toRecord(storageItemChangeConverter);
-        save(originalTonyCreationAsRecord);
+        storageAdapter.save(originalTonyCreationAsRecord);
 
         // Now, lookup what records we have in the storage.
-        List<StorageItemChange.Record> recordsInStorage = query();
+        List<StorageItemChange.Record> recordsInStorage =
+            storageAdapter.query(StorageItemChange.Record.class);
 
         // There should be 1, and it should be the original creation for Tony.
         assertEquals(1, recordsInStorage.size());
@@ -164,7 +158,7 @@ public final class StorageItemChangeRecordIntegrationTest {
     public void saveIsObservedForChangeRecord() throws DataStoreException {
         // Start watching observe() ...
         TestObserver<StorageItemChange.Record> saveObserver = TestObserver.create();
-        records().subscribe(saveObserver);
+        storageAdapter.observe().subscribe(saveObserver);
 
         // Save something ..
         StorageItemChange.Record record = StorageItemChange.<BlogOwner>builder()
@@ -178,14 +172,7 @@ public final class StorageItemChangeRecordIntegrationTest {
             .toRecord(storageItemChangeConverter);
 
         // Wait for it to save...
-        Await.result(OPERATION_TIMEOUT_MS,
-            (Consumer<StorageItemChange.Record> onResult, Consumer<DataStoreException> onError) ->
-                localStorageAdapter.save(
-                    record,
-                    StorageItemChange.Initiator.SYNC_ENGINE,
-                    onResult, onError
-                )
-        );
+        storageAdapter.save(record);
 
         // Assert that our observer got the item;
         // The record we get back has the saved record inside of it, as the contained item field.
@@ -216,7 +203,7 @@ public final class StorageItemChangeRecordIntegrationTest {
     public void updatesAreObservedForChangeRecords() throws DataStoreException {
         // Establish a subscription to listen for storage change records
         TestObserver<StorageItemChange.Record> storageObserver = TestObserver.create();
-        records().subscribe(storageObserver);
+        storageAdapter.observe().subscribe(storageObserver);
 
         // Create a record for Joe, and a change to save him into storage
         BlogOwner joeLastNameMispelled = BlogOwner.builder()
@@ -232,7 +219,7 @@ public final class StorageItemChangeRecordIntegrationTest {
             createJoeWrongLastName.toRecord(storageItemChangeConverter);
 
         // Save our saveJoeWrongLastName change item, as a record.
-        save(createJoeWrongLastNameAsRecord);
+        storageAdapter.save(createJoeWrongLastNameAsRecord);
 
         // Now, suppose we have to update that change object. Maybe it contained a bad item payload.
         BlogOwner joeWithLastNameFix = BlogOwner.builder()
@@ -249,7 +236,7 @@ public final class StorageItemChangeRecordIntegrationTest {
             createJoeCorrectLastName.toRecord(storageItemChangeConverter);
 
         // Save an update (same model type, same unique ID) to the change we saved previously.
-        save(createJoeCorrectLastNameAsRecord);
+        storageAdapter.save(createJoeCorrectLastNameAsRecord);
 
         // Our observer got the records to save Joe with wrong age, and also to save joe with right age
         List<StorageItemChange.Record> values = storageObserver.awaitCount(2).values();
@@ -281,7 +268,7 @@ public final class StorageItemChangeRecordIntegrationTest {
         // What we are really observing are items of type StorageItemChange.Record that contain
         // StorageItemChange.Record of BlogOwner
         TestObserver<StorageItemChange.Record> storageObserver = TestObserver.create();
-        records().subscribe(storageObserver);
+        storageAdapter.observe().subscribe(storageObserver);
 
         BlogOwner beatrice = BlogOwner.builder()
             .name("Beatrice Stone")
@@ -295,7 +282,7 @@ public final class StorageItemChangeRecordIntegrationTest {
         StorageItemChange.Record createBeatriceRecord =
             createBeatrice.toRecord(storageItemChangeConverter);
 
-        save(createBeatriceRecord);
+        storageAdapter.save(createBeatriceRecord);
 
         // Assert that we do observe the record being saved ...
         assertEquals(
@@ -309,10 +296,10 @@ public final class StorageItemChangeRecordIntegrationTest {
         storageObserver.dispose();
 
         TestObserver<StorageItemChange.Record> deletionObserver = TestObserver.create();
-        records().subscribe(deletionObserver);
+        storageAdapter.observe().subscribe(deletionObserver);
 
         // The mutation record doesn't change, but we want to delete it, itself.
-        delete(createBeatriceRecord);
+        storageAdapter.delete(createBeatriceRecord);
 
         assertEquals(
             createBeatriceRecord,
@@ -324,78 +311,5 @@ public final class StorageItemChangeRecordIntegrationTest {
                 .item()
         );
         deletionObserver.dispose();
-    }
-
-    private void save(StorageItemChange.Record storageItemChangeRecord) throws DataStoreException {
-        // The thing we are saving is a StorageItemChange.Record.
-        // The fact that it is getting saved means it gets wrapped into another
-        // StorageItemChange.Record, which itself contains the original StorageItemChange.Record.
-        final StorageItemChange<?> convertedResult = Await.result(OPERATION_TIMEOUT_MS,
-            (Consumer<StorageItemChange.Record> onResult, Consumer<DataStoreException> onError) ->
-                localStorageAdapter.save(
-                    storageItemChangeRecord,
-                    StorageItemChange.Initiator.SYNC_ENGINE,
-                    onResult,
-                    onError
-                )
-        ).toStorageItemChange(storageItemChangeConverter);
-
-        // Peel out the item from the save result - the item inside is the thing we tried to save,
-        // e.g., the mutation to create BlogOwner
-        // It should be identical to the thing that we tried to save.
-        assertEquals(storageItemChangeRecord, convertedResult.item());
-    }
-
-    private List<StorageItemChange.Record> query() throws DataStoreException {
-        // TODO: if/when there is a form of query() which shall accept QueryPredicate, use that instead.
-        final Iterator<StorageItemChange.Record> queryResultsIterator = Await.result(
-            (Consumer<Iterator<StorageItemChange.Record>> onResult, Consumer<DataStoreException> onError) ->
-                localStorageAdapter.query(
-                    StorageItemChange.Record.class,
-                    onResult,
-                    onError
-                )
-            );
-
-        final List<StorageItemChange.Record> storageItemChangeRecords = new ArrayList<>();
-        while (queryResultsIterator.hasNext()) {
-            storageItemChangeRecords.add(queryResultsIterator.next());
-        }
-        return storageItemChangeRecords;
-    }
-
-    private void delete(StorageItemChange.Record record) throws DataStoreException {
-        // The thing we are deleting is a StorageItemChange.Record, which is wrapping
-        // a StorageItemChange.Record, which is wrapping an item.
-        StorageItemChange.Record deletionResult = Await.result(
-            (Consumer<StorageItemChange.Record> onResult, Consumer<DataStoreException> onError) ->
-                localStorageAdapter.delete(
-                    record,
-                    StorageItemChange.Initiator.SYNC_ENGINE,
-                    onResult,
-                    onError
-                )
-        );
-
-        // Peel out the inner record out from the save result -
-        // the record inside is the thing we tried to save,
-        // that is, the record to change an item
-        // That interior record should be identical to the thing that we tried to save.
-        StorageItemChange<StorageItemChange.Record> recordOfDeletion =
-            deletionResult.toStorageItemChange(storageItemChangeConverter);
-        assertEquals(record, recordOfDeletion.item());
-
-        // The record of the record itself has type DELETE, corresponding to our call to delete().
-        assertEquals(StorageItemChange.Type.DELETE, recordOfDeletion.type());
-    }
-
-    private Observable<StorageItemChange.Record> records() {
-        return Observable.create(emitter -> {
-            CompositeDisposable disposable = new CompositeDisposable();
-            emitter.setDisposable(disposable);
-            Cancelable cancelable =
-                localStorageAdapter.observe(emitter::onNext, emitter::onError, emitter::onComplete);
-            disposable.add(Disposables.fromAction(cancelable::cancel));
-        });
     }
 }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore.storage.sqlite;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.StrictMode;
+import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
@@ -27,7 +28,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Set;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -70,7 +71,7 @@ public final class SQLiteStorageAdapterDeleteTest {
         adapter.delete(raphael);
 
         // Get the BlogOwner record from the database
-        final Set<BlogOwner> blogOwners = adapter.query(BlogOwner.class);
+        final List<BlogOwner> blogOwners = adapter.query(BlogOwner.class);
         assertTrue(blogOwners.isEmpty());
     }
 
@@ -99,11 +100,11 @@ public final class SQLiteStorageAdapterDeleteTest {
         adapter.delete(raphael);
 
         // Get the BlogOwner record from the database
-        final Set<BlogOwner> blogOwners = adapter.query(BlogOwner.class);
+        final List<BlogOwner> blogOwners = adapter.query(BlogOwner.class);
         assertTrue(blogOwners.isEmpty());
 
         // Get the Blog record from the database
-        final Set<Blog> blogs = adapter.query(Blog.class);
+        final List<Blog> blogs = adapter.query(Blog.class);
         assertTrue(blogs.isEmpty());
     }
 
@@ -134,7 +135,7 @@ public final class SQLiteStorageAdapterDeleteTest {
         //noinspection ThrowableNotThrown This is the point of this method.
         adapter.deleteExpectingError(mark, predicate); // Should not be deleted
 
-        Set<BlogOwner> blogOwners = adapter.query(BlogOwner.class);
+        List<BlogOwner> blogOwners = adapter.query(BlogOwner.class);
         assertEquals(1, blogOwners.size());
         assertTrue(blogOwners.contains(mark));
     }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/TestStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/TestStorageAdapter.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
 
 import java.util.Objects;
 
@@ -54,7 +55,7 @@ final class TestStorageAdapter {
             SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
 
         SynchronousStorageAdapter synchronousStorageAdapter =
-            SynchronousStorageAdapter.instance(sqLiteStorageAdapter);
+            SynchronousStorageAdapter.delegatingTo(sqLiteStorageAdapter);
         Context context = ApplicationProvider.getApplicationContext();
         try {
             synchronousStorageAdapter.initialize(context);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -215,14 +215,6 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
         changeRecordStream.onComplete();
     }
 
-    /**
-     * Get the items that are in the storage.
-     * @return Items in storage
-     */
-    public List<Model> items() {
-        return items;
-    }
-
     private int indexOf(Model item) {
         int index = 0;
         for (Model savedItem : items) {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/StorageItemChangeRecordTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/StorageItemChangeRecordTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertEquals;
  * API category.
  */
 public class StorageItemChangeRecordTest {
-
     /**
      * Generation of a ModelSchema for the {@link StorageItemChange.Record}
      * succeeds.

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.testutils.Await;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.Observable;
+
+/**
+ * A synchronization wrapper on top of a {@link LocalStorageAdapter} instance, which presents
+ * the storage adapter's functionality via synchronous methods, without callbacks.
+ * If any of the synchronous operations timeout, they will throw {@link RuntimeException}.
+ * If the operation can return an {@link DataStoreException} via an error callback in async form,
+ * then this adapter will throw that exception on the calling thread directly, to interrupt the
+ * flow of execution.
+ */
+public final class SynchronousStorageAdapter {
+    private static final long DEFAULT_OPERATION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(2);
+
+    private final long operationTimeoutMs;
+    private final LocalStorageAdapter asyncDelegate;
+
+    private SynchronousStorageAdapter(LocalStorageAdapter asyncDelegate, long operationTimeoutMs) {
+        this.asyncDelegate = asyncDelegate;
+        this.operationTimeoutMs = operationTimeoutMs;
+    }
+
+    /**
+     * Creates a new instance which will proxy calls to the provided {@link LocalStorageAdapter}.
+     * The synchronous operations exposed by the returned adapter will timeout after a default,
+     * "reasonable" delay.
+     * @param asyncDelegate Adapter to which calls will be delegated
+     * @return A SynchronousStorageAdapter configured to proxy towards the provided async storage adapter
+     */
+    public static SynchronousStorageAdapter delegatingTo(@NonNull LocalStorageAdapter asyncDelegate) {
+        Objects.requireNonNull(asyncDelegate);
+        return new SynchronousStorageAdapter(asyncDelegate, DEFAULT_OPERATION_TIMEOUT_MS);
+    }
+
+    /**
+     * Creates a new instance which will proxy calls to the provided {@link LocalStorageAdapter}.
+     * The synchronous operations exposed by the returned adapter will timeout after the provided
+     * amount of time, in milliseconds.
+     * @param asyncDelegate Adapter to which calls will be delegated
+     * @param operationTimeoutMs Amount of time after which an operation will time out
+     * @return A SynchronousStorageAdapter configured to proxy towards the provided async storage adapter
+     */
+    public static SynchronousStorageAdapter create(
+        @NonNull LocalStorageAdapter asyncDelegate, long operationTimeoutMs) {
+        Objects.requireNonNull(asyncDelegate);
+        return new SynchronousStorageAdapter(asyncDelegate, operationTimeoutMs);
+    }
+
+    /**
+     * Save a model into the storage adapter.
+     * @param model Model to save
+     * @param <T> Type of model being saved
+     * @throws DataStoreException On any failure to save model into storage adapter
+     */
+    public <T extends Model> void save(@NonNull T model) throws DataStoreException {
+        //noinspection ConstantConditions
+        save(model, null);
+    }
+
+    /**
+     * Save a model.
+     * @param model Model to save
+     * @param predicate An existing instance of the model in the storage adapter must meet these criteria
+     *                  in order for the save to succeed. If null, no criteria are considered
+     * @param <T> Type of model being saved
+     * @throws DataStoreException On any failure to save the model
+     */
+    public <T extends Model> void save(@NonNull T model, @NonNull QueryPredicate predicate)
+        throws DataStoreException {
+        Await.result(
+            operationTimeoutMs,
+            (Consumer<StorageItemChange.Record> onResult, Consumer<DataStoreException> onError) ->
+                asyncDelegate.save(
+                    model,
+                    StorageItemChange.Initiator.DATA_STORE_API,
+                    predicate,
+                    onResult,
+                    onError
+                )
+        );
+    }
+
+    /**
+     * Save some models.
+     * @param models Models to save
+     * @param <T> Type of models
+     * @throws DataStoreException On failure to save any of the models
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public final <T extends Model> void save(@NonNull T... models) throws DataStoreException {
+        for (T model : models) {
+            save(model);
+        }
+    }
+
+    /**
+     * Query the storage adapter for models of a given class.
+     * @param modelClass Class of models being queried
+     * @param <T> Type of models being queried
+     * @return The list of models in the storage adapter that are of the requested class
+     * @throws DataStoreException On any failure to query storage adapter
+     */
+    public <T extends Model> List<T> query(@NonNull Class<T> modelClass) throws DataStoreException {
+        //noinspection ConstantConditions
+        return query(modelClass, null);
+    }
+
+    /**
+     * Query for all models that are of the types provided in the given model provider.
+     * For example, if the model provider returns A.class, B.class, then this query
+     * methods would return all instances of model types A and B.
+     * @param modelProvider Provides of model classes
+     * @return All instances of the provided models that exist in the store
+     * @throws DataStoreException On failure to query the store
+     */
+    public List<? extends Model> query(@NonNull ModelProvider modelProvider) throws DataStoreException {
+        final List<Model> models = new ArrayList<>();
+        for (Class<? extends Model> modelClass : modelProvider.models()) {
+            models.addAll(query(modelClass));
+        }
+        return models;
+    }
+
+    /**
+     * Query the storage adapter for models of a given class, and considering some additional criteria
+     * that each model must meet.
+     * @param modelClass Class of models being queried
+     * @param predicate Additional criteria that the models must match
+     * @param <T> Type of model being queried
+     * @return The list of models which are of the requested class and meet the requested criteria
+     * @throws DataStoreException On any failure to query the storage adapter
+     */
+    public <T extends Model> List<T> query(@NonNull Class<T> modelClass, @NonNull QueryPredicate predicate)
+        throws DataStoreException {
+        Iterator<T> resultIterator = Await.result(
+            operationTimeoutMs,
+            (Consumer<Iterator<T>> onResult, Consumer<DataStoreException> onError) ->
+                asyncDelegate.query(modelClass, predicate, onResult, onError)
+        );
+        final List<T> results = new ArrayList<>();
+        while (resultIterator.hasNext()) {
+            results.add(resultIterator.next());
+        }
+        return results;
+    }
+
+    /**
+     * Delete a model, unconditionally. Expect success.
+     * @param model A model to be deleted
+     * @param <T> Type of model being deleted
+     * @throws DataStoreException On any failure to delete model
+     */
+    public <T extends Model> void delete(@NonNull T model) throws DataStoreException {
+        //noinspection ConstantConditions
+        delete(model, null);
+    }
+
+    /**
+     * Delete a model, and expect success.
+     * @param model Model to delete
+     * @param predicate Conditions that must be met before model is candidate for deletion
+     * @param <T> Type of model being deleted
+     * @throws DataStoreException On any failure to delete the model
+     */
+    public <T extends Model> void delete(@NonNull T model, @NonNull QueryPredicate predicate)
+        throws DataStoreException {
+        Await.result(
+            operationTimeoutMs,
+            (Consumer<StorageItemChange.Record> onResult, Consumer<DataStoreException> onError) ->
+                asyncDelegate.delete(
+                    model,
+                    StorageItemChange.Initiator.DATA_STORE_API,
+                    predicate,
+                    onResult,
+                    onError
+                )
+        );
+    }
+
+    /**
+     * Delete a model, but /expect/ the operation to fail, due to some exception being thrown.
+     * Return the raised {@link DataStoreException} in a synchronous way,
+     * instead of letting it crash the calling thread.
+     * @param model Try to delete this
+     * @param <T> Type of thing being deleted
+     * @return The exception that was thrown while attempting to delete
+     */
+    @SuppressWarnings("unused")
+    public <T extends Model> DataStoreException deleteExpectingError(@NonNull T model) {
+        return Await.error(
+            operationTimeoutMs,
+            (Consumer<StorageItemChange.Record> onResult, Consumer<DataStoreException> onError) ->
+                asyncDelegate.delete(
+                    model,
+                    StorageItemChange.Initiator.DATA_STORE_API,
+                    null,
+                    onResult,
+                    onError
+                )
+        );
+    }
+
+    /**
+     * Observe changes in the adapter.
+     * @return An observable stream of storage item changes.
+     */
+    public Observable<StorageItemChange.Record> observe() {
+        return Observable.create(emitter ->
+            asyncDelegate.observe(emitter::onNext, emitter::onError, emitter::onComplete)
+        );
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
@@ -15,25 +15,20 @@
 
 package com.amplifyframework.datastore.syncengine;
 
-import androidx.annotation.NonNull;
-
-import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
-import com.amplifyframework.testutils.Await;
 import com.amplifyframework.testutils.random.RandomString;
 import com.amplifyframework.util.Time;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import edu.emory.mathcs.backport.java.util.Collections;
@@ -51,13 +46,14 @@ import static org.junit.Assert.assertTrue;
 public final class MergerTest {
     private static final long REASONABLE_WAIT_TIME = TimeUnit.SECONDS.toMillis(2);
 
-    private InMemoryStorageAdapter inMemoryStorageAdapter;
+    private SynchronousStorageAdapter storageAdapter;
     private MutationOutbox mutationOutbox;
     private Merger merger;
 
     @Before
     public void setup() {
-        this.inMemoryStorageAdapter = InMemoryStorageAdapter.create();
+        InMemoryStorageAdapter inMemoryStorageAdapter = InMemoryStorageAdapter.create();
+        this.storageAdapter = SynchronousStorageAdapter.delegatingTo(inMemoryStorageAdapter);
         this.mutationOutbox = new MutationOutbox(inMemoryStorageAdapter);
         this.merger = new Merger(mutationOutbox, inMemoryStorageAdapter);
     }
@@ -66,7 +62,8 @@ public final class MergerTest {
      * Assume there is a record A in the store. Then, we try to merge
      * a mutation to delete record A. This should succeed. After the
      * merge, A should NOT be in the store anymore.
-     * @throws DataStoreException On failure to arrange test data into store
+     * @throws DataStoreException On failure to arrange test data into store,
+     *                            or on failure to query results for test assertions
      */
     @Test
     public void mergeDeletionForExistingRecord() throws DataStoreException {
@@ -76,9 +73,9 @@ public final class MergerTest {
             .build();
         ModelMetadata originalMetadata =
             new ModelMetadata(blogOwner.getId(), false, 1, Time.now());
-        putInStore(blogOwner, originalMetadata);
+        storageAdapter.save(blogOwner, originalMetadata);
         // Just to be sure, our arrangement worked, and that thing is in there, right? Good.
-        assertEquals(Collections.singletonList(blogOwner), findModels(BlogOwner.class));
+        assertEquals(Collections.singletonList(blogOwner), storageAdapter.query(BlogOwner.class));
 
         // Act: merge a deletion record against the model.
         ModelMetadata deletionMetadata =
@@ -89,7 +86,7 @@ public final class MergerTest {
         observer.assertNoErrors().assertComplete();
 
         // Assert: the blog owner is no longer in the store.
-        assertEquals(0, findModels(BlogOwner.class).size());
+        assertEquals(0, storageAdapter.query(BlogOwner.class).size());
     }
 
     /**
@@ -97,9 +94,10 @@ public final class MergerTest {
      * merge a mutation to delete record A. This should succeed, since
      * there was no work to be performed (it was already deleted.) After
      * the merge, there should STILL be no matching record in the store.
+     * @throws DataStoreException On failure to query results for assertions
      */
     @Test
-    public void mergeDeletionForNotExistingRecord() {
+    public void mergeDeletionForNotExistingRecord() throws DataStoreException {
         // Arrange, to start, there are no records matching the incoming deletion request.
         BlogOwner blogOwner = BlogOwner.builder()
             .name("Jameson")
@@ -116,15 +114,16 @@ public final class MergerTest {
         observer.assertNoErrors().assertComplete();
 
         // Assert: there is still nothing in the store.
-        assertEquals(0, findModels(BlogOwner.class).size());
+        assertEquals(0, storageAdapter.query(BlogOwner.class).size());
     }
 
     /**
      * Assume there is NO record A. Then, we try to merge a save for a
      * record A. This should succeed, with A being in the store, at the end.
+     * @throws DataStoreException On failure to query results for assertions
      */
     @Test
-    public void mergeSaveForNotExistingRecord() {
+    public void mergeSaveForNotExistingRecord() throws DataStoreException {
         // Arrange: nothing in the store, to start.
         BlogOwner blogOwner = BlogOwner.builder()
             .name("Jameson")
@@ -139,8 +138,8 @@ public final class MergerTest {
         observer.assertNoErrors().assertComplete();
 
         // Assert: the record & its associated metadata are now in the store.
-        assertEquals(Collections.singletonList(blogOwner), findModels(BlogOwner.class));
-        assertEquals(Collections.singletonList(metadata), findModels(ModelMetadata.class));
+        assertEquals(Collections.singletonList(blogOwner), storageAdapter.query(BlogOwner.class));
+        assertEquals(Collections.singletonList(metadata), storageAdapter.query(ModelMetadata.class));
     }
 
     /**
@@ -157,7 +156,7 @@ public final class MergerTest {
             .build();
         ModelMetadata originalMetadata =
             new ModelMetadata(originalModel.getId(), false, 1, Time.now());
-        putInStore(originalModel, originalMetadata);
+        storageAdapter.save(originalModel, originalMetadata);
 
         // Act: merge a save.
         BlogOwner updatedModel = originalModel.copyOfBuilder()
@@ -170,8 +169,8 @@ public final class MergerTest {
         observer.assertComplete().assertNoErrors();
 
         // Assert: the *UPDATED* stuff is in the store, *only*.
-        assertEquals(Collections.singletonList(updatedModel), findModels(BlogOwner.class));
-        assertEquals(Collections.singletonList(updatedMetadata), findModels(ModelMetadata.class));
+        assertEquals(Collections.singletonList(updatedModel), storageAdapter.query(BlogOwner.class));
+        assertEquals(Collections.singletonList(updatedMetadata), storageAdapter.query(ModelMetadata.class));
     }
 
     /**
@@ -191,7 +190,7 @@ public final class MergerTest {
             .build();
         ModelMetadata localMetadata =
             new ModelMetadata(blogOwner.getId(), false, 1, Time.now());
-        putInStore(blogOwner, localMetadata);
+        storageAdapter.save(blogOwner, localMetadata);
         mutationOutbox.enqueue(StorageItemChange.<BlogOwner>builder()
             .changeId(knownId)
             .initiator(StorageItemChange.Initiator.DATA_STORE_API)
@@ -209,41 +208,8 @@ public final class MergerTest {
         // Assert: the record is NOT deleted from the local store.
         // The original is still there.
         // Or in other words, the cloud data was NOT merged.
-        final List<BlogOwner> blogOwnersInStorage = findModels(BlogOwner.class);
+        final List<BlogOwner> blogOwnersInStorage = storageAdapter.query(BlogOwner.class);
         assertEquals(1, blogOwnersInStorage.size());
         assertEquals(blogOwner, blogOwnersInStorage.get(0));
-    }
-
-    /**
-     * Saves a variable argument list of models into the {@link InMemoryStorageAdapter}.
-     * @param models Models to save
-     * @param <T> Type of models
-     * @throws DataStoreException On failure to save
-     */
-    @SuppressWarnings("varargs")
-    @SafeVarargs
-    private final <T extends Model> void putInStore(final T... models) throws DataStoreException {
-        for (T model : models) {
-            Await.<StorageItemChange.Record, DataStoreException>result((onResult, onError) ->
-                inMemoryStorageAdapter.save(model, StorageItemChange.Initiator.DATA_STORE_API, onResult, onError)
-            );
-        }
-    }
-
-    /**
-     * Find models in the {@link InMemoryStorageAdapter} of a given class.
-     * @param modelClass Class of model being looked up
-     * @return A list of matching records; empty, if there are no matches
-     */
-    @SuppressWarnings({"SameParameterValue", "unchecked"})
-    private <T extends Model> List<T> findModels(@NonNull Class<T> modelClass) {
-        Objects.requireNonNull(modelClass);
-        final List<T> results = new ArrayList<>();
-        for (Model model : inMemoryStorageAdapter.items()) {
-            if (model.getClass().isAssignableFrom(modelClass)) {
-                results.add((T) model);
-            }
-        }
-        return results;
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -28,7 +28,6 @@ import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.SimpleModelProvider;
 import com.amplifyframework.datastore.appsync.AppSync;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
-import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testutils.Await;
@@ -90,7 +89,7 @@ public final class OrchestratorTest {
         }).when(appSync)
             .create(eq(susan), any(Consumer.class), any(Consumer.class));
 
-        LocalStorageAdapter localStorageAdapter = InMemoryStorageAdapter.create();
+        InMemoryStorageAdapter localStorageAdapter = InMemoryStorageAdapter.create();
         ModelProvider modelProvider = SimpleModelProvider.withRandomVersion();
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.clear();


### PR DESCRIPTION
Littered around the test code were various synchronous operations on top
of a `LocalStorageAdapter`. Likewise, the `InMemoryStorageAdapter` had grown
a couple of synchronous operations which it exposed in tests. The
responsibility for synchronous access to a storage adapter was split
into a few different places, *including* the utility that is meant to
achieve this, the `SynchronousStorageAdapter`.

To resolve this, numerous tests are refactored to make singular
reference to the `SynchronousStorageAdapter` only, and in lieu of the
other previously mechanisms of doing synchronous storage access.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
