### PR TITLE
[aws-datastore] Re-enable cloud synchronization test

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/CloudSyncInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/CloudSyncInstrumentedTest.java
@@ -32,6 +32,7 @@ import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.appsync.SynchronousAppSync;
 import com.amplifyframework.datastore.syncengine.PendingMutation;
 import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.hub.HubEventFilter;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.Blog;
@@ -41,35 +42,31 @@ import com.amplifyframework.testutils.Resources;
 import com.amplifyframework.testutils.sync.SynchronousApi;
 import com.amplifyframework.testutils.sync.SynchronousDataStore;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.UUID;
+import java.util.Arrays;
+import java.util.List;
+
+import io.reactivex.Observable;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Tests the functions of {@link AWSDataStorePlugin}.
+ * Tests the synchronization of models between the local storage and the remote App Sync
+ * system.
+ *
  * This test expects a backend API that has support for the {@link Blog} family of models,
  * which were defined by the schema in:
  * testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/schema.graphql.
  */
-@Ignore("AWSDataStorePlugin must not refer to Amplify.API - need to update source")
-public final class AWSDataStorePluginInstrumentedTest {
-    private static SynchronousApi api;
-    private static SynchronousAppSync appSync;
-    private static SynchronousDataStore dataStore;
-
-    /**
-     * Enable strict mode for catching SQLite leaks.
-     */
-    @BeforeClass
-    public static void enableStrictMode() {
-        StrictMode.enable();
-    }
+public final class CloudSyncInstrumentedTest {
+    private SynchronousApi api;
+    private SynchronousAppSync appSync;
+    private SynchronousDataStore dataStore;
 
     /**
      * Once, before any/all tests in this class, setup miscellaneous dependencies,
@@ -78,8 +75,9 @@ public final class AWSDataStorePluginInstrumentedTest {
      * {@link AWSDataStorePlugin}, which is the thing we're actually testing.
      * @throws AmplifyException On failure to read config, setup API or DataStore categories
      */
-    @BeforeClass
-    public static void beforeAllTests() throws AmplifyException {
+    @Before
+    public void setup() throws AmplifyException {
+        StrictMode.enable();
         Context context = getApplicationContext();
         @RawRes int configResourceId = Resources.getRawResourceId(context, "amplifyconfiguration");
 
@@ -105,19 +103,19 @@ public final class AWSDataStorePluginInstrumentedTest {
      * @throws DataStoreException On failure to save item into DataStore (first step)
      * @throws ApiException On failure to retrieve a valid response from API when checking
      *                      for remote presence of saved item
+     * @throws AmplifyException On failure to arrange a {@link DataStoreCategory} via the
+     *                          {@link DataStoreCategoryConfigurator}
      */
     @Test
-    public void syncUpToCloudIsWorking() throws DataStoreException, ApiException {
+    public void syncUpToCloudIsWorking() throws AmplifyException {
         // Start listening for model publication events on the Hub.
-        String expectedId = UUID.randomUUID().toString();
-        HubAccumulator publishedMutationsAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(expectedId), 1).start();
-
-        // Save Charley Crockett, a guy who has a blog, into the DataStore.
         BlogOwner localCharley = BlogOwner.builder()
             .name("Charley Crockett")
-            .id(expectedId)
             .build();
+        HubAccumulator publishedMutationsAccumulator =
+            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(localCharley), 1).start();
+
+        // Save Charley Crockett, a guy who has a blog, into the DataStore.
         dataStore.save(localCharley);
 
         // Wait for a Hub event telling us that our Charley model got published to the cloud.
@@ -137,41 +135,37 @@ public final class AWSDataStorePluginInstrumentedTest {
      * by processing the subscription event and saving the model locally.
      * @throws DataStoreException On failure to query the local data store for
      *                            local presence of arranged data (second step)
+     * @throws AmplifyException On failure to arrange a {@link DataStoreCategory} via the
+     *                          {@link DataStoreCategoryConfigurator}
      */
+    @Ignore("This test is not passing reliably right now. Further investigation is needed.")
     @Test
-    public void syncDownFromCloudIsWorking() throws DataStoreException {
-        // Arrange a stable ID for the model we create/update,
-        // so that we can match it in an event accumulator, below.
-        String expectedId = UUID.randomUUID().toString();
+    @SuppressWarnings("unchecked") // Unwrapping hub event data
+    public void syncDownFromCloudIsWorking() throws AmplifyException {
+        // Arrange two models up front, so we can know their IDs for other arrangements.
+        // First is Jameson with a typo. We create him.
+        // Second is Jameson with typo fixed -- we update the original with this record.
+        BlogOwner originalModel = BlogOwner.builder()
+            .name("Jameson Willlllliams")
+            .build();
+        BlogOwner updatedModel = originalModel.copyOfBuilder() // This uses the same model ID
+            .name("Jameson Williams") // But with corrected name
+            .build();
 
         // Now, start watching the Hub for notifications that we received and processed models
         // from the Cloud. Look specifically for events relating to the model with the above ID.
-        HubAccumulator inboundModelEventAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(expectedId), 1).start();
+        // We expected 2: a creation, and an update.
+        HubAccumulator receiptAccumulator =
+            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(originalModel), 2).start();
 
         // Act: externally in the Cloud, someone creates a BlogOwner,
         // that contains a misspelling in the last name
-        BlogOwner originalModel = BlogOwner.builder()
-            .name("Jameson Willlllliams")
-            .id(expectedId)
-            .build();
         GraphQLResponse<ModelWithMetadata<BlogOwner>> createResponse = appSync.create(originalModel);
         ModelMetadata originalMetadata = createResponse.getData().getSyncMetadata();
         assertNotNull(originalMetadata.getVersion());
         int originalVersion = originalMetadata.getVersion();
 
-        // A hub event tells us that a model was created in the cloud;
-        // this model was synced into our local store.
-        inboundModelEventAccumulator.await();
-
-        // Now, wait for another.
-        inboundModelEventAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(expectedId), 1).start();
-
         // Act: externally, the BlogOwner in the Cloud is updated, to correct the entry's last name
-        BlogOwner updatedModel = originalModel.copyOfBuilder() // This uses the same model ID
-            .name("Jameson Williams") // But with corrected name
-            .build();
         GraphQLResponse<ModelWithMetadata<BlogOwner>> updateResponse =
             appSync.update(updatedModel, originalVersion);
         ModelMetadata newMetadata = updateResponse.getData().getSyncMetadata();
@@ -179,31 +173,58 @@ public final class AWSDataStorePluginInstrumentedTest {
         int newVersion = newMetadata.getVersion();
         assertEquals(originalVersion + 1, newVersion);
 
+        // Wait for the events to show up on Hub.
+        List<HubEvent<?>> seenEvents = receiptAccumulator.await();
+
         // Another HubEvent tells us that an update occurred in the Cloud;
         // the update was applied locally, to an existing BlogOwner.
-        inboundModelEventAccumulator.await();
+        assertEquals(
+            Arrays.asList(originalModel, updatedModel),
+            Observable.fromIterable(seenEvents)
+                .map(HubEvent::getData)
+                .map(data -> (ModelWithMetadata<BlogOwner>) data)
+                .map(ModelWithMetadata::getModel)
+                .toList()
+                .blockingGet()
+        );
 
         // Jameson should be in the local DataStore, and last name should be updated.
-        BlogOwner localOwner = dataStore.get(BlogOwner.class, originalModel.getId());
-        assertEquals("Jameson Williams", localOwner.getName());
+        BlogOwner owner = dataStore.get(BlogOwner.class, originalModel.getId());
+        assertEquals("Jameson Williams", owner.getName());
+        assertEquals(originalModel.getId(), owner.getId());
     }
 
-    private HubEventFilter publicationOf(String expectedId) {
-        return filterFor(DataStoreChannelEventName.PUBLISHED_TO_CLOUD, expectedId);
-    }
-
-    private HubEventFilter receiptOf(String expectedId) {
-        return filterFor(DataStoreChannelEventName.RECEIVED_FROM_CLOUD, expectedId);
-    }
-
-    private static HubEventFilter filterFor(DataStoreChannelEventName expectedEventName, String expectedId) {
+    private <T extends Model> HubEventFilter publicationOf(T model) {
         return event -> {
-            if (!DataStoreChannelEventName.fromString(event.getName()).equals(expectedEventName)) {
+            DataStoreChannelEventName actualEventName = DataStoreChannelEventName.fromString(event.getName());
+            if (!DataStoreChannelEventName.PUBLISHED_TO_CLOUD.equals(actualEventName)) {
                 return false;
             }
-            PendingMutation<? extends Model> mutation = (PendingMutation<? extends Model>) event.getData();
-            String modelId = event.getData() == null ? null : mutation.getMutatedItem().getId();
-            return expectedId.equals(modelId);
+            @SuppressWarnings("unchecked")
+            PendingMutation<T> pendingMutation = (PendingMutation<T>) event.getData();
+            if (pendingMutation == null) {
+                return false;
+            } else if (!model.getClass().isAssignableFrom(pendingMutation.getMutatedItem().getClass())) {
+                return false;
+            }
+            return model.getId().equals(pendingMutation.getMutatedItem().getId());
+        };
+    }
+
+    private <T extends Model> HubEventFilter receiptOf(T model) {
+        return event -> {
+            DataStoreChannelEventName actualEventName = DataStoreChannelEventName.fromString(event.getName());
+            if (!DataStoreChannelEventName.RECEIVED_FROM_CLOUD.equals(actualEventName)) {
+                return false;
+            }
+            @SuppressWarnings("unchecked")
+            ModelWithMetadata<T> modelWithMetadata = (ModelWithMetadata<T>) event.getData();
+            if (modelWithMetadata == null) {
+                return false;
+            } else if (!model.getClass().isAssignableFrom(modelWithMetadata.getModel().getClass())) {
+                return false;
+            }
+            return model.getId().equals(modelWithMetadata.getModel().getId());
         };
     }
 }


### PR DESCRIPTION
`syncUpToCloudIsWorking` is passing reliably and should be re-enabled, so
we can detect and prevent new failure modes.

`syncDownFromCloudIsWorking` needs further auditing, and is left Ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
