### PR TITLE
[aws-datastore] thread safe rx publish subjects

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -69,6 +69,7 @@ import io.reactivex.Completable;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.Subject;
 
 /**
  * An implementation of {@link LocalStorageAdapter} using {@link android.database.sqlite.SQLiteDatabase}.
@@ -99,7 +100,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     private final Gson gson;
 
     // Used to publish events to the observables subscribed.
-    private final PublishSubject<StorageItemChange<? extends Model>> itemChangeSubject;
+    private final Subject<StorageItemChange<? extends Model>> itemChangeSubject;
 
     // Map of tableName => Insert Prepared statement.
     private Map<String, SqlCommand> insertSqlPreparedStatements;
@@ -134,7 +135,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         this.threadPool = Executors.newCachedThreadPool();
         this.insertSqlPreparedStatements = Collections.emptyMap();
         this.gson = new Gson();
-        this.itemChangeSubject = PublishSubject.create();
+        this.itemChangeSubject = PublishSubject.<StorageItemChange<? extends Model>>create().toSerialized();
         this.toBeDisposed = new CompositeDisposable();
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
@@ -35,6 +35,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.Subject;
 
 /*
  * The {@link MutationOutbox} is a persistently-backed in-order staging ground
@@ -49,12 +50,12 @@ final class MutationOutbox {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
     private final LocalStorageAdapter storage;
-    private final PublishSubject<PendingMutation<? extends Model>> pendingMutations;
+    private final Subject<PendingMutation<? extends Model>> pendingMutations;
     private final PendingMutation.Converter converter;
 
     MutationOutbox(@NonNull final LocalStorageAdapter localStorageAdapter) {
         this.storage = Objects.requireNonNull(localStorageAdapter);
-        this.pendingMutations = PublishSubject.create();
+        this.pendingMutations = PublishSubject.<PendingMutation<? extends Model>>create().toSerialized();
         this.converter = new GsonPendingMutationConverter();
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.Subject;
 
 /**
  * A simple in-memory implementation of the LocalStorageAdapter
@@ -42,11 +43,11 @@ import io.reactivex.subjects.PublishSubject;
  */
 public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     private final List<Model> items;
-    private final PublishSubject<StorageItemChange<? extends Model>> itemChangeStream;
+    private final Subject<StorageItemChange<? extends Model>> itemChangeStream;
 
     private InMemoryStorageAdapter() {
         this.items = new ArrayList<>();
-        this.itemChangeStream = PublishSubject.create();
+        this.itemChangeStream = PublishSubject.<StorageItemChange<? extends Model>>create().toSerialized();
     }
 
     /**


### PR DESCRIPTION
The Rx `PublishSubject` is not thread-safe. It is being used around the
code base in locations where `PublishSubject#on<Event>(...)` methods may
be invoked from different threads.

One strategy to resolve this is to use a serialized `PublishSubject`,
via the `toSerialized()` operator.

Refer: https://stackoverflow.com/a/43008419/695787
Resolves: https://github.com/aws-amplify/amplify-android/issues/451

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
