### PR TITLE
Transitive dependencies already included for AWS Mobile Client

### DIFF
--- a/aws-analytics-pinpoint/build.gradle
+++ b/aws-analytics-pinpoint/build.gradle
@@ -21,9 +21,7 @@ dependencies {
     implementation project(path: ':core')
     implementation dependency.androidx.appcompat
     implementation dependency.aws.pinpoint
-    implementation (dependency.aws.mobileclient) {
-        transitive = true
-    }
+    implementation dependency.aws.mobileclient
 
     testImplementation dependency.junit
     testImplementation dependency.mockito
@@ -31,6 +29,7 @@ dependencies {
         // https://github.com/robolectric/robolectric/issues/5245
         exclude group: 'com.google.auto.service', module: 'auto-service'
     }
+
     androidTestImplementation project(path: ':testutils')
     androidTestImplementation dependency.androidx.test.core
     androidTestImplementation dependency.androidx.test.runner

--- a/aws-api/build.gradle
+++ b/aws-api/build.gradle
@@ -23,11 +23,8 @@ dependencies {
     implementation dependency.androidx.appcompat
     implementation dependency.okhttp
     implementation dependency.gson
-
     implementation dependency.aws.authcore
-    implementation (dependency.aws.mobileclient) {
-        transitive = true
-    }
+    implementation dependency.aws.mobileclient
 
     testImplementation project(path: ':testutils')
     testImplementation project(path: ':testmodels')

--- a/aws-storage-s3/build.gradle
+++ b/aws-storage-s3/build.gradle
@@ -21,9 +21,7 @@ dependencies {
     implementation project(path: ':core')
     implementation dependency.androidx.appcompat
     implementation dependency.aws.s3
-    implementation (dependency.aws.mobileclient) {
-        transitive = true
-    }
+    implementation dependency.aws.mobileclient
 
     testImplementation project(path: ':testutils')
     testImplementation dependency.junit

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     testImplementation dependency.androidx.test.core
     testImplementation dependency.jsonassert
 
-    androidTestImplementation(project(path: ':testutils')) {
+    androidTestImplementation (project(path: ':testutils')) {
         transitive = false
     }
     androidTestImplementation dependency.androidx.annotation

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -18,11 +18,8 @@ apply from: rootProject.file("configuration/checkstyle.gradle")
 
 dependencies {
     implementation project(path: ':core')
-    implementation (dependency.aws.mobileclient) {
-        transitive = true
-    }
+    implementation dependency.aws.mobileclient
     implementation dependency.junit
     implementation dependency.androidx.test.core
     implementation dependency.rxjava
 }
-


### PR DESCRIPTION
Specifying transitive = true is not necessary for the AWS Mobile Client
Gradle dependencies. This clause had been carried over from usages that
use the @aar artifact declaration. For _those_ declarations, transitive
is _not_ true by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
