### PR TITLE
Add unit tests for offline predictions

### DIFF
--- a/aws-predictions-tensorflow/build.gradle
+++ b/aws-predictions-tensorflow/build.gradle
@@ -21,5 +21,9 @@ dependencies {
     implementation project(':core')
     implementation dependency.androidx.appcompat
     implementation dependency.tensorflow
+
+    testImplementation project(':testutils')
+    testImplementation dependency.junit
+    testImplementation dependency.mockito
 }
 

--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/asset/TextClassificationDictionary.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/asset/TextClassificationDictionary.java
@@ -47,7 +47,7 @@ import java.util.Map;
  * ...
  * </pre>
  */
-public final class TextClassificationDictionary implements Loadable<Map<String, Integer>, PredictionsException> {
+public class TextClassificationDictionary implements Loadable<Map<String, Integer>, PredictionsException> {
     private static final String DICTIONARY_PATH = "text_classification_vocab.txt";
 
     // The maximum length of an input sentence.

--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/asset/TextClassificationModel.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/asset/TextClassificationModel.java
@@ -37,7 +37,7 @@ import java.nio.channels.FileChannel;
  * Loads the pre-trained text classification model into
  * a TensorFlow Lite interpreter instance.
  */
-public final class TextClassificationModel implements Loadable<Interpreter, PredictionsException> {
+public class TextClassificationModel implements Loadable<Interpreter, PredictionsException> {
 
     private static final String MODEL_PATH = "text_classification.tflite";
 

--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/service/TensorFlowPredictionsService.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/service/TensorFlowPredictionsService.java
@@ -45,7 +45,7 @@ public final class TensorFlowPredictionsService {
      * @param context the Android context
      */
     public TensorFlowPredictionsService(@NonNull Context context) {
-        this.textClassificationService = new TensorFlowTextClassificationService(context);
+        this.textClassificationService = TensorFlowTextClassificationService.fromContext(context);
     }
 
     public void classify(

--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/service/TensorFlowTextClassificationService.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/service/TensorFlowTextClassificationService.java
@@ -36,6 +36,7 @@ import org.tensorflow.lite.Interpreter;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -61,14 +62,12 @@ final class TensorFlowTextClassificationService {
      * Constructs an instance of service to perform text
      * sentiment interpretation using TensorFlow Lite
      * interpreter.
-     * @param context the Android context
+     * @param interpreter the TensorFlow Lite interpreter with
+     *                    loaded model
+     * @param dictionary the dictionary of words and respective
+     *                   tokens
+     * @param labels the list of labels for a feature
      */
-    TensorFlowTextClassificationService(@NonNull Context context) {
-        this(new TextClassificationModel(context),
-                new TextClassificationDictionary(context),
-                new TextClassificationLabels(context));
-    }
-
     @VisibleForTesting
     TensorFlowTextClassificationService(
             TextClassificationModel interpreter,
@@ -87,6 +86,20 @@ final class TensorFlowTextClassificationService {
                 error -> this.loadingError = error
             );
         }
+    }
+
+    /**
+     * Constructs an instance of text classifier service by
+     * loading the assets from provided Android context.
+     * @param context the Android context
+     * @return an instance of text classification service
+     */
+    static TensorFlowTextClassificationService fromContext(@NonNull Context context) {
+        Objects.requireNonNull(context);
+        TextClassificationModel model = new TextClassificationModel(context);
+        TextClassificationDictionary dictionary = new TextClassificationDictionary(context);
+        TextClassificationLabels labels = new TextClassificationLabels(context);
+        return new TensorFlowTextClassificationService(model, dictionary, labels);
     }
 
     /**

--- a/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/InputTokenizerTest.java
+++ b/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/InputTokenizerTest.java
@@ -22,8 +22,6 @@ import com.amplifyframework.predictions.PredictionsException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -43,7 +41,6 @@ import static org.mockito.Mockito.when;
  * Test that input conversion to TensorFlow Lite tokens
  * works as intended.
  */
-@RunWith(JUnit4.class)
 public final class InputTokenizerTest {
     private static final long LOAD_TIMEOUT_MS = 100;
 

--- a/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/InputTokenizerTest.java
+++ b/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/InputTokenizerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.tensorflow.asset;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+
+import com.amplifyframework.predictions.PredictionsException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test that input conversion to TensorFlow Lite tokens
+ * works as intended.
+ */
+@RunWith(JUnit4.class)
+public final class InputTokenizerTest {
+    private static final long LOAD_TIMEOUT_MS = 100;
+
+    private Context mockContext;
+    private AssetManager mockAssets;
+
+    /**
+     * Set up mock behavior before each test.
+     */
+    @Before
+    public void setUp() {
+        // Mock Android context and asset manager
+        mockContext = mock(Context.class);
+        mockAssets = mock(AssetManager.class);
+    }
+
+    /**
+     * Test that text tokenizer converts input text into a 2-D
+     * array of equivalent token values and pads the rest with 0's.
+     * @throws Exception if dictionary fails to load
+     */
+    @Test
+    @SuppressWarnings("MagicNumber") // word tokens
+    public void testInputTextTokenizer() throws Exception {
+        final CountDownLatch loaded = new CountDownLatch(1);
+        final AtomicReference<Map<String, Integer>> tokens = new AtomicReference<>();
+        final AtomicReference<PredictionsException> error = new AtomicReference<>();
+
+        final String inputText = "Where is the bathroom?";
+        final InputStream stream = new FileInputStream("src/test/resources/word-tokens.txt");
+
+        // Make mock context return mock asset manager
+        when(mockContext.getAssets()).thenReturn(mockAssets);
+
+        // Make mock asset manager return pre-determined input stream
+        when(mockAssets.open(anyString())).thenReturn(stream);
+
+        // Load!! (from mock assets)
+        TextClassificationDictionary dictionary = new TextClassificationDictionary(mockContext)
+                .onLoaded(
+                    onLoad -> {
+                        loaded.countDown();
+                        tokens.set(onLoad);
+                    },
+                    onError -> {
+                        loaded.countDown();
+                        error.set(onError);
+                    }
+                );
+        dictionary.load();
+        loaded.await(LOAD_TIMEOUT_MS, TimeUnit.MICROSECONDS);
+        if (error.get() != null) {
+            fail("Failed to load dictionary.");
+        }
+
+        // Assert that load was successful
+        assertEquals(tokens.get(), dictionary.getValue());
+
+        // Tokenize input
+        float[][] input = dictionary.tokenizeInputText(inputText);
+        float[][] expected = new float[1][input[0].length];
+        expected[0][0] = 1; // <START>
+        expected[0][1] = 2; // Where (<UNKNOWN>)
+        expected[0][2] = 9; // is
+        expected[0][3] = 4; // the
+        expected[0][4] = 2; // bathroom (<UNKNOWN>)
+        // Followed by 0's (<PAD>)
+
+        assertArrayEquals(expected, input);
+    }
+}

--- a/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/service/TextClassificationTest.java
+++ b/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/service/TextClassificationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.tensorflow.service;
+
+import com.amplifyframework.predictions.models.Sentiment;
+import com.amplifyframework.predictions.models.SentimentType;
+import com.amplifyframework.predictions.tensorflow.asset.TextClassificationDictionary;
+import com.amplifyframework.predictions.tensorflow.asset.TextClassificationLabels;
+import com.amplifyframework.predictions.tensorflow.asset.TextClassificationModel;
+import com.amplifyframework.testutils.random.RandomString;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test that sentiment detection using TensorFlow Lite interpreter
+ * to output Amplify text interpretation result works.
+ */
+@RunWith(JUnit4.class)
+public final class TextClassificationTest {
+
+    private TextClassificationModel mockInterpreter;
+    private TextClassificationDictionary mockDictionary;
+    private TextClassificationLabels mockLabels;
+
+    private TensorFlowTextClassificationService service;
+
+    /**
+     * Set up mock behavior before each test.
+     */
+    @Before
+    public void setUp() {
+        // Mock asset loaders
+        mockInterpreter = mock(TextClassificationModel.class);
+        mockDictionary = mock(TextClassificationDictionary.class);
+        mockLabels = mock(TextClassificationLabels.class);
+
+        // Create text classifier with mock asset loaders
+        service = new TensorFlowTextClassificationService(
+                mockInterpreter,
+                mockDictionary,
+                mockLabels
+        );
+    }
+
+    /**
+     * Test that fetchSentiment() can do the following.
+     *
+     *  - Choose the output with highest score,
+     *  - obtain the column index,
+     *  - obtain the label located at that index,
+     *  - convert the label into {@link SentimentType}, and
+     *  - return appropriate {@link Sentiment}
+     *
+     * @throws Exception if sentiment fetch fails
+     */
+    @Test
+    @SuppressWarnings("MagicNumber") // Double comparison delta epsilon
+    public void testFetchSentiment() throws Exception {
+        // List of labels to expect
+        final List<String> labels = Arrays.asList(
+                "negative",
+                "positive",
+                "unknown1",
+                "unknown2"
+        );
+        // Mock random confidence score
+        final float confidenceScore = new Random().nextFloat();
+
+        // Make mock interpreter set confidence score for
+        // "positive" label into pre-determined random value
+        doAnswer(invocation -> {
+            float[][] output = invocation.getArgument(1, float[][].class);
+            output[0][labels.indexOf("positive")] = confidenceScore;
+            return null;
+        }).when(mockInterpreter).run(any(), any(float[][].class));
+
+        // Make mock dictionary return any valid input format
+        when(mockDictionary.tokenizeInputText(anyString()))
+                .thenReturn(new float[0][]);
+
+        // Make mock labels emulate an actual list of labels
+        when(mockLabels.size())
+                .thenReturn(labels.size());
+        when(mockLabels.get(anyInt()))
+                .thenAnswer(invocation -> labels.get(invocation.getArgument(0)));
+
+        // Assert that detected sentiment is positive
+        Sentiment sentiment = service.fetchSentiment(RandomString.string());
+        assertEquals(SentimentType.POSITIVE, sentiment.getValue());
+        assertEquals(confidenceScore * 100, sentiment.getConfidence(), 1E-5);
+    }
+}

--- a/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/service/TextClassificationTest.java
+++ b/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/service/TextClassificationTest.java
@@ -24,8 +24,6 @@ import com.amplifyframework.testutils.random.RandomString;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,7 +41,6 @@ import static org.mockito.Mockito.when;
  * Test that sentiment detection using TensorFlow Lite interpreter
  * to output Amplify text interpretation result works.
  */
-@RunWith(JUnit4.class)
 public final class TextClassificationTest {
 
     private TextClassificationModel mockInterpreter;

--- a/aws-predictions-tensorflow/src/test/resources/word-tokens.txt
+++ b/aws-predictions-tensorflow/src/test/resources/word-tokens.txt
@@ -1,0 +1,10 @@
+<PAD> 0
+<START> 1
+<UNKNOWN> 2
+<UNUSED> 3
+the 4
+and 5
+a 6
+of 7
+to 8
+is 9


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add unit tests for `fetchSentiment()` and `tokenizeInputText()`
- Remove `final` keyword from loaders to make them mockable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
