### PR TITLE
[aws-datastore] Optimize record lookup

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -730,9 +730,9 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             @NonNull String tableName,
             @NonNull String columnName,
             @NonNull String columnValue) {
-        // SELECT * FROM '{tableName}' WHERE {columnName} = '{columnValue}'
+        // SELECT 1 FROM '{tableName}' WHERE {columnName} = '{columnValue}'
         final String queryString = "" +
-            SqlKeyword.SELECT + SqlKeyword.DELIMITER + "*" + SqlKeyword.DELIMITER +
+            SqlKeyword.SELECT + SqlKeyword.DELIMITER + "1" + SqlKeyword.DELIMITER +
             SqlKeyword.FROM + SqlKeyword.DELIMITER + Quotes.wrapInSingle(tableName) + SqlKeyword.DELIMITER +
             SqlKeyword.WHERE + SqlKeyword.DELIMITER + columnName + SqlKeyword.DELIMITER +
             SqlKeyword.EQUAL + SqlKeyword.DELIMITER + Quotes.wrapInSingle(columnValue);


### PR DESCRIPTION
`SELECT 1`, instead `SELECT *`, since we are only interested in presence,
not in the record data itself.

Refer: https://stackoverflow.com/a/7171072/695787

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
