### PR TITLE
Improve latched assets loader design

### DIFF
--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/asset/LatchedCompoundLoader.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/asset/LatchedCompoundLoader.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.tensorflow.asset;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
+
+import com.amplifyframework.core.Latch;
+import com.amplifyframework.predictions.PredictionsException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Loads multiple {@link Loadable} assets and waits for its completion.
+ */
+public final class LatchedCompoundLoader implements Latch<PredictionsException> {
+    private final List<Loadable<?, PredictionsException>> assets;
+    private final CountDownLatch loaded;
+    private final AtomicReference<PredictionsException> failed;
+
+    private LatchedCompoundLoader(List<Loadable<?, PredictionsException>> assets) {
+        this.assets = assets;
+        this.loaded = new CountDownLatch(assets.size());
+        this.failed = new AtomicReference<>();
+
+        // Attach latch countdown
+        for (Loadable<?, PredictionsException> asset : this.assets) {
+            asset.onLoaded(onLoad -> this.loaded.countDown(), this.failed::set);
+        }
+    }
+
+    /**
+     * Constructs an instance of latched loader containing multiple loadable
+     * assets. The process will be blocked until load is completed.
+     * @param assets the list of assets to do a blocking load on
+     * @return the latched loader to load every specified asset
+     * @throws IllegalArgumentException if assets list is empty
+     */
+    public static LatchedCompoundLoader with(@NonNull List<Loadable<?, PredictionsException>> assets) {
+        if (Objects.requireNonNull(assets).isEmpty()) {
+            throw new IllegalArgumentException("Requires at least one loadable asset.");
+        }
+
+        // Check that they are all non-null
+        for (Loadable<?, PredictionsException> asset : assets) {
+            Objects.requireNonNull(asset);
+        }
+
+        return new LatchedCompoundLoader(assets);
+    }
+
+    /**
+     * Constructs an instance of latched loader containing multiple loadable
+     * assets. The process will be blocked until load is completed.
+     * @param assets the list of assets to do a blocking load on
+     * @return the latched loader to load every specified asset
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static LatchedCompoundLoader with(@NonNull Loadable... assets) {
+        return with(Arrays.asList(assets));
+    }
+
+    /**
+     * Start loading all of the assets.
+     */
+    @WorkerThread
+    public synchronized void start() {
+        for (Loadable<?, PredictionsException> asset : this.assets) {
+            asset.load();
+        }
+    }
+
+    /**
+     * Latch onto load task and wait for its completion.
+     * Escapes early if an exception was already emitted by the task.
+     * @throws PredictionsException if load failed or was interrupted
+     */
+    public void await() throws PredictionsException {
+        if (failed.get() != null) {
+            throw failed.get();
+        }
+
+        try {
+            loaded.await();
+        } catch (InterruptedException exception) {
+            throw new PredictionsException(
+                    "Service initialization was interrupted.",
+                    "Please wait for the required assets to be fully loaded."
+            );
+        }
+    }
+}

--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/service/TensorFlowPredictionsService.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/service/TensorFlowPredictionsService.java
@@ -19,9 +19,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
-import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.Consumer;
-import com.amplifyframework.logging.Logger;
 import com.amplifyframework.predictions.PredictionsException;
 import com.amplifyframework.predictions.result.InterpretResult;
 
@@ -35,9 +33,6 @@ import java.util.Map;
  * pre-trained models to make predictions offline.
  */
 public final class TensorFlowPredictionsService {
-
-    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-predictions-tensorflow");
-
     private final TensorFlowTextClassificationService textClassificationService;
 
     /**

--- a/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/FakeLoadable.java
+++ b/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/FakeLoadable.java
@@ -24,22 +24,22 @@ import com.amplifyframework.testutils.Sleep;
 import com.amplifyframework.testutils.random.RandomString;
 
 /**
- * Simple mock loadable class that completes load after
+ * Simple fake loadable class that completes load after
  * a pre-determined amount of time.
  */
-final class MockLoadable implements Loadable<String, PredictionsException> {
+final class FakeLoadable implements Loadable<String, PredictionsException> {
     private final long loadDuration;
 
     private Consumer<String> onLoaded;
     private boolean loaded;
 
     /**
-     * Constructs a new instance of {@link MockLoadable}
+     * Constructs a new instance of {@link FakeLoadable}
      * with the given load duration.
      * @param millis the amount of time that passes before
      *               load completes after being called
      */
-    MockLoadable(long millis) {
+    FakeLoadable(long millis) {
         this.loadDuration = millis;
     }
 

--- a/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/LatchedLoaderTest.java
+++ b/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/LatchedLoaderTest.java
@@ -47,7 +47,7 @@ public final class LatchedLoaderTest {
         List<Loadable<?, PredictionsException>> assets = new ArrayList<>();
         for (int i = 1; i <= count; i++) {
             final long loadDuration = i * UNIT_TIME_MS;
-            assets.add(new MockLoadable(loadDuration));
+            assets.add(new FakeLoadable(loadDuration));
         }
 
         // Create latched compound loader with mock loadable instances
@@ -77,7 +77,7 @@ public final class LatchedLoaderTest {
         // Create a loadable that takes 400ms to load
         final int loadDuration = 400;
         final int waitDuration = 100;
-        Loadable<String, PredictionsException> loadable = new MockLoadable(loadDuration);
+        Loadable<String, PredictionsException> loadable = new FakeLoadable(loadDuration);
         LatchedCompoundLoader loader = LatchedCompoundLoader.with(loadable);
 
         // Start a thread that sleeps for 100ms

--- a/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/LatchedLoaderTest.java
+++ b/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/LatchedLoaderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.tensorflow.asset;
+
+import com.amplifyframework.predictions.PredictionsException;
+import com.amplifyframework.testutils.Sleep;
+import com.amplifyframework.util.Time;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test that asset loader properly blocks operations
+ * until load completion.
+ */
+public final class LatchedLoaderTest {
+    private static final int TIMEOUT_MS = 1000;
+    private static final long UNIT_TIME_MS = 100;
+
+    /**
+     * Test that latched load will only be completed after
+     * all of its component tasks finish loading.
+     * @throws Exception if latched load fails or times out
+     */
+    @Test(timeout = TIMEOUT_MS)
+    public void testLatchedCompoundLoaderWaitsForCompletion() throws Exception {
+        // Make 5 mock loadable instances, each with load duration of
+        // 100ms, 200ms, 300ms, 400ms, and 500ms, respectively.
+        final int count = 5;
+        List<Loadable<?, PredictionsException>> assets = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            final long loadDuration = i * UNIT_TIME_MS;
+            assets.add(new MockLoadable(loadDuration));
+        }
+
+        // Create latched compound loader with mock loadable instances
+        LatchedCompoundLoader loader = LatchedCompoundLoader.with(assets);
+        long startTime = Time.now();
+        loader.start();
+        loader.await();
+        long endTime = Time.now();
+
+        // Assert every asset is loaded
+        for (Loadable<?, PredictionsException> asset : assets) {
+            assertTrue(asset.isLoaded());
+        }
+
+        // Assert the entire load took at least 500ms
+        assertTrue("Load completed earlier than its tasks.",
+                endTime - startTime > count * UNIT_TIME_MS);
+    }
+
+    /**
+     * Test that latched load will await load completion even if
+     * the load task was not started yet.
+     * @throws Exception if latched load fails or times out
+     */
+    @Test(timeout = TIMEOUT_MS)
+    public void testStartCanBeCalledAfterAwait() throws Exception {
+        // Create a loadable that takes 400ms to load
+        final int loadDuration = 400;
+        final int waitDuration = 100;
+        Loadable<String, PredictionsException> loadable = new MockLoadable(loadDuration);
+        LatchedCompoundLoader loader = LatchedCompoundLoader.with(loadable);
+
+        // Start a thread that sleeps for 100ms
+        // before starting loader.
+        long startTime = Time.now();
+        new Thread(() -> {
+            Sleep.milliseconds(waitDuration);
+            loader.start();
+        }).start();
+
+        // Await immediately after starting the thread.
+        // Loader will start 100ms from now.
+        loader.await();
+        long endTime = Time.now();
+
+        // Assert that the loadable is loaded
+        assertTrue(loadable.isLoaded());
+
+        // Assert the entire load took at least 400ms + 100ms
+        assertTrue("Load completed earlier than its tasks.",
+                endTime - startTime >= waitDuration + loadDuration);
+    }
+}

--- a/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/MockLoadable.java
+++ b/aws-predictions-tensorflow/src/test/java/com/amplifyframework/predictions/tensorflow/asset/MockLoadable.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.tensorflow.asset;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Action;
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.predictions.PredictionsException;
+import com.amplifyframework.testutils.Sleep;
+import com.amplifyframework.testutils.random.RandomString;
+
+/**
+ * Simple mock loadable class that completes load after
+ * a pre-determined amount of time.
+ */
+final class MockLoadable implements Loadable<String, PredictionsException> {
+    private final long loadDuration;
+
+    private Consumer<String> onLoaded;
+    private boolean loaded;
+
+    /**
+     * Constructs a new instance of {@link MockLoadable}
+     * with the given load duration.
+     * @param millis the amount of time that passes before
+     *               load completes after being called
+     */
+    MockLoadable(long millis) {
+        this.loadDuration = millis;
+    }
+
+    @Override
+    public void load() {
+        new Thread(() -> {
+            Sleep.milliseconds(loadDuration);
+            onLoaded.accept(RandomString.string());
+            loaded = true;
+        }).start();
+    }
+
+    @Override
+    public void unload() {
+        // Do nothing.
+    }
+
+    @Override
+    public boolean isLoaded() {
+        return loaded;
+    }
+
+    @Override
+    public Loadable<String, PredictionsException> onLoaded(
+            Consumer<String> onLoaded,
+            Consumer<PredictionsException> onLoadError
+    ) {
+        this.onLoaded = onLoaded;
+        return this;
+    }
+
+    @Override
+    public Loadable<String, PredictionsException> onUnloaded(
+            Action onUnloaded,
+            Consumer<PredictionsException> onUnloadError
+    ) {
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public String getValue() {
+        return RandomString.string();
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/Latch.java
+++ b/core/src/main/java/com/amplifyframework/core/Latch.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core;
+
+/**
+ * Executes a latched task and awaits its completion.
+ * @param <E> Type of exception thrown upon encountering error
+ */
+public interface Latch<E extends Exception> {
+    /**
+     * Start the latched task.
+     */
+    void start();
+
+    /**
+     * Await the completion of latched task.
+     * @throws E When task fails or is interrupted
+     */
+    void await() throws E;
+}


### PR DESCRIPTION
Offline predictions implementation relies on local machine learning models to make inferences. This requires the plugin to load several local assets (which may or may not be present) in order to proceed with its operations. 

- At `configure` stage, the plugin should not attempt any heavy workload so assets will not load yet.
- At `initialize` stage, the plugin should begin to load assets once and for all. The load should not be attempted after this stage. 

After `initialize` is called, an operation can be called in the following scenarios:
1. The assets are not present
    - Initialize must succeed
    - Dependent operation must fail (via callback)
2. The assets are present, but load failed for a different reason
    - Initialize must succeed/throw (TBD)
    - Dependent operation must fail (via callback)
3. Loading is in-progress
    - Operation must be put on hold!!!
    - Wait for load completion/failure
    - Proceed to (2) or (4) once load finishes
4. Load was successful
    - Operation should go through normally

(2) is yet to be addressed in detail, and scenarios (1) and (2) are both currently being handled the same way. Initialize will succeed without complaining, and only complain once the dependent operation is called. 

This PR mainly addresses the behavior for (3) and tests that the latch behaves as expected.

*Description of changes:*
- Add `Latch` in core module
- Encapsulate the blocking logic on `load` with `LatchedCompoundLoader` class
- Unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
