### PR TITLE
[aws-datastore] PendingMutations are now Comparable according to their creation times

### DIFF
--- a/aws-datastore/build.gradle
+++ b/aws-datastore/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation dependency.gson
     implementation dependency.rxjava
     implementation dependency.rxandroid
+    implementation dependency.uuidgen
 
     testImplementation project(path: ':testmodels')
     testImplementation project(path: ':testutils')

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
@@ -21,6 +21,7 @@ import androidx.annotation.WorkerThread;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryField;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
@@ -65,8 +66,10 @@ final class MutationOutbox {
     @NonNull
     Single<Boolean> hasPendingMutation(@NonNull String modelId) {
         Objects.requireNonNull(modelId);
+        // Note that the getId() on the mutation is different from the ID of the decoded model.
+        QueryPredicate hasMatchingId = QueryField.field("decodedModelId").eq(modelId);
         return Single.create(emitter ->
-            storage.query(PendingMutation.PersistentRecord.class, QueryField.field("id").eq(modelId),
+            storage.query(PendingMutation.PersistentRecord.class, hasMatchingId,
                 results -> emitter.onSuccess(results.hasNext()),
                 emitter::onError
             )

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
@@ -37,7 +37,7 @@ import java.util.UUID;
  * logic onto them, before ultimately uploading to a remote endpoint.
  * @param <T> Type of model that has experienced a mutation
  */
-public final class PendingMutation<T extends Model> implements Comparable<PendingMutation<T>> {
+public final class PendingMutation<T extends Model> implements Comparable<PendingMutation<? extends Model>> {
     private final T mutatedItem;
     private final Class<T> classOfMutatedItem;
     private final Type mutationType;
@@ -65,7 +65,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
             @NonNull T mutatedItem,
             @NonNull Class<T> classOfMutatedItem,
             @NonNull Type mutationType) {
-        return new PendingMutation<T>(
+        return new PendingMutation<>(
             Objects.requireNonNull(mutationId),
             Objects.requireNonNull(mutatedItem),
             Objects.requireNonNull(classOfMutatedItem),
@@ -198,7 +198,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      * @return -1, 0, 1 if this mutation is smaller, same, or bigger than another
      */
     @Override
-    public int compareTo(@NonNull PendingMutation<T> another) {
+    public int compareTo(@NonNull PendingMutation<? extends Model> another) {
         Objects.requireNonNull(another);
         return this.mutationId.compareTo(another.getMutationId());
     }
@@ -216,6 +216,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      * referenced model is just a Gson-serialized String version of itself -- handled external
      * to the data modeling system.
      */
+    @SuppressWarnings("unused")
     @ModelConfig(pluralName = "PersistentRecords")
     @Index(fields = "decodedModelClassName", name = "decodedModelClassNameBasedIndex")
     public static final class PersistentRecord implements Model, Comparable<PersistentRecord> {
@@ -259,6 +260,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
          * @return The record id
          */
         @NonNull
+        @Override
         public String getId() {
             return this.id;
         }
@@ -273,7 +275,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
          *         decoded and {@link Model#getId()} were called.
          */
         @NonNull
-        public String getDecodedModelId() {
+        String getDecodedModelId() {
             return this.decodedModelId;
         }
 
@@ -283,7 +285,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
          * @return The model data, in its encoded string form
          */
         @NonNull
-        public String getEncodedModelData() {
+        String getEncodedModelData() {
             return this.encodedModelData;
         }
 
@@ -294,7 +296,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
          * @return Class of encoded model
          */
         @NonNull
-        public String getDecodedModelClassName() {
+        String getDecodedModelClassName() {
             return decodedModelClassName;
         }
 
@@ -362,7 +364,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
          * Utility for construction of {@link PersistentRecord} through chained configurator calls.
          * @param <T> Type of model for which a pending mutation is being built
          */
-        public static final class Builder<T extends Model> {
+        static final class Builder<T extends Model> {
             private TimeBasedUuid recordId;
             private UUID decodedModelId;
             private String encodedModelData;
@@ -374,7 +376,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
              * @return Current builder, for fluent configuration chaining
              */
             @NonNull
-            public PersistentRecord.Builder<T> recordId(@NonNull TimeBasedUuid timeBasedUuid) {
+            PersistentRecord.Builder<T> recordId(@NonNull TimeBasedUuid timeBasedUuid) {
                 Objects.requireNonNull(timeBasedUuid);
                 this.recordId = timeBasedUuid;
                 return this;
@@ -389,7 +391,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
              * @return The ID of the model, when that model is in its decoded form
              */
             @NonNull
-            public PersistentRecord.Builder<T> decodedModelId(@NonNull String decodedModelId) {
+            PersistentRecord.Builder<T> decodedModelId(@NonNull String decodedModelId) {
                 Objects.requireNonNull(decodedModelId);
                 // This is stored this way for the purpose of validating hte input.
                 this.decodedModelId = UUID.fromString(decodedModelId);
@@ -403,7 +405,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
              * @return Current Builder instance, for fluent configuration chaining
              */
             @NonNull
-            public PersistentRecord.Builder<T> encodedModelData(@NonNull String encodedModelData) {
+            PersistentRecord.Builder<T> encodedModelData(@NonNull String encodedModelData) {
                 this.encodedModelData = Objects.requireNonNull(encodedModelData);
                 return this;
             }
@@ -417,7 +419,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
              * @return Current builder for fluent method chaining
              */
             @NonNull
-            public PersistentRecord.Builder<T> decodedModelClassName(@NonNull String decodedModelClassName) {
+            PersistentRecord.Builder<T> decodedModelClassName(@NonNull String decodedModelClassName) {
                 this.decodedModelClassName = Objects.requireNonNull(decodedModelClassName);
                 return this;
             }
@@ -427,7 +429,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
              * @return A new instance of a {@link PersistentRecord}.
              */
             @NonNull
-            public PendingMutation.PersistentRecord build() {
+            PendingMutation.PersistentRecord build() {
                 return new PendingMutation.PersistentRecord(
                     Objects.requireNonNull(recordId).toString(),
                     Objects.requireNonNull(decodedModelId).toString(),
@@ -441,7 +443,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     /**
      * The type of mutation this is.
      */
-    public enum Type {
+    enum Type {
         /**
          * A model-creation mutation.
          */
@@ -455,7 +457,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
         /**
          * The removal of a previously-created model.
          */
-        DELETE;
+        DELETE
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/TimeBasedUuid.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/TimeBasedUuid.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import androidx.annotation.NonNull;
+
+import com.fasterxml.uuid.Generators;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A version 1, time-based UUID.
+ *
+ * This is uses instead of {@link UUID} directly, so that we can encapsulate
+ * how the UUID is generated. This implementation uses FasterXML's Java UUID Generator.
+ * But, we want to encapsulate that behind our own facade, here.
+ *
+ * The class is {@link Comparable}, so that we can sort based on timestamp.
+ *
+ * @see <a href="https://www.ietf.org/rfc/rfc4122.txt">RFC 4122</a>
+ */
+final class TimeBasedUuid implements Comparable<TimeBasedUuid> {
+    private final UUID delegate;
+
+    private TimeBasedUuid(UUID delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Creates a time-based UUID.
+     * @return A time-based UUID
+     */
+    static TimeBasedUuid create() {
+        UUID delegate = Generators.timeBasedGenerator().generate();
+        validateVersion(delegate);
+        return new TimeBasedUuid(delegate);
+    }
+
+    static TimeBasedUuid fromString(@NonNull String uuid) {
+        Objects.requireNonNull(uuid);
+        UUID delegate = UUID.fromString(uuid);
+        validateVersion(delegate);
+        return new TimeBasedUuid(delegate);
+    }
+
+    private static void validateVersion(UUID delegate) {
+        if (1 != delegate.version()) {
+            throw new IllegalStateException("Found UUID that is not a V1, time-based, UUID.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        TimeBasedUuid that = (TimeBasedUuid) thatObject;
+
+        return delegate.equals(that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public int compareTo(@NonNull TimeBasedUuid another) {
+        Objects.requireNonNull(another);
+        return (int) Math.signum(this.delegate.timestamp() - another.delegate.timestamp());
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/PendingMutationPersistentRecordTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/PendingMutationPersistentRecordTest.java
@@ -52,6 +52,12 @@ public class PendingMutationPersistentRecordTest {
                 .type(String.class)
                 .build(),
             ModelField.builder()
+                .name("decodedModelId")
+                .targetType("String")
+                .isRequired(true)
+                .type(String.class)
+                .build(),
+            ModelField.builder()
                 .name("encodedModelData")
                 .targetType("String")
                 .isRequired(true)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PendingMutationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PendingMutationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Tests the {@link PendingMutation}.
+ */
+public final class PendingMutationTest {
+    private Random random;
+
+    /**
+     * Sets up test dependencies.
+     */
+    @Before
+    public void setup() {
+        random = new Random();
+    }
+
+    /**
+     * It is possible to sort pending mutations according to their TimeBasedUUID field.
+     */
+    @Test
+    public void pendingMutationsAreComparable() {
+        // First, create a bunch of pending mutations.
+        List<PendingMutation<BlogOwner>> expectedOrder = new ArrayList<>();
+        final int desiredQuantity = 10;
+        for (int index = 0; index < desiredQuantity; index++) {
+            BlogOwner blogger = BlogOwner.builder()
+                .name(String.format(Locale.US, "Blogger #%d", index))
+                .build();
+            expectedOrder.add(PendingMutation.creation(blogger, BlogOwner.class));
+        }
+
+        // Okay! Now, scatter them.
+        List<PendingMutation<BlogOwner>> outOfOrder = new ArrayList<>(expectedOrder);
+        //noinspection ComparatorMethodParameterNotUsed Intentional; result is random
+        Collections.sort(outOfOrder, (one, two) -> random.nextInt());
+        assertNotEquals(expectedOrder, outOfOrder);
+
+        // Now sort them according to the item comparator, {@link PendingMutation#compareTo(Object)}.
+        List<PendingMutation<BlogOwner>> actualOrder = new ArrayList<>(outOfOrder);
+        Collections.sort(actualOrder);
+
+        assertEquals(expectedOrder, actualOrder);
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TimeBasedUuidTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TimeBasedUuidTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+
+/**
+ * Tests the {@link TimeBasedUuid}.
+ */
+public final class TimeBasedUuidTest {
+    private Random random;
+
+    /**
+     * Sets up test dependencies.
+     */
+    @Before
+    public void setup() {
+        this.random = new Random();
+    }
+
+    /**
+     * Time-based UUIDs should be comparable, and they are compared according
+     * to their timestamp. An out-of-order sequence of these UUIDs should be sort-able.
+     * Doing so should restore them to the ordering in which they were created.
+     */
+    @Test
+    public void timeBasedUuidsMayBeSortedByCreationTime() {
+        // First, make a bunch of TimeBasedUuids.
+        List<TimeBasedUuid> expectedOrder = new ArrayList<>();
+        final int amountDesired = 10;
+        for (int index = 0; index < amountDesired; index++) {
+            expectedOrder.add(TimeBasedUuid.create());
+        }
+
+        // Now, scatter them, into a new array.
+        List<TimeBasedUuid> randomOrder = new ArrayList<>(expectedOrder);
+        Collections.sort(randomOrder, (one, two) -> random.nextInt());
+        // Sanity check: this is actually out of order, now, right?
+        assertNotEquals(expectedOrder, randomOrder);
+
+        // Act! sort them using the *default* comparator for the items.
+        List<TimeBasedUuid> actualSortedOrder = new ArrayList<>(randomOrder);
+        Collections.sort(actualSortedOrder);
+
+        assertEquals(expectedOrder, actualSortedOrder);
+    }
+
+    /**
+     * Two {@link TimeBasedUuid} with the same string representation
+     * should be equals().
+     */
+    @Test
+    public void timeBasedUNIDsHasSaneEqualsImplementation() {
+        // Create a record, get its value as String.
+        TimeBasedUuid first = TimeBasedUuid.create();
+        String firstUuidAsString = first.toString();
+
+        // Now, reconstruct it.
+        TimeBasedUuid second = TimeBasedUuid.fromString(firstUuidAsString);
+
+        // This is a different object instance:
+        assertNotSame(first, second);
+        // But, they are considered to be equals() based on the content of their character!
+        assertEquals(first, second);
+    }
+
+    /**
+     * Two {@link TimeBasedUuid}s with the same string contents should both evaluate
+     * to the same hash-code. This way they can be included into collections safely, etc.
+     */
+    @Test
+    public void timeBasedUuidHasSanHashCode() {
+        TimeBasedUuid first = TimeBasedUuid.create();
+        TimeBasedUuid second = TimeBasedUuid.fromString(first.toString());
+
+        final Set<TimeBasedUuid> uuids = new HashSet<>();
+        uuids.add(first);
+        uuids.add(second);
+        assertEquals(1, uuids.size());
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TimeBasedUuidTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TimeBasedUuidTest.java
@@ -94,7 +94,7 @@ public final class TimeBasedUuidTest {
      * to the same hash-code. This way they can be included into collections safely, etc.
      */
     @Test
-    public void timeBasedUuidHasSanHashCode() {
+    public void timeBasedUuidHasSaneHashCode() {
         TimeBasedUuid first = TimeBasedUuid.create();
         TimeBasedUuid second = TimeBasedUuid.fromString(first.toString());
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ ext {
         rxjava: 'io.reactivex.rxjava2:rxjava:2.2.13',
         tensorflow: 'org.tensorflow:tensorflow-lite:2.0.0',
         threetenabp: 'com.jakewharton.threetenabp:threetenabp:1.2.3',
+        uuidgen: 'com.fasterxml.uuid:java-uuid-generator:4.0.1',
 
         junit: 'junit:junit:4.13',
         mockito: 'org.mockito:mockito-core:3.1.0',


### PR DESCRIPTION
Changes the ID type of the `PendingMutation`. The `PendingMutation` now
has its own UUID. A mechnism still exists to obtain the ID of the
associated model:

    pendingMutation.getMutationId();
    pendingMutation.getMutatedItem().getId();

The `PendingMuation.PersistentRecord` now has *two* IDs, a "mutation
ID", and a "decoded model ID":

    record.getId();
    record.getDecodedModelId();

Previously, the getId() on the record would return the same ID as
`pendingMutation.getMutatedItem().getId()`.

After this change, the mutation ID is uniquely for the PendingMutation
itself. This ID is also of a different type. It is a time-based UUIDv1.
This type of UUID was chosen as it may be sorted according to its
timestamp. And as a consequence, `PendingMutation`s themselves may now
be sorted by their UUIDv1s. `PendingMutation.PersistentRecord`s use this
as their primary `getId()` value.

The old ID of `PendingMutation.PersistentRecord` is now available by
`getDecodedModelIs()`. This is the ID of the _associated model_ -- the
thing that had undergone some mutation, to begin with. As before, this
UUID is still a v4 UUID, maintained for its technical superiority over
the time-based V1. This value is stored on the record, so that we can
still query for records based on _model ID_, which is what is generally
used around the DataStore system.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
