### PR TITLE
Do not require a particular profile to run copy-configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,8 @@ commands:
       - run:
           name: configure aws profile
           command: |
-            aws configure --profile amplify_sdk_test set region us-west-2
-            echo -e "[amplify_sdk_test]\naws_access_key_id=${AWS_ACCESS_KEY_ID_TEST}\naws_secret_access_key=${AWS_SECRET_ACCESS_KEY_TEST}\n" >> ~/.aws/credentials
+            echo -e "[default]\naws_access_key_id=${AWS_ACCESS_KEY_ID_TEST}\naws_secret_access_key=${AWS_SECRET_ACCESS_KEY_TEST}\n" >> ~/.aws/credentials
+            echo -e "[default]\nregion=us-west-2\noutput=json\n" > ~/.aws/config
   setup_emulator:
     description: >-
       setup emulator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ commands:
       - run:
           name: configure aws profile
           command: |
+            mkdir ~/.aws
             echo -e "[default]\naws_access_key_id=${AWS_ACCESS_KEY_ID_TEST}\naws_secret_access_key=${AWS_SECRET_ACCESS_KEY_TEST}\n" >> ~/.aws/credentials
             echo -e "[default]\nregion=us-west-2\noutput=json\n" > ~/.aws/config
   setup_emulator:

--- a/.circleci/copy-configs
+++ b/.circleci/copy-configs
@@ -3,10 +3,6 @@
 set -x
 set -e
 
-# In your ~/.aws/config and ~/.aws/credentials, we expect this profile
-# It must have S3 read-only access to the config bucket.
-readonly cli_profile='amplify_sdk_test'
-
 # This bucket contains a collection of config files that are used by the
 # integration tests. They contain sensitive
 # tokens/credentials/identifiers, so are not published publicly.
@@ -73,8 +69,7 @@ readonly end_index=$(($source_array_size - 1))
 
 # Iterate source and target, coying out of s3 to local path.
 for index in $(seq $start_index $end_index); do
-    aws --profile "$cli_profile" \
-        s3 cp \
+    aws s3 cp \
         "${sources[$index]}" \
         "${targets[$index]}"
 done


### PR DESCRIPTION
Instead of requiring that credentials be kept in `~/.aws/credentials`, in
a profile with a particular name, the credentials will be obtained via
environment variables, e.g.:
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_SESSION_TOKEN`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
