### PR TITLE
[core] Handle missing configuration file

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
+++ b/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.core;
 
 import android.content.Context;
+import android.content.res.Resources;
 import androidx.annotation.NonNull;
 import androidx.annotation.RawRes;
 
@@ -139,8 +140,17 @@ public final class AmplifyConfiguration {
     }
 
     private static JSONObject readInputJson(Context context, int resourceId) throws AmplifyException {
-        final InputStream inputStream =
-            context.getResources().openRawResource(resourceId);
+        InputStream inputStream;
+
+        try {
+            inputStream = context.getResources().openRawResource(resourceId);
+        } catch (Resources.NotFoundException exception) {
+            throw new AmplifyException(
+                    "Failed to find " + DEFAULT_IDENTIFIER + ".",
+                    exception, "Please check that it has been created."
+            );
+        }
+
         final Scanner in = new Scanner(inputStream);
         final StringBuilder sb = new StringBuilder();
         while (in.hasNextLine()) {

--- a/core/src/test/java/com/amplifyframework/core/AmplifyConfigurationTest.java
+++ b/core/src/test/java/com/amplifyframework/core/AmplifyConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.amplifyframework.AmplifyException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Tests for {@link AmplifyConfiguration} behavior.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AmplifyConfigurationTest {
+    private Context context = ApplicationProvider.getApplicationContext();
+
+    /**
+     * Attempting to call {@link AmplifyConfiguration#fromConfigFile(Context)}
+     * without a generated configuration file throws an AmplifyException.
+     *
+     * @throws Exception if the premise of the test is incorrect
+     */
+    @Test(expected = AmplifyException.class)
+    public void testMissingConfigurationFileThrowsAmplifyException() throws Exception {
+        AmplifyConfiguration.fromConfigFile(context);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Handle missing configuration file

If you do not generate a configuration file with Amplify init, your
application will crash with an unhandled exception. This change throws
an AmplifyException instead to allow the developer to catch their error
during development.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.