### PR TITLE
[aws-datastore] Additional logging

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/model/ModelHelper.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/model/ModelHelper.java
@@ -55,7 +55,7 @@ public final class ModelHelper {
             final Method fieldGetter = modelClass.getMethod(getterName);
             return fieldGetter.invoke(model);
         } catch (Exception exception) {
-            LOGGER.warn(String.format(
+            LOGGER.verbose(String.format(
                     "Could not find %s() on %s. Fallback to direct field access.",
                     getterName, modelClass.getName()
             ));

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -81,7 +81,7 @@ final class Merger {
                 LOG.verbose("Remote model update was sync'd down into local storage: " + modelWithMetadata);
             })
             .doOnError(failure ->
-                LOG.warn("Failed to sync remote model into local storage: " + modelWithMetadata)
+                LOG.warn("Failed to sync remote model into local storage: " + modelWithMetadata, failure)
             );
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -40,7 +40,6 @@ import io.reactivex.Completable;
  * All of these sources must be rectified with the current state of the local storage.
  * This is the purpose of the merger.
  */
-@SuppressWarnings("CodeBlock2Expr")
 final class Merger {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
     private final MutationOutbox mutationOutbox;
@@ -77,22 +76,24 @@ final class Merger {
             // Update the metadata for it
             .andThen(save(metadata))
             // Let the world know that we've done a good thing.
-            .andThen(announceSuccessfulMerge(modelWithMetadata));
+            .doOnComplete(() -> {
+                announceSuccessfulMerge(modelWithMetadata);
+                LOG.verbose("Remote model update was sync'd down into local storage: " + modelWithMetadata);
+            })
+            .doOnError(failure ->
+                LOG.warn("Failed to sync remote model into local storage: " + modelWithMetadata)
+            );
     }
 
     /**
      * Announce a successful merge over Hub.
      * @param modelWithMetadata Model with metadata that was successfully merged
      * @param <T> Type of model
-     * @return A completable operation for the publication.
      */
-    private <T extends Model> Completable announceSuccessfulMerge(ModelWithMetadata<T> modelWithMetadata) {
-        return Completable.fromAction(() -> {
-            Amplify.Hub.publish(HubChannel.DATASTORE,
-                HubEvent.create(DataStoreChannelEventName.RECEIVED_FROM_CLOUD, modelWithMetadata)
-            );
-            LOG.info("Remote model update was sync'd down into local storage: " + modelWithMetadata);
-        });
+    private <T extends Model> void announceSuccessfulMerge(ModelWithMetadata<T> modelWithMetadata) {
+        Amplify.Hub.publish(HubChannel.DATASTORE,
+            HubEvent.create(DataStoreChannelEventName.RECEIVED_FROM_CLOUD, modelWithMetadata)
+        );
     }
 
     // Delete a model.
@@ -101,27 +102,28 @@ final class Merger {
             // First, check if the thing exists.
             // If we don't, we'll get an exception saying basically,
             // "failed to delete a non-existing thing."
-            ifPresent(model.getClass(), model.getId(), () -> {
-                localStorageAdapter.delete(
+            ifPresent(model.getClass(), model.getId(),
+                () -> localStorageAdapter.delete(
                     model,
                     StorageItemChange.Initiator.SYNC_ENGINE,
                     ignored -> emitter.onComplete(),
                     emitter::onError
-                );
-            }, emitter::onComplete);
+                ),
+                emitter::onComplete
+            );
         }));
     }
 
     // Create or update a model.
     private <T extends Model> Completable save(T model) {
-        return Completable.defer(() -> Completable.create(emitter -> {
+        return Completable.defer(() -> Completable.create(emitter ->
             localStorageAdapter.save(
                 model,
                 StorageItemChange.Initiator.SYNC_ENGINE,
                 ignored -> emitter.onComplete(),
                 emitter::onError
-            );
-        }));
+            )
+        ));
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
@@ -112,7 +112,7 @@ final class MutationOutbox {
                     subscriber.onComplete();
                 },
                 failure -> {
-                    LOG.warn("Failed to enqueue mutation into mutation outbox: " + pendingMutation);
+                    LOG.warn("Failed to enqueue mutation into mutation outbox: " + pendingMutation, failure);
                     pendingMutations.onError(failure);
                     subscriber.onError(failure);
                 }
@@ -152,11 +152,11 @@ final class MutationOutbox {
                 converter.toRecord(pendingMutation),
                 StorageItemChange.Initiator.SYNC_ENGINE,
                 deletionResult -> {
-                    LOG.verbose("Successfully remove pending mutation from mutation outbox: " + pendingMutation);
+                    LOG.verbose("Successfully removed pending mutation from mutation outbox: " + pendingMutation);
                     subscriber.onComplete();
                 },
                 failure -> {
-                    LOG.warn("Failed to remove pending mutation from mutation outbox: " + pendingMutation);
+                    LOG.warn("Failed to remove pending mutation from mutation outbox: " + pendingMutation, failure);
                     subscriber.onError(failure);
                 }
             )

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
@@ -98,29 +98,26 @@ final class MutationOutbox {
     @NonNull
     <T extends Model> Completable enqueue(@NonNull PendingMutation<T> pendingMutation) {
         Objects.requireNonNull(pendingMutation);
-
-        // defer() the creation of a Completable, until someone subscribes enqueue().
-        // When they do, create() a Completable that wraps a save() call to LocalStorageAdapter.
-        return Completable.defer(() -> Completable.create(subscriber -> {
-            // Convert the PendingMutation (that we want to store) into a Record
-            PendingMutation.PersistentRecord record = converter.toRecord(pendingMutation);
-            // Save it.
-            storage.save(record, StorageItemChange.Initiator.SYNC_ENGINE,
-                saved -> {
+        return Completable.defer(() -> Completable.create(subscriber ->
+            storage.save(
+                converter.toRecord(pendingMutation),
+                StorageItemChange.Initiator.SYNC_ENGINE,
+                saveResult -> {
                     // The return value is a record that we saved a record.
                     // So, we would have to "unwrap" it, to get the item we saved, out.
                     // Forget that. We know the save succeeded, so just emit the
                     // original thing enqueue() got as a param.
-                    LOG.info("Successfully enqueued " + pendingMutation);
+                    LOG.verbose("New mutation has been enqueued to mutation outbox: " + pendingMutation);
                     pendingMutations.onNext(pendingMutation);
                     subscriber.onComplete();
                 },
-                error -> {
-                    pendingMutations.onError(error);
-                    subscriber.onError(error);
+                failure -> {
+                    LOG.warn("Failed to enqueue mutation into mutation outbox: " + pendingMutation);
+                    pendingMutations.onError(failure);
+                    subscriber.onError(failure);
                 }
-            );
-        }));
+            )
+        ));
     }
 
     /**
@@ -150,19 +147,20 @@ final class MutationOutbox {
      */
     @NonNull
     <T extends Model> Completable remove(PendingMutation<T> pendingMutation) {
-        // defer() creation of the Completable until someone subscribe()s via remove() method.
-        // At that time, create() a Completable that wraps a call to LocalStorageAdapter#delete(...).
-        return Completable.defer(() -> Completable.create(subscriber -> {
-            // Convert the PendingMutation into a Record
-            PendingMutation.PersistentRecord record = converter.toRecord(pendingMutation);
-            // Delete it.
+        return Completable.defer(() -> Completable.create(subscriber ->
             storage.delete(
-                record,
+                converter.toRecord(pendingMutation),
                 StorageItemChange.Initiator.SYNC_ENGINE,
-                ignored -> subscriber.onComplete(),
-                subscriber::onError
-            );
-        }));
+                deletionResult -> {
+                    LOG.verbose("Successfully remove pending mutation from mutation outbox: " + pendingMutation);
+                    subscriber.onComplete();
+                },
+                failure -> {
+                    LOG.warn("Failed to remove pending mutation from mutation outbox: " + pendingMutation);
+                    subscriber.onError(failure);
+                }
+            )
+        ));
     }
 
     /**
@@ -173,15 +171,14 @@ final class MutationOutbox {
      * @return An observable stream of mutations that weren't handled in the last session
      */
     private Observable<PendingMutation<? extends Model>> previouslyUnprocessedMutations() {
-        // defer() creation of this Observable until someone subscribe()s to previouslyUnprocessedMutations()
-        // when they do, respond by create()ing an Observable which emits the results of a
-        // query to LocalStorageAdapter, for any existing instances of PendingMutation.Record.
         return Observable.defer(() -> Observable.create(emitter ->
             storage.query(PendingMutation.PersistentRecord.class,
                 results -> {
                     while (results.hasNext()) {
                         try {
-                            emitter.onNext(converter.fromRecord(results.next()));
+                            PendingMutation<? extends Model> pendingMutation = converter.fromRecord(results.next());
+                            LOG.verbose("Found a previously unprocessed mutation. Enqueuing " + pendingMutation);
+                            emitter.onNext(pendingMutation);
                         } catch (DataStoreException conversionFailure) {
                             emitter.onError(conversionFailure);
                         }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -74,7 +74,10 @@ final class MutationProcessor {
         ongoingOperationsDispoable.add(
             mutationOutbox.observe()
                 .doOnSubscribe(disposable ->
-                    LOG.info("Started processing the mutation outbox. Pending mutations will be published to cloud.")
+                    LOG.info(
+                        "Started processing the mutation outbox. " +
+                            "Pending mutations will be published to the cloud."
+                    )
                 )
                 .subscribeOn(Schedulers.io())
                 .observeOn(Schedulers.io())
@@ -102,7 +105,7 @@ final class MutationProcessor {
             .doOnComplete(() -> {
                 LOG.verbose(
                     "Pending mutation was published to cloud successfully, " +
-                    "and removed from the mutation outbox: " + mutationOutboxItem
+                        "and removed from the mutation outbox: " + mutationOutboxItem
                 );
                 announceSuccessfulPublication(mutationOutboxItem);
             })

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -41,7 +41,6 @@ import io.reactivex.schedulers.Schedulers;
  * {@link AppSync}. The responses to these mutations are themselves forwarded to the Merger,
  * which may again modify the store.
  */
-@SuppressWarnings("CodeBlock2Expr")
 final class MutationProcessor {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
@@ -49,7 +48,7 @@ final class MutationProcessor {
     private final Merger merger;
     private final AppSync appSync;
     private final MutationOutbox mutationOutbox;
-    private final CompositeDisposable disposable;
+    private final CompositeDisposable ongoingOperationsDispoable;
 
     MutationProcessor(
             @NonNull Merger merger,
@@ -60,7 +59,7 @@ final class MutationProcessor {
         this.versionRepository = Objects.requireNonNull(versionRepository);
         this.appSync = Objects.requireNonNull(appSync);
         this.mutationOutbox = Objects.requireNonNull(mutationOutbox);
-        this.disposable = new CompositeDisposable();
+        this.ongoingOperationsDispoable = new CompositeDisposable();
     }
 
     /**
@@ -72,8 +71,11 @@ final class MutationProcessor {
      * it again later, when network conditions become favorable again.
      */
     void startDrainingMutationOutbox() {
-        disposable.add(
+        ongoingOperationsDispoable.add(
             mutationOutbox.observe()
+                .doOnSubscribe(disposable ->
+                    LOG.info("Started processing the mutation outbox. Pending mutations will be published to cloud.")
+                )
                 .subscribeOn(Schedulers.io())
                 .observeOn(Schedulers.io())
                 .flatMapCompletable(this::processOutboxItem)
@@ -97,10 +99,14 @@ final class MutationProcessor {
             .flatMapCompletable(merger::merge)
             // Lastly, remove the item from the outbox, so we don't process it again.
             .andThen(mutationOutbox.remove(mutationOutboxItem))
-            .andThen(Completable.fromAction(() -> {
-                LOG.info("Pending mutation was published up to Cloud: " + mutationOutboxItem);
+            .doOnComplete(() -> {
+                LOG.verbose(
+                    "Pending mutation was published to cloud successfully, " +
+                    "and removed from the mutation outbox: " + mutationOutboxItem
+                );
                 announceSuccessfulPublication(mutationOutboxItem);
-            }));
+            })
+            .doOnError(error -> LOG.warn("Failed to publish a local change = " + mutationOutboxItem, error));
     }
 
     /**
@@ -109,16 +115,17 @@ final class MutationProcessor {
      * @param <T> Type of model
      */
     private <T extends Model> void announceSuccessfulPublication(PendingMutation<T> processedMutation) {
-        HubEvent<PendingMutation<? extends Model>> publishedToCloudEvent =
-            HubEvent.create(DataStoreChannelEventName.PUBLISHED_TO_CLOUD, processedMutation);
-        Amplify.Hub.publish(HubChannel.DATASTORE, publishedToCloudEvent);
+        Amplify.Hub.publish(
+            HubChannel.DATASTORE,
+            HubEvent.create(DataStoreChannelEventName.PUBLISHED_TO_CLOUD, processedMutation)
+        );
     }
 
     /**
      * Don't process any more mutations.
      */
     void stopDrainingMutationOutbox() {
-        disposable.dispose();
+        ongoingOperationsDispoable.dispose();
     }
 
     /**
@@ -146,11 +153,12 @@ final class MutationProcessor {
 
     // For an item in the outbox, dispatch an update mutation
     private <T extends Model> Single<ModelWithMetadata<T>> update(PendingMutation<T> mutation) {
-        return versionRepository.findModelVersion(mutation.getMutatedItem()).flatMap(version -> {
-            return publishWithStrategy(mutation, (model, onSuccess, onError) -> {
-                appSync.update(model, version, onSuccess, onError);
-            });
-        });
+        final T updatedItem = mutation.getMutatedItem();
+        return versionRepository.findModelVersion(updatedItem).flatMap(version ->
+            publishWithStrategy(mutation, (model, onSuccess, onError) ->
+                appSync.update(model, version, onSuccess, onError)
+            )
+        );
     }
 
     // For an item in the outbox, dispatch a create mutation
@@ -160,13 +168,13 @@ final class MutationProcessor {
 
     // For an item in the outbox, dispatch a delete mutation
     private <T extends Model> Single<ModelWithMetadata<T>> delete(PendingMutation<T> mutation) {
-        return versionRepository.findModelVersion(mutation.getMutatedItem()).flatMap(version -> {
-            return publishWithStrategy(mutation, (model, onSuccess, onError) -> {
-                final Class<T> modelClass = mutation.getClassOfMutatedItem();
-                final String modelId = mutation.getMutatedItem().getId();
-                appSync.delete(modelClass, modelId, version, onSuccess, onError);
-            });
-        });
+        final T deletedItem = mutation.getMutatedItem();
+        final Class<T> deletedItemClass = mutation.getClassOfMutatedItem();
+        return versionRepository.findModelVersion(deletedItem).flatMap(version ->
+            publishWithStrategy(mutation, (model, onSuccess, onError) ->
+                appSync.delete(deletedItemClass, deletedItem.getId(), version, onSuccess, onError)
+            )
+        );
     }
 
     /**
@@ -179,24 +187,25 @@ final class MutationProcessor {
      */
     private <T extends Model> Single<ModelWithMetadata<T>> publishWithStrategy(
             PendingMutation<T> mutation, PublicationStrategy<T> publicationStrategy) {
-        return Single.defer(() -> Single.create(subscriber -> {
+        T mutatedItem = mutation.getMutatedItem();
+        String modelClassName = mutation.getClassOfMutatedItem().getSimpleName();
+        return Single.defer(() -> Single.create(subscriber ->
             publicationStrategy.publish(
-                mutation.getMutatedItem(),
+                mutatedItem,
                 result -> {
                     if (!result.hasErrors() && result.hasData()) {
                         subscriber.onSuccess(result.getData());
                         return;
                     }
-                    String modelName = mutation.getClassOfMutatedItem().getSimpleName();
                     subscriber.onError(new DataStoreException(
                         "Mutation failed. Failed mutation = " + mutation + ". " +
                             "AppSync response contained errors = " + result.getErrors(),
-                        "Verify that your AppSync endpoint is able to store " + modelName + " models."
+                        "Verify that your AppSync endpoint is able to store " + modelClassName + " models."
                     ));
                 },
                 subscriber::onError
-            );
-        }));
+            )
+        ));
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -48,7 +48,7 @@ final class MutationProcessor {
     private final Merger merger;
     private final AppSync appSync;
     private final MutationOutbox mutationOutbox;
-    private final CompositeDisposable ongoingOperationsDispoable;
+    private final CompositeDisposable ongoingOperationsDisposable;
 
     MutationProcessor(
             @NonNull Merger merger,
@@ -59,7 +59,7 @@ final class MutationProcessor {
         this.versionRepository = Objects.requireNonNull(versionRepository);
         this.appSync = Objects.requireNonNull(appSync);
         this.mutationOutbox = Objects.requireNonNull(mutationOutbox);
-        this.ongoingOperationsDispoable = new CompositeDisposable();
+        this.ongoingOperationsDisposable = new CompositeDisposable();
     }
 
     /**
@@ -71,7 +71,7 @@ final class MutationProcessor {
      * it again later, when network conditions become favorable again.
      */
     void startDrainingMutationOutbox() {
-        ongoingOperationsDispoable.add(
+        ongoingOperationsDisposable.add(
             mutationOutbox.observe()
                 .doOnSubscribe(disposable ->
                     LOG.info(
@@ -128,7 +128,7 @@ final class MutationProcessor {
      * Don't process any more mutations.
      */
     void stopDrainingMutationOutbox() {
-        ongoingOperationsDispoable.dispose();
+        ongoingOperationsDisposable.dispose();
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
@@ -38,14 +38,14 @@ final class StorageObserver {
 
     private final LocalStorageAdapter localStorageAdapter;
     private final MutationOutbox mutationOutbox;
-    private final CompositeDisposable disposable;
+    private final CompositeDisposable ongoingOperationsDisposable;
 
     StorageObserver(
             @NonNull LocalStorageAdapter localStorageAdapter,
             @NonNull MutationOutbox mutationOutbox) {
         this.localStorageAdapter = Objects.requireNonNull(localStorageAdapter);
         this.mutationOutbox = Objects.requireNonNull(mutationOutbox);
-        this.disposable = new CompositeDisposable();
+        this.ongoingOperationsDisposable = new CompositeDisposable();
     }
 
     /**
@@ -53,7 +53,13 @@ final class StorageObserver {
      * by the sync engine, then place that change into the mutation outbox.
      */
     void startObservingStorageChanges() {
-        disposable.add(streamOfStorageChanges()
+        ongoingOperationsDisposable.add(
+            Observable.<StorageItemChange<? extends Model>>create(emitter ->
+                localStorageAdapter.observe(emitter::onNext, emitter::onError, emitter::onComplete)
+            )
+            .doOnSubscribe(disposable ->
+                LOG.info("Now observing local storage. Local changes will be enqueued to mutation outbox.")
+            )
             .filter(possiblyCyclicChange -> {
                 // Don't continue if the storage change was caused by the sync engine itself
                 return !StorageItemChange.Initiator.SYNC_ENGINE.equals(possiblyCyclicChange.initiator());
@@ -84,12 +90,6 @@ final class StorageObserver {
      * Stop observing changes in the storage adapter.
      */
     void stopObservingStorageChanges() {
-        disposable.clear();
-    }
-
-    private Observable<StorageItemChange<? extends Model>> streamOfStorageChanges() {
-        return Observable.create(emitter ->
-            localStorageAdapter.observe(emitter::onNext, emitter::onError, emitter::onComplete)
-        );
+        ongoingOperationsDisposable.clear();
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -127,9 +127,9 @@ final class SubscriptionProcessor {
         })
         .doOnError(subscriptionError ->
             LOG.warn(String.format(Locale.US,
-        "An error occurred on the remote %s subscription for model %s: %s",
-        clazz.getSimpleName(), subscriptionType.name(), subscriptionError.getCause()
-            ))
+                "An error occurred on the remote %s subscription for model %s.",
+                clazz.getSimpleName(), subscriptionType.name()
+            ), subscriptionError)
         )
         .onErrorResumeNext((ObservableSource<GraphQLResponse<ModelWithMetadata<T>>>) Observer::onComplete)
         .subscribeOn(Schedulers.io())

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -171,7 +171,7 @@ final class SyncProcessor {
         }).doOnSuccess(results ->
             LOG.verbose("Successfully sync'd down cloud state for model type = " + modelClass.getSimpleName())
         ).doOnError(failureToSync ->
-            LOG.warn("Failed to sync down cloud state for model type = " + modelClass.getSimpleName())
+            LOG.warn("Failed to sync down cloud state for model type = " + modelClass.getSimpleName(), failureToSync)
         );
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -15,7 +15,6 @@
 
 package com.amplifyframework.datastore.syncengine;
 
-import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.api.graphql.GraphQLResponse;
@@ -55,6 +54,7 @@ import io.reactivex.schedulers.Schedulers;
  */
 final class SyncProcessor {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
+
     private final ModelProvider modelProvider;
     private final ModelSchemaRegistry modelSchemaRegistry;
     private final SyncTimeRegistry syncTimeRegistry;
@@ -114,11 +114,14 @@ final class SyncProcessor {
                         // For each ModelWithMetadata, merge it into the local store.
                         .flatMapCompletable(merger::merge)
                     )
-                    .doOnError(exception -> {
-                        LOG.warn("Remote synchronization failed to start due to an exception.", exception);
-                    })
-                    .onErrorComplete()
                     .andThen(syncTimeRegistry.saveLastSyncTime(modelClass, SyncTime.now()))
+                    .doOnError(failureToSync ->
+                        LOG.warn("Initial cloud sync failed.", failureToSync)
+                    )
+                    .doOnComplete(() ->
+                        LOG.info("Successfully sync'd down model state from cloud.")
+                    )
+                    .onErrorComplete()
             );
     }
 
@@ -161,11 +164,15 @@ final class SyncProcessor {
     private <T extends Model> Single<Iterable<ModelWithMetadata<T>>> syncModel(
             Class<T> modelClass, SyncTime syncTime) {
         final Long lastSyncTimeAsLong = syncTime.exists() ? syncTime.toLong() : null;
-        return Single.create(emitter -> {
+        return Single.<Iterable<ModelWithMetadata<T>>>create(emitter -> {
             final Cancelable cancelable =
                 appSync.sync(modelClass, lastSyncTimeAsLong, metadataEmitter(emitter), emitter::onError);
             emitter.setDisposable(asDisposable(cancelable));
-        });
+        }).doOnSuccess(results ->
+            LOG.verbose("Successfully sync'd down cloud state for model type = " + modelClass.getSimpleName())
+        ).doOnError(failureToSync ->
+            LOG.warn("Failed to sync down cloud state for model type = " + modelClass.getSimpleName())
+        );
     }
 
     /**
@@ -273,7 +280,6 @@ final class SyncProcessor {
             return Builder.this;
         }
 
-        @SuppressLint("SyntheticAccessor")
         @NonNull
         @Override
         public SyncProcessor build() {


### PR DESCRIPTION
Adds more detailed logging about the system state.

Changes some existing logs to verbose, which is not printed in
production, by default.

General strategy is to log lifecycle events at `INFO` (visible to
production), recoverable failures as `WARN`. Everything else as `VERBOSE`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
