### PR TITLE
Add Javadoc to resolve checkstyle error

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/operation/AWSIdentifyOperation.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/operation/AWSIdentifyOperation.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ExecutorService;
 
 /**
  *
- * Operation that identifies objects within an image via AWS Translate, AWS Rekognition, or AWS Comprehend.
+ * Operation that identifies objects within an image via Amazon Translate, Amazon Rekognition, or Amazon Comprehend.
  */
 public final class AWSIdentifyOperation
         extends IdentifyOperation<AWSRekognitionRequest> {

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/operation/AWSIdentifyOperation.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/operation/AWSIdentifyOperation.java
@@ -29,6 +29,10 @@ import com.amplifyframework.predictions.result.IdentifyResult;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 
+/**
+ *
+ * Operation that identifies objects within an image via AWS Translate, AWS Rekognition, or AWS Comprehend.
+ */
 public final class AWSIdentifyOperation
         extends IdentifyOperation<AWSRekognitionRequest> {
     private final AWSPredictionsService predictionsService;

--- a/core/src/main/java/com/amplifyframework/predictions/operation/IdentifyOperation.java
+++ b/core/src/main/java/com/amplifyframework/predictions/operation/IdentifyOperation.java
@@ -24,6 +24,11 @@ import com.amplifyframework.predictions.models.IdentifyAction;
 
 import java.util.Objects;
 
+/**
+ * Abstract representation of an operation that identifies elements within an image.
+ *
+ * @param <R> type of the request object
+ */
 public abstract class IdentifyOperation<R> extends AmplifyOperation<R> {
     private final IdentifyAction identifyAction;
 


### PR DESCRIPTION
Follow up to https://github.com/aws-amplify/amplify-android/pull/403.   The build passed on this PR above, but failed after the rebase.  This resolves the issue by adding Javadoc to missing classes, since [MissingJavadocType](https://checkstyle.sourceforge.io/config_javadoc.html#MissingJavadocType) is a new checkstyle rule.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
