### PR TITLE
Add MissingJavadocType to checkstyle-rules

### DIFF
--- a/configuration/checkstyle-rules.xml
+++ b/configuration/checkstyle-rules.xml
@@ -234,6 +234,12 @@
             <property name="validateThrows" value="true" />
         </module>
         <!--
+            Checks for missing Javadoc comments on public and protected class/interface definitions.
+        -->
+        <module name="MissingJavadocType">
+            <property name="scope" value="protected" />
+        </module>
+        <!--
             public and protected class/interface definitions should
             include a high-level descriptive doc.
         -->

--- a/configuration/checkstyle-suppressions.xml
+++ b/configuration/checkstyle-suppressions.xml
@@ -32,5 +32,6 @@
     -->
     <suppress checks="AvoidStaticImport" files="src/(androidTest|test)" />
     <suppress checks="MagicNumber" files="src/(androidTest|test)" />
+    <suppress checks="MissingJavadocType" files="src/(androidTest|test)" />
 </suppressions>
 

--- a/core/src/main/java/com/amplifyframework/analytics/UserProfile.java
+++ b/core/src/main/java/com/amplifyframework/analytics/UserProfile.java
@@ -117,6 +117,9 @@ public final class UserProfile {
                 '}';
     }
 
+    /**
+     * Builder for creating a UserProfile object.
+     */
     public static final class Builder {
         private String name;
         private String email;
@@ -165,6 +168,9 @@ public final class UserProfile {
         }
     }
 
+    /**
+     * Represents a user's location.
+     */
     public static final class Location {
         private final Double latitude;
         private final Double longitude;
@@ -270,6 +276,9 @@ public final class UserProfile {
                     '}';
         }
 
+        /**
+         * Builder for creating a Location object.
+         */
         public static final class Builder {
             private Double latitude;
             private Double longitude;

--- a/core/src/main/java/com/amplifyframework/predictions/operation/InterpretOperation.java
+++ b/core/src/main/java/com/amplifyframework/predictions/operation/InterpretOperation.java
@@ -20,6 +20,11 @@ import androidx.annotation.Nullable;
 import com.amplifyframework.core.async.AmplifyOperation;
 import com.amplifyframework.core.category.CategoryType;
 
+/**
+ *  Abstract representation of a operation that interprets text from any source, online or offline.
+ *
+ * @param <R> type of the request object
+ */
 public abstract class InterpretOperation<R> extends AmplifyOperation<R> {
     /**
      * Constructs a new {@link InterpretOperation}.

--- a/core/src/main/java/com/amplifyframework/predictions/operation/TranslateTextOperation.java
+++ b/core/src/main/java/com/amplifyframework/predictions/operation/TranslateTextOperation.java
@@ -20,6 +20,11 @@ import androidx.annotation.Nullable;
 import com.amplifyframework.core.async.AmplifyOperation;
 import com.amplifyframework.core.category.CategoryType;
 
+/**
+ *  Abstract representation of a operation that translates text from any source, online or offline.
+ *
+ * @param <R> type of the request object
+ */
 public abstract class TranslateTextOperation<R> extends AmplifyOperation<R> {
     /**
      * Constructs a new {@link TranslateTextOperation}.


### PR DESCRIPTION
We already have a checkstyle rule to ensure that Javadoc on public/protected classes/interfaces is formatted correctly ([JavadocType](https://checkstyle.sourceforge.io/config_javadoc.html#JavadocType)).  This PR adds [MissingJavadocType](https://checkstyle.sourceforge.io/config_javadoc.html#MissingJavadocType), which ensures that Javadoc actually exists in the first place.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

