### PR TITLE
[aws-datastore] Include mutation details in publication exception

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -189,7 +189,8 @@ final class MutationProcessor {
                     }
                     String modelName = mutation.getClassOfMutatedItem().getSimpleName();
                     subscriber.onError(new DataStoreException(
-                        "Mutation failed. AppSync response contained errors. Failed mutation = " + mutation,
+                        "Mutation failed. Failed mutation = " + mutation + ". " +
+                            "AppSync response contained errors = " + response.getErrors(),
                         "Verify that your AppSync endpoint is able to store " + modelName + " models."
                     ));
                 },

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -187,11 +187,10 @@ final class MutationProcessor {
                         subscriber.onSuccess(result.getData());
                         return;
                     }
+                    String modelName = mutation.getClassOfMutatedItem().getSimpleName();
                     subscriber.onError(new DataStoreException(
-                        "Failed to publish an item to the network. AppSync response contained errors: "
-                            + result.getErrors(),
-                        "Verify that your endpoint is configured to accept "
-                            + mutation.getClassOfMutatedItem().getSimpleName() + " models."
+                        "Mutation failed. AppSync response contained errors. Failed mutation = " + mutation,
+                        "Verify that your AppSync endpoint is able to store " + modelName + " models."
                     ));
                 },
                 subscriber::onError

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -190,7 +190,7 @@ final class MutationProcessor {
                     String modelName = mutation.getClassOfMutatedItem().getSimpleName();
                     subscriber.onError(new DataStoreException(
                         "Mutation failed. Failed mutation = " + mutation + ". " +
-                            "AppSync response contained errors = " + response.getErrors(),
+                            "AppSync response contained errors = " + result.getErrors(),
                         "Verify that your AppSync endpoint is able to store " + modelName + " models."
                     ));
                 },


### PR DESCRIPTION
When the `MutationProcessor` fails to publish a `PendingMutation`, it emits
an error. This error message currently contains no information about the
mutation that failed. To help debug, include the contents of the
mutation in the error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
