### PR TITLE
Expose all GraphQL error properties

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.api.graphql.error.GraphQLLocation;
+import com.amplifyframework.api.graphql.error.GraphQLPathSegment;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Error> {
+    private static final String MESSAGE_KEY = "message";
+    private static final String LOCATIONS_KEY = "locations";
+    private static final String PATH_KEY = "path";
+    private static final String EXTENSIONS_KEY = "extensions";
+
+    @Override
+    public GraphQLResponse.Error deserialize(JsonElement json,
+                 Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        if (!(json.isJsonObject())) {
+            throw new JsonParseException("Expected a JSONObject but found a " +
+                    json.getClass().getName() + " while deserializing error");
+        }
+
+        String message = null;
+        List<GraphQLLocation> locations = null;
+        List<GraphQLPathSegment> path = null;
+        Map<String, Object> extensions = null;
+        JsonObject extensionsJson = new JsonObject();
+        JsonObject nonSpecifiedData = new JsonObject();
+
+        JsonObject error = json.getAsJsonObject();
+
+        for (String key : error.keySet()) {
+            JsonElement value = error.get(key);
+            if (value != null && !value.isJsonNull()) {
+                if (key.equals(MESSAGE_KEY)) {
+                    message = context.deserialize(value, String.class);
+                } else if (key.equals(LOCATIONS_KEY)) {
+                    Type locationsType = new TypeToken<List<GraphQLLocation>>() { }.getType();
+                    locations = context.deserialize(value, locationsType);
+                } else if (key.equals(PATH_KEY)) {
+                    path = getPath(value);
+                } else if (key.equals(EXTENSIONS_KEY)) {
+                    extensionsJson = value.getAsJsonObject();
+                } else {
+                    nonSpecifiedData.add(key, value);
+                }
+            }
+        }
+
+        // Merge nonSpecifiedData into extensions, but don't overwrite anything already there.
+        for (String key : nonSpecifiedData.keySet()) {
+            if (!extensionsJson.has(key)) {
+                extensionsJson.add(key, nonSpecifiedData.get(key));
+            }
+        }
+
+        // Deserialize the extensions JSON to a Map
+        if (extensionsJson.size() > 0) {
+            Type extensionType = new TypeToken<Map<String, Object>>() {
+            }.getType();
+            extensions = context.deserialize(extensionsJson, extensionType);
+        }
+
+        return new GraphQLResponse.Error(message, locations, path, extensions);
+    }
+
+    private List<GraphQLPathSegment> getPath(JsonElement pathElement) {
+        List<GraphQLPathSegment> path = new ArrayList<>();
+        if (!pathElement.isJsonArray()) {
+            throw new JsonParseException("Expected a JsonArray but found a " +
+                    pathElement.getClass().getName() + " while deserializing path");
+        }
+        for (JsonElement element : pathElement.getAsJsonArray()) {
+            JsonPrimitive primitive = (JsonPrimitive) element;
+            if (primitive.isNumber()) {
+                path.add(new GraphQLPathSegment(primitive.getAsInt()));
+            } else if (primitive.isString()) {
+                path.add(new GraphQLPathSegment(primitive.getAsString()));
+            } else {
+                throw new JsonParseException("Expected a String or int, but found a " +
+                        primitive.getClass().getSimpleName() + " while deserializing path segment");
+            }
+        }
+        return path;
+    }
+}

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Error> {
+final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Error> {
     private static final String MESSAGE_KEY = "message";
     private static final String LOCATIONS_KEY = "locations";
     private static final String PATH_KEY = "path";
@@ -57,11 +57,11 @@ public final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResp
 
         for (String key : error.keySet()) {
             JsonElement value = error.get(key);
-            if (value != null && !value.isJsonNull()) {
+            if (value != null) {
                 if (key.equals(MESSAGE_KEY)) {
                     message = context.deserialize(value, String.class);
                 } else if (key.equals(LOCATIONS_KEY)) {
-                    Type locationsType = new TypeToken<List<GraphQLLocation>>() { }.getType();
+                    Type locationsType = new TypeToken<List<GraphQLLocation>>() {}.getType();
                     locations = context.deserialize(value, locationsType);
                 } else if (key.equals(PATH_KEY)) {
                     path = getPath(value);
@@ -82,8 +82,7 @@ public final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResp
 
         // Deserialize the extensions JSON to a Map
         if (extensionsJson.size() > 0) {
-            Type extensionType = new TypeToken<Map<String, Object>>() {
-            }.getType();
+            Type extensionType = new TypeToken<Map<String, Object>>() {}.getType();
             extensions = context.deserialize(extensionsJson, extensionType);
         }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
@@ -46,6 +46,7 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
         this(
                 new GsonBuilder()
                 .registerTypeAdapter(List.class, new GsonListDeserializer())
+                .registerTypeAdapter(GraphQLResponse.Error.class, new GsonErrorDeserializer())
                 .create()
         );
     }

--- a/aws-api/src/test/resources/error-extensions-gql-response.json
+++ b/aws-api/src/test/resources/error-extensions-gql-response.json
@@ -1,0 +1,117 @@
+{
+  "data": {
+    "listTodos": null
+  },
+  "errors": [
+    {
+      "path": [
+        "listTodos",
+        "items",
+        0,
+        "name"
+      ],
+      "data": {
+        "id": "EF48518C-92EB-4F7A-A64E-D1B9325205CF",
+        "title": "new3",
+        "content": "Original content from DataStoreEndToEndTests at 2020-03-26 21:55:47 +0000",
+        "_version": 2
+      },
+      "errorType": "ConflictUnhandled",
+      "errorInfo": null,
+      "locations": [
+        {
+          "line": 11,
+          "column": 3,
+          "sourceName": null
+        }
+      ],
+      "message": "Conflict resolver rejects mutation."
+    },
+    {
+      "path": [
+        "listTodos",
+        "items",
+        0,
+        "name"
+      ],
+      "locations": [
+        {
+          "line": 11,
+          "column": 3,
+          "sourceName": null
+        }
+      ],
+      "message": "Conflict resolver rejects mutation.",
+      "extensions" : {
+        "data": {
+          "id": "EF48518C-92EB-4F7A-A64E-D1B9325205CF",
+          "title": "new3",
+          "content": "Original content from DataStoreEndToEndTests at 2020-03-26 21:55:47 +0000",
+          "_version": 2
+        },
+        "errorType": "ConflictUnhandled",
+        "errorInfo": null
+      }
+    },
+    {
+      "path": [
+        "listTodos",
+        "items",
+        0,
+        "name"
+      ],
+      "data": {
+        "id": "EF48518C-92EB-4F7A-A64E-D1B9325205CF",
+        "title": "new3",
+        "content": "Original content from DataStoreEndToEndTests at 2020-03-26 21:55:47 +0000",
+        "_version": 2
+      },
+      "errorType": "This should be discarded since it exists inside of the extensions object",
+      "errorInfo": null,
+      "locations": [
+        {
+          "line": 11,
+          "column": 3,
+          "sourceName": null
+        }
+      ],
+      "message": "Conflict resolver rejects mutation.",
+      "extensions" : {
+        "data": {
+          "id": "EF48518C-92EB-4F7A-A64E-D1B9325205CF",
+          "title": "new3",
+          "content": "Original content from DataStoreEndToEndTests at 2020-03-26 21:55:47 +0000",
+          "_version": 2
+        },
+        "errorType": "ConflictUnhandled",
+        "errorInfo": null
+      }
+    },
+    {
+      "path": [
+        "listTodos",
+        "items",
+        0,
+        "name"
+      ],
+      "errorType": "ConflictUnhandled",
+      "locations": [
+        {
+          "line": 11,
+          "column": 3,
+          "sourceName": null
+        }
+      ],
+      "message": "Conflict resolver rejects mutation.",
+      "extensions" : {
+        "data": {
+          "id": "EF48518C-92EB-4F7A-A64E-D1B9325205CF",
+          "title": "new3",
+          "content": "Original content from DataStoreEndToEndTests at 2020-03-26 21:55:47 +0000",
+          "_version": 2
+        },
+        "errorInfo": null
+      }
+    }
+  ]
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncExtensions.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncExtensions.java
@@ -13,14 +13,20 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.api.graphql.error;
+package com.amplifyframework.datastore.appsync;
 
 import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.util.Immutable;
 
 import java.util.Map;
 
+/**
+ * Model representing a AppSync specific extensions map.  This data may be included on a
+ * GraphQLResponse.Error object, and is represented as a Map&lt;String, Object&gt;.  This class can be
+ * used to create a strongly typed model by passing the Map&lt;String, Object&gt; to the constructor.
+ */
 public final class AppSyncExtensions {
     private static final String ERROR_TYPE_KEY = "errorType";
     private static final String ERROR_INFO_KEY = "errorInfo";
@@ -28,7 +34,6 @@ public final class AppSyncExtensions {
 
     private final String errorType;
     private final String errorInfo;
-
     private final Map<String, Object> data;
 
     @SuppressWarnings("unchecked")
@@ -36,6 +41,12 @@ public final class AppSyncExtensions {
         this.errorType = (String) extensions.get(ERROR_TYPE_KEY);
         this.errorInfo = (String) extensions.get(ERROR_INFO_KEY);
         this.data = (Map<String, Object>) extensions.get(DATA_KEY);
+    }
+
+    public AppSyncExtensions(String errorType, String errorInfo, Map<String, Object> data) {
+        this.errorType = errorType;
+        this.errorInfo = errorInfo;
+        this.data = data;
     }
 
     /**
@@ -60,13 +71,36 @@ public final class AppSyncExtensions {
     }
 
     /**
-     * For conflict unhandled errors, this returns a map containing a version number, and the model
-     * fields corresponding to the current server state.
+     * For conflict unhandled errors, returns a map containing the same fields as the model type.
      *
      * @return data
      */
     @Nullable
     public Map<String, Object> getData() {
         return Immutable.of(data);
+    }
+
+    @Override
+    public boolean equals(Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        AppSyncExtensions extensions = (AppSyncExtensions) thatObject;
+
+        return ObjectsCompat.equals(errorType, extensions.errorType) &&
+                ObjectsCompat.equals(errorInfo, extensions.errorInfo) &&
+                ObjectsCompat.equals(data, extensions.data);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = errorType.hashCode();
+        result = 31 * result + (errorInfo != null ? errorInfo.hashCode() : 0);
+        result = 31 * result + (data != null ? data.hashCode() : 0);
+        return result;
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncExtensionsTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncExtensionsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.appsync;
+
+import com.google.gson.internal.LinkedTreeMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link AppSyncExtensions}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AppSyncExtensionsTest {
+
+    /**
+     * Validates the construction of an AppSyncExtensions object from a Map&lt;String, Object&gt;.
+     */
+    @Test
+    public void validateObjectCreation() {
+        String errorType = "conflictUnhandled";
+        String errorInfo = null;
+        Map<String, Object> data = new LinkedTreeMap<>();
+        data.put("id", "EF48518C-92EB-4F7A-A64E-D1B9325205CF");
+        data.put("title", "new3");
+        data.put("content", "Original content from DataStoreEndToEndTests at 2020-03-26 21:55:47 " +
+                "+0000");
+        data.put("_version", 2.0);
+
+        AppSyncExtensions expected = new AppSyncExtensions(errorType, errorInfo, data);
+
+        Map<String, Object> extensions = new LinkedTreeMap<>();
+        extensions.put("errorType", errorType);
+        extensions.put("errorInfo", null);
+        extensions.put("data", data);
+        AppSyncExtensions actual = new AppSyncExtensions(extensions);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/configuration/checkstyle-rules.xml
+++ b/configuration/checkstyle-rules.xml
@@ -105,6 +105,12 @@
                  EmptyConsumer.create(), etc., instead of value -> {}.
             -->
             <property name="allowEmptyLambdas" value="false" />
+
+            <!--
+                Allows empty class bodies.  Useful for creating an
+                anonymous inner class, such as when defining a TypeToken.
+            -->
+            <property name="allowEmptyTypes" value="true" />
         </module>
 
         <!-- Disallow methods from having too many parameters. -->

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
@@ -177,8 +177,9 @@ public final class GraphQLResponse<T> {
         }
 
         /**
-         * Returns additional error information of type E.  Reserved for GraphQL implementors to
-         * add details however they see fit.  No additional restrictions on its contents.
+         * Returns additional error information of type Map&lt;String, Object&gt;.  Reserved for GraphQL
+         * implementors to add details however they see fit.  No additional restrictions on its
+         * contents.
          *
          * @return extensions
          */

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
@@ -22,6 +22,7 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.error.GraphQLLocation;
 import com.amplifyframework.api.graphql.error.GraphQLPathSegment;
+import com.amplifyframework.util.Immutable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -132,8 +133,10 @@ public final class GraphQLResponse<T> {
          * @param path The key path of the response field with error.
          * @param extensions additional error map, reserved for implementors.
          */
-        public Error(@NonNull String message, List<GraphQLLocation> locations, List<GraphQLPathSegment> path,
-                     Map<String, Object> extensions) {
+        public Error(@NonNull String message,
+                     @Nullable List<GraphQLLocation> locations,
+                     @Nullable List<GraphQLPathSegment> path,
+                     @Nullable Map<String, Object> extensions) {
             this.message = Objects.requireNonNull(message);
             this.locations = locations;
             this.path = path;
@@ -145,6 +148,7 @@ public final class GraphQLResponse<T> {
          *
          * @return error message
          */
+        @NonNull
         public String getMessage() {
             return message;
         }
@@ -155,8 +159,9 @@ public final class GraphQLResponse<T> {
          *
          * @return locations
          */
+        @Nullable
         public List<GraphQLLocation> getLocations() {
-            return locations;
+            return Immutable.of(locations);
         }
 
         /**
@@ -166,8 +171,9 @@ public final class GraphQLResponse<T> {
          *
          * @return path
          */
+        @Nullable
         public List<GraphQLPathSegment> getPath() {
-            return path;
+            return Immutable.of(path);
         }
 
         /**
@@ -176,8 +182,9 @@ public final class GraphQLResponse<T> {
          *
          * @return extensions
          */
+        @Nullable
         public Map<String, Object> getExtensions() {
-            return extensions;
+            return Immutable.of(extensions);
         }
 
         @Override

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
@@ -20,9 +20,12 @@ import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.graphql.error.GraphQLLocation;
+import com.amplifyframework.api.graphql.error.GraphQLPathSegment;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -110,22 +113,71 @@ public final class GraphQLResponse<T> {
      * See https://graphql.github.io/graphql-spec/June2018/#sec-Response-Format
      */
     public static final class Error {
+        // Description of the error
         private final String message;
+
+        // list of locations describing the syntax element
+        private final List<GraphQLLocation> locations;
+
+        // Details the key path of the response field with error.
+        private final List<GraphQLPathSegment> path;
+
+        // Additional error map, reserved for implementors to use however they see fit.
+        private final Map<String, Object> extensions;
 
         /**
          * Constructs error response in accordance with GraphQL specs.
          * @param message error message
+         * @param locations list of locations describing the syntax element
+         * @param path The key path of the response field with error.
+         * @param extensions additional error map, reserved for implementors.
          */
-        public Error(@NonNull String message) {
+        public Error(@NonNull String message, List<GraphQLLocation> locations, List<GraphQLPathSegment> path,
+                     Map<String, Object> extensions) {
             this.message = Objects.requireNonNull(message);
+            this.locations = locations;
+            this.path = path;
+            this.extensions = extensions;
         }
 
         /**
          * Gets the error message.
+         *
          * @return error message
          */
         public String getMessage() {
             return message;
+        }
+
+        /**
+         * Gets the list of locations where each location describes the beginning of an associated
+         * syntax element.
+         *
+         * @return locations
+         */
+        public List<GraphQLLocation> getLocations() {
+            return locations;
+        }
+
+        /**
+         * Gets the key path of the response field which experienced the error.  This allows clients
+         * to identify whether a null result is intentional or caused by a runtime error.  The
+         * values are either strings or 0-index integers.
+         *
+         * @return path
+         */
+        public List<GraphQLPathSegment> getPath() {
+            return path;
+        }
+
+        /**
+         * Returns additional error information of type E.  Reserved for GraphQL implementors to
+         * add details however they see fit.  No additional restrictions on its contents.
+         *
+         * @return extensions
+         */
+        public Map<String, Object> getExtensions() {
+            return extensions;
         }
 
         @Override
@@ -139,12 +191,19 @@ public final class GraphQLResponse<T> {
 
             Error error = (Error) thatObject;
 
-            return message.equals(error.message);
+            return ObjectsCompat.equals(message, error.message) &&
+                   ObjectsCompat.equals(path, error.path) &&
+                   ObjectsCompat.equals(extensions, error.extensions) &&
+                   ObjectsCompat.equals(locations, error.locations);
         }
 
         @Override
         public int hashCode() {
-            return message.hashCode();
+            int result = message.hashCode();
+            result = 31 * result + (path != null ? path.hashCode() : 0);
+            result = 31 * result + (extensions != null ? extensions.hashCode() : 0);
+            result = 31 * result + (locations != null ? locations.hashCode() : 0);
+            return result;
         }
 
         @Override

--- a/core/src/main/java/com/amplifyframework/api/graphql/error/AppSyncExtensions.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/error/AppSyncExtensions.java
@@ -15,9 +15,13 @@
 
 package com.amplifyframework.api.graphql.error;
 
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.util.Immutable;
+
 import java.util.Map;
 
-public class AppSyncExtensions {
+public final class AppSyncExtensions {
     private static final String ERROR_TYPE_KEY = "errorType";
     private static final String ERROR_INFO_KEY = "errorInfo";
     private static final String DATA_KEY = "data";
@@ -40,6 +44,7 @@ public class AppSyncExtensions {
      *
      * @return errorType
      */
+    @Nullable
     public String getErrorType() {
         return errorType;
     }
@@ -49,6 +54,7 @@ public class AppSyncExtensions {
      *
      * @return errorInfo
      */
+    @Nullable
     public String getErrorInfo() {
         return errorInfo;
     }
@@ -59,7 +65,8 @@ public class AppSyncExtensions {
      *
      * @return data
      */
+    @Nullable
     public Map<String, Object> getData() {
-        return data;
+        return Immutable.of(data);
     }
 }

--- a/core/src/main/java/com/amplifyframework/api/graphql/error/AppSyncExtensions.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/error/AppSyncExtensions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.graphql.error;
+
+import java.util.Map;
+
+public class AppSyncExtensions {
+    private static final String ERROR_TYPE_KEY = "errorType";
+    private static final String ERROR_INFO_KEY = "errorInfo";
+    private static final String DATA_KEY = "data";
+
+    private final String errorType;
+    private final String errorInfo;
+
+    private final Map<String, Object> data;
+
+    @SuppressWarnings("unchecked")
+    public AppSyncExtensions(Map<String, Object> extensions) {
+        this.errorType = (String) extensions.get(ERROR_TYPE_KEY);
+        this.errorInfo = (String) extensions.get(ERROR_INFO_KEY);
+        this.data = (Map<String, Object>) extensions.get(DATA_KEY);
+    }
+
+    /**
+     * Returns the specific AppSync error type, often related to handling conflicts.
+     * https://docs.aws.amazon.com/appsync/latest/devguide/conflict-detection-and-sync.html#errors
+     *
+     * @return errorType
+     */
+    public String getErrorType() {
+        return errorType;
+    }
+
+    /**
+     * Returns more info about the error.
+     *
+     * @return errorInfo
+     */
+    public String getErrorInfo() {
+        return errorInfo;
+    }
+
+    /**
+     * For conflict unhandled errors, this returns a map containing a version number, and the model
+     * fields corresponding to the current server state.
+     *
+     * @return data
+     */
+    public Map<String, Object> getData() {
+        return data;
+    }
+}

--- a/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLLocation.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLLocation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.graphql.error;
+
+/**
+ * Location mapping to a particular line and column in the request.
+ */
+public class GraphQLLocation {
+    private int line;
+    private int column;
+
+    /**
+     * Returns line number corresponding to position in the request where an error occurred.
+     *
+     * @return line
+     */
+    public int getLine() {
+        return line;
+    }
+
+    /**
+     * Returns column number corresponding to position in the request where an error occurred.
+     *
+     * @return column
+     */
+    public int getColumn() {
+        return column;
+    }
+}

--- a/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLLocation.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLLocation.java
@@ -44,4 +44,25 @@ public final class GraphQLLocation {
     public int getColumn() {
         return column;
     }
+
+    @Override
+    public boolean equals(Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        GraphQLLocation location = (GraphQLLocation) thatObject;
+
+        return line == location.line && column == location.column;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = line;
+        result = 31 * result + column;
+        return result;
+    }
 }

--- a/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLLocation.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLLocation.java
@@ -18,9 +18,14 @@ package com.amplifyframework.api.graphql.error;
 /**
  * Location mapping to a particular line and column in the request.
  */
-public class GraphQLLocation {
+public final class GraphQLLocation {
     private int line;
     private int column;
+
+    public GraphQLLocation(int line, int column) {
+        this.line = line;
+        this.column = column;
+    }
 
     /**
      * Returns line number corresponding to position in the request where an error occurred.

--- a/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLPathSegment.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLPathSegment.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.graphql.error;
+
+public class GraphQLPathSegment {
+    private final Object value;
+
+    public GraphQLPathSegment(int value) {
+        this.value = Integer.valueOf(value);
+    }
+
+    public GraphQLPathSegment(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Used before calling getAsInt() to confirm if value is int.
+     *
+     * @return boolean, whether segment is an int
+     */
+    public boolean isInteger() {
+        return value instanceof Integer;
+    }
+
+    /**
+     * Used before calling getAsString() to confirm if value is String.
+     *
+     * @return boolean, whether segment is a String
+     */
+    public boolean isString() {
+        return value instanceof String;
+    }
+
+    /**
+     * Convenience method to get this element as a String.
+     *
+     * @return get this element as a String
+     * @throws IllegalStateException if the value contained is not a String.
+     */
+    public String getAsString() {
+        if (isString()) {
+            return (String) value;
+        }
+        throw new IllegalStateException("Not a String: " + value.getClass().getSimpleName());
+    }
+
+    /**
+     * Convenience method to get this element as an int.
+     *
+     * @return get this element as an int
+     * @throws IllegalStateException if the value contained is not an Integer.
+     */
+    public int getAsInt() {
+        if (isInteger()) {
+            return ((Integer) value).intValue();
+        }
+        throw new IllegalStateException("Not an int: " + value.getClass().getSimpleName());
+    }
+}

--- a/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLPathSegment.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLPathSegment.java
@@ -16,7 +16,17 @@
 package com.amplifyframework.api.graphql.error;
 
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
+/**
+ * If a GraphQLResponse contains an error that can be associated with a particular field in the
+ * requested GraphQL document, it will contain an entry with the key, path.  This entry should be a
+ * list of GraphQLPathSegments starting at the root of the response and ending with the field
+ * associated with the error.  This allows clients to determine whether a null result is intentional
+ * or caused by a runtime error.  Path segments that represent fields should be strings, and path
+ * segments that represent list indices should be 0‐indexed integers.
+ * https://spec.graphql.org/June2018/#sec-Errors
+ */
 public final class GraphQLPathSegment {
     private final Object value;
 
@@ -71,5 +81,30 @@ public final class GraphQLPathSegment {
             return ((Integer) value).intValue();
         }
         throw new ClassCastException("Not an int: " + value.getClass().getSimpleName());
+    }
+
+    @Override
+    public boolean equals(Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        GraphQLPathSegment segment = (GraphQLPathSegment) thatObject;
+
+        if (isString() && segment.isString()) {
+            return ObjectsCompat.equals(getAsString(), segment.getAsString());
+        }
+        if (isInteger() && segment.isInteger()) {
+            return ObjectsCompat.equals(getAsInt(), segment.getAsInt());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
     }
 }

--- a/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLPathSegment.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/error/GraphQLPathSegment.java
@@ -15,14 +15,16 @@
 
 package com.amplifyframework.api.graphql.error;
 
-public class GraphQLPathSegment {
+import androidx.annotation.NonNull;
+
+public final class GraphQLPathSegment {
     private final Object value;
 
     public GraphQLPathSegment(int value) {
         this.value = Integer.valueOf(value);
     }
 
-    public GraphQLPathSegment(String value) {
+    public GraphQLPathSegment(@NonNull String value) {
         this.value = value;
     }
 
@@ -48,25 +50,26 @@ public class GraphQLPathSegment {
      * Convenience method to get this element as a String.
      *
      * @return get this element as a String
-     * @throws IllegalStateException if the value contained is not a String.
+     * @throws ClassCastException if the value contained is not a String.
      */
+    @NonNull
     public String getAsString() {
         if (isString()) {
             return (String) value;
         }
-        throw new IllegalStateException("Not a String: " + value.getClass().getSimpleName());
+        throw new ClassCastException("Not a String: " + value.getClass().getSimpleName());
     }
 
     /**
      * Convenience method to get this element as an int.
      *
      * @return get this element as an int
-     * @throws IllegalStateException if the value contained is not an Integer.
+     * @throws ClassCastException if the value contained is not an Integer.
      */
     public int getAsInt() {
         if (isInteger()) {
             return ((Integer) value).intValue();
         }
-        throw new IllegalStateException("Not an int: " + value.getClass().getSimpleName());
+        throw new ClassCastException("Not an int: " + value.getClass().getSimpleName());
     }
 }


### PR DESCRIPTION
*Description of changes:*
The [2018 GraphQL spec](https://spec.graphql.org/June2018/#sec-Errors) specifies that the error type has 4 fields: `message`, `location`, `path`, `extensions`).   The `extensions` field is designed to point to a Map, and can contain any custom error information, as desired by the implementor.   AppSync added some additional fields at the root (`errorType`, `errorInfo`, `data`) of the error object, which goes against the 2018 GraphQL specification (likely because AppSync implemented it prior to 2018, when `extensions` was not part of the spec).   This PR handles this by merged all non-expected fields into the `extensions` map.  If the same field exist in both places, the field inside of extensions take precedence, and the field at the root level is discarded.

After deserialization, the extensions data is stored as a Map<String, Object>.  I considered adding a type parameter, E, to represent the data inside of extensions, but I did not end up going with this approach because it would have needed to be added as a second type parameter to all of the APICategoryBehavior method response types, and that seemed overly complex.  I'm open to other suggestions for how to make this work though, there may be another approach I'm not thinking of.

I did create an `AppSyncExtensions` model object (currently only used by the unit test), which can be used by DataStore to convert from a Map to a strongly-typed object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
