### PR TITLE
API Pagination

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -103,6 +103,15 @@ final class AppSyncGraphQLRequestFactory {
             Class<T> modelClass,
             QueryPredicate predicate
     ) throws ApiException {
+        return buildQuery(modelClass, predicate, DEFAULT_QUERY_LIMIT, null);
+    }
+
+    static <T extends Model> GraphQLRequest<T> buildQuery(
+            Class<T> modelClass,
+            QueryPredicate predicate,
+            int limit,
+            String nextToken
+    ) throws ApiException {
         try {
             StringBuilder doc = new StringBuilder();
             Map<String, Object> variables = new HashMap<>();
@@ -124,8 +133,11 @@ final class AppSyncGraphQLRequestFactory {
 
             if (predicate != null) {
                 variables.put("filter", parsePredicate(predicate));
-                variables.put("limit", DEFAULT_QUERY_LIMIT);
             }
+            if(nextToken != null) {
+                variables.put("nextToken", nextToken);
+            }
+            variables.put("limit", limit);
 
             return new GraphQLRequest<>(
                     doc.toString(),

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
@@ -41,6 +41,7 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
     private static final String DATA_KEY = "data";
     private static final String ERRORS_KEY = "errors";
     private static final String ITEMS_KEY = "items";
+    private static final String NEXT_TOKEN_KEY = "nextToken";
 
     private final Gson gson;
 
@@ -124,7 +125,11 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
                 jsonData.getAsJsonObject().has(ITEMS_KEY)
         ) {
             Iterable<T> data = parseDataAsList(jsonData.getAsJsonObject().get(ITEMS_KEY), classToCast);
-            return new GraphQLResponse<>(data, errors);
+            String nextToken = null;
+            if(jsonData.getAsJsonObject().has(NEXT_TOKEN_KEY) && jsonData.getAsJsonObject().get(NEXT_TOKEN_KEY).isJsonPrimitive()) {
+                nextToken = jsonData.getAsJsonObject().get(NEXT_TOKEN_KEY).getAsString();
+            }
+            return new GraphQLResponse<>(data, errors, nextToken);
         } else if (jsonData.isJsonObject() || jsonData.isJsonPrimitive() || JsonElement.class.equals(classToCast)) {
             T data = parseData(jsonData, classToCast);
             return new GraphQLResponse<>(Collections.singletonList(data), errors);

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
@@ -35,19 +35,30 @@ import java.util.Objects;
 public final class GraphQLResponse<T> {
     private final T data;
     private final List<Error> errors;
+    private final String nextToken;
 
     /**
      * Constructs a wrapper for GraphQL response.
      * @param data response data with user-defined cast type
-     * @param errors list of error responses as defined
-     *               by GraphQL doc
+     * @param errors list of error responses as defined by GraphQL doc
      */
     public GraphQLResponse(@Nullable T data, @Nullable List<Error> errors) {
+        this(data, errors, null);
+    }
+
+    /**
+     * Constructs a wrapper for GraphQL response.
+     * @param data response data with user-defined cast type
+     * @param errors list of error responses as defined by GraphQL doc
+     * @param nextToken token for retrieving the next batch of results if there are any, otherwise null.
+     */
+    public GraphQLResponse(@Nullable T data, @Nullable List<Error> errors, @Nullable String nextToken) {
         this.data = data;
         this.errors = new ArrayList<>();
         if (errors != null) {
             this.errors.addAll(errors);
         }
+        this.nextToken = nextToken;
     }
 
     /**
@@ -81,6 +92,23 @@ public final class GraphQLResponse<T> {
      */
     public boolean hasData() {
         return data != null;
+    }
+
+    /**
+     * Gets the token for fetching more results, if there are any.
+     * @return nextToken
+     */
+    @Nullable
+    public String getNextToken() {
+        return nextToken;
+    }
+
+    /**
+     * Checks if a nextToken exists, indicating more results can be fetched.
+     * @return true if nextToken is not null, false otherwise
+     */
+    public boolean hasNextToken() {
+        return nextToken != null;
     }
 
     @Override


### PR DESCRIPTION
*Goal:* 
 - Expose pagination related properties so that datastore can query API and obtain all results.

*Description of changes:*
 - Adds `nextToken` property to GraphQLResponse
 - Add new AppSyncGraphQLRequestFactory.buildQuery method which accepts `limit` and `nextToken`
 
*Problems with this approach:*
1.  I've added `nextToken` as a property of GraphQLResponse, though this doesn't feel right because `nextToken` is not part of the [GraphQL spec](https://spec.graphql.org/June2018/#sec-Response-Format), it is specific to AppSync.  

      * ~~The GraphQL spec does allow for an `extensions` object at the same level as `data` and `errors`. It would probably make sense to move `nextToken` into this `extensions` map on the client side.  This is very similar to what we ended up doing with custom fields on `GraphQLResponse.Error`~~
      * `nextToken` is at the same levels as `items` in the response JSON, so I think it actually doesn't make sense to modify GraphQLResponse at all, and instead create a new type which wraps `items` and `nextToken`, which is [how it's implemented on iOS](https://github.com/aws-amplify/amplify-ios/blob/461c3cfd8923fbbb6eb10b60495b0f4594879cf4/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift).  I will investigate this further.


2. I updated the AppSyncGraphQLRequestFactory (part of `aws-api`) to support passing in `limit` and `nextToken` so that requests can be made.  However, this factory is part of the API plugin, so it can't be used by datastore.
     * I don't think this is actually an issue that blocks datastore from making paginated requests, because datastore is already able to construct whatever GraphQLRequest it needs.  Adding nextToken and limit to the request shouldn't require an changes in `aws-api`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
