### PR TITLE
[aws-datastore] Move AppSync and SQL type enums out of core spec

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AWSAppSyncScalarType.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AWSAppSyncScalarType.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.core.model.types;
+package com.amplifyframework.datastore.appsync;
 
 import androidx.annotation.NonNull;
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -38,7 +38,6 @@ import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
 import com.amplifyframework.core.model.types.JavaFieldType;
-import com.amplifyframework.core.model.types.internal.TypeConverter;
 import com.amplifyframework.datastore.CompoundModelProvider;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.GsonStorageItemChangeConverter;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqliteDataType.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqliteDataType.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.core.model.types;
+package com.amplifyframework.datastore.storage.sqlite;
 
 import androidx.annotation.NonNull;
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
@@ -13,13 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.core.model.types.internal;
+package com.amplifyframework.datastore.storage.sqlite;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.model.types.AWSAppSyncScalarType;
 import com.amplifyframework.core.model.types.JavaFieldType;
-import com.amplifyframework.core.model.types.SqliteDataType;
+import com.amplifyframework.datastore.appsync.AWSAppSyncScalarType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +29,6 @@ import java.util.Objects;
  * GraphQL, Java and SQL data types.
  */
 public final class TypeConverter {
-
     private static final Map<AWSAppSyncScalarType, JavaFieldType> AWS_GRAPH_QL_TO_JAVA = new HashMap<>();
     private static final Map<JavaFieldType, SqliteDataType> JAVA_TO_SQL = new HashMap<>();
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteColumn.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteColumn.java
@@ -16,7 +16,7 @@
 package com.amplifyframework.datastore.storage.sqlite.adapter;
 
 import com.amplifyframework.core.model.PrimaryKey;
-import com.amplifyframework.core.model.types.SqliteDataType;
+import com.amplifyframework.datastore.storage.sqlite.SqliteDataType;
 
 /**
  * Adapts a {@link com.amplifyframework.core.model.ModelField}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
@@ -24,8 +24,8 @@ import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.PrimaryKey;
 import com.amplifyframework.core.model.types.JavaFieldType;
-import com.amplifyframework.core.model.types.SqliteDataType;
-import com.amplifyframework.core.model.types.internal.TypeConverter;
+import com.amplifyframework.datastore.storage.sqlite.SqliteDataType;
+import com.amplifyframework.datastore.storage.sqlite.TypeConverter;
 import com.amplifyframework.util.Immutable;
 
 import java.util.Collections;


### PR DESCRIPTION
The Core Model schema includes an enumeration of some various
`JavaFieldType`. This will remain in the Core Models package.

The AWS DataStore implementation maps between these types, and the
various `SqliteDataType`, and `AWSAppSyncScalarType`. These types, and
the business of mapping them, belongs as a detail of the AWS DataStore
plugin.

As consequences of this change:

1. AppSync business details are not part of Amplify's core
   specification.
2. If the CLI shall generate references to any of these types, it will
   bind the implementation specifically for use of the AWS DataStore
   Plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
