### PR TITLE
[aws-api] Fix JsonParseException when parsing null path in Error object

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
@@ -91,6 +91,9 @@ final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Er
 
     private List<GraphQLPathSegment> getPath(JsonElement pathElement) {
         List<GraphQLPathSegment> path = new ArrayList<>();
+        if (pathElement.isJsonNull()) {
+            return null;
+        }
         if (!pathElement.isJsonArray()) {
             throw new JsonParseException("Expected a JsonArray but found a " +
                     pathElement.getClass().getName() + " while deserializing path");

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
@@ -200,6 +200,29 @@ public final class GsonGraphQLResponseFactoryTest {
         assertEquals(expectedResponse, response);
     }
 
+    @Test
+    public void errorWithNullFieldsCanBeParsed() throws ApiException {
+        // Arrange some JSON string from a "server"
+        final String responseJson = Resources.readAsString("error-null-properties.json");
+
+        // Act! Parse it into a model.
+        final GraphQLResponse<ListTodosResult> response =
+                responseFactory.buildSingleItemResponse(responseJson, ListTodosResult.class);
+
+        // Build the expected response.
+        Map<String, Object> extensions = new HashMap<>();
+        extensions.put("errorType", null);
+        extensions.put("errorInfo", null);
+        extensions.put("data", null);
+
+        GraphQLResponse.Error expectedError = new GraphQLResponse.Error("the message", null, null, extensions);
+        GraphQLResponse<ListTodosResult> expectedResponse = new GraphQLResponse<>(null, Arrays.asList(expectedError));
+
+        // Assert that the response is expected
+        assertEquals(expectedResponse, response);
+    }
+
+
     /**
      * It is possible to cast the response data as a string, instead of as the strongly
      * modeled type, if you choose to do so.

--- a/aws-api/src/test/resources/error-null-properties.json
+++ b/aws-api/src/test/resources/error-null-properties.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "listTodos": null
+  },
+  "errors": [
+    {
+      "path": null,
+      "data": null,
+      "errorType": null,
+      "errorInfo": null,
+      "locations": null,
+      "message": "the message"
+    }
+  ]
+}


### PR DESCRIPTION
*Description of changes:* Fixes a bug where a `JsonParseException` is thrown if `path` on an error object is null.  `path` is not required, so no exception should be thrown.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
