### PR TITLE
[aws-api] Use SubscriptionListener in API subscription methods

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
@@ -22,6 +22,7 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategoryBehavior;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.GraphQlBehavior;
+import com.amplifyframework.api.graphql.DelegatingApiSubscriptionListener;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.SubscriptionType;
@@ -286,10 +287,12 @@ public final class AppSyncClient implements AppSync {
 
         final Cancelable cancelable = api.subscribe(
             request,
-            onSubscriptionStarted,
-            stringResponseConsumer,
-            failureConsumer,
-            onSubscriptionCompleted
+            DelegatingApiSubscriptionListener.create(
+                onSubscriptionStarted,
+                stringResponseConsumer,
+                failureConsumer,
+                onSubscriptionCompleted
+            )
         );
         if (cancelable != null) {
             return cancelable;

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -19,9 +19,9 @@ import android.content.Context;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiPlugin;
+import com.amplifyframework.api.graphql.ApiSubscriptionListener;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.AmplifyConfiguration;
 import com.amplifyframework.core.Consumer;
@@ -153,10 +153,7 @@ public final class AWSDataStorePluginTest {
             return null;
         }).when(mockApiPlugin).subscribe(
             any(GraphQLRequest.class),
-            any(Consumer.class),
-            any(Consumer.class),
-            any(Consumer.class),
-            any(Action.class)
+            any(ApiSubscriptionListener.class)
         );
 
         return mockApiPlugin;

--- a/core/src/main/java/com/amplifyframework/api/ApiCategory.java
+++ b/core/src/main/java/com/amplifyframework/api/ApiCategory.java
@@ -18,6 +18,7 @@ package com.amplifyframework.api;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.api.graphql.ApiSubscriptionListener;
 import com.amplifyframework.api.graphql.GraphQLOperation;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
@@ -26,7 +27,6 @@ import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.api.rest.RestOperation;
 import com.amplifyframework.api.rest.RestOptions;
 import com.amplifyframework.api.rest.RestResponse;
-import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryType;
@@ -194,24 +194,16 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T extends Model> GraphQLOperation<T> subscribe(
             @NonNull Class<T> modelClass,
             @NonNull SubscriptionType subscriptionType,
-            @NonNull Consumer<String> onSubscriptionEstablished,
-            @NonNull Consumer<GraphQLResponse<T>> onNextResponse,
-            @NonNull Consumer<ApiException> onSubscriptionFailure,
-            @NonNull Action onSubscriptionCompleted) {
-        return getSelectedPlugin().subscribe(modelClass, subscriptionType,
-            onSubscriptionEstablished, onNextResponse, onSubscriptionFailure, onSubscriptionCompleted);
+            @NonNull ApiSubscriptionListener<T> apiSubscriptionListener) {
+        return getSelectedPlugin().subscribe(modelClass, subscriptionType, apiSubscriptionListener);
     }
 
     @Nullable
     @Override
     public <T> GraphQLOperation<T> subscribe(
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull Consumer<String> onSubscriptionEstablished,
-            @NonNull Consumer<GraphQLResponse<T>> onNextResponse,
-            @NonNull Consumer<ApiException> onSubscriptionFailure,
-            @NonNull Action onSubscriptionCompleted) {
-        return getSelectedPlugin().subscribe(graphQlRequest,
-            onSubscriptionEstablished, onNextResponse, onSubscriptionFailure, onSubscriptionCompleted);
+            @NonNull ApiSubscriptionListener<T> apiSubscriptionListener) {
+        return getSelectedPlugin().subscribe(graphQlRequest, apiSubscriptionListener);
     }
 
     @Nullable
@@ -220,12 +212,8 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
             @NonNull SubscriptionType subscriptionType,
-            @NonNull Consumer<String> onSubscriptionEstablished,
-            @NonNull Consumer<GraphQLResponse<T>> onNextResponse,
-            @NonNull Consumer<ApiException> onSubscriptionFailure,
-            @NonNull Action onSubscriptionCompleted) {
-        return getSelectedPlugin().subscribe(apiName, modelClass, subscriptionType,
-            onSubscriptionEstablished, onNextResponse, onSubscriptionFailure, onSubscriptionCompleted);
+            @NonNull ApiSubscriptionListener<T> apiSubscriptionListener) {
+        return getSelectedPlugin().subscribe(apiName, modelClass, subscriptionType, apiSubscriptionListener);
     }
 
     @Nullable
@@ -233,12 +221,8 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
     public <T> GraphQLOperation<T> subscribe(
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull Consumer<String> onSubscriptionEstablished,
-            @NonNull Consumer<GraphQLResponse<T>> onNextResponse,
-            @NonNull Consumer<ApiException> onSubscriptionFailure,
-            @NonNull Action onSubscriptionCompleted) {
-        return getSelectedPlugin().subscribe(apiName, graphQlRequest,
-            onSubscriptionEstablished, onNextResponse, onSubscriptionFailure, onSubscriptionCompleted);
+            @NonNull ApiSubscriptionListener<T> apiSubscriptionListener) {
+        return getSelectedPlugin().subscribe(apiName, graphQlRequest, apiSubscriptionListener);
     }
 
     @Nullable
@@ -355,4 +339,3 @@ public final class ApiCategory extends Category<ApiPlugin<?>> implements ApiCate
         return getSelectedPlugin().patch(apiName, request, onResponse, onFailure);
     }
 }
-

--- a/core/src/main/java/com/amplifyframework/api/GraphQlBehavior.java
+++ b/core/src/main/java/com/amplifyframework/api/GraphQlBehavior.java
@@ -18,12 +18,12 @@ package com.amplifyframework.api;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.api.graphql.ApiSubscriptionListener;
 import com.amplifyframework.api.graphql.GraphQLOperation;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.api.graphql.SubscriptionType;
-import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
@@ -415,80 +415,50 @@ public interface GraphQlBehavior {
      *
      * Initiates a GraphQL subscription against a configured GraphQL
      * endpoint. The operation is on-going and emits a stream of
-     * {@link GraphQLResponse}s to the provided `onNextResponse` callback.
+     * {@link GraphQLResponse}s to the provided {@link ApiSubscriptionListener}.
      * The subscription may be canceled by calling {@link GraphQLOperation#cancel()} on the
      * returned object.
      *
      * Requires that only one API is configured in your `amplifyconfiguration.json`.
-     * Otherwise, emits an ApiException to the provided `onSubscriptionFailure` callback.
+     * Otherwise, emits an {@link ApiException} to the provided {@link ApiSubscriptionListener}.
      *
      * @param modelClass The class of the Model we are subscribing to
      * @param subscriptionType
      *        The type of events for which notifications are requested
      *        (e.g. OnCreate, OnUpdate, OnDelete)
-     * @param onSubscriptionEstablished
-     *        Called when a subscription has been established over the network
-     * @param onNextResponse
-     *        Consumes a stream of responses on the subscription. This may be
-     *        called 0..n times per subscription.
-     * @param onSubscriptionFailure
-     *        Called when the subscription stream terminates with a failure.
-     *        Note that items passed via onNextResponse may themselves contain
-     *        errors in the response from the endpoint, but the subscription
-     *        may continue to be active even after these are received.
-     *        This is a terminal event following 0..n many calls to onNextResponse.
-     * @param onSubscriptionComplete
-     *        Called when a subscription has ended gracefully (without failure).
-     *        This is a terminal event following 0..n many calls to onNextResponse.
-     * @param <T> The type of data expected in the subscription stream. Must extend Model.
+     * @param apiSubscriptionListener Called back when subscriptions starts, produces data,
+     *                             fails or completes
+     * @param <T> Type of application data received over subscription
      * @return A {@link GraphQLOperation} representing this ongoing subscription
      */
     @Nullable
     <T extends Model> GraphQLOperation<T> subscribe(
             @NonNull Class<T> modelClass,
             @NonNull SubscriptionType subscriptionType,
-            @NonNull Consumer<String> onSubscriptionEstablished,
-            @NonNull Consumer<GraphQLResponse<T>> onNextResponse,
-            @NonNull Consumer<ApiException> onSubscriptionFailure,
-            @NonNull Action onSubscriptionComplete
+            @NonNull ApiSubscriptionListener<T> apiSubscriptionListener
     );
 
     /**
      * Initiates a GraphQL subscription against a configured GraphQL
      * endpoint. The operation is on-going and emits a stream of
-     * {@link GraphQLResponse}s to the provided `onNextResponse` callback.
+     * {@link GraphQLResponse}s to the provided {@link ApiSubscriptionListener}.
      * The subscription may be canceled by calling {@link GraphQLOperation#cancel()} on
      * the returned object.
      *
      * Requires that only one API is configured in your
-     * `amplifyconfiguration.json`. Otherwise, emits an ApiException to
-     * the provided `onSubscriptionFailure` callback.
+     * `amplifyconfiguration.json`. Otherwise, emits an {@link ApiException}
+     * to the provided {@link ApiSubscriptionListener}.
      *
      * @param graphQlRequest Wrapper for request details
-     * @param onSubscriptionEstablished
-     *        Called when a subscription has been established over the network
-     * @param onNextResponse
-     *        Consumes a stream of responses on the subscription. This may be
-     *        called 0..n times per subscription.
-     * @param onSubscriptionFailure
-     *        Called when the subscription stream terminates with a failure.
-     *        Note that items passed via onNextResponse may themselves contain
-     *        errors in the response from the endpoint, but the subscription
-     *        may continue to be active even after these are received.
-     *        This is a terminal event following 0..n many calls to onNextResponse.
-     * @param onSubscriptionComplete
-     *        Called when a subscription has ended gracefully (without failure).
-     *        This is a terminal event following 0..n many calls to onNextResponse.
-     * @param <T> The type of data expected in the subscription stream
+     * @param apiSubscriptionListener Called back when subscriptions starts, produces data,
+     *                             fails or completes
+     * @param <T> Type of application data received over subscription
      * @return An {@link GraphQLOperation} representing this ongoing subscription
      */
     @Nullable
     <T> GraphQLOperation<T> subscribe(
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull Consumer<String> onSubscriptionEstablished,
-            @NonNull Consumer<GraphQLResponse<T>> onNextResponse,
-            @NonNull Consumer<ApiException> onSubscriptionFailure,
-            @NonNull Action onSubscriptionComplete
+            @NonNull ApiSubscriptionListener<T> apiSubscriptionListener
     );
 
     /**
@@ -497,7 +467,7 @@ public interface GraphQlBehavior {
      *
      * Initiates a GraphQL subscription against a configured GraphQL
      * endpoint. The operation is on-going and emits a stream of
-     * {@link GraphQLResponse}s to the provided `onNextResponse` callback.
+     * {@link GraphQLResponse}s to the provided {@link ApiSubscriptionListener}.
      * The subscription may be canceled by calling {@link GraphQLOperation#cancel()}
      * on the returned object.
      *
@@ -506,21 +476,9 @@ public interface GraphQlBehavior {
      * @param subscriptionType
      *        The type of events for which notifications are requested
      *        (e.g. OnCreate, OnUpdate, OnDelete)
-     * @param onSubscriptionEstablished
-     *        Called when a subscription has been established over the network
-     * @param onNextResponse
-     *        Consumes a stream of responses on the subscription. This may be
-     *        called 0..n times per subscription.
-     * @param onSubscriptionFailure
-     *        Called when the subscription stream terminates with a failure.
-     *        Note that items passed via onNextResponse may themselves contain
-     *        errors in the response from the endpoint, but the subscription
-     *        may continue to be active even after these are received.
-     *        This is a terminal event following 0..n many calls to onNextResponse.
-     * @param onSubscriptionComplete
-     *        Called when a subscription has ended gracefully (without failure).
-     *        This is a terminal event following 0..n many calls to onNextResponse.
-     * @param <T> The type of data expected in the subscription stream. Must extend Model.
+     * @param apiSubscriptionListener Called back when subscriptions starts, produces data,
+     *                             fails or completes
+     * @param <T> Type of application data received over subscription
      * @return An {@link GraphQLOperation} representing this ongoing subscription
      */
     @Nullable
@@ -528,45 +486,26 @@ public interface GraphQlBehavior {
             @NonNull String apiName,
             @NonNull Class<T> modelClass,
             @NonNull SubscriptionType subscriptionType,
-            @NonNull Consumer<String> onSubscriptionEstablished,
-            @NonNull Consumer<GraphQLResponse<T>> onNextResponse,
-            @NonNull Consumer<ApiException> onSubscriptionFailure,
-            @NonNull Action onSubscriptionComplete
+            @NonNull ApiSubscriptionListener<T> apiSubscriptionListener
     );
 
     /**
      * Initiates a GraphQL subscription against a configured GraphQL
      * endpoint. The operation is on-going and emits a stream of
-     * {@link GraphQLResponse}s to the provided `onNextResponse` callback.
+     * {@link GraphQLResponse}s to the provided {@link ApiSubscriptionListener}.
      * The subscription may be canceled by calling {@link GraphQLOperation#cancel()}
      * on the returned object.
      *
      * @param apiName The name of a configured API
      * @param graphQlRequest Wrapper for request details
-     * @param onSubscriptionEstablished
-     *        Called when a subscription has been established over the network
-     * @param onNextResponse
-     *        Consumes a stream of responses on the subscription. This may be
-     *        called 0..n times per subscription.
-     * @param onSubscriptionFailure
-     *        Called when the subscription stream terminates with a failure.
-     *        Note that items passed via onNextResponse may themselves contain
-     *        errors in the response from the endpoint, but the subscription
-     *        may continue to be active even after these are received.
-     *        This is a terminal event following 0..n many calls to onNextResponse.
-     * @param onSubscriptionComplete
-     *        Called when a subscription has ended gracefully (without failure).
-     *        This is a terminal event following 0..n many calls to onNextResponse.
-     * @param <T> The type of data expected in the subscription stream
-     * @return An {@link GraphQLOperation} representing this ongoing subscription
+     * @param apiSubscriptionListener Called back when subscriptions starts, produces data,
+     *                             fails or completes
+     * @param <T> Type of application data received over subscription
+     * @return A {@link GraphQLOperation} that represents the ongoing subscription
      */
-    @Nullable
     <T> GraphQLOperation<T> subscribe(
             @NonNull String apiName,
             @NonNull GraphQLRequest<T> graphQlRequest,
-            @NonNull Consumer<String> onSubscriptionEstablished,
-            @NonNull Consumer<GraphQLResponse<T>> onNextResponse,
-            @NonNull Consumer<ApiException> onSubscriptionFailure,
-            @NonNull Action onSubscriptionComplete
+            @NonNull ApiSubscriptionListener<T> apiSubscriptionListener
     );
 }

--- a/core/src/main/java/com/amplifyframework/api/graphql/ApiSubscriptionListener.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/ApiSubscriptionListener.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.graphql;
+
+import com.amplifyframework.api.ApiCategory;
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.GraphQlBehavior;
+
+/**
+ * A listener to a GraphQL subscription. Used when registering for subscription data via the
+ * {@link GraphQlBehavior}s in the {@link ApiCategory}. Extend this class or provide an anonymous
+ * inline instance when registering with the
+ * {@link GraphQlBehavior#subscribe(GraphQLRequest, ApiSubscriptionListener)} family of methods.
+ * @param <T> Type of application data found on the subscription
+ */
+public /* extensible */ class ApiSubscriptionListener<T> {
+    /**
+     * Called when a subscription starts.
+     * @param subscriptionToken A token which uniquely identifies this new subscription.
+     */
+    public void onSubscriptionStarted(String subscriptionToken) {
+    }
+
+    /**
+     * Called when the next installment of data is available on the subscription.
+     * This is always called after {@link #onSubscriptionStarted(String)}, and
+     * may be called 0 or more times before either {@link #onSubscriptionFailure(ApiException)}
+     * or {@link #onSubscriptionComplete()}.
+     * @param subscriptionData Data found on the subscription, enveloped in an {@link GraphQLResponse}.
+     */
+    public void onSubscriptionData(GraphQLResponse<T> subscriptionData) {
+    }
+
+    /**
+     * Called when the subscription terminates gracefully, perhaps because there
+     * is no more data available on the subscription.
+     */
+    public void onSubscriptionComplete() {
+    }
+
+    /**
+     * Called when either (1) a not-yet-started subscription fails to start, or (2) an already-started
+     * subscription terminates, with an unrecoverable failure.
+     * @param subscriptionFailure A failure to begin subscription, or a failure which terminates an
+     *                            ongoing subscription
+     */
+    public void onSubscriptionFailure(ApiException subscriptionFailure) {
+    }
+}

--- a/core/src/main/java/com/amplifyframework/api/graphql/DelegatingApiSubscriptionListener.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/DelegatingApiSubscriptionListener.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.graphql;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.core.Action;
+import com.amplifyframework.core.Consumer;
+
+import java.util.Objects;
+
+/**
+ * A {@link ApiSubscriptionListener} which works by delegating its lifecycle callbacks
+ * to one of four provided functional interfaces. For example:
+ * <pre>
+ *     DelegatingSubscriptionListener.create(
+ *         start -> {},
+ *         data -> {},
+ *         failure > {},
+ *         () -> {}
+ *     );
+ * </pre>
+ * @param <T> Type of data found on subscription
+ */
+public final class DelegatingApiSubscriptionListener<T> extends ApiSubscriptionListener<T> {
+    private final Consumer<String> onStart;
+    private final Consumer<GraphQLResponse<T>> onNext;
+    private final Consumer<ApiException> onFailure;
+    private final Action onComplete;
+
+    private DelegatingApiSubscriptionListener(
+            Consumer<String> onStart,
+            Consumer<GraphQLResponse<T>> onNext,
+            Consumer<ApiException> onFailure,
+            Action onComplete) {
+        this.onStart = onStart;
+        this.onNext = onNext;
+        this.onFailure = onFailure;
+        this.onComplete = onComplete;
+    }
+
+    /**
+     * Creates a new {@link DelegatingApiSubscriptionListener}.
+     * @param onStart Called for {@link ApiSubscriptionListener#onSubscriptionStarted(String)}
+     * @param onNext Called for {@link ApiSubscriptionListener#onSubscriptionData(GraphQLResponse)}
+     * @param onFailure Called for {@link ApiSubscriptionListener#onSubscriptionFailure(ApiException)}
+     * @param onComplete Called for {@link ApiSubscriptionListener#onSubscriptionComplete()}
+     * @param <T> The type of application data found on the subscription
+     * @return A subscription listener which delegates to the provided lambda arguments.
+     */
+    public static <T> DelegatingApiSubscriptionListener<T> create(
+            Consumer<String> onStart,
+            Consumer<GraphQLResponse<T>> onNext,
+            Consumer<ApiException> onFailure,
+            Action onComplete) {
+        Objects.requireNonNull(onStart);
+        Objects.requireNonNull(onNext);
+        Objects.requireNonNull(onFailure);
+        Objects.requireNonNull(onComplete);
+        return new DelegatingApiSubscriptionListener<>(onStart, onNext, onFailure, onComplete);
+    }
+
+    @Override
+    public void onSubscriptionStarted(String subscriptionToken) {
+        onStart.accept(subscriptionToken);
+    }
+
+    @Override
+    public void onSubscriptionData(GraphQLResponse<T> subscriptionData) {
+        onNext.accept(subscriptionData);
+    }
+
+    @Override
+    public void onSubscriptionComplete() {
+        onComplete.call();
+    }
+
+    @Override
+    public void onSubscriptionFailure(ApiException subscriptionFailure) {
+        onFailure.accept(subscriptionFailure);
+    }
+}

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxApiBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxApiBinding.java
@@ -21,6 +21,7 @@ import androidx.annotation.VisibleForTesting;
 import com.amplifyframework.api.ApiCategory;
 import com.amplifyframework.api.ApiCategoryBehavior;
 import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.graphql.DelegatingApiSubscriptionListener;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.MutationType;
@@ -156,14 +157,20 @@ final class RxApiBinding implements RxApiCategoryBehavior {
     public <T extends Model> Observable<GraphQLResponse<T>> subscribe(
             @NonNull Class<T> modelClass, @NonNull SubscriptionType subscriptionType) {
         return toObservable((onStart, onResult, onError, onComplete) ->
-            api.subscribe(modelClass, subscriptionType, onStart, onResult, onError, onComplete));
+            api.subscribe(modelClass, subscriptionType,
+                DelegatingApiSubscriptionListener.create(onStart, onResult, onError, onComplete)
+            )
+        );
     }
 
     @NonNull
     @Override
     public <T> Observable<GraphQLResponse<T>> subscribe(@NonNull GraphQLRequest<T> graphQlRequest) {
         return toObservable((onStart, onResult, onError, onComplete) ->
-            api.subscribe(graphQlRequest, onStart, onResult, onError, onComplete));
+            api.subscribe(graphQlRequest,
+                DelegatingApiSubscriptionListener.create(onStart, onResult, onError, onComplete)
+            )
+        );
     }
 
     @NonNull
@@ -171,7 +178,10 @@ final class RxApiBinding implements RxApiCategoryBehavior {
     public <T extends Model> Observable<GraphQLResponse<T>> subscribe(
             @NonNull String apiName, @NonNull Class<T> modelClass, @NonNull SubscriptionType subscriptionType) {
         return toObservable((onStart, onResult, onError, onComplete) ->
-            api.subscribe(apiName, modelClass, subscriptionType, onStart, onResult, onError, onComplete));
+            api.subscribe(apiName, modelClass, subscriptionType,
+                DelegatingApiSubscriptionListener.create(onStart, onResult, onError, onComplete)
+            )
+        );
     }
 
     @NonNull
@@ -179,7 +189,10 @@ final class RxApiBinding implements RxApiCategoryBehavior {
     public <T> Observable<GraphQLResponse<T>> subscribe(
             @NonNull String apiName, @NonNull GraphQLRequest<T> graphQlRequest) {
         return toObservable((onStart, onResult, onError, onComplete) ->
-            api.subscribe(apiName, graphQlRequest, onStart, onResult, onError, onComplete));
+            api.subscribe(apiName, graphQlRequest,
+                DelegatingApiSubscriptionListener.create(onStart, onResult, onError, onComplete)
+            )
+        );
     }
 
     @NonNull

--- a/rxbindings/src/test/java/com/amplifyframework/rx/Matchers.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/Matchers.java
@@ -17,6 +17,7 @@ package com.amplifyframework.rx;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.api.graphql.ApiSubscriptionListener;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
@@ -52,6 +53,16 @@ final class Matchers {
      */
     @NonNull
     static <T> Consumer<T> anyConsumer() {
+        return ArgumentMatchers.any();
+    }
+
+    /**
+     * Match any {@link ApiSubscriptionListener}.
+     * @param <T> Type of data that the subscription receives
+     * @return A matched subscription listener
+     */
+    @NonNull
+    static <T> ApiSubscriptionListener<T> anySubscriptionListener() {
         return ArgumentMatchers.any();
     }
 

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousApi.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousApi.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import com.amplifyframework.api.ApiCategory;
 import com.amplifyframework.api.ApiCategoryBehavior;
 import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.graphql.DelegatingApiSubscriptionListener;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.MutationType;
@@ -282,10 +283,12 @@ public final class SynchronousApi {
                         apiName,
                         clazz,
                         SubscriptionType.ON_CREATE,
-                        onSubscriptionStarted,
-                        emitter::onNext,
-                        onError,
-                        emitter::onComplete
+                        DelegatingApiSubscriptionListener.create(
+                            onSubscriptionStarted,
+                            emitter::onNext,
+                            onError,
+                            emitter::onComplete
+                        )
                     );
                     if (cancelable != null) {
                         disposable.add(Disposables.fromAction(cancelable::cancel));
@@ -312,10 +315,12 @@ public final class SynchronousApi {
                     Cancelable cancelable = asyncDelegate.subscribe(
                         apiName,
                         request,
-                        onSubscriptionStarted,
-                        emitter::onNext,
-                        onError,
-                        emitter::onComplete
+                        DelegatingApiSubscriptionListener.create(
+                            onSubscriptionStarted,
+                            emitter::onNext,
+                            onError,
+                            emitter::onComplete
+                        )
                     );
                     if (cancelable != null) {
                         disposable.add(Disposables.fromAction(cancelable::cancel));


### PR DESCRIPTION
The API category includes a collection of GraphQL behaviors. One of the
behaviors is to create a subscription to a GraphQL endpoint.

Currently, the signatures for these subscription methods require
numerous arguments to be provided:

  1. `Consumer<String>`, to receive notification of subscription start;
  2. `Consumer<GraphQLResponse<T>>` to receive subscription data;
  3. `Consumer<ApiException>`, when subscription terminates in failure;
  4. `Action`, called when the subscription terminates gracefully.

The user may or may not care about all of the data provided in the
various callbacks, but yet each must still be specified.

To resolve this, the callbacks are consolidated into a single base class,
an `ApiSubscriptionListener`. A user may extend this class and override any
methods for which they would like to instrument custom logic. For
example:

```
api.subscribe(BlogPost.class, SubscriptionType.CREATE,
    new ApiSubscriptionListener<BlogPost>() {
        @Override
        public void onSubscriptionStarted(String token) {
            Log.i(TAG, "Subscription started!");
        }

        @Override
        public void onSubscriptionData(GraphQLResponse<BlogPost> data) {
            Log.i(TAG, "Got some data on subscription = " + data);
        }

        @Override
        public void onSubscriptionFailure(ApiException failure) {
            Log.w(TAG, "Subscription terminated with failure", failure);
        }

        @Override
        public void onSubscriptionComplete() {
            Log.i(TAG, "Subscription terminated gracefully.");
        }
    }
);
```

Or, if only interested in subscription data:
```
api.subscribe(BlogPost.class, SubscriptionType.CREATE,
    new ApiSubscriptionListener<BlogPost>() {
        @Override
        public void onSubscriptionData(GraphQLResponse<BlogPost> data) {
            Log.i(TAG, "Got some data on subscription = " + data);
        }
    }
);
```

A `DelegatingApiSubscriptionListener` is provided for compatibility. It
accepts the four `Consumer`/`Action` arguments previously available:
```
api.subscribe(BlogPost.class, SubscriptionType.CREATE,
    DelegatingApiSubscriptionListener.create(
        startToken -> {},
        nextData -> {},
        failure -> {},
        () -> {}
    )
);
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
