### PR TITLE
[aws-datastore] Test reliability in TimeBasedUuidTest

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TimeBasedUuidTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TimeBasedUuidTest.java
@@ -26,7 +26,6 @@ import java.util.Random;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 
 /**
@@ -59,9 +58,10 @@ public final class TimeBasedUuidTest {
 
         // Now, scatter them, into a new array.
         List<TimeBasedUuid> randomOrder = new ArrayList<>(expectedOrder);
-        Collections.sort(randomOrder, (one, two) -> random.nextInt());
-        // Sanity check: this is actually out of order, now, right?
-        assertNotEquals(expectedOrder, randomOrder);
+        while (expectedOrder.equals(randomOrder)) {
+            //noinspection ComparatorMethodParameterNotUsed Intenionally ignored in favor of random result
+            Collections.sort(randomOrder, (one, two) -> random.nextInt());
+        }
 
         // Act! sort them using the *default* comparator for the items.
         List<TimeBasedUuid> actualSortedOrder = new ArrayList<>(randomOrder);


### PR DESCRIPTION
The mechanism to obtain a unique, randomly-ordered list is subtly
flawed. It does produce a random list, but that list may not be unique
from the input.

As a consequence, the call to `assertNotEquals` would occasionally cause
the test to fail. This was observed on a development machine, already.

Instead, keep re-ordering the list in random order, until it is
different.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
