### PR TITLE
Expose all GraphQL error properties (part 2)

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
@@ -29,8 +29,8 @@ import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings("unchecked")
 final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Error> {
@@ -50,7 +50,7 @@ final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Er
         String message = null;
         List<GraphQLLocation> locations = null;
         List<GraphQLPathSegment> path = null;
-        HashMap<String, Object> extensions = null;
+        Map<String, Object> extensions = null;
         JsonObject extensionsJson = new JsonObject();
         JsonObject nonSpecifiedData = new JsonObject();
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
@@ -15,9 +15,9 @@
 
 package com.amplifyframework.api.aws;
 
+import com.amplifyframework.api.graphql.GraphQLLocation;
+import com.amplifyframework.api.graphql.GraphQLPathSegment;
 import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.api.graphql.error.GraphQLLocation;
-import com.amplifyframework.api.graphql.error.GraphQLPathSegment;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -29,9 +29,10 @@ import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
+@SuppressWarnings("unchecked")
 final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Error> {
     private static final String MESSAGE_KEY = "message";
     private static final String LOCATIONS_KEY = "locations";
@@ -49,7 +50,7 @@ final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Er
         String message = null;
         List<GraphQLLocation> locations = null;
         List<GraphQLPathSegment> path = null;
-        Map<String, Object> extensions = null;
+        HashMap<String, Object> extensions = null;
         JsonObject extensionsJson = new JsonObject();
         JsonObject nonSpecifiedData = new JsonObject();
 
@@ -82,8 +83,7 @@ final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Er
 
         // Deserialize the extensions JSON to a Map
         if (extensionsJson.size() > 0) {
-            Type extensionType = new TypeToken<Map<String, Object>>() {}.getType();
-            extensions = context.deserialize(extensionsJson, extensionType);
+            extensions = GsonUtil.toMap(extensionsJson);
         }
 
         return new GraphQLResponse.Error(message, locations, path, extensions);

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonUtil.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+final class GsonUtil {
+
+    private GsonUtil() {
+        throw new UnsupportedOperationException("No instances allowed.");
+    }
+
+    static HashMap<String, Object> toMap(JsonObject object) {
+        HashMap<String, Object> map = new HashMap<>();
+        for (String key : object.keySet()) {
+            JsonElement element = object.get(key);
+            map.put(key, toObject(element));
+        }
+        return map;
+    }
+
+    static List<Object> toList(JsonArray array) {
+        List<Object> list = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            JsonElement element = array.get(i);
+            list.add(toObject(element));
+        }
+        return list;
+    }
+
+    private static Object toObject(JsonElement element) {
+        if (element != null) {
+            if (element.isJsonArray()) {
+                return toList(element.getAsJsonArray());
+            } else if (element.isJsonObject()) {
+                return toMap(element.getAsJsonObject());
+            } else if (element.isJsonPrimitive()) {
+                JsonPrimitive primitive = element.getAsJsonPrimitive();
+                if (primitive.isString()) {
+                    return primitive.getAsString();
+                } else if (primitive.isNumber()) {
+                    Number number = primitive.getAsNumber();
+                    if (number.floatValue() == number.intValue()) {
+                        return number.intValue();
+                    } else {
+                        return number.floatValue();
+                    }
+                } else if (primitive.isBoolean()) {
+                    return primitive.getAsBoolean();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonUtil.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonUtil.java
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.api.aws;
 
+import com.amplifyframework.util.Immutable;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -23,6 +25,7 @@ import com.google.gson.JsonPrimitive;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 final class GsonUtil {
 
@@ -30,13 +33,13 @@ final class GsonUtil {
         throw new UnsupportedOperationException("No instances allowed.");
     }
 
-    static HashMap<String, Object> toMap(JsonObject object) {
-        HashMap<String, Object> map = new HashMap<>();
+    static Map<String, Object> toMap(JsonObject object) {
+        Map<String, Object> map = new HashMap<>();
         for (String key : object.keySet()) {
             JsonElement element = object.get(key);
             map.put(key, toObject(element));
         }
-        return map;
+        return Immutable.of(map);
     }
 
     static List<Object> toList(JsonArray array) {
@@ -45,7 +48,7 @@ final class GsonUtil {
             JsonElement element = array.get(i);
             list.add(toObject(element));
         }
-        return list;
+        return Immutable.of(list);
     }
 
     private static Object toObject(JsonElement element) {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
@@ -16,12 +16,11 @@
 package com.amplifyframework.api.aws;
 
 import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.graphql.GraphQLLocation;
+import com.amplifyframework.api.graphql.GraphQLPathSegment;
 import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.api.graphql.error.GraphQLLocation;
-import com.amplifyframework.api.graphql.error.GraphQLPathSegment;
 import com.amplifyframework.testutils.Resources;
 
-import com.google.gson.internal.LinkedTreeMap;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -31,6 +30,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -137,7 +137,7 @@ public final class GsonGraphQLResponseFactoryTest {
                     new GraphQLPathSegment(i),
                     new GraphQLPathSegment("name")
             );
-            Map<String, Object> extensions = new LinkedTreeMap<>();
+            Map<String, Object> extensions = new HashMap<>();
             extensions.put("errorType", null);
             extensions.put("errorInfo", null);
             extensions.put("data", null);
@@ -169,7 +169,7 @@ public final class GsonGraphQLResponseFactoryTest {
         final GraphQLResponse<ListTodosResult> response =
                 responseFactory.buildSingleItemResponse(partialResponseJson, ListTodosResult.class);
 
-        // Assert that the response contained things...
+        // Build the expected response.
         String message = "Conflict resolver rejects mutation.";
         List<GraphQLLocation> locations = Arrays.asList(
                 new GraphQLLocation(11, 3));
@@ -180,14 +180,14 @@ public final class GsonGraphQLResponseFactoryTest {
                 new GraphQLPathSegment("name")
         );
 
-        Map<String, Object> data = new LinkedTreeMap<>();
+        Map<String, Object> data = new HashMap<>();
         data.put("id", "EF48518C-92EB-4F7A-A64E-D1B9325205CF");
         data.put("title", "new3");
         data.put("content", "Original content from DataStoreEndToEndTests at 2020-03-26 21:55:47 " +
                 "+0000");
-        data.put("_version", 2.0);
+        data.put("_version", 2);
 
-        Map<String, Object> extensions = new LinkedTreeMap<>();
+        Map<String, Object> extensions = new HashMap<>();
         extensions.put("errorType", "ConflictUnhandled");
         extensions.put("errorInfo", null);
         extensions.put("data", data);
@@ -196,23 +196,7 @@ public final class GsonGraphQLResponseFactoryTest {
         GraphQLResponse<ListTodosResult> expectedResponse = new GraphQLResponse<>(null,
                 Arrays.asList(expectedError, expectedError, expectedError, expectedError));
 
-        assertNotNull(response);
-        assertNotNull(response.getErrors());
-        assertEquals(expectedResponse.getErrors().size(), response.getErrors().size());
-
-        // Assert that each error has been parsed to the same output object.
-        for (int i = 0; i < response.getErrors().size(); i++) {
-            GraphQLResponse.Error actual = response.getErrors().get(i);
-            GraphQLResponse.Error expected = expectedResponse.getErrors().get(i);
-            assertEquals("Unexpected message on error[" + i + "]", expected.getMessage(), actual.getMessage());
-            assertEquals("Unexpected extensions on error[" + i + "]", expected.getExtensions(), actual.getExtensions());
-            assertEquals("Unexpected path on error[" + i + "]", expected.getPath(), actual.getPath());
-            assertEquals("Unexpected locations on error[" + i + "]", expected.getLocations(), actual.getLocations());
-            assertEquals("Unexpected error[" + i + "]", expected, actual);
-        }
-
-        // This test could be shortened to only include the single assert below, but by checking the
-        // individual properties of the error objects above, debugging test failures is much easier.
+        // Assert that the response is expected
         assertEquals(expectedResponse, response);
     }
 

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonUtilTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonUtilTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+import com.amplifyframework.testutils.Resources;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class GsonUtilTest {
+
+    @Test
+    public void validateJsonObjectToMap() {
+
+        // Build the expected Map
+        List<Object> innerArray = Arrays.asList(
+                "foo",
+                0,
+                2,
+                3.5f,
+                true,
+                false,
+                null);
+
+        Map<String, Object> innerObject = new HashMap<>();
+        innerObject.put("someString", "bar");
+
+        List<Object> array = Arrays.asList(
+                innerArray,
+                innerObject
+        );
+
+        Map<String, Object> object = new HashMap<>();
+        object.put("someString", "baz");
+        object.put("someInteger", 4);
+        object.put("someFloat", 5.5f);
+        object.put("someBoolean", false);
+        object.put("someNull", null);
+
+        Map<String, Object> expected = new HashMap<String, Object>();
+        expected.put("array", array);
+        expected.put("object", object);
+
+        // Build the actual Map using GsonUtil
+        final String json = Resources.readAsString("gson-util.json");
+        JsonObject jsonObject = JsonParser.parseString(json).getAsJsonObject();
+        Map<String, Object> actual = GsonUtil.toMap(jsonObject);
+
+        // Assert that the response is expected
+        assertEquals(expected, actual);
+    }
+}

--- a/aws-api/src/test/resources/gson-util.json
+++ b/aws-api/src/test/resources/gson-util.json
@@ -1,0 +1,23 @@
+{
+  "array": [
+    [
+      "foo",
+      0,
+      2,
+      3.5,
+      true,
+      false,
+      null
+    ],
+    {
+      "someString": "bar"
+    }
+  ],
+  "object" : {
+    "someString": "baz",
+    "someInteger": 4,
+    "someFloat" : 5.5,
+    "someBoolean" : false,
+    "someNull" : null
+  }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncExtensions.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncExtensions.java
@@ -103,4 +103,13 @@ public final class AppSyncExtensions {
         result = 31 * result + (data != null ? data.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "AppSyncExtensions{" +
+                "errorType=\'" + errorType + "\'" +
+                ", errorInfo=\'" + errorInfo + "\'" +
+                ", data=\'" + data + "\'" +
+                '}';
+    }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncExtensionsTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncExtensionsTest.java
@@ -15,11 +15,11 @@
 
 package com.amplifyframework.datastore.appsync;
 
-import com.google.gson.internal.LinkedTreeMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -37,16 +37,16 @@ public class AppSyncExtensionsTest {
     public void validateObjectCreation() {
         String errorType = "conflictUnhandled";
         String errorInfo = null;
-        Map<String, Object> data = new LinkedTreeMap<>();
+        HashMap<String, Object> data = new HashMap<>();
         data.put("id", "EF48518C-92EB-4F7A-A64E-D1B9325205CF");
         data.put("title", "new3");
         data.put("content", "Original content from DataStoreEndToEndTests at 2020-03-26 21:55:47 " +
                 "+0000");
-        data.put("_version", 2.0);
+        data.put("_version", 2);
 
         AppSyncExtensions expected = new AppSyncExtensions(errorType, errorInfo, data);
 
-        Map<String, Object> extensions = new LinkedTreeMap<>();
+        Map<String, Object> extensions = new HashMap<>();
         extensions.put("errorType", errorType);
         extensions.put("errorInfo", null);
         extensions.put("data", data);

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLLocation.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLLocation.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.api.graphql.error;
+package com.amplifyframework.api.graphql;
 
 /**
  * Location mapping to a particular line and column in the request.
@@ -64,5 +64,13 @@ public final class GraphQLLocation {
         int result = line;
         result = 31 * result + column;
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GraphQLLocation{" +
+                "line=\'" + line + "\'" +
+                ", column=\'" + column + "\'" +
+                '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLPathSegment.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLPathSegment.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.api.graphql.error;
+package com.amplifyframework.api.graphql;
 
 import androidx.annotation.NonNull;
 import androidx.core.util.ObjectsCompat;
@@ -106,5 +106,12 @@ public final class GraphQLPathSegment {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "GraphQLPathSegment{" +
+                "value=\'" + value + "\'" +
+                '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
@@ -20,8 +20,6 @@ import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.api.ApiException;
-import com.amplifyframework.api.graphql.error.GraphQLLocation;
-import com.amplifyframework.api.graphql.error.GraphQLPathSegment;
 import com.amplifyframework.util.Immutable;
 
 import java.util.ArrayList;
@@ -109,21 +107,22 @@ public final class GraphQLResponse<T> {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return "GraphQLResponse{" +
+                "data=\'" + data + "\'" +
+                ", errors=\'" + errors + "\'" +
+                '}';
+    }
+
     /**
      * Error object that models GraphQL error.
      * See https://graphql.github.io/graphql-spec/June2018/#sec-Response-Format
      */
     public static final class Error {
-        // Description of the error
         private final String message;
-
-        // list of locations describing the syntax element
         private final List<GraphQLLocation> locations;
-
-        // Details the key path of the response field with error.
         private final List<GraphQLPathSegment> path;
-
-        // Additional error map, reserved for implementors to use however they see fit.
         private final Map<String, Object> extensions;
 
         /**
@@ -200,23 +199,29 @@ public final class GraphQLResponse<T> {
             Error error = (Error) thatObject;
 
             return ObjectsCompat.equals(message, error.message) &&
+                   ObjectsCompat.equals(locations, error.locations) &&
                    ObjectsCompat.equals(path, error.path) &&
-                   ObjectsCompat.equals(extensions, error.extensions) &&
-                   ObjectsCompat.equals(locations, error.locations);
+                   ObjectsCompat.equals(extensions, error.extensions);
+
         }
 
         @Override
         public int hashCode() {
             int result = message.hashCode();
+            result = 31 * result + (locations != null ? locations.hashCode() : 0);
             result = 31 * result + (path != null ? path.hashCode() : 0);
             result = 31 * result + (extensions != null ? extensions.hashCode() : 0);
-            result = 31 * result + (locations != null ? locations.hashCode() : 0);
             return result;
         }
 
         @Override
         public String toString() {
-            return String.valueOf(message);
+            return "GraphQLResponse.Error{" +
+                    "message=\'" + message + "\'" +
+                    ", locations=\'" + locations + "\'" +
+                    ", path=\'" + path + "\'" +
+                    ", extensions=\'" + extensions + "\'" +
+                    '}';
         }
     }
 


### PR DESCRIPTION
Addresses the last bits of feedback on https://github.com/aws-amplify/amplify-android/pull/392, specifically:
 - Moves GraphQLLocation, GraphQLPathSegment into same package as GraphQLResponse
 - Implements custom deserialization of GraphQL error extension into HashMap to eliminate gson's LinkedTreeMap leaking to public interface.
 - Adds `toString` implementations to error models

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
