### PR TITLE
Flip constant equality checks

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -186,7 +186,7 @@ final class AppSyncGraphQLRequestFactory {
 
             Map<String, Object> variables = new HashMap<>();
 
-            if (type.equals(MutationType.DELETE)) {
+            if (MutationType.DELETE.equals(type)) {
                 variables.put("input", Collections.singletonMap("id", model.getId()));
             } else {
                 try {
@@ -314,7 +314,7 @@ final class AppSyncGraphQLRequestFactory {
         } else if (queryPredicate instanceof QueryPredicateGroup) {
             QueryPredicateGroup qpg = (QueryPredicateGroup) queryPredicate;
 
-            if (qpg.type().equals(QueryPredicateGroup.Type.NOT)) {
+            if (QueryPredicateGroup.Type.NOT.equals(qpg.type())) {
                 try {
                     return Collections.singletonMap("not", parsePredicate(qpg.predicates().get(0)));
                 } catch (IndexOutOfBoundsException exception) {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonErrorDeserializer.java
@@ -58,19 +58,26 @@ final class GsonErrorDeserializer implements JsonDeserializer<GraphQLResponse.Er
 
         for (String key : error.keySet()) {
             JsonElement value = error.get(key);
-            if (value != null) {
-                if (key.equals(MESSAGE_KEY)) {
+            if (value == null) {
+                continue;
+            }
+            switch (key) {
+                case MESSAGE_KEY:
                     message = context.deserialize(value, String.class);
-                } else if (key.equals(LOCATIONS_KEY)) {
+                    break;
+                case LOCATIONS_KEY:
                     Type locationsType = new TypeToken<List<GraphQLLocation>>() {}.getType();
                     locations = context.deserialize(value, locationsType);
-                } else if (key.equals(PATH_KEY)) {
+                    break;
+                case PATH_KEY:
                     path = getPath(value);
-                } else if (key.equals(EXTENSIONS_KEY)) {
+                    break;
+                case EXTENSIONS_KEY:
                     extensionsJson = value.getAsJsonObject();
-                } else {
+                    break;
+                default:
                     nonSpecifiedData.add(key, value);
-                }
+                    break;
             }
         }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
@@ -87,7 +87,7 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
 
         if (jsonData == null || jsonData.isJsonNull()) {
             return new GraphQLResponse<>(null, errors);
-        } else if (jsonData.isJsonObject() || jsonData.isJsonPrimitive() || classToCast.equals(JsonElement.class)) {
+        } else if (jsonData.isJsonObject() || jsonData.isJsonPrimitive() || JsonElement.class.equals(classToCast)) {
             T data = parseData(jsonData, classToCast);
             return new GraphQLResponse<>(data, errors);
         } else {
@@ -131,7 +131,7 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
         ) {
             Iterable<T> data = parseDataAsList(jsonData.getAsJsonObject().get("items"), classToCast);
             return new GraphQLResponse<>(data, errors);
-        } else if (jsonData.isJsonObject() || jsonData.isJsonPrimitive() || classToCast.equals(JsonElement.class)) {
+        } else if (jsonData.isJsonObject() || jsonData.isJsonPrimitive() || JsonElement.class.equals(classToCast)) {
             T data = parseData(jsonData, classToCast);
             return new GraphQLResponse<>(Collections.singletonList(data), errors);
         } else {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/utils/S3Keys.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/utils/S3Keys.java
@@ -63,7 +63,7 @@ public final class S3Keys {
             @NonNull StorageAccessLevel accessLevel,
             @NonNull String identityId
     ) {
-        if (accessLevel.equals(StorageAccessLevel.PRIVATE) || accessLevel.equals(StorageAccessLevel.PROTECTED)) {
+        if (StorageAccessLevel.PRIVATE.equals(accessLevel) || StorageAccessLevel.PROTECTED.equals(accessLevel)) {
             return accessLevel.name().toLowerCase(Locale.US) + BUCKET_SEPARATOR + identityId;
         } else {
             return accessLevel.name().toLowerCase(Locale.US);

--- a/core/src/main/java/com/amplifyframework/core/model/ModelAssociation.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelAssociation.java
@@ -104,7 +104,7 @@ public final class ModelAssociation {
      * @return True if this field owns the identity of another model
      */
     public boolean isOwner() {
-        return getName().equals(BelongsTo.class.getSimpleName());
+        return BelongsTo.class.getSimpleName().equals(getName());
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateGroup.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateGroup.java
@@ -69,7 +69,7 @@ public final class QueryPredicateGroup implements QueryPredicate {
      * @return a group connecting this group with another group/operation with an AND type
      */
     public QueryPredicateGroup and(QueryPredicate predicate) {
-        if (type.equals(Type.AND)) {
+        if (Type.AND.equals(type)) {
             predicates.add(predicate);
             return this;
         }
@@ -83,7 +83,7 @@ public final class QueryPredicateGroup implements QueryPredicate {
      * @return a group connecting this group with another group/operation with an OR type
      */
     public QueryPredicateGroup or(QueryPredicate predicate) {
-        if (type.equals(Type.OR)) {
+        if (Type.OR.equals(type)) {
             predicates.add(predicate);
             return this;
         }


### PR DESCRIPTION
`KNOWN_NON_NULL.equals(maybeNull)` is always safer than
`maybeNull.equals(KNOWN_NON_NULL)`. In any place this occurs, flip the
equality check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
