### PR TITLE
[aws-api] Use latest OkHttp3, 4.5.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext {
             mobileclient: "com.amazonaws:aws-android-sdk-mobile-client:$awsSdkVersion",
             translate: "com.amazonaws:aws-android-sdk-translate:$awsSdkVersion"
         ],
-        okhttp: 'com.squareup.okhttp3:okhttp:4.4.0',
+        okhttp: 'com.squareup.okhttp3:okhttp:4.5.0',
         gson: 'com.google.code.gson:gson:2.8.6',
         rxandroid: 'io.reactivex.rxjava2:rxandroid:2.1.1',
         rxjava: 'io.reactivex.rxjava2:rxjava:2.2.13',


### PR DESCRIPTION
While we are on the 4.x release train for OkHttp3, continue to use the
latest, most up-to-date version there-of.

In the future, this project may switch to the 3.12.x release train,
which will support older API levels than 21.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
