### PR TITLE
[aws-datastore] Clarify AWSDataStorePlugin dependency on API Category

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/DataStoreCategoryConfigurator.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/DataStoreCategoryConfigurator.java
@@ -20,7 +20,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RawRes;
 
 import com.amplifyframework.AmplifyException;
-import com.amplifyframework.api.GraphQlBehavior;
+import com.amplifyframework.api.ApiCategory;
 import com.amplifyframework.core.AmplifyConfiguration;
 import com.amplifyframework.core.InitializationStatus;
 import com.amplifyframework.core.category.CategoryConfiguration;
@@ -36,7 +36,7 @@ final class DataStoreCategoryConfigurator {
     private Context context;
     @RawRes private Integer resourceId;
     private ModelProvider modelProvider;
-    private GraphQlBehavior api;
+    private ApiCategory api;
     private boolean clearRequested;
 
     private DataStoreCategoryConfigurator() {}
@@ -71,7 +71,7 @@ final class DataStoreCategoryConfigurator {
     }
 
     @NonNull
-    DataStoreCategoryConfigurator api(@NonNull GraphQlBehavior api) {
+    DataStoreCategoryConfigurator api(@NonNull ApiCategory api) {
         this.api = Objects.requireNonNull(api);
         return DataStoreCategoryConfigurator.this;
     }


### PR DESCRIPTION
The `AWSDataStorePlugin` has a dependency on a `GraphQlBehavior` in one
place, as the portal through which to perform synchronization. In
another place, `Amplify.API` is referenced directly, to determine if there
are plugins available in the API category.

For the purposes of test, consolidate both uses to an `ApiCategory`
instance, which satisfies both purposes. This dependency is wired
through to the constructor, for dependency injection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
