### PR TITLE
Use File instead of String input parameters

### DIFF
--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadAccessLevelTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadAccessLevelTest.java
@@ -56,7 +56,6 @@ public final class AWSS3StorageDownloadAccessLevelTest {
     private static Credential userTwo;
 
     private File downloadFile;
-    private String downloadPath;
     private StorageDownloadFileOptions downloadOptions;
 
     /**
@@ -94,7 +93,6 @@ public final class AWSS3StorageDownloadAccessLevelTest {
 
         // Create a new download destination
         downloadFile = new RandomTempFile();
-        downloadPath = downloadFile.getPath();
 
         // Override this per test-case
         downloadOptions = StorageDownloadFileOptions.defaultInstance();
@@ -110,7 +108,7 @@ public final class AWSS3StorageDownloadAccessLevelTest {
         downloadOptions = StorageDownloadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PUBLIC)
                 .build();
-        storage.downloadFile(UPLOAD_NAME, downloadPath, downloadOptions);
+        storage.downloadFile(UPLOAD_NAME, downloadFile, downloadOptions);
         FileAssert.assertEquals(uploadFile, downloadFile);
     }
 
@@ -128,7 +126,7 @@ public final class AWSS3StorageDownloadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.downloadFile(UPLOAD_NAME, downloadPath, downloadOptions);
+        storage.downloadFile(UPLOAD_NAME, downloadFile, downloadOptions);
         FileAssert.assertEquals(uploadFile, downloadFile);
     }
 
@@ -147,7 +145,7 @@ public final class AWSS3StorageDownloadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.downloadFile(UPLOAD_NAME, downloadPath, downloadOptions);
+        storage.downloadFile(UPLOAD_NAME, downloadFile, downloadOptions);
         FileAssert.assertEquals(uploadFile, downloadFile);
     }
 
@@ -163,7 +161,7 @@ public final class AWSS3StorageDownloadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.downloadFile(UPLOAD_NAME, downloadPath, downloadOptions);
+        storage.downloadFile(UPLOAD_NAME, downloadFile, downloadOptions);
         FileAssert.assertEquals(uploadFile, downloadFile);
     }
 
@@ -179,7 +177,7 @@ public final class AWSS3StorageDownloadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.downloadFile(UPLOAD_NAME, downloadPath, downloadOptions);
+        storage.downloadFile(UPLOAD_NAME, downloadFile, downloadOptions);
         FileAssert.assertEquals(uploadFile, downloadFile);
     }
 
@@ -199,7 +197,7 @@ public final class AWSS3StorageDownloadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userTwo.getIdentityId())
                 .build();
-        storage.downloadFile(UPLOAD_NAME, downloadPath, downloadOptions);
+        storage.downloadFile(UPLOAD_NAME, downloadFile, downloadOptions);
         FileAssert.assertEquals(uploadFile, downloadFile);
     }
 
@@ -219,7 +217,7 @@ public final class AWSS3StorageDownloadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userTwo.getIdentityId())
                 .build();
-        storage.downloadFile(UPLOAD_NAME, downloadPath, downloadOptions);
+        storage.downloadFile(UPLOAD_NAME, downloadFile, downloadOptions);
         FileAssert.assertEquals(uploadFile, downloadFile);
     }
 
@@ -227,7 +225,6 @@ public final class AWSS3StorageDownloadAccessLevelTest {
         // Create a temporary file to upload
         uploadFile = new RandomTempFile(UPLOAD_NAME, UPLOAD_SIZE);
         final String key = UPLOAD_NAME;
-        final String local = uploadFile.getAbsolutePath();
 
         StorageUploadFileOptions options;
 
@@ -236,7 +233,7 @@ public final class AWSS3StorageDownloadAccessLevelTest {
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PUBLIC)
                 .build();
-        storage.uploadFile(key, local, options);
+        storage.uploadFile(key, uploadFile, options);
 
         // Upload as user one
         mobileClient.signOut();
@@ -244,11 +241,11 @@ public final class AWSS3StorageDownloadAccessLevelTest {
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .build();
-        storage.uploadFile(key, local, options);
+        storage.uploadFile(key, uploadFile, options);
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .build();
-        storage.uploadFile(key, local, options);
+        storage.uploadFile(key, uploadFile, options);
 
         // Upload as user two
         mobileClient.signOut();
@@ -256,10 +253,10 @@ public final class AWSS3StorageDownloadAccessLevelTest {
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .build();
-        storage.uploadFile(key, local, options);
+        storage.uploadFile(key, uploadFile, options);
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .build();
-        storage.uploadFile(key, local, options);
+        storage.uploadFile(key, uploadFile, options);
     }
 }

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadTest.java
@@ -71,13 +71,13 @@ public final class AWSS3StorageDownloadTest {
     private static SynchronousStorage synchronousStorage;
 
     private File downloadFile;
-    private String downloadPath;
     private StorageDownloadFileOptions options;
     private Set<SubscriptionToken> subscriptions;
 
     /**
      * Initialize mobile client and configure the storage.
      * Upload the test files ahead of time.
+     *
      * @throws Exception if mobile client initialization fails
      */
     @BeforeClass
@@ -101,14 +101,12 @@ public final class AWSS3StorageDownloadTest {
         // Upload large test file
         largeFile = new RandomTempFile(LARGE_FILE_NAME, LARGE_FILE_SIZE);
         key = LARGE_FILE_NAME;
-        local = largeFile.getAbsolutePath();
-        synchronousStorage.uploadFile(key, local, uploadOptions, EXTENDED_TIMEOUT_MS);
+        synchronousStorage.uploadFile(key, largeFile, uploadOptions, EXTENDED_TIMEOUT_MS);
 
         // Upload small test file
         smallFile = new RandomTempFile(SMALL_FILE_NAME, SMALL_FILE_SIZE);
         key = SMALL_FILE_NAME;
-        local = smallFile.getAbsolutePath();
-        synchronousStorage.uploadFile(key, local, uploadOptions);
+        synchronousStorage.uploadFile(key, smallFile, uploadOptions);
     }
 
     /**
@@ -128,7 +126,6 @@ public final class AWSS3StorageDownloadTest {
 
         // Create a file to download to
         downloadFile = new RandomTempFile();
-        downloadPath = downloadFile.getPath();
     }
 
     /**
@@ -149,7 +146,7 @@ public final class AWSS3StorageDownloadTest {
      */
     @Test
     public void testDownloadSmallFile() throws Exception {
-        synchronousStorage.downloadFile(SMALL_FILE_NAME, downloadPath, options);
+        synchronousStorage.downloadFile(SMALL_FILE_NAME, downloadFile, options);
         FileAssert.assertEquals(smallFile, downloadFile);
     }
 
@@ -160,7 +157,7 @@ public final class AWSS3StorageDownloadTest {
      */
     @Test
     public void testDownloadLargeFile() throws Exception {
-        synchronousStorage.downloadFile(LARGE_FILE_NAME, downloadPath, options, EXTENDED_TIMEOUT_MS);
+        synchronousStorage.downloadFile(LARGE_FILE_NAME, downloadFile, options, EXTENDED_TIMEOUT_MS);
         FileAssert.assertEquals(largeFile, downloadFile);
     }
 
@@ -169,7 +166,7 @@ public final class AWSS3StorageDownloadTest {
      * transfer hasn't completed yet.
      *
      * @throws Exception if download is not canceled successfully
-     *         before timeout
+     *                   before timeout
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -205,7 +202,7 @@ public final class AWSS3StorageDownloadTest {
         // Begin downloading a large file
         StorageDownloadFileOperation<?> op = storageCategory.downloadFile(
             LARGE_FILE_NAME,
-            downloadPath,
+            downloadFile,
             options,
             onResult -> errorContainer.set(new RuntimeException("Download completed without canceling.")),
             errorContainer::set
@@ -222,7 +219,7 @@ public final class AWSS3StorageDownloadTest {
      * while the transfer hasn't completed yet.
      *
      * @throws Exception if download is not paused, resumed, and
-     *         completed successfully before timeout
+     *                   completed successfully before timeout
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -262,7 +259,7 @@ public final class AWSS3StorageDownloadTest {
         // Begin downloading a large file
         StorageDownloadFileOperation<?> op = storageCategory.downloadFile(
             LARGE_FILE_NAME,
-            downloadPath,
+            downloadFile,
             options,
             onResult -> completed.countDown(),
             errorContainer::set

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadTest.java
@@ -93,7 +93,6 @@ public final class AWSS3StorageDownloadTest {
 
         // Upload to PUBLIC for consistency
         String key;
-        String local;
         StorageUploadFileOptions uploadOptions = StorageUploadFileOptions.builder()
                 .accessLevel(TESTING_ACCESS_LEVEL)
                 .build();

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageListAccessLevelTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageListAccessLevelTest.java
@@ -242,7 +242,7 @@ public final class AWSS3StorageListAccessLevelTest {
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PUBLIC)
                 .build();
-        storage.uploadFile(uploadKey, uploadPath, options);
+        storage.uploadFile(uploadKey, uploadFile, options);
 
         // Upload as user one
         mobileClient.signOut();
@@ -250,11 +250,11 @@ public final class AWSS3StorageListAccessLevelTest {
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .build();
-        storage.uploadFile(uploadKey, uploadPath, options);
+        storage.uploadFile(uploadKey, uploadFile, options);
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .build();
-        storage.uploadFile(uploadKey, uploadPath, options);
+        storage.uploadFile(uploadKey, uploadFile, options);
 
         // Upload as user two
         mobileClient.signOut();
@@ -262,10 +262,10 @@ public final class AWSS3StorageListAccessLevelTest {
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .build();
-        storage.uploadFile(uploadKey, uploadPath, options);
+        storage.uploadFile(uploadKey, uploadFile, options);
         options = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .build();
-        storage.uploadFile(uploadKey, uploadPath, options);
+        storage.uploadFile(uploadKey, uploadFile, options);
     }
 }

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadAccessLevelTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadAccessLevelTest.java
@@ -52,7 +52,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
     private static Credential userTwo;
 
     private File uploadFile;
-    private String fileName;
+    private String remoteKey;
     private StorageUploadFileOptions uploadOptions;
 
     /**
@@ -89,7 +89,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
 
         // Create a new file to upload
         uploadFile = new RandomTempFile(UPLOAD_SIZE);
-        fileName = uploadFile.getName();
+        remoteKey = uploadFile.getName();
 
         // Override this per test-case
         uploadOptions = StorageUploadFileOptions.defaultInstance();
@@ -105,7 +105,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
         uploadOptions = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PUBLIC)
                 .build();
-        storage.uploadFile(fileName, uploadFile, uploadOptions);
+        storage.uploadFile(remoteKey, uploadFile, uploadOptions);
     }
 
     /**
@@ -123,7 +123,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, uploadFile, uploadOptions);
+        storage.uploadFile(remoteKey, uploadFile, uploadOptions);
     }
 
     /**
@@ -141,7 +141,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, uploadFile, uploadOptions);
+        storage.uploadFile(remoteKey, uploadFile, uploadOptions);
     }
 
     /**
@@ -156,7 +156,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, uploadFile, uploadOptions);
+        storage.uploadFile(remoteKey, uploadFile, uploadOptions);
     }
 
     /**
@@ -171,7 +171,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, uploadFile, uploadOptions);
+        storage.uploadFile(remoteKey, uploadFile, uploadOptions);
     }
 
     /**
@@ -190,7 +190,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userTwo.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, uploadFile, uploadOptions);
+        storage.uploadFile(remoteKey, uploadFile, uploadOptions);
     }
 
     /**
@@ -209,6 +209,6 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userTwo.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, uploadFile, uploadOptions);
+        storage.uploadFile(remoteKey, uploadFile, uploadOptions);
     }
 }

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadAccessLevelTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadAccessLevelTest.java
@@ -51,8 +51,8 @@ public final class AWSS3StorageUploadAccessLevelTest {
     private static Credential userOne;
     private static Credential userTwo;
 
+    private File uploadFile;
     private String fileName;
-    private String filePath;
     private StorageUploadFileOptions uploadOptions;
 
     /**
@@ -88,9 +88,8 @@ public final class AWSS3StorageUploadAccessLevelTest {
         mobileClient.signOut();
 
         // Create a new file to upload
-        File fileToUpload = new RandomTempFile(UPLOAD_SIZE);
-        fileName = fileToUpload.getName();
-        filePath = fileToUpload.getPath();
+        uploadFile = new RandomTempFile(UPLOAD_SIZE);
+        fileName = uploadFile.getName();
 
         // Override this per test-case
         uploadOptions = StorageUploadFileOptions.defaultInstance();
@@ -106,7 +105,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
         uploadOptions = StorageUploadFileOptions.builder()
                 .accessLevel(StorageAccessLevel.PUBLIC)
                 .build();
-        storage.uploadFile(fileName, filePath, uploadOptions);
+        storage.uploadFile(fileName, uploadFile, uploadOptions);
     }
 
     /**
@@ -124,7 +123,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, filePath, uploadOptions);
+        storage.uploadFile(fileName, uploadFile, uploadOptions);
     }
 
     /**
@@ -142,7 +141,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, filePath, uploadOptions);
+        storage.uploadFile(fileName, uploadFile, uploadOptions);
     }
 
     /**
@@ -157,7 +156,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, filePath, uploadOptions);
+        storage.uploadFile(fileName, uploadFile, uploadOptions);
     }
 
     /**
@@ -172,7 +171,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userOne.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, filePath, uploadOptions);
+        storage.uploadFile(fileName, uploadFile, uploadOptions);
     }
 
     /**
@@ -191,7 +190,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PROTECTED)
                 .targetIdentityId(userTwo.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, filePath, uploadOptions);
+        storage.uploadFile(fileName, uploadFile, uploadOptions);
     }
 
     /**
@@ -210,6 +209,6 @@ public final class AWSS3StorageUploadAccessLevelTest {
                 .accessLevel(StorageAccessLevel.PRIVATE)
                 .targetIdentityId(userTwo.getIdentityId())
                 .build();
-        storage.uploadFile(fileName, filePath, uploadOptions);
+        storage.uploadFile(fileName, uploadFile, uploadOptions);
     }
 }

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadTest.java
@@ -116,8 +116,7 @@ public final class AWSS3StorageUploadTest {
     public void testUploadSmallFile() throws Exception {
         File uploadFile = new RandomTempFile(SMALL_FILE_SIZE);
         String fileName = uploadFile.getName();
-        String filePath = uploadFile.getPath();
-        synchronousStorage.uploadFile(fileName, filePath, options);
+        synchronousStorage.uploadFile(fileName, uploadFile, options);
     }
 
     /**
@@ -129,8 +128,7 @@ public final class AWSS3StorageUploadTest {
     public void testUploadLargeFile() throws Exception {
         File uploadFile = new RandomTempFile(LARGE_FILE_SIZE);
         String fileName = uploadFile.getName();
-        String filePath = uploadFile.getPath();
-        synchronousStorage.uploadFile(fileName, filePath, options, EXTENDED_TIMEOUT_MS);
+        synchronousStorage.uploadFile(fileName, uploadFile, options, EXTENDED_TIMEOUT_MS);
     }
 
     /**
@@ -177,7 +175,7 @@ public final class AWSS3StorageUploadTest {
         // Begin uploading a large file
         StorageUploadFileOperation<?> op = storageCategory.uploadFile(
             uploadFile.getName(),
-            uploadFile.getAbsolutePath(),
+            uploadFile,
             options,
             onResult -> errorContainer.set(new RuntimeException("Upload completed without canceling.")),
             errorContainer::set
@@ -237,7 +235,7 @@ public final class AWSS3StorageUploadTest {
         // Begin uploading a large file
         StorageUploadFileOperation<?> op = storageCategory.uploadFile(
             uploadFile.getName(),
-            uploadFile.getAbsolutePath(),
+            uploadFile,
             options,
             onResult -> completed.countDown(),
             errorContainer::set

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -57,6 +57,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.File;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -210,7 +211,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull Consumer<StorageDownloadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
@@ -221,7 +222,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageDownloadFileOptions options,
             @NonNull Consumer<StorageDownloadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
@@ -248,7 +249,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
@@ -259,7 +260,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageUploadFileOptions options,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.java
@@ -82,7 +82,7 @@ public final class AWSS3StorageDownloadFileOperation
                 getRequest().getKey()
         );
       
-        this.file = new File(getRequest().getLocal());
+        this.file = getRequest().getLocal();
       
         try {
             transferObserver = storageService.downloadToFile(serviceKey, file);

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
@@ -83,7 +83,7 @@ public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOper
         );
 
         // Grab the file to upload...
-        File file = new File(getRequest().getLocal());
+        File file = getRequest().getLocal();
 
         // Set up the metadata
         ObjectMetadata objectMetadata = new ObjectMetadata();

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageDownloadFileRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageDownloadFileRequest.java
@@ -19,27 +19,29 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.storage.StorageAccessLevel;
 
+import java.io.File;
+
 /**
  * Parameters to provide to S3 that describe a request to download a
  * file.
  */
 public final class AWSS3StorageDownloadFileRequest {
     private final String key;
-    private final String local;
+    private final File local;
     private final StorageAccessLevel accessLevel;
     private final String targetIdentityId;
 
     /**
      * Constructs a new AWSS3StorageDownloadFileRequest.
      * @param key key for item to download
-     * @param local Target path for the downloaded file to be saved to
+     * @param local Target file for the downloaded file to be saved to
      * @param accessLevel Storage access level
      * @param targetIdentityId The user id for the user this file should be downloaded for
      *                         (to override it from assuming the currently logged in user)
      */
     public AWSS3StorageDownloadFileRequest(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageAccessLevel accessLevel,
             @NonNull String targetIdentityId
     ) {
@@ -77,11 +79,11 @@ public final class AWSS3StorageDownloadFileRequest {
     }
 
     /**
-     * Gets the local file path where the object should be saved.
-     * @return local file path
+     * Gets the local file where the object will be saved.
+     * @return local file
      */
     @NonNull
-    public String getLocal() {
+    public File getLocal() {
         return local;
     }
 }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadFileRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadFileRequest.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 
 import com.amplifyframework.storage.StorageAccessLevel;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +30,7 @@ import java.util.Map;
  */
 public final class AWSS3StorageUploadFileRequest {
     private final String key;
-    private final String local;
+    private final File local;
     private final StorageAccessLevel accessLevel;
     private final String targetIdentityId;
     private final String contentType;
@@ -38,7 +39,7 @@ public final class AWSS3StorageUploadFileRequest {
     /**
      * Constructs a new AWSS3StorageUploadFileRequest.
      * @param key key for item to upload
-     * @param local Target path of file to upload
+     * @param local File to upload
      * @param accessLevel Storage access level
      * @param targetIdentityId The user id for the user this file should be uploaded for
      *                         (to override it from assuming the currently logged in user)
@@ -47,7 +48,7 @@ public final class AWSS3StorageUploadFileRequest {
      */
     public AWSS3StorageUploadFileRequest(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageAccessLevel accessLevel,
             @NonNull String targetIdentityId,
             @Nullable String contentType,
@@ -74,11 +75,11 @@ public final class AWSS3StorageUploadFileRequest {
     }
 
     /**
-     * Gets the local file path of the file to upload.
+     * Gets the file to upload.
      * @return local file path
      */
     @NonNull
-    public String getLocal() {
+    public File getLocal() {
         return local;
     }
 

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
@@ -36,6 +36,8 @@ import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.result.StorageRemoveResult;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 
+import java.io.File;
+
 /**
  * Defines the Client API consumed by the application.
  * Internally routes the calls to the Storage Category
@@ -72,7 +74,7 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull Consumer<StorageDownloadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
@@ -83,7 +85,7 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
     @Override
     public StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageDownloadFileOptions options,
             @NonNull Consumer<StorageDownloadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
@@ -95,7 +97,7 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
@@ -106,7 +108,7 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
     @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageUploadFileOptions options,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
@@ -34,6 +34,8 @@ import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.result.StorageRemoveResult;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 
+import java.io.File;
+
 /**
  * Defines the behavior of the Storage category that clients will use.
  */
@@ -87,7 +89,7 @@ public interface StorageCategoryBehavior {
     @NonNull
     StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull Consumer<StorageDownloadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError);
 
@@ -108,7 +110,7 @@ public interface StorageCategoryBehavior {
     @NonNull
     StorageDownloadFileOperation<?> downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageDownloadFileOptions options,
             @NonNull Consumer<StorageDownloadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError);
@@ -117,7 +119,7 @@ public interface StorageCategoryBehavior {
      * Upload local file on given path to storage.
      * Register consumers to obtain the results of the upload.
      * @param key the unique identifier of the object in storage
-     * @param local the path to a local file
+     * @param local the local file
      * @param onSuccess Called if operation completed successfully and furnishes a result
      * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
@@ -126,7 +128,7 @@ public interface StorageCategoryBehavior {
     @NonNull
     StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError);
 
@@ -135,7 +137,7 @@ public interface StorageCategoryBehavior {
      * Specify options such as the access level the file should have.
      * Register consumers to observe results of upload request.
      * @param key the unique identifier of the object in storage
-     * @param local the path to a local file
+     * @param local the local file
      * @param options parameters specific to plugin behavior
      * @param onSuccess Called if operation completed successfully and furnishes a result
      * @param onError Called if an error occurs during operation
@@ -145,7 +147,7 @@ public interface StorageCategoryBehavior {
     @NonNull
     StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageUploadFileOptions options,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError);

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageBinding.java
@@ -32,6 +32,8 @@ import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.result.StorageRemoveResult;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 
+import java.io.File;
+
 import io.reactivex.Single;
 
 final class RxStorageBinding implements RxStorageCategoryBehavior {
@@ -48,27 +50,27 @@ final class RxStorageBinding implements RxStorageCategoryBehavior {
 
     @NonNull
     @Override
-    public Single<StorageDownloadFileResult> downloadFile(@NonNull String key, @NonNull String local) {
+    public Single<StorageDownloadFileResult> downloadFile(@NonNull String key, @NonNull File local) {
         return toSingle((onResult, onError) -> storage.downloadFile(key, local, onResult, onError));
     }
 
     @NonNull
     @Override
     public Single<StorageDownloadFileResult> downloadFile(
-            @NonNull String key, @NonNull String local, @NonNull StorageDownloadFileOptions options) {
+            @NonNull String key, @NonNull File local, @NonNull StorageDownloadFileOptions options) {
         return toSingle((onResult, onError) -> storage.downloadFile(key, local, options, onResult, onError));
     }
 
     @NonNull
     @Override
-    public Single<StorageUploadFileResult> uploadFile(@NonNull String key, @NonNull String local) {
+    public Single<StorageUploadFileResult> uploadFile(@NonNull String key, @NonNull File local) {
         return toSingle((onResult, onError) -> storage.uploadFile(key, local, onResult, onError));
     }
 
     @NonNull
     @Override
     public Single<StorageUploadFileResult> uploadFile(
-            @NonNull String key, @NonNull String local, @NonNull StorageUploadFileOptions options) {
+            @NonNull String key, @NonNull File local, @NonNull StorageUploadFileOptions options) {
         return toSingle((onResult, onError) -> storage.uploadFile(key, local, options, onResult, onError));
     }
 

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageCategoryBehavior.java
@@ -27,6 +27,8 @@ import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.result.StorageRemoveResult;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 
+import java.io.File;
+
 import io.reactivex.Single;
 
 /**
@@ -37,7 +39,7 @@ public interface RxStorageCategoryBehavior {
     /**
      * Download a file.
      * @param key Remote key of file
-     * @param local Local path to which to save
+     * @param local Local file to which to save
      * @return A single which emits a download result on success, or an error on failure.
      *         The download does not begin until subscription. You can cancel the download
      *         by disposing the single subscription.
@@ -45,13 +47,13 @@ public interface RxStorageCategoryBehavior {
     @NonNull
     Single<StorageDownloadFileResult> downloadFile(
             @NonNull String key,
-            @NonNull String local
+            @NonNull File local
     );
 
     /**
      * Download a file.
      * @param key Remote key of file
-     * @param local Local path to which to save
+     * @param local Local file to which to save
      * @param options Additional download options
      * @return A single which emits a download result on success, or an error on failure.
      *         The download does not begin until subscription. You can cancel the download
@@ -60,14 +62,14 @@ public interface RxStorageCategoryBehavior {
     @NonNull
     Single<StorageDownloadFileResult> downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageDownloadFileOptions options
     );
 
     /**
      * Upload a file.
      * @param key Remote key of file
-     * @param local Local path from which to read contents
+     * @param local Local file from which to read contents
      * @return A single which emits an upload result on success, or an error on failure.
      *         The upload does not begin until subscription. You can cancel the upload
      *         by disposing the single subscription.
@@ -75,13 +77,13 @@ public interface RxStorageCategoryBehavior {
     @NonNull
     Single<StorageUploadFileResult> uploadFile(
             @NonNull String key,
-            @NonNull String local
+            @NonNull File local
     );
 
     /**
      * Upload a file.
      * @param key Remote key of file
-     * @param local Local path from which to read contents
+     * @param local Local file from which to read contents
      * @param options Additional upload options
      * @return A single which emits an upload result on success, or an error on failure.
      *         The upload does not begin until subscription. You can cancel the upload
@@ -90,7 +92,7 @@ public interface RxStorageCategoryBehavior {
     @NonNull
     Single<StorageUploadFileResult> uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageUploadFileOptions options
     );
 

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxStorageBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxStorageBindingTest.java
@@ -38,6 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 
 import io.reactivex.Single;
@@ -54,7 +55,7 @@ import static org.mockito.Mockito.when;
 public final class RxStorageBindingTest {
     private RxStorageCategoryBehavior rxStorage;
     private StoragePlugin<?> delegate;
-    private String localPath;
+    private File localFile;
     private String remoteKey;
 
     /**
@@ -78,17 +79,18 @@ public final class RxStorageBindingTest {
     /**
      * Creates stable/expected values for a local path and remote key, to be matched
      * against in behavior mocks/verifications.
+     * @throws IOException when a temporary file cannot be created
      */
     @Before
-    public void createRandomRequestParams() {
-        localPath = RandomString.string();
+    public void createRandomRequestParams() throws IOException {
+        localFile = File.createTempFile("random", "data");
         remoteKey = RandomString.string();
     }
 
     /**
-     * When {@link StorageCategoryBehavior#downloadFile(String, String, Consumer, Consumer)}
+     * When {@link StorageCategoryBehavior#downloadFile(String, File, Consumer, Consumer)}
      * invokes its success callback, the {@link StorageDownloadFileResult} should propagate
-     * via the {@link Single} returned by {@link RxStorageCategoryBehavior#downloadFile(String, String)}.
+     * via the {@link Single} returned by {@link RxStorageCategoryBehavior#downloadFile(String, File)}.
      */
     @Test
     public void downloadFileReturnsResult() {
@@ -100,17 +102,17 @@ public final class RxStorageBindingTest {
             return mock(StorageDownloadFileOperation.class);
         })
         .when(delegate)
-            .downloadFile(eq(remoteKey), eq(localPath), anyConsumer(), anyConsumer());
+            .downloadFile(eq(remoteKey), eq(localFile), anyConsumer(), anyConsumer());
 
-        rxStorage.downloadFile(remoteKey, localPath)
+        rxStorage.downloadFile(remoteKey, localFile)
             .test()
             .assertValues(result);
     }
 
     /**
-     * When {@link StorageCategoryBehavior#downloadFile(String, String, Consumer, Consumer)} invokes
+     * When {@link StorageCategoryBehavior#downloadFile(String, File, Consumer, Consumer)} invokes
      * its error callback, the {@link StorageException} is communicated via the {@link Single}
-     * returned by {@link RxStorageCategoryBehavior#downloadFile(String, String)}.
+     * returned by {@link RxStorageCategoryBehavior#downloadFile(String, File)}.
      */
     @Test
     public void downloadFileReturnsError() {
@@ -122,17 +124,17 @@ public final class RxStorageBindingTest {
             return mock(StorageDownloadFileOperation.class);
         })
         .when(delegate)
-            .downloadFile(eq(remoteKey), eq(localPath), anyConsumer(), anyConsumer());
+            .downloadFile(eq(remoteKey), eq(localFile), anyConsumer(), anyConsumer());
 
-        rxStorage.downloadFile(remoteKey, localPath)
+        rxStorage.downloadFile(remoteKey, localFile)
             .test()
             .assertError(downloadError);
     }
 
     /**
-     * When {@link StorageCategoryBehavior#uploadFile(String, String, Consumer, Consumer)} returns
+     * When {@link StorageCategoryBehavior#uploadFile(String, File, Consumer, Consumer)} returns
      * a {@link StorageUploadFileResult}, then the {@link Single} returned by
-     * {@link RxStorageCategoryBehavior#uploadFile(String, String)} should emit that result.
+     * {@link RxStorageCategoryBehavior#uploadFile(String, File)} should emit that result.
      */
     @Test
     public void uploadFileReturnsResult() {
@@ -144,18 +146,18 @@ public final class RxStorageBindingTest {
             return mock(StorageUploadFileOperation.class);
         })
         .when(delegate)
-            .uploadFile(eq(remoteKey), eq(localPath), anyConsumer(), anyConsumer());
+            .uploadFile(eq(remoteKey), eq(localFile), anyConsumer(), anyConsumer());
 
         rxStorage
-            .uploadFile(remoteKey, localPath)
+            .uploadFile(remoteKey, localFile)
             .test()
             .assertValues(result);
     }
 
     /**
-     * When {@link StorageCategoryBehavior#uploadFile(String, String, Consumer, Consumer)} returns
+     * When {@link StorageCategoryBehavior#uploadFile(String, File, Consumer, Consumer)} returns
      * an {@link StorageException}, then the {@link Single} returned by
-     * {@link RxStorageCategoryBehavior#uploadFile(String, String)} should emit a {@link StorageException}.
+     * {@link RxStorageCategoryBehavior#uploadFile(String, File)} should emit a {@link StorageException}.
      */
     @Test
     public void uploadFileReturnsError() {
@@ -167,10 +169,10 @@ public final class RxStorageBindingTest {
             return mock(StorageUploadFileOperation.class);
         })
         .when(delegate)
-            .uploadFile(eq(remoteKey), eq(localPath), anyConsumer(), anyConsumer());
+            .uploadFile(eq(remoteKey), eq(localFile), anyConsumer(), anyConsumer());
 
         rxStorage
-            .uploadFile(remoteKey, localPath)
+            .uploadFile(remoteKey, localFile)
             .test()
             .assertError(error);
     }
@@ -190,10 +192,10 @@ public final class RxStorageBindingTest {
             return mock(StorageListOperation.class);
         })
         .when(delegate)
-            .list(eq(localPath), anyConsumer(), anyConsumer());
+            .list(eq(remoteKey), anyConsumer(), anyConsumer());
 
         rxStorage
-            .list(localPath)
+            .list(remoteKey)
             .test()
             .assertValues(result);
     }
@@ -213,10 +215,10 @@ public final class RxStorageBindingTest {
             return mock(StorageListOperation.class);
         })
         .when(delegate)
-            .list(eq(localPath), anyConsumer(), anyConsumer());
+            .list(eq(remoteKey), anyConsumer(), anyConsumer());
 
         rxStorage
-            .list(localPath)
+            .list(remoteKey)
             .test()
             .assertError(error);
     }

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousStorage.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousStorage.java
@@ -31,6 +31,7 @@ import com.amplifyframework.storage.result.StorageRemoveResult;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 import com.amplifyframework.testutils.Await;
 
+import java.io.File;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +52,7 @@ public final class SynchronousStorage {
     /**
      * Creates a synchronous storage wrapper which delegates calls to the provided storage
      * category behavior.
+     *
      * @param asyncDelegate Performs the actual storage operations
      * @return A synchronous storage wrapper
      */
@@ -62,6 +64,7 @@ public final class SynchronousStorage {
 
     /**
      * Creates a synchronous storage wrapper which delegates to the {@link Amplify#Storage} facade.
+     *
      * @return A synchronous storage wrapper
      */
     @NonNull
@@ -71,8 +74,9 @@ public final class SynchronousStorage {
 
     /**
      * Download a file synchronously and return the result of operation.
-     * @param key Key to uniquely identify the file
-     * @param local Path to save downloaded file to
+     *
+     * @param key     Key to uniquely identify the file
+     * @param local   File to save downloaded object to
      * @param options Download options
      * @return Download operation result containing downloaded file
      * @throws StorageException if download fails or times out
@@ -80,7 +84,7 @@ public final class SynchronousStorage {
     @NonNull
     public StorageDownloadFileResult downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageDownloadFileOptions options
     ) throws StorageException {
         return downloadFile(key, local, options, STORAGE_OPERATION_TIMEOUT_MS);
@@ -88,9 +92,10 @@ public final class SynchronousStorage {
 
     /**
      * Download a file synchronously and return the result of operation.
-     * @param key Key to uniquely identify the file
-     * @param local Path to save downloaded file to
-     * @param options Download options
+     *
+     * @param key       Key to uniquely identify the file
+     * @param local     File to save downloaded object to
+     * @param options   Download options
      * @param timeoutMs Custom time-out duration in milliseconds
      * @return Download operation result containing downloaded file
      * @throws StorageException if download fails or times out
@@ -98,7 +103,7 @@ public final class SynchronousStorage {
     @NonNull
     public StorageDownloadFileResult downloadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageDownloadFileOptions options,
             long timeoutMs
     ) throws StorageException {
@@ -109,8 +114,9 @@ public final class SynchronousStorage {
 
     /**
      * Upload a file synchronously and return the result of operation.
-     * @param key Key to uniquely identify the file
-     * @param local Path of the file being uploaded
+     *
+     * @param key     Key to uniquely identify the file
+     * @param local   File to upload
      * @param options Upload options
      * @return Upload operation result
      * @throws StorageException if upload fails or times out
@@ -118,7 +124,7 @@ public final class SynchronousStorage {
     @NonNull
     public StorageUploadFileResult uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageUploadFileOptions options
     ) throws StorageException {
         return uploadFile(key, local, options, STORAGE_OPERATION_TIMEOUT_MS);
@@ -126,9 +132,10 @@ public final class SynchronousStorage {
 
     /**
      * Upload a file synchronously and return the result of operation.
-     * @param key Key to uniquely identify the file
-     * @param local Path of the file being uploaded
-     * @param options Upload options
+     *
+     * @param key       Key to uniquely identify the file
+     * @param local     File to upload
+     * @param options   Upload options
      * @param timeoutMs Custom time-out duration in milliseconds
      * @return Upload operation result
      * @throws StorageException if upload fails or times out
@@ -136,7 +143,7 @@ public final class SynchronousStorage {
     @NonNull
     public StorageUploadFileResult uploadFile(
             @NonNull String key,
-            @NonNull String local,
+            @NonNull File local,
             @NonNull StorageUploadFileOptions options,
             long timeoutMs
     ) throws StorageException {
@@ -147,7 +154,8 @@ public final class SynchronousStorage {
 
     /**
      * Remove a file from S3 bucket synchronously.
-     * @param key Key to uniquely identify the file
+     *
+     * @param key     Key to uniquely identify the file
      * @param options Remove options
      * @return Remove operation result containing name of the removed file
      * @throws StorageException if removal fails or times out
@@ -162,8 +170,9 @@ public final class SynchronousStorage {
 
     /**
      * Remove a file from S3 bucket synchronously.
-     * @param key Key to uniquely identify the file
-     * @param options Remove options
+     *
+     * @param key       Key to uniquely identify the file
+     * @param options   Remove options
      * @param timeoutMs Custom time-out duration in milliseconds
      * @return Remove operation result containing name of the removed file
      * @throws StorageException if removal fails or times out
@@ -181,7 +190,8 @@ public final class SynchronousStorage {
 
     /**
      * List the files in S3 bucket synchronously.
-     * @param path Path inside S3 bucket to list files from
+     *
+     * @param path    Path inside S3 bucket to list files from
      * @param options List options
      * @return List operation result containing list of stored objects
      * @throws StorageException if list fails or times out
@@ -196,8 +206,9 @@ public final class SynchronousStorage {
 
     /**
      * List the files in S3 bucket synchronously.
-     * @param path Path inside S3 bucket to list files from
-     * @param options List options
+     *
+     * @param path      Path inside S3 bucket to list files from
+     * @param options   List options
      * @param timeoutMs Custom time-out duration in milliseconds
      * @return List operation result containing list of stored objects
      * @throws StorageException if list fails or times out


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Currently `downloadFile` and `uploadFile` expect a String with the local path for the source file and destination file respectively. To move us closer to iOS and to simplify the iOS, use a File instead as the input parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
