### PR TITLE
[aws-datastore] Only start Orchestrator if API configured

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -186,9 +186,11 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     @WorkerThread
     @Override
     public void initialize(@NonNull Context context) {
-        initializeStorageAdapter(context)
-            .andThen(orchestrator.start())
-            .blockingAwait();
+        Completable completable = initializeStorageAdapter(context);
+        if (Amplify.API.getPlugins().size() > 0) {
+            completable = completable.andThen(orchestrator.start());
+        }
+        completable.blockingAwait();
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -33,7 +33,6 @@ import com.amplifyframework.testutils.random.RandomString;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -41,38 +40,41 @@ import org.robolectric.RobolectricTestRunner;
 import java.util.Collections;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public final class AWSDataStorePluginTest {
     private Context context;
     private AWSDataStorePlugin awsDataStorePlugin;
+    private ModelProvider modelProvider;
 
     @Before
     public void setup() {
         this.context = getApplicationContext();
-        ModelProvider modelProvider = SimpleModelProvider.builder()
+        modelProvider = spy(SimpleModelProvider.builder()
             .version(RandomString.string())
             .addModel(Person.class)
-            .build();
+            .build());
         this.awsDataStorePlugin = new AWSDataStorePlugin(modelProvider);
     }
 
     /**
      * Configuring and initializing the plugin succeeds without freezing or
      * crashing the calling thread. Basic. 🙄
-     * @throws JSONException Not expected; on failure to arrange configuration object
-     * @throws DataStoreException Not expected; on failure to configure of initialize plugin
+     * @throws AmplifyException Not expected; on failure to configure of initialize plugin
      */
-    @Ignore("TODO: need a mechanism to re-enable this scenario........")
     @Test
-    public void configureAndInitializeInLocalMode() throws DataStoreException, JSONException {
-        JSONObject pluginJson = new JSONObject().put("syncMode", "none");
-        awsDataStorePlugin.configure(pluginJson, context);
+    public void configureAndInitializeInLocalMode() throws AmplifyException {
+        //Configure DataStore with an empty config (All defaults)
+        awsDataStorePlugin.configure(new JSONObject(), context);
         awsDataStorePlugin.initialize(context);
+        assertSyncProcessorNotStarted();
     }
 
     /**
@@ -93,6 +95,25 @@ public final class AWSDataStorePluginTest {
             .put("syncIntervalInMinutes", 60);
         awsDataStorePlugin.configure(pluginJson, context);
         awsDataStorePlugin.initialize(context);
+        assertSyncProcessorStarted();
+    }
+
+    private void assertSyncProcessorStarted() {
+        boolean syncProcessorInvoked = mockingDetails(modelProvider)
+            .getInvocations()
+            .stream()
+            .anyMatch(invocation -> invocation.getLocation().getSourceFile().contains("SyncProcessor"));
+
+        assertTrue(syncProcessorInvoked);
+    }
+
+    private void assertSyncProcessorNotStarted() {
+        boolean syncProcessorNotInvoked = mockingDetails(modelProvider)
+            .getInvocations()
+            .stream()
+            .noneMatch(invocation -> invocation.getLocation().getSourceFile().contains("SyncProcessor"));
+
+        assertTrue(syncProcessorNotInvoked);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes the initialization of the DataStore plugin such that the `Orchestrator` will only start if the API category is configured for Amplify.

If API is not present, we basically start without the synchronization processes. 

**NOTE on the testing strategy**

I'm asserting whether or not we're in the correct mode, by creating a spy on the modelProvider we're passing to the DataStore plugin. If the `SyncProcessor` interacts with the spy, we know the `Orchestrator` started.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
