### PR TITLE
[aws-datastore] Maintain insertion order in ModelProviders

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
@@ -107,7 +107,7 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
 
         // Assert if version is stored correctly
         String expectedVersion =
-            CompoundModelProvider.of(modelProvider, SystemModelsProviderFactory.create())
+            CompoundModelProvider.of(SystemModelsProviderFactory.create(), modelProvider)
                 .version();
         PersistentModelVersion persistentModelVersion =
                 PersistentModelVersion
@@ -136,7 +136,7 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
 
         // Check if the new version is stored in local storage.
         expectedVersion =
-            CompoundModelProvider.of(modelProviderThatUpgradesVersion, SystemModelsProviderFactory.create())
+            CompoundModelProvider.of(SystemModelsProviderFactory.create(), modelProviderThatUpgradesVersion)
                 .version();
         persistentModelVersion = PersistentModelVersion
                 .fromLocalStorage(sqliteStorageAdapter)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/CompoundModelProvider.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/CompoundModelProvider.java
@@ -20,11 +20,7 @@ import androidx.annotation.NonNull;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -58,14 +54,9 @@ public final class CompoundModelProvider implements ModelProvider {
      */
     @NonNull
     public static CompoundModelProvider of(@NonNull ModelProvider... modelProviders) {
-        // We want to always add the versions to the string builder in the same order
-        // This helps to guarantee that of(A,B) == of(B,A).
-        final List<ModelProvider> sortedProviders = new ArrayList<>(Arrays.asList(modelProviders));
-        Collections.sort(sortedProviders, (one, two) -> one.version().compareTo(two.version()));
-
-        Set<Class<? extends Model>> modelClasses = new HashSet<>();
+        final LinkedHashSet<Class<? extends Model>> modelClasses = new LinkedHashSet<>();
         StringBuilder componentVersionBuffer = new StringBuilder();
-        for (ModelProvider componentProvider : sortedProviders) {
+        for (ModelProvider componentProvider : modelProviders) {
             componentVersionBuffer.append(componentProvider.version());
             modelClasses.addAll(componentProvider.models());
         }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/SimpleModelProvider.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/SimpleModelProvider.java
@@ -21,10 +21,9 @@ import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
-import com.amplifyframework.util.Immutable;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -35,9 +34,9 @@ import java.util.UUID;
  */
 public final class SimpleModelProvider implements ModelProvider {
     private final String version;
-    private final Set<Class<? extends Model>> modelClasses;
+    private final LinkedHashSet<Class<? extends Model>> modelClasses;
 
-    private SimpleModelProvider(String version, Set<Class<? extends Model>> modelClasses) {
+    private SimpleModelProvider(String version, LinkedHashSet<Class<? extends Model>> modelClasses) {
         this.version = version;
         this.modelClasses = modelClasses;
     }
@@ -55,7 +54,9 @@ public final class SimpleModelProvider implements ModelProvider {
     public static SimpleModelProvider instance(@NonNull String version, @NonNull Class<? extends Model>... classes) {
         Objects.requireNonNull(version);
         Objects.requireNonNull(classes);
-        return new SimpleModelProvider(version, Immutable.of(new HashSet<>(Arrays.asList(classes))));
+        LinkedHashSet<Class<? extends Model>> modelClasses = new LinkedHashSet<>();
+        Collections.addAll(modelClasses, classes);
+        return new SimpleModelProvider(version, modelClasses);
     }
 
     /**
@@ -69,7 +70,7 @@ public final class SimpleModelProvider implements ModelProvider {
     public static SimpleModelProvider instance(@NonNull String version, @NonNull Set<Class<? extends Model>> classes) {
         Objects.requireNonNull(version);
         Objects.requireNonNull(classes);
-        return new SimpleModelProvider(version, classes);
+        return new SimpleModelProvider(version, new LinkedHashSet<>(classes));
     }
 
     /**
@@ -92,7 +93,7 @@ public final class SimpleModelProvider implements ModelProvider {
     @NonNull
     @Override
     public Set<Class<? extends Model>> models() {
-        return modelClasses;
+        return Collections.unmodifiableSet(modelClasses);
     }
 
     @NonNull
@@ -146,11 +147,11 @@ public final class SimpleModelProvider implements ModelProvider {
      * Configures and builds instances of SimpleModelProvider.
      */
     static final class Builder {
-        private final Set<Class<? extends Model>> modelClasses;
+        private final LinkedHashSet<Class<? extends Model>> modelClasses;
         private String version;
 
         Builder() {
-            this.modelClasses = new HashSet<>();
+            this.modelClasses = new LinkedHashSet<>();
         }
 
         <T extends Model> Builder addModel(@NonNull Class<T> modelClass) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -139,7 +139,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             ModelProvider userModelsProvider,
             ModelProvider systemModelsProvider) {
         this.modelSchemaRegistry = modelSchemaRegistry;
-        this.modelsProvider = CompoundModelProvider.of(userModelsProvider, systemModelsProvider);
+        this.modelsProvider = CompoundModelProvider.of(systemModelsProvider, userModelsProvider);
         this.threadPool = Executors.newCachedThreadPool();
         this.insertSqlPreparedStatements = Collections.emptyMap();
         this.gson = new Gson();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/CompoundModelProviderTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/CompoundModelProviderTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -112,10 +113,15 @@ public final class CompoundModelProviderTest {
     }
 
     /**
-     * A compound provider of A, B, should be the same as a compound provider of B, A.
+     * A compound provider of A, B, should NOT be the same as a compound provider of B, A.
+     * This is because the provided models have a dependency ordering that is important.
+     * For user models, this is the topological ordering of the models. And beyond that,
+     * system models must be present before user models. These are business details that
+     * are outside the humble scope of a compound model provider's implementation, except
+     * for that this component must maintain order, to maintain the external ordering rules.
      */
     @Test
-    public void parameterOrderDoesNotMatter() {
+    public void parameterOrderIsSignificant() {
         // Arrange two providers that have inputs provided out-of-order
         SimpleModelProvider one = SimpleModelProvider.withRandomVersion(Blog.class);
         SimpleModelProvider two = SimpleModelProvider.withRandomVersion(BlogOwner.class);
@@ -123,14 +129,12 @@ public final class CompoundModelProviderTest {
         CompoundModelProvider twoAndOne = CompoundModelProvider.of(two, one);
 
         // They should be equivalent.
-        assertEquals(oneAndTwo, twoAndOne);
+        assertNotEquals(oneAndTwo, twoAndOne);
 
-        // And hashCode() should also work, duh.
+        // And hashCode() should produce a distinct result for each.
         Set<CompoundModelProvider> providers = new HashSet<>();
         providers.add(oneAndTwo);
         providers.add(twoAndOne);
-        assertEquals(1, providers.size());
-        assertEquals(oneAndTwo, providers.iterator().next());
-        assertEquals(twoAndOne, providers.iterator().next());
+        assertEquals(2, providers.size());
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -86,7 +86,7 @@ public final class SyncProcessorTest {
     public void setup() throws AmplifyException {
         this.storageRecordDeserializer = new GsonStorageItemChangeConverter();
         this.modelProvider =
-            CompoundModelProvider.of(AmplifyModelProvider.getInstance(), SystemModelsProviderFactory.create());
+            CompoundModelProvider.of(SystemModelsProviderFactory.create(), AmplifyModelProvider.getInstance());
 
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.clear();


### PR DESCRIPTION
The order in which models are provided is significant.

1. System models must be provided before user models. This is because
   system models store information about user models. It is not possible
   to store user models without these storage areas having first been
   created. The model provider itself should not encode these ordering
   rules, but it must be able to store an ordering, that was determined
   by an external actor.

2. User models depend on eachother, and so have a topological ordering.
   Some models must be known to the system before others, so that
   references can be created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
