### PR TITLE
Add unit tests for predictions result transformers

### DIFF
--- a/aws-predictions/build.gradle
+++ b/aws-predictions/build.gradle
@@ -32,6 +32,7 @@ dependencies {
         // https://github.com/robolectric/robolectric/issues/5245
         exclude group: 'com.google.auto.service', module: 'auto-service'
     }
+    testImplementation dependency.rxjava
 
     androidTestImplementation project(path: ':testutils')
     androidTestImplementation dependency.androidx.test.core

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformers.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformers.java
@@ -19,6 +19,7 @@ import android.graphics.PointF;
 import android.graphics.RectF;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.predictions.models.BoundedKeyValue;
@@ -209,7 +210,13 @@ public final class TextractResultTransformers {
                 .build();
     }
 
-    private static Cell fetchTableCell(Block block, Map<String, Block> blockMap) {
+    @VisibleForTesting
+    @Nullable
+    static Cell fetchTableCell(@Nullable Block block, @NonNull Map<String, Block> blockMap) {
+        Objects.requireNonNull(blockMap);
+        if (block == null || !BlockType.CELL.toString().equals(block.getBlockType())) {
+            return null;
+        }
         StringBuilder wordsBuilder = new StringBuilder();
         AtomicBoolean isSelected = new AtomicBoolean(false);
 

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformers.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformers.java
@@ -19,7 +19,6 @@ import android.graphics.PointF;
 import android.graphics.RectF;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.predictions.models.BoundedKeyValue;
@@ -210,9 +209,8 @@ public final class TextractResultTransformers {
                 .build();
     }
 
-    @VisibleForTesting
     @Nullable
-    static Cell fetchTableCell(@Nullable Block block, @NonNull Map<String, Block> blockMap) {
+    private static Cell fetchTableCell(@Nullable Block block, @NonNull Map<String, Block> blockMap) {
         Objects.requireNonNull(blockMap);
         if (block == null || !BlockType.CELL.toString().equals(block.getBlockType())) {
             return null;

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/AWSPredictionsPluginConfigurationTest.java
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/AWSPredictionsPluginConfigurationTest.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.predictions.aws;
 
 import com.amplifyframework.predictions.PredictionsException;
+import com.amplifyframework.predictions.aws.configuration.IdentifyEntitiesConfiguration;
 import com.amplifyframework.predictions.aws.configuration.InterpretTextConfiguration;
 import com.amplifyframework.predictions.aws.configuration.TranslateTextConfiguration;
 import com.amplifyframework.predictions.models.LanguageType;
@@ -28,7 +29,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public final class AWSPredictionsPluginConfigurationTest {
@@ -121,5 +124,47 @@ public final class AWSPredictionsPluginConfigurationTest {
         assertNotNull(interpretConfig);
         assertEquals(InterpretTextConfiguration.InterpretType.SENTIMENT, interpretConfig.getType());
         assertEquals(NetworkPolicy.OFFLINE, interpretConfig.getNetworkPolicy());
+    }
+
+    /**
+     * Test that configuration with explicit "identifyEntities" section creates
+     * customized entities identification configuration instance for general
+     * entity detection if max-entities or collection ID is invalid.
+     * @throws Exception if configuration fails
+     */
+    @Test
+    public void testIdentifyEntitiesConfiguration() throws Exception {
+        JSONObject json = Resources.readAsJson("configuration-with-identify-entities.json");
+        AWSPredictionsPluginConfiguration pluginConfig = AWSPredictionsPluginConfiguration.fromJson(json);
+
+        // Custom identify entities configuration with invalid match detection settings
+        IdentifyEntitiesConfiguration identifyConfig = pluginConfig.getIdentifyEntitiesConfiguration();
+        assertNotNull(identifyConfig);
+        assertTrue(identifyConfig.isCelebrityDetectionEnabled());
+        assertEquals(NetworkPolicy.AUTO, identifyConfig.getNetworkPolicy());
+        assertEquals(0, identifyConfig.getMaxEntities());
+        assertTrue(identifyConfig.getCollectionId().isEmpty());
+        assertTrue(identifyConfig.isGeneralEntityDetection());
+    }
+
+    /**
+     * Test that configuration with explicit "identifyEntities" section creates
+     * customized entities identification configuration instance for entity
+     * match detection if max-entities and collection ID are both valid.
+     * @throws Exception if configuration fails
+     */
+    @Test
+    public void testIdentifyEntityMatchesConfiguration() throws Exception {
+        JSONObject json = Resources.readAsJson("configuration-with-identify-entity-matches.json");
+        AWSPredictionsPluginConfiguration pluginConfig = AWSPredictionsPluginConfiguration.fromJson(json);
+
+        // Custom identify entities configuration with valid match detection settings
+        IdentifyEntitiesConfiguration identifyConfig = pluginConfig.getIdentifyEntitiesConfiguration();
+        assertNotNull(identifyConfig);
+        assertFalse(identifyConfig.isCelebrityDetectionEnabled());
+        assertEquals(NetworkPolicy.AUTO, identifyConfig.getNetworkPolicy());
+        assertEquals(10, identifyConfig.getMaxEntities());
+        assertEquals("some-collection-id", identifyConfig.getCollectionId());
+        assertFalse(identifyConfig.isGeneralEntityDetection());
     }
 }

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/adapter/RekognitionResultTransformersTest.java
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/adapter/RekognitionResultTransformersTest.java
@@ -20,25 +20,32 @@ import android.graphics.RectF;
 
 import com.amplifyframework.predictions.models.AgeRange;
 import com.amplifyframework.predictions.models.BinaryFeature;
+import com.amplifyframework.predictions.models.IdentifiedText;
 import com.amplifyframework.predictions.models.Landmark;
 import com.amplifyframework.predictions.models.LandmarkType;
+import com.amplifyframework.predictions.models.Polygon;
 import com.amplifyframework.predictions.models.Pose;
 import com.amplifyframework.testutils.FeatureAssert;
+import com.amplifyframework.testutils.random.RandomString;
 
 import com.amazonaws.services.rekognition.model.Beard;
 import com.amazonaws.services.rekognition.model.BoundingBox;
 import com.amazonaws.services.rekognition.model.EyeOpen;
 import com.amazonaws.services.rekognition.model.Eyeglasses;
 import com.amazonaws.services.rekognition.model.FaceDetail;
+import com.amazonaws.services.rekognition.model.Geometry;
 import com.amazonaws.services.rekognition.model.MouthOpen;
 import com.amazonaws.services.rekognition.model.Mustache;
+import com.amazonaws.services.rekognition.model.Point;
 import com.amazonaws.services.rekognition.model.Smile;
 import com.amazonaws.services.rekognition.model.Sunglasses;
+import com.amazonaws.services.rekognition.model.TextDetection;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -54,8 +61,9 @@ import static org.junit.Assert.assertTrue;
  * as intended.
  */
 @RunWith(RobolectricTestRunner.class)
+@SuppressWarnings("ConstantConditions") // NullPointerException will not be thrown
 public final class RekognitionResultTransformersTest {
-    private static final double DELTA = 1E-5; // Enough precision for each pixel per image
+    private static final double DELTA = 1E-5;
 
     private Random random;
 
@@ -70,17 +78,28 @@ public final class RekognitionResultTransformersTest {
      */
     @Test
     public void testBoundingBoxConversion() {
-        BoundingBox box = new BoundingBox()
-                .withHeight(random.nextFloat())
-                .withLeft(random.nextFloat())
-                .withTop(random.nextFloat())
-                .withWidth(random.nextFloat());
-
+        BoundingBox box = randomBox();
         RectF rect = RekognitionResultTransformers.fromBoundingBox(box);
         assertEquals(box.getHeight(), rect.height(), DELTA);
         assertEquals(box.getWidth(), rect.width(), DELTA);
         assertEquals(box.getLeft(), rect.left, DELTA);
         assertEquals(box.getTop(), rect.top, DELTA);
+    }
+
+    /**
+     * Tests that the polygonal boundary from Textract in the form
+     * of list of points is converted to an Amplify shape for polygons.
+     */
+    @Test
+    public void testPolygonConversion() {
+        List<Point> randomPolygon = randomPolygon();
+        Polygon polygon = RekognitionResultTransformers.fromPoints(randomPolygon);
+        List<PointF> actualPoints = polygon.getPoints();
+        List<PointF> expectedPoints = new ArrayList<>();
+        for (Point point : randomPolygon) {
+            expectedPoints.add(new PointF(point.getX(), point.getY()));
+        }
+        assertEquals(expectedPoints, actualPoints);
     }
 
     /**
@@ -126,12 +145,28 @@ public final class RekognitionResultTransformersTest {
     }
 
     /**
+     * Tests that the text detection from Rekognition is converted
+     * to an Amplify image text feature.
+     */
+    @Test
+    public void testTextDetectionConversion() {
+        TextDetection detection = new TextDetection()
+                .withDetectedText(RandomString.string())
+                .withConfidence(random.nextFloat())
+                .withGeometry(randomGeometry());
+
+        // Test text detection conversion
+        IdentifiedText text = RekognitionResultTransformers.fromTextDetection(detection);
+        assertEquals(detection.getDetectedText(), text.getText());
+        assertEquals(detection.getConfidence(), text.getConfidence(), DELTA);
+    }
+
+    /**
      * Tests that the landmarks from Rekognition are converted
      * from a list of individual points to a list of Amplify
      * landmarks that are mapped by their types.
      */
     @Test
-    @SuppressWarnings("ConstantConditions") // NullPointerException will not be thrown
     public void testLandmarksConversion() {
         com.amazonaws.services.rekognition.model.Landmark leftEyeDown =
                 new com.amazonaws.services.rekognition.model.Landmark()
@@ -223,5 +258,31 @@ public final class RekognitionResultTransformersTest {
                 ),
                 features
         );
+    }
+
+    private BoundingBox randomBox() {
+        return new BoundingBox()
+                .withHeight(random.nextFloat())
+                .withLeft(random.nextFloat())
+                .withTop(random.nextFloat())
+                .withWidth(random.nextFloat());
+    }
+
+    private List<Point> randomPolygon() {
+        final int minPoints = 3;
+        List<Point> points = new ArrayList<>();
+        for (int i = 0; i < minPoints; i++) {
+            points.add(new Point()
+                    .withX(random.nextFloat())
+                    .withY(random.nextFloat())
+            );
+        }
+        return points;
+    }
+
+    private Geometry randomGeometry() {
+        return new Geometry()
+                .withBoundingBox(randomBox())
+                .withPolygon(randomPolygon());
     }
 }

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformersTest.java
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformersTest.java
@@ -140,10 +140,10 @@ public final class TextractResultTransformersTest {
 
     /**
      * Tests that the graph of related blocks from Textract is properly
-     * converted to an Amplify cell item.
+     * converted to an Amplify table item.
      */
     @Test
-    public void testTableCellConversion() {
+    public void testTableConversion() {
         Block cellTextBlock = new Block()
                 .withId(RandomString.string())
                 .withText(RandomString.string());
@@ -159,40 +159,6 @@ public final class TextractResultTransformersTest {
                 .withColumnIndex(random.nextInt())
                 .withRelationships(new Relationship()
                         .withIds(cellTextBlock.getId(), cellSelectionBlock.getId()));
-
-        // Construct a map to act as a graph
-        Map<String, Block> blockMap = new HashMap<>();
-        blockMap.put(cellTextBlock.getId(), cellTextBlock);
-        blockMap.put(cellSelectionBlock.getId(), cellSelectionBlock);
-        blockMap.put(cellBlock.getId(), cellBlock);
-
-        // Test block conversion
-        Cell cell = TextractResultTransformers.fetchTableCell(cellBlock, blockMap);
-        assertEquals(cellTextBlock.getText(), cell.getText());
-        assertEquals(cellBlock.getConfidence(), cell.getConfidence(), DELTA);
-        assertTrue(cell.isSelected());
-        assertEquals(cellBlock.getRowIndex() - 1, cell.getRow());
-        assertEquals(cellBlock.getColumnIndex() - 1, cell.getColumn());
-    }
-
-    /**
-     * Tests that the graph of related blocks from Textract is properly
-     * converted to an Amplify table item.
-     */
-    @Test
-    public void testTableConversion() {
-        Block cellTextBlock = new Block()
-                .withId(RandomString.string())
-                .withText(RandomString.string());
-        Block cellBlock = new Block()
-                .withId(RandomString.string())
-                .withBlockType(BlockType.CELL)
-                .withConfidence(random.nextFloat())
-                .withGeometry(randomGeometry())
-                .withRowIndex(random.nextInt())
-                .withColumnIndex(random.nextInt())
-                .withRelationships(new Relationship()
-                        .withIds(cellTextBlock.getId()));
         Block tableBlock = new Block()
                 .withId(RandomString.string())
                 .withBlockType(BlockType.TABLE)
@@ -204,15 +170,24 @@ public final class TextractResultTransformersTest {
         // Construct a map to act as a graph
         Map<String, Block> blockMap = new HashMap<>();
         blockMap.put(cellTextBlock.getId(), cellTextBlock);
+        blockMap.put(cellSelectionBlock.getId(), cellSelectionBlock);
         blockMap.put(cellBlock.getId(), cellBlock);
         blockMap.put(tableBlock.getId(), tableBlock);
 
-        // Test block conversion
+        // Test table block conversion
         Table table = TextractResultTransformers.fetchTable(tableBlock, blockMap);
         assertEquals(1, table.getCells().size());
         assertEquals(tableBlock.getConfidence(), table.getConfidence(), DELTA);
         assertEquals(1, table.getRowSize());
         assertEquals(1, table.getColumnSize());
+
+        // Test cell block conversion
+        Cell cell = table.getCells().iterator().next();
+        assertEquals(cellTextBlock.getText(), cell.getText());
+        assertEquals(cellBlock.getConfidence(), cell.getConfidence(), DELTA);
+        assertTrue(cell.isSelected());
+        assertEquals(cellBlock.getRowIndex() - 1, cell.getRow());
+        assertEquals(cellBlock.getColumnIndex() - 1, cell.getColumn());
     }
 
     /**

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformersTest.java
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformersTest.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import io.reactivex.Observable;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -169,10 +171,8 @@ public final class TextractResultTransformersTest {
 
         // Construct a map to act as a graph
         Map<String, Block> blockMap = new HashMap<>();
-        blockMap.put(cellTextBlock.getId(), cellTextBlock);
-        blockMap.put(cellSelectionBlock.getId(), cellSelectionBlock);
-        blockMap.put(cellBlock.getId(), cellBlock);
-        blockMap.put(tableBlock.getId(), tableBlock);
+        Observable.fromArray(cellTextBlock, cellSelectionBlock, cellBlock, tableBlock)
+                .blockingForEach(block -> blockMap.put(block.getId(), block));
 
         // Test table block conversion
         Table table = TextractResultTransformers.fetchTable(tableBlock, blockMap);
@@ -219,10 +219,8 @@ public final class TextractResultTransformersTest {
 
         // Construct a map to act as a graph
         Map<String, Block> blockMap = new HashMap<>();
-        blockMap.put(valueTextBlock.getId(), valueTextBlock);
-        blockMap.put(keyTextBlock.getId(), keyTextBlock);
-        blockMap.put(valueBlock.getId(), valueBlock);
-        blockMap.put(keyBlock.getId(), keyBlock);
+        Observable.fromArray(valueTextBlock, keyTextBlock, valueBlock, keyBlock)
+                .blockingForEach(block -> blockMap.put(block.getId(), block));
 
         // Test block conversion
         BoundedKeyValue keyValue = TextractResultTransformers.fetchKeyValue(keyBlock, blockMap);

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformersTest.java
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformersTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.aws.adapter;
+
+import android.graphics.PointF;
+import android.graphics.RectF;
+
+import com.amplifyframework.predictions.models.BoundedKeyValue;
+import com.amplifyframework.predictions.models.Cell;
+import com.amplifyframework.predictions.models.IdentifiedText;
+import com.amplifyframework.predictions.models.Polygon;
+import com.amplifyframework.predictions.models.Selection;
+import com.amplifyframework.predictions.models.Table;
+import com.amplifyframework.testutils.random.RandomString;
+
+import com.amazonaws.services.textract.model.Block;
+import com.amazonaws.services.textract.model.BlockType;
+import com.amazonaws.services.textract.model.BoundingBox;
+import com.amazonaws.services.textract.model.EntityType;
+import com.amazonaws.services.textract.model.Geometry;
+import com.amazonaws.services.textract.model.Point;
+import com.amazonaws.services.textract.model.Relationship;
+import com.amazonaws.services.textract.model.SelectionStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that the result transformer utility methods work
+ * as intended.
+ */
+@RunWith(RobolectricTestRunner.class)
+@SuppressWarnings("ConstantConditions") // NullPointerException will not be thrown
+public final class TextractResultTransformersTest {
+    private static final double DELTA = 1E-5;
+
+    private Random random;
+
+    @Before
+    public void setUp() {
+        random = new Random();
+    }
+
+    /**
+     * Tests that the rectangular boundary from Textract
+     * is converted to an equivalent Android rectangle object.
+     */
+    @Test
+    public void testBoundingBoxConversion() {
+        BoundingBox box = randomBox();
+        RectF rect = TextractResultTransformers.fromBoundingBox(box);
+        assertEquals(box.getHeight(), rect.height(), DELTA);
+        assertEquals(box.getWidth(), rect.width(), DELTA);
+        assertEquals(box.getLeft(), rect.left, DELTA);
+        assertEquals(box.getTop(), rect.top, DELTA);
+    }
+
+    /**
+     * Tests that the polygonal boundary from Textract in the form
+     * of list of points is converted to an Amplify shape for polygons.
+     */
+    @Test
+    public void testPolygonConversion() {
+        List<Point> randomPolygon = randomPolygon();
+        Polygon polygon = TextractResultTransformers.fromPoints(randomPolygon);
+        List<PointF> actualPoints = polygon.getPoints();
+        List<PointF> expectedPoints = new ArrayList<>();
+        for (Point point : randomPolygon) {
+            expectedPoints.add(new PointF(point.getX(), point.getY()));
+        }
+        assertEquals(expectedPoints, actualPoints);
+    }
+
+    /**
+     * Tests that the individual block from Textract is converted to
+     * an Amplify image text feature.
+     */
+    @Test
+    public void testIdentifiedTextConversion() {
+        Block block = new Block()
+                .withText(RandomString.string())
+                .withConfidence(random.nextFloat())
+                .withGeometry(randomGeometry())
+                .withPage(random.nextInt());
+
+        // Test block conversion
+        IdentifiedText text = TextractResultTransformers.fetchIdentifiedText(block);
+        assertEquals(block.getText(), text.getText());
+        assertEquals(block.getConfidence(), text.getConfidence(), DELTA);
+        assertEquals((int) block.getPage(), text.getPage());
+    }
+
+    /**
+     * Tests that the individual block from Textract is properly
+     * converted to an Amplify selection item.
+     */
+    @Test
+    public void testSelectionConversion() {
+        Block block;
+        Selection selection;
+
+        // Assert that SELECTED sets it to selected
+        block = new Block()
+                .withSelectionStatus(SelectionStatus.SELECTED)
+                .withGeometry(randomGeometry());
+        selection = TextractResultTransformers.fetchSelection(block);
+        assertTrue(selection.isSelected());
+
+        // Assert that NOT_SELECTED sets it to not selected
+        block = new Block()
+                .withSelectionStatus(SelectionStatus.NOT_SELECTED)
+                .withGeometry(randomGeometry());
+        selection = TextractResultTransformers.fetchSelection(block);
+        assertFalse(selection.isSelected());
+    }
+
+    /**
+     * Tests that the graph of related blocks from Textract is properly
+     * converted to an Amplify cell item.
+     */
+    @Test
+    public void testTableCellConversion() {
+        Block cellTextBlock = new Block()
+                .withId(RandomString.string())
+                .withText(RandomString.string());
+        Block cellSelectionBlock = new Block()
+                .withId(RandomString.string())
+                .withSelectionStatus(SelectionStatus.SELECTED);
+        Block cellBlock = new Block()
+                .withId(RandomString.string())
+                .withBlockType(BlockType.CELL)
+                .withConfidence(random.nextFloat())
+                .withGeometry(randomGeometry())
+                .withRowIndex(random.nextInt())
+                .withColumnIndex(random.nextInt())
+                .withRelationships(new Relationship()
+                        .withIds(cellTextBlock.getId(), cellSelectionBlock.getId()));
+
+        // Construct a map to act as a graph
+        Map<String, Block> blockMap = new HashMap<>();
+        blockMap.put(cellTextBlock.getId(), cellTextBlock);
+        blockMap.put(cellSelectionBlock.getId(), cellSelectionBlock);
+        blockMap.put(cellBlock.getId(), cellBlock);
+
+        // Test block conversion
+        Cell cell = TextractResultTransformers.fetchTableCell(cellBlock, blockMap);
+        assertEquals(cellTextBlock.getText(), cell.getText());
+        assertEquals(cellBlock.getConfidence(), cell.getConfidence(), DELTA);
+        assertTrue(cell.isSelected());
+        assertEquals(cellBlock.getRowIndex() - 1, cell.getRow());
+        assertEquals(cellBlock.getColumnIndex() - 1, cell.getColumn());
+    }
+
+    /**
+     * Tests that the graph of related blocks from Textract is properly
+     * converted to an Amplify table item.
+     */
+    @Test
+    public void testTableConversion() {
+        Block cellTextBlock = new Block()
+                .withId(RandomString.string())
+                .withText(RandomString.string());
+        Block cellBlock = new Block()
+                .withId(RandomString.string())
+                .withBlockType(BlockType.CELL)
+                .withConfidence(random.nextFloat())
+                .withGeometry(randomGeometry())
+                .withRowIndex(random.nextInt())
+                .withColumnIndex(random.nextInt())
+                .withRelationships(new Relationship()
+                        .withIds(cellTextBlock.getId()));
+        Block tableBlock = new Block()
+                .withId(RandomString.string())
+                .withBlockType(BlockType.TABLE)
+                .withConfidence(random.nextFloat())
+                .withGeometry(randomGeometry())
+                .withRelationships(new Relationship()
+                        .withIds(cellBlock.getId()));
+
+        // Construct a map to act as a graph
+        Map<String, Block> blockMap = new HashMap<>();
+        blockMap.put(cellTextBlock.getId(), cellTextBlock);
+        blockMap.put(cellBlock.getId(), cellBlock);
+        blockMap.put(tableBlock.getId(), tableBlock);
+
+        // Test block conversion
+        Table table = TextractResultTransformers.fetchTable(tableBlock, blockMap);
+        assertEquals(1, table.getCells().size());
+        assertEquals(tableBlock.getConfidence(), table.getConfidence(), DELTA);
+        assertEquals(1, table.getRowSize());
+        assertEquals(1, table.getColumnSize());
+    }
+
+    /**
+     * Tests that the graph of related blocks from Textract is properly
+     * converted to an Amplify key-value pair item.
+     */
+    @Test
+    public void testKeyValueConversion() {
+        Block valueTextBlock = new Block()
+                .withId(RandomString.string())
+                .withText(RandomString.string());
+        Block keyTextBlock = new Block()
+                .withId(RandomString.string())
+                .withText(RandomString.string());
+        Block valueBlock = new Block()
+                .withId(RandomString.string())
+                .withBlockType(BlockType.KEY_VALUE_SET)
+                .withEntityTypes(EntityType.VALUE.toString())
+                .withRelationships(new Relationship()
+                        .withIds(valueTextBlock.getId()));
+        Block keyBlock = new Block()
+                .withId(RandomString.string())
+                .withBlockType(BlockType.KEY_VALUE_SET)
+                .withEntityTypes(EntityType.KEY.toString())
+                .withConfidence(random.nextFloat())
+                .withGeometry(randomGeometry())
+                .withRelationships(new Relationship()
+                        .withIds(keyTextBlock.getId(), valueBlock.getId()));
+
+        // Construct a map to act as a graph
+        Map<String, Block> blockMap = new HashMap<>();
+        blockMap.put(valueTextBlock.getId(), valueTextBlock);
+        blockMap.put(keyTextBlock.getId(), keyTextBlock);
+        blockMap.put(valueBlock.getId(), valueBlock);
+        blockMap.put(keyBlock.getId(), keyBlock);
+
+        // Test block conversion
+        BoundedKeyValue keyValue = TextractResultTransformers.fetchKeyValue(keyBlock, blockMap);
+        assertEquals(keyTextBlock.getText(), keyValue.getKey());
+        assertEquals(valueTextBlock.getText(), keyValue.getKeyValue());
+        assertEquals(keyBlock.getConfidence(), keyValue.getConfidence(), DELTA);
+    }
+
+    private BoundingBox randomBox() {
+        return new BoundingBox()
+                .withHeight(random.nextFloat())
+                .withLeft(random.nextFloat())
+                .withTop(random.nextFloat())
+                .withWidth(random.nextFloat());
+    }
+
+    private List<Point> randomPolygon() {
+        final int minPoints = 3;
+        List<Point> points = new ArrayList<>();
+        for (int i = 0; i < minPoints; i++) {
+            points.add(new Point()
+                    .withX(random.nextFloat())
+                    .withY(random.nextFloat())
+            );
+        }
+        return points;
+    }
+
+    private Geometry randomGeometry() {
+        return new Geometry()
+                .withBoundingBox(randomBox())
+                .withPolygon(randomPolygon());
+    }
+}

--- a/aws-predictions/src/test/resources/configuration-with-identify-entities.json
+++ b/aws-predictions/src/test/resources/configuration-with-identify-entities.json
@@ -1,0 +1,11 @@
+{
+  "defaultRegion": "us-west-1",
+  "identify": {
+    "identifyEntities": {
+      "maxEntities": "0",
+      "celebrityDetectionEnabled": "true",
+      "region": "us-west-2",
+      "defaultNetworkPolicy": "auto"
+    }
+  }
+}

--- a/aws-predictions/src/test/resources/configuration-with-identify-entity-matches.json
+++ b/aws-predictions/src/test/resources/configuration-with-identify-entity-matches.json
@@ -1,0 +1,12 @@
+{
+  "defaultRegion": "us-west-1",
+  "identify": {
+    "identifyEntities": {
+      "maxEntities": "10",
+      "celebrityDetectionEnabled": "false",
+      "region": "us-west-2",
+      "defaultNetworkPolicy": "auto",
+      "collectionId": "some-collection-id"
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Unit test for AWS Textract result -> Amplify model transformers
* Add more unit tests for AWS Rekognition result -> Amplify model transformers
* Add entities detection configuration unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
