### PR TITLE
[aws-datastore] Logging cleanups

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/model/ModelHelper.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/model/ModelHelper.java
@@ -17,7 +17,6 @@ package com.amplifyframework.datastore.model;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
-import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.datastore.DataStoreException;
@@ -30,8 +29,7 @@ import java.lang.reflect.Method;
  * Helpers class that contains {@link Model} related utilities.
  */
 public final class ModelHelper {
-
-    private static final Logger LOGGER = Amplify.Logging.forCategory(CategoryType.DATASTORE);
+    private static final Logger LOGGER = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
     private ModelHelper() {
         // contains only static helper methods and should not be instantiated

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -16,7 +16,6 @@
 package com.amplifyframework.datastore.storage.sqlite;
 
 import android.database.Cursor;
-
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
@@ -32,6 +31,7 @@ import com.amplifyframework.datastore.model.ModelHelper;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteColumn;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteTable;
 import com.amplifyframework.logging.Logger;
+
 import com.google.gson.Gson;
 
 import java.io.IOException;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -16,11 +16,11 @@
 package com.amplifyframework.datastore.storage.sqlite;
 
 import android.database.Cursor;
+
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
-import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelSchema;
@@ -32,7 +32,6 @@ import com.amplifyframework.datastore.model.ModelHelper;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteColumn;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteTable;
 import com.amplifyframework.logging.Logger;
-
 import com.google.gson.Gson;
 
 import java.io.IOException;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -50,8 +50,7 @@ import java.util.Objects;
  * valid in a <code>SQLiteStatement</code>.
  */
 final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConverter<Cursor, Model> {
-
-    private static final Logger LOGGER = Amplify.Logging.forCategory(CategoryType.DATASTORE);
+    private static final Logger LOGGER = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
     private final Class<? extends Model> modelType;
     private final ModelSchemaRegistry modelSchemaRegistry;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -633,8 +633,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             int columnIndex,
             @Nullable Object value
     ) throws DataStoreException {
-        System.out.println("SQLiteStorageAdapter.bindValueToStatement");
-        System.out.println("value = " + value);
+        LOG.verbose("SQLiteStorageAdapter.bindValueToStatement");
+        LOG.verbose("value = " + value);
         if (value == null) {
             statement.bindNull(columnIndex);
         } else if (value instanceof String) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -47,8 +47,8 @@ import java.util.List;
  *     {@code
  *     QueryPredicate nameCheck = QueryField.field("name").eq("Jane");
  *     SQLPredicate adapted = new SQLPredicate(nameCheck);
- *     System.out.println(adapted.toString()); // Prints "name = ?"
- *     System.out.println(adapted.getSelectionArgs()); // Prints "[Jane]"
+ *     LOG.verbose(adapted.toString()); // Prints "name = ?"
+ *     LOG.verbose(adapted.getSelectionArgs()); // Prints "[Jane]"
  *     }
  *</pre>
  *

--- a/core/src/main/java/com/amplifyframework/logging/AndroidLoggingPlugin.java
+++ b/core/src/main/java/com/amplifyframework/logging/AndroidLoggingPlugin.java
@@ -28,7 +28,6 @@ import org.json.JSONObject;
  * AWS' default implementation of the {@link LoggingCategoryBehavior},
  * which emits logs to Android's {@link Log} class.
  */
-@SuppressWarnings("WeakerAccess")
 final class AndroidLoggingPlugin extends LoggingPlugin<Void> {
     @NonNull
     @Override

--- a/core/src/main/java/com/amplifyframework/logging/LoggingCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/logging/LoggingCategoryBehavior.java
@@ -66,5 +66,4 @@ public interface LoggingCategoryBehavior {
      */
     @NonNull
     Logger forCategory(@NonNull CategoryType categoryType);
-
 }


### PR DESCRIPTION
Removes debugging calls to `System.out.println`.  These should be
redirected through the Amplify log facility, instead.

Updates the logging namespace in a few places. The AWS DataStore Plugin
is using a namespace of `"amplify:aws-datastore"`. The f`orCategory()`
factory is a promising addition, but it is currently generating a
different slug. The AWS DataStore Plugin can adopt use of this factory
more uniformly, in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
