### PR TITLE
[aws-datastore] Further refinements to log levels

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionOperation.java
@@ -108,7 +108,7 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
     @Override
     public void start() {
         executorService.submit(() -> {
-            LOG.debug("Request " + getRequest().getContent());
+            LOG.debug("Requesting subscription: " + getRequest().getContent());
             subscriptionId = subscriptionEndpoint.requestSubscription(
                 getRequest(),
                 onSubscriptionStarted,

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -139,7 +139,7 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
             }
 
             final String valueAsString = cursor.getString(columnIndex);
-            LOGGER.debug(String.format(
+            LOGGER.verbose(String.format(
                     "Attempt to convert value \"%s\" from field %s of type %s from model %s",
                     valueAsString, field.getName(), field.getType(), modelType.getSimpleName()
             ));

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -634,8 +634,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             int columnIndex,
             @Nullable Object value
     ) throws DataStoreException {
-        LOG.verbose("SQLiteStorageAdapter.bindValueToStatement");
-        LOG.verbose("value = " + value);
+        LOG.verbose("SQLiteStorageAdapter.bindValueToStatement(..., value = " + value);
         if (value == null) {
             statement.bindNull(columnIndex);
         } else if (value instanceof String) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
@@ -214,7 +214,7 @@ final class SQLiteStorageHelper extends SQLiteOpenHelper implements ModelUpdateS
                     continue;
                 }
                 sqliteDatabase.execSQL("DROP TABLE IF EXISTS " + table);
-                LOG.verbose("Dropped table: " + table);
+                LOG.debug("Dropped table: " + table);
             }
             sqliteDatabase.setTransactionSuccessful();
             sqliteDatabase.endTransaction();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -78,7 +78,7 @@ final class Merger {
             // Let the world know that we've done a good thing.
             .doOnComplete(() -> {
                 announceSuccessfulMerge(modelWithMetadata);
-                LOG.verbose("Remote model update was sync'd down into local storage: " + modelWithMetadata);
+                LOG.debug("Remote model update was sync'd down into local storage: " + modelWithMetadata);
             })
             .doOnError(failure ->
                 LOG.warn("Failed to sync remote model into local storage: " + modelWithMetadata, failure)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationOutbox.java
@@ -107,7 +107,7 @@ final class MutationOutbox {
                     // So, we would have to "unwrap" it, to get the item we saved, out.
                     // Forget that. We know the save succeeded, so just emit the
                     // original thing enqueue() got as a param.
-                    LOG.verbose("New mutation has been enqueued to mutation outbox: " + pendingMutation);
+                    LOG.debug("New mutation has been enqueued to mutation outbox: " + pendingMutation);
                     pendingMutations.onNext(pendingMutation);
                     subscriber.onComplete();
                 },
@@ -152,7 +152,7 @@ final class MutationOutbox {
                 converter.toRecord(pendingMutation),
                 StorageItemChange.Initiator.SYNC_ENGINE,
                 deletionResult -> {
-                    LOG.verbose("Successfully removed pending mutation from mutation outbox: " + pendingMutation);
+                    LOG.debug("Successfully removed pending mutation from mutation outbox: " + pendingMutation);
                     subscriber.onComplete();
                 },
                 failure -> {
@@ -177,7 +177,7 @@ final class MutationOutbox {
                     while (results.hasNext()) {
                         try {
                             PendingMutation<? extends Model> pendingMutation = converter.fromRecord(results.next());
-                            LOG.verbose("Found a previously unprocessed mutation. Enqueuing " + pendingMutation);
+                            LOG.debug("Found a previously unprocessed mutation. Enqueuing " + pendingMutation);
                             emitter.onNext(pendingMutation);
                         } catch (DataStoreException conversionFailure) {
                             emitter.onError(conversionFailure);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -103,7 +103,7 @@ final class MutationProcessor {
             // Lastly, remove the item from the outbox, so we don't process it again.
             .andThen(mutationOutbox.remove(mutationOutboxItem))
             .doOnComplete(() -> {
-                LOG.verbose(
+                LOG.debug(
                     "Pending mutation was published to cloud successfully, " +
                         "and removed from the mutation outbox: " + mutationOutboxItem
                 );

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -169,7 +169,7 @@ final class SyncProcessor {
                 appSync.sync(modelClass, lastSyncTimeAsLong, metadataEmitter(emitter), emitter::onError);
             emitter.setDisposable(asDisposable(cancelable));
         }).doOnSuccess(results ->
-            LOG.verbose("Successfully sync'd down cloud state for model type = " + modelClass.getSimpleName())
+            LOG.debug("Successfully sync'd down cloud state for model type = " + modelClass.getSimpleName())
         ).doOnError(failureToSync ->
             LOG.warn("Failed to sync down cloud state for model type = " + modelClass.getSimpleName(), failureToSync)
         );


### PR DESCRIPTION
Move debugging logs to debug level, to avoid the noise that is present
in the verbose level.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
