### PR TITLE
Add new pagedQuery methods to GraphQLBehavior

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -103,6 +103,15 @@ final class AppSyncGraphQLRequestFactory {
             Class<T> modelClass,
             QueryPredicate predicate
     ) throws ApiException {
+        return buildQuery(modelClass, predicate, DEFAULT_QUERY_LIMIT, null);
+    }
+
+    static <T extends Model> GraphQLRequest<T> buildQuery(
+            Class<T> modelClass,
+            QueryPredicate predicate,
+            int limit,
+            String nextToken
+    ) throws ApiException {
         try {
             StringBuilder doc = new StringBuilder();
             Map<String, Object> variables = new HashMap<>();
@@ -124,8 +133,11 @@ final class AppSyncGraphQLRequestFactory {
 
             if (predicate != null) {
                 variables.put("filter", parsePredicate(predicate));
-                variables.put("limit", DEFAULT_QUERY_LIMIT);
             }
+            if(nextToken != null) {
+                variables.put("nextToken", nextToken);
+            }
+            variables.put("limit", limit);
 
             return new GraphQLRequest<>(
                     doc.toString(),

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncPage.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncPage.java
@@ -1,0 +1,42 @@
+package com.amplifyframework.api.aws;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.graphql.GraphQLOperation;
+import com.amplifyframework.api.graphql.GraphQLRequest;
+import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.api.graphql.Page;
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.Consumer;
+
+public class AppSyncPage<T> extends Page<T> {
+    private final String NEXT_TOKEN_KEY = "nextToken";
+
+    private GraphQLRequest<T> request;
+    private String nextToken;
+
+    public AppSyncPage(@NonNull GraphQLResponse<Iterable<T>> response) {
+        this(response, null, null);
+    }
+
+    public AppSyncPage(@NonNull GraphQLResponse<Iterable<T>> response,
+                       @NonNull GraphQLRequest<T> request,
+                       String nextToken) {
+        super(response);
+        this.request = request;
+        this.nextToken = nextToken;
+    }
+
+    @Override
+    public boolean hasNextPage() {
+        return nextToken != null;
+    }
+
+    @Override
+    public GraphQLOperation<T> queryNextPage(@NonNull Consumer<Page<T>> onResponse,
+                                             @NonNull Consumer<ApiException> onFailure) {
+        this.request.addVariable(NEXT_TOKEN_KEY, nextToken);
+        return Amplify.API.pagedQuery(request, onResponse, onFailure);
+    }
+}

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/PagedResultOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/PagedResultOperation.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+import android.annotation.SuppressLint;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.graphql.GraphQLOperation;
+import com.amplifyframework.api.graphql.GraphQLRequest;
+import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.api.graphql.Page;
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.logging.Logger;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * An operation to enqueue a GraphQL request to OkHttp client,
+ * with the goal of obtaining a list of responses. For example,
+ * this is used for a LIST query vs. a GET query or most mutations.
+ * @param <T> Casted type of GraphQL result data
+ */
+public final class PagedResultOperation<T> extends GraphQLOperation<T> {
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-api");
+    private static final String CONTENT_TYPE = "application/json";
+
+    private final String endpoint;
+    private final OkHttpClient client;
+    private final Consumer<Page<T>> onPage;
+    private final Consumer<ApiException> onFailure;
+
+    private Call ongoingCall;
+
+    /**
+     * Constructs a new SingleResultOperation.
+     * @param endpoint API endpoint being hit
+     * @param client OkHttp client being used to hit the endpoint
+     * @param request GraphQL request being enacted
+     * @param responseFactory an implementation of GsonGraphQLResponseFactory
+     * @param onPage Invoked when response is attained from endpoint
+     * @param onFailure Invoked upon failure to obtain response from endpoint
+     */
+    private PagedResultOperation(
+            @NonNull String endpoint,
+            @NonNull OkHttpClient client,
+            @NonNull GraphQLRequest<T> request,
+            @NonNull GraphQLResponse.Factory responseFactory,
+            @NonNull Consumer<Page<T>> onPage,
+            @NonNull Consumer<ApiException> onFailure) {
+        super(request, responseFactory);
+        this.endpoint = endpoint;
+        this.client = client;
+        this.onPage = onPage;
+        this.onFailure = onFailure;
+    }
+
+    @Override
+    public void start() {
+        // No-op if start() is called post-execution
+        if (ongoingCall != null && ongoingCall.isExecuted()) {
+            return;
+        }
+
+        try {
+            LOG.debug("Request: " + getRequest().getContent());
+            ongoingCall = client.newCall(new Request.Builder()
+                    .url(endpoint)
+                    .addHeader("accept", CONTENT_TYPE)
+                    .addHeader("content-type", CONTENT_TYPE)
+                    .post(RequestBody.create(getRequest().getContent(), MediaType.parse(CONTENT_TYPE)))
+                    .build());
+            ongoingCall.enqueue(new OkHttpCallback());
+        } catch (Exception error) {
+            // Cancel if possible
+            if (ongoingCall != null) {
+                ongoingCall.cancel();
+            }
+
+            onFailure.accept(new ApiException(
+                    "OkHttp client failed to make a successful request.",
+                    error, AmplifyException.TODO_RECOVERY_SUGGESTION
+            ));
+        }
+    }
+
+    @Override
+    public void cancel() {
+        ongoingCall.cancel();
+    }
+
+    static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    @SuppressLint("SyntheticAccessor")
+    class OkHttpCallback implements Callback {
+        @Override
+        public void onResponse(@NonNull Call call,
+                               @NonNull Response response) {
+            final ResponseBody responseBody = response.body();
+            String jsonResponse = null;
+            if (responseBody != null) {
+                try {
+                    jsonResponse = responseBody.string();
+                } catch (IOException exception) {
+                    onFailure.accept(new ApiException(
+                            "Could not retrieve the response body from the returned JSON",
+                            exception, AmplifyException.TODO_RECOVERY_SUGGESTION
+                    ));
+                    return;
+                }
+            }
+
+            try {
+                onPage.accept(wrapPagedResultResponse(jsonResponse));
+                //TODO: Dispatch to hub
+            } catch (ApiException exception) {
+                onFailure.accept(exception);
+            }
+        }
+
+        @Override
+        public void onFailure(@NonNull Call call,
+                              @NonNull IOException exception) {
+            onFailure.accept(new ApiException(
+                    "Could not retrieve the response body from the returned JSON",
+                    exception, AmplifyException.TODO_RECOVERY_SUGGESTION
+            ));
+        }
+    }
+
+    static final class Builder<T> {
+        private String endpoint;
+        private OkHttpClient client;
+        private GraphQLRequest<T> request;
+        private GraphQLResponse.Factory responseFactory;
+        private Consumer<Page<T>> onPage;
+        private Consumer<ApiException> onFailure;
+
+        Builder<T> endpoint(@NonNull String endpoint) {
+            this.endpoint = Objects.requireNonNull(endpoint);
+            return this;
+        }
+
+        Builder<T> client(@NonNull OkHttpClient client) {
+            this.client = Objects.requireNonNull(client);
+            return this;
+        }
+
+        Builder<T> request(@NonNull GraphQLRequest<T> request) {
+            this.request = Objects.requireNonNull(request);
+            return this;
+        }
+
+        Builder<T> responseFactory(@NonNull GraphQLResponse.Factory responseFactory) {
+            this.responseFactory = Objects.requireNonNull(responseFactory);
+            return this;
+        }
+
+        Builder<T> onPage(@NonNull Consumer<Page<T>> onPage) {
+            this.onPage = Objects.requireNonNull(onPage);
+            return this;
+        }
+
+        Builder<T> onFailure(@NonNull Consumer<ApiException> onFailure) {
+            this.onFailure = Objects.requireNonNull(onFailure);
+            return this;
+        }
+
+        @SuppressLint("SyntheticAccessor")
+        PagedResultOperation<T> build() {
+            return new PagedResultOperation<T>(
+                    Objects.requireNonNull(endpoint),
+                    Objects.requireNonNull(client),
+                    Objects.requireNonNull(request),
+                    Objects.requireNonNull(responseFactory),
+                    Objects.requireNonNull(onPage),
+                    Objects.requireNonNull(onFailure)
+            );
+        }
+    }
+}

--- a/core/src/main/java/com/amplifyframework/api/ApiCategory.java
+++ b/core/src/main/java/com/amplifyframework/api/ApiCategory.java
@@ -22,6 +22,7 @@ import com.amplifyframework.api.graphql.GraphQLOperation;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.MutationType;
+import com.amplifyframework.api.graphql.Page;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.api.rest.RestOperation;
 import com.amplifyframework.api.rest.RestOptions;
@@ -86,6 +87,15 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
 
     @Nullable
     @Override
+    public <T> GraphQLOperation<T> pagedQuery(
+            @NonNull GraphQLRequest<T> graphQlRequest,
+            @NonNull Consumer<Page<T>> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().pagedQuery(graphQlRequest, onResponse, onFailure);
+    }
+
+    @Nullable
+    @Override
     public <T extends Model> GraphQLOperation<T> query(
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
@@ -124,6 +134,15 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
             @NonNull Consumer<GraphQLResponse<Iterable<T>>> onResponse,
             @NonNull Consumer<ApiException> onFailure) {
         return getSelectedPlugin().query(apiName, graphQlRequest, onResponse, onFailure);
+    }
+
+    @Nullable
+    public <T> GraphQLOperation<T> pagedQuery(
+            @NonNull String apiName,
+            @NonNull GraphQLRequest<T> graphQlRequest,
+            @NonNull Consumer<Page<T>> onResponse,
+            @NonNull Consumer<ApiException> onFailure) {
+        return getSelectedPlugin().pagedQuery(apiName, graphQlRequest, onResponse, onFailure);
     }
 
     @Nullable

--- a/core/src/main/java/com/amplifyframework/api/GraphQlBehavior.java
+++ b/core/src/main/java/com/amplifyframework/api/GraphQlBehavior.java
@@ -22,6 +22,7 @@ import com.amplifyframework.api.graphql.GraphQLOperation;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.MutationType;
+import com.amplifyframework.api.graphql.Page;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
@@ -140,6 +141,29 @@ public interface GraphQlBehavior {
     );
 
     /**
+     * Perform a GraphQL query against a configured GraphQL endpoint.
+     * This operation is asynchronous and may be canceled by calling
+     * cancel on the returned operation. The response will be provided
+     * to the `onResponse` callback.  If there is data present
+     * in the response, it will be cast as the requested class type.
+     * Requires that only one API is configured in your
+     * `amplifyconfiguration.json`. Otherwise, emits an ApiException to
+     * the provided `onFailure` callback.
+     * @param graphQlRequest Wrapper for request details
+     * @param onPage Invoked when a page of results is available; may contain errors from endpoint
+     * @param onFailure Invoked when a response is not available due to operational failures
+     * @param <T> The type of data in the response, if available
+     * @return An {@link ApiOperation} to track progress and provide
+     *         a means to cancel the asynchronous operation
+     */
+    @Nullable
+    <T> GraphQLOperation<T> pagedQuery(
+            @NonNull GraphQLRequest<T> graphQlRequest,
+            @NonNull Consumer<Page<T>> onPage,
+            @NonNull Consumer<ApiException> onFailure
+    );
+
+    /**
      * This is a special helper method for easily calling a list query for
      * all items of the specified model type with no filtering condition.
      *
@@ -217,7 +241,6 @@ public interface GraphQlBehavior {
             @NonNull Consumer<GraphQLResponse<Iterable<T>>> onResponse,
             @NonNull Consumer<ApiException> onFailure
     );
-
     /**
      * Perform a GraphQL query against a configured GraphQL endpoint.
      * This operation is asynchronous and may be canceled by calling
@@ -237,6 +260,28 @@ public interface GraphQlBehavior {
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
             @NonNull Consumer<GraphQLResponse<Iterable<T>>> onResponse,
+            @NonNull Consumer<ApiException> onFailure
+    );
+
+    /**
+     * Perform a GraphQL query against a configured GraphQL endpoint.
+     * This operation is asynchronous and may be canceled by calling
+     * cancel on the returned operation. The response will be provided
+     * to the `onResponse` callback.  If there is data present
+     * in the response, it will be cast as the requested class type.
+     * @param apiName The name of a configured API
+     * @param graphQlRequest Wrapper for request details
+     * @param onPage Invoked when a response is available; may contain errors from endpoint
+     * @param onFailure Invoked when a response is not available due to operational failures
+     * @param <T> The type of data in the response, if available
+     * @return An {@link ApiOperation} to track progress and provide
+     *         a means to cancel the asynchronous operation
+     */
+    @Nullable
+    <T> GraphQLOperation<T> pagedQuery(
+            @NonNull String apiName,
+            @NonNull GraphQLRequest<T> graphQlRequest,
+            @NonNull Consumer<Page<T>> onPage,
             @NonNull Consumer<ApiException> onFailure
     );
 

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLOperation.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLOperation.java
@@ -76,6 +76,23 @@ public abstract class GraphQLOperation<T> extends ApiOperation<GraphQLRequest<T>
     }
 
     /**
+     * Converts a response json string containing a list of objects to a formatted
+     * {@link GraphQLResponse} object that a response consumer can receive.
+     * @param jsonResponse json response from API to be converted
+     * @return wrapped response object
+     * @throws ApiException If the class provided mismatches the data
+     */
+    protected final Page<T> wrapPagedResultResponse(String jsonResponse) throws ApiException {
+        try {
+            return responseFactory.buildPage(getRequest(), jsonResponse, classToCast);
+        } catch (ClassCastException cce) {
+            throw new ApiException("Amplify encountered an error while deserializing an object",
+                    AmplifyException.TODO_RECOVERY_SUGGESTION);
+        }
+    }
+
+
+    /**
      * Gets the casting class.
      * @return Class to cast.
      */

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
@@ -259,5 +259,20 @@ public final class GraphQLResponse<T> {
          */
         <T> GraphQLResponse<Iterable<T>> buildSingleArrayResponse(String apiResponseJson, Class<T> classToCast)
             throws ApiException;
+
+        /**
+         * Builds a response containing a list of data objects from JSON returned by an API.
+         * @param apiResponseJson
+         *        Response from the endpoint, containing a string response
+         * @param classToCast
+         *        The class type to which the JSON string should be
+         *        interpreted
+         * @param <T> The type of the elements in the data field list in the response object
+         * @return An instance of the casting class which models the data
+         *         provided in the response JSON string
+         * @throws ApiException If the class provided mismatches the data
+         */
+        <T> Page<T> buildPage(GraphQLRequest<T> request, String apiResponseJson, Class<T> classToCast)
+            throws ApiException;
     }
 }

--- a/core/src/main/java/com/amplifyframework/api/graphql/Page.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/Page.java
@@ -1,0 +1,23 @@
+package com.amplifyframework.api.graphql;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.core.Consumer;
+
+public abstract class Page<T> {
+    private final GraphQLResponse<Iterable<T>> response;
+
+    public abstract boolean hasNextPage();
+
+    public abstract GraphQLOperation<T> queryNextPage(@NonNull Consumer<Page<T>> onResponse,
+                                                      @NonNull Consumer<ApiException> onFailure);
+
+    protected Page(GraphQLResponse<Iterable<T>> response) {
+        this.response = response;
+    }
+
+    public GraphQLResponse<Iterable<T>> getResponse() {
+        return response;
+    }
+}


### PR DESCRIPTION
This PR replaces https://github.com/aws-amplify/amplify-android/pull/434

_Goal:_

- Expose pagination related properties so that datastore can query API and obtain all results.

_Description of changes:_

- Adds new `pagedQuery` method to GraphQLBehavior for obtaining the next set of results.
- Adds `Page` model, which encapsulates a GraphQLResponse, and knows if there is a nextPage (`hasNextPage()`), and how to get the next page (`queryNextPage(success, failure)`)

_To do before merging (but after team consensus on this approach):_

- Review this design and get consensus with iOS / JS
- Add integration test
- We don't actually need to add a new `pagedQuery` method to GraphQLBehavior, but it was easier for me to do it this way just to prove that this works.    Now that it does, we should just update the existing `query` methods which return a GraphQLResponse<Iterable<T>> to return a `Page<T>` instead.
 - Replace `Iterable` with `List`
 - Add Javadoc, address check-style issues.

_Customer Experience_

```
    private void listTodos() {
        try {
            int limit = 3;
            GraphQLRequest<Todo> request = AppSyncGraphQLRequestFactory.buildQuery(Todo.class, null, limit, null);
            Amplify.API.pagedQuery(request, this::handlePage, this::handleError);
        } catch(ApiException apiFailure) {
            handleError(apiFailure);
        }
    }

    private void handlePage(Page<Todo> page) {
        GraphQLResponse<Iterable<Todo>> response = page.getResponse();
        if (response.hasData()) {
            for (Todo todo : response.getData()) {
                Log.d(TAG, "todo: " + todo.getName());
            }
        }
        if (response.hasErrors()) {
            Log.d(TAG, "error: " + error);
        }

        if(page.hasNextPage()) {
            page.queryNextPage(this::handlePage, this::handleError);
        }
    }

    private void handleError(ApiException exception) {
        Log.e(TAG, exception.getMessage(), exception);
    }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
