### PR TITLE
[testutils] Prevent deadlocks in Latch and Await

### DIFF
--- a/testutils/src/main/java/com/amplifyframework/testutils/Latch.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Latch.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  * This is done frequently enough in the test code that its best
  * to centralize a single pattern for it.
  */
-@SuppressWarnings({"SameParameterValue", "WeakerAccess"})
+@SuppressWarnings("SameParameterValue")
 final class Latch {
     private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(5);
 
@@ -38,13 +38,14 @@ final class Latch {
      * @throws RuntimeException If the latch doesn't count down in the allotted timeout
      */
     static void await(@NonNull CountDownLatch latch, long waitTimeMs) {
+        final boolean didCountDown;
         try {
-            latch.await(waitTimeMs, TimeUnit.MILLISECONDS);
+            didCountDown = latch.await(waitTimeMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException interruptedException) {
-            // Will check regardless in a moment ...
+            throw new RuntimeException("Thread interrupted while wait for latch count down.", interruptedException);
         }
-        if (latch.getCount() != 0) {
-            throw new RuntimeException("Failed to count down latch.");
+        if (!didCountDown || latch.getCount() != 0) {
+            throw new RuntimeException("Failed to count down latch within " + waitTimeMs + "ms.");
         }
     }
 


### PR DESCRIPTION
`Await.java`: if `Await.result(...)` is called from thread A, and its method
fires callbacks on that same thread A, they may never be invoked. This
is because the `CountDownLatch` is sleeping the thread A. To address this
situation, ensure that the `ResultErrorEmitter` function always run on a
different (new) thread.

`Latch.java`: `InterruptedException`was being gobbled. But, this needs to be
raised to crash the thread. Otherwise, the thread can hang.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
