### PR TITLE
Add text and label configuration

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPluginConfiguration.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPluginConfiguration.java
@@ -19,6 +19,8 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.predictions.PredictionsException;
 import com.amplifyframework.predictions.aws.configuration.IdentifyEntitiesConfiguration;
+import com.amplifyframework.predictions.aws.configuration.IdentifyLabelsConfiguration;
+import com.amplifyframework.predictions.aws.configuration.IdentifyTextConfiguration;
 import com.amplifyframework.predictions.aws.configuration.InterpretTextConfiguration;
 import com.amplifyframework.predictions.aws.configuration.SpeechGeneratorConfiguration;
 import com.amplifyframework.predictions.aws.configuration.TranslateTextConfiguration;
@@ -37,21 +39,27 @@ public final class AWSPredictionsPluginConfiguration {
     private final NetworkPolicy defaultNetworkPolicy;
     private final SpeechGeneratorConfiguration speechGeneratorConfiguration;
     private final TranslateTextConfiguration translateTextConfiguration;
+    private final IdentifyLabelsConfiguration identifyLabelsConfiguration;
     private final IdentifyEntitiesConfiguration identifyEntitiesConfiguration;
+    private final IdentifyTextConfiguration identifyTextConfiguration;
     private final InterpretTextConfiguration interpretTextConfiguration;
 
     private AWSPredictionsPluginConfiguration(
             Region defaultRegion,
             SpeechGeneratorConfiguration speechGeneratorConfiguration,
             TranslateTextConfiguration translateTextConfiguration,
+            IdentifyLabelsConfiguration identifyLabelsConfiguration,
             IdentifyEntitiesConfiguration identifyEntitiesConfiguration,
+            IdentifyTextConfiguration identifyTextConfiguration,
             InterpretTextConfiguration interpretTextConfiguration
     ) {
         this.defaultRegion = defaultRegion;
         this.defaultNetworkPolicy = NetworkPolicy.AUTO;
         this.speechGeneratorConfiguration = speechGeneratorConfiguration;
         this.translateTextConfiguration = translateTextConfiguration;
+        this.identifyLabelsConfiguration = identifyLabelsConfiguration;
         this.identifyEntitiesConfiguration = identifyEntitiesConfiguration;
+        this.identifyTextConfiguration = identifyTextConfiguration;
         this.interpretTextConfiguration = interpretTextConfiguration;
     }
 
@@ -74,10 +82,11 @@ public final class AWSPredictionsPluginConfiguration {
         final Region defaultRegion;
         final SpeechGeneratorConfiguration speechGeneratorConfiguration;
         final TranslateTextConfiguration translateTextConfiguration;
-        final InterpretTextConfiguration interpretConfiguration;
+        final IdentifyLabelsConfiguration identifyLabelsConfiguration;
         final IdentifyEntitiesConfiguration identifyEntitiesConfiguration;
+        final IdentifyTextConfiguration identifyTextConfiguration;
+        final InterpretTextConfiguration interpretConfiguration;
 
-        // Required sections
         try {
             // Get default region
             String regionString = configurationJson.getString(ConfigKey.DEFAULT_REGION.key());
@@ -94,9 +103,13 @@ public final class AWSPredictionsPluginConfiguration {
 
             if (configurationJson.has(ConfigKey.IDENTIFY.key())) {
                 JSONObject identifyJson = configurationJson.getJSONObject(ConfigKey.IDENTIFY.key());
+                identifyLabelsConfiguration = IdentifyLabelsConfiguration.fromJson(identifyJson);
                 identifyEntitiesConfiguration = IdentifyEntitiesConfiguration.fromJson(identifyJson);
+                identifyTextConfiguration = IdentifyTextConfiguration.fromJson(identifyJson);
             } else {
+                identifyLabelsConfiguration = null;
                 identifyEntitiesConfiguration = null;
+                identifyTextConfiguration = null;
             }
 
             if (configurationJson.has(ConfigKey.INTERPRET.key())) {
@@ -105,7 +118,6 @@ public final class AWSPredictionsPluginConfiguration {
             } else {
                 interpretConfiguration = null;
             }
-
         } catch (JSONException | IllegalArgumentException exception) {
             throw new PredictionsException(
                     "Issue encountered while parsing configuration JSON",
@@ -118,7 +130,9 @@ public final class AWSPredictionsPluginConfiguration {
                 defaultRegion,
                 speechGeneratorConfiguration,
                 translateTextConfiguration,
+                identifyLabelsConfiguration,
                 identifyEntitiesConfiguration,
+                identifyTextConfiguration,
                 interpretConfiguration
         );
     }
@@ -176,6 +190,23 @@ public final class AWSPredictionsPluginConfiguration {
     }
 
     /**
+     * Gets the configuration for labels detection.
+     * Null if not configured.
+     * @return the configuration for labels detection
+     * @throws PredictionsException if not configured
+     */
+    @NonNull
+    public IdentifyLabelsConfiguration getIdentifyLabelsConfiguration() throws PredictionsException {
+        if (identifyLabelsConfiguration == null) {
+            throw new PredictionsException(
+                    "Labels detection is not configured.",
+                    "Verify that identifyLabels is configured under " + ConfigKey.IDENTIFY.key()
+            );
+        }
+        return identifyLabelsConfiguration;
+    }
+
+    /**
      * Gets the configuration for entities detection.
      * Null if not configured.
      * @return the configuration for entities detection
@@ -190,6 +221,23 @@ public final class AWSPredictionsPluginConfiguration {
             );
         }
         return identifyEntitiesConfiguration;
+    }
+
+    /**
+     * Gets the configuration for text detection.
+     * Null if not configured.
+     * @return the configuration for text detection
+     * @throws PredictionsException if not configured
+     */
+    @NonNull
+    public IdentifyTextConfiguration getIdentifyTextConfiguration() throws PredictionsException {
+        if (identifyTextConfiguration == null) {
+            throw new PredictionsException(
+                    "Text detection is not configured.",
+                    "Verify that identifyText is configured under " + ConfigKey.IDENTIFY.key()
+            );
+        }
+        return identifyTextConfiguration;
     }
 
     /**

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/configuration/IdentifyLabelsConfiguration.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/configuration/IdentifyLabelsConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.aws.configuration;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.predictions.aws.NetworkPolicy;
+import com.amplifyframework.predictions.models.LabelType;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Configures the behavior for identifying labels.
+ */
+public final class IdentifyLabelsConfiguration {
+    private static final String CONFIG_NAME = "identifyLabels";
+    private final LabelType type;
+    private final NetworkPolicy networkPolicy;
+
+    private IdentifyLabelsConfiguration(
+            LabelType type,
+            NetworkPolicy networkPolicy
+    ) {
+        this.type = type;
+        this.networkPolicy = networkPolicy;
+    }
+
+    /**
+     * Construct an instance of {@link IdentifyLabelsConfiguration} from
+     * plugin configuration JSON object.
+     * @param configurationJson the plugin configuration
+     * @return the configuration for label identification
+     * @throws JSONException if identify configuration is malformed
+     */
+    @Nullable
+    public static IdentifyLabelsConfiguration fromJson(@NonNull JSONObject configurationJson) throws JSONException {
+        if (!configurationJson.has(CONFIG_NAME)) {
+            return null;
+        }
+
+        JSONObject identifyLabelsJson = configurationJson.getJSONObject(CONFIG_NAME);
+        String typeString = identifyLabelsJson.getString("type");
+        String networkPolicyString = identifyLabelsJson.getString("defaultNetworkPolicy");
+
+        final LabelType type = LabelType.valueOf(typeString);
+        final NetworkPolicy networkPolicy = NetworkPolicy.fromKey(networkPolicyString);
+
+        return new IdentifyLabelsConfiguration(type, networkPolicy);
+    }
+
+    /**
+     * Gets the type of label identification to perform.
+     * @return the type of label identification
+     */
+    @NonNull
+    public LabelType getType() {
+        return type;
+    }
+
+    /**
+     * Gets the type of network policy for resource access.
+     * @return the network policy type
+     */
+    @NonNull
+    public NetworkPolicy getNetworkPolicy() {
+        return networkPolicy;
+    }
+}

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/configuration/IdentifyTextConfiguration.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/configuration/IdentifyTextConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.aws.configuration;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.predictions.aws.NetworkPolicy;
+import com.amplifyframework.predictions.models.TextFormatType;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Configures the behavior for identifying text.
+ */
+public final class IdentifyTextConfiguration {
+    private static final String CONFIG_NAME = "identifyText";
+    private final TextFormatType format;
+    private final NetworkPolicy networkPolicy;
+
+    private IdentifyTextConfiguration(
+            TextFormatType format,
+            NetworkPolicy networkPolicy
+    ) {
+        this.format = format;
+        this.networkPolicy = networkPolicy;
+    }
+
+    /**
+     * Construct an instance of {@link IdentifyTextConfiguration} from
+     * plugin configuration JSON object.
+     * @param configurationJson the plugin configuration
+     * @return the configuration for text identification
+     * @throws JSONException if identify configuration is malformed
+     */
+    @Nullable
+    public static IdentifyTextConfiguration fromJson(@NonNull JSONObject configurationJson) throws JSONException {
+        if (!configurationJson.has(CONFIG_NAME)) {
+            return null;
+        }
+
+        JSONObject identifyLabelsJson = configurationJson.getJSONObject(CONFIG_NAME);
+        String formatString = identifyLabelsJson.getString("format");
+        String networkPolicyString = identifyLabelsJson.getString("defaultNetworkPolicy");
+
+        final TextFormatType format = TextFormatType.valueOf(formatString);
+        final NetworkPolicy networkPolicy = NetworkPolicy.fromKey(networkPolicyString);
+
+        return new IdentifyTextConfiguration(format, networkPolicy);
+    }
+
+    /**
+     * Gets the type of text identification to perform.
+     * @return the type of text identification
+     */
+    @NonNull
+    public TextFormatType getFormat() {
+        return format;
+    }
+
+    /**
+     * Gets the type of network policy for resource access.
+     * @return the network policy type
+     */
+    @NonNull
+    public NetworkPolicy getNetworkPolicy() {
+        return networkPolicy;
+    }
+}

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/operation/AWSIdentifyOperation.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/operation/AWSIdentifyOperation.java
@@ -22,8 +22,6 @@ import com.amplifyframework.predictions.PredictionsException;
 import com.amplifyframework.predictions.aws.request.AWSImageIdentifyRequest;
 import com.amplifyframework.predictions.aws.service.AWSPredictionsService;
 import com.amplifyframework.predictions.models.IdentifyAction;
-import com.amplifyframework.predictions.models.LabelType;
-import com.amplifyframework.predictions.models.TextFormatType;
 import com.amplifyframework.predictions.operation.IdentifyOperation;
 import com.amplifyframework.predictions.result.IdentifyResult;
 
@@ -85,83 +83,36 @@ public final class AWSIdentifyOperation
     }
 
     private void startCelebritiesDetection() {
-        executorService.execute(() ->
-            predictionsService.recognizeCelebrities(
-                    getRequest().getImageData(),
-                    onSuccess,
-                    onError
-            )
-        );
+        executorService.execute(() -> predictionsService.recognizeCelebrities(
+                getRequest().getImageData(),
+                onSuccess,
+                onError
+        ));
     }
 
     private void startLabelsDetection() {
-        executorService.execute(() -> {
-            final LabelType labelType;
-            try {
-                labelType = (LabelType) getIdentifyAction();
-            } catch (ClassCastException notLabelType) {
-                onError.accept(new PredictionsException(
-                        "The identify action type does not specify a label type.",
-                        "When passing in action type for label detection, use " +
-                                "LabelType instead of IdentifyActionType."
-                ));
-                return;
-            }
-            predictionsService.detectLabels(
-                    labelType,
-                    getRequest().getImageData(),
-                    onSuccess,
-                    onError
-            );
-        });
+        executorService.execute(() -> predictionsService.detectLabels(
+                getIdentifyAction(),
+                getRequest().getImageData(),
+                onSuccess,
+                onError
+        ));
     }
 
     private void startEntitiesDetection() {
-        executorService.execute(() ->
-            predictionsService.detectEntities(getRequest().getImageData(),
-                    onSuccess,
-                    onError
-            )
-        );
+        executorService.execute(() -> predictionsService.detectEntities(
+                getRequest().getImageData(),
+                onSuccess,
+                onError
+        ));
     }
 
     private void startTextDetection() {
-        executorService.execute(() -> {
-            final TextFormatType textFormatType;
-            try {
-                textFormatType = (TextFormatType) getIdentifyAction();
-            } catch (ClassCastException notLabelType) {
-                onError.accept(new PredictionsException(
-                        "The identify action type does not specify a text format type.",
-                        "When passing in action type for text detection, use " +
-                                "TextFormatType instead of IdentifyActionType."
-                ));
-                return;
-            }
-
-            switch (textFormatType) {
-                case PLAIN:
-                    predictionsService.detectPlainText(
-                            getRequest().getImageData(),
-                            onSuccess,
-                            onError
-                    );
-                    return;
-                case FORM:
-                case TABLE:
-                case ALL:
-                    predictionsService.detectDocumentText(
-                            textFormatType,
-                            getRequest().getImageData(),
-                            onSuccess,
-                            onError);
-                    return;
-                default:
-                    onError.accept(new PredictionsException(
-                            "Unexpected error: invalid or unsupported identify action type.",
-                            "Please verify that a valid implementation of IdentifyAction was used."
-                    ));
-            }
-        });
+        executorService.execute(() -> predictionsService.detectText(
+                getIdentifyAction(),
+                getRequest().getImageData(),
+                onSuccess,
+                onError
+        ));
     }
 }

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSPredictionsService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSPredictionsService.java
@@ -21,6 +21,7 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.predictions.PredictionsException;
 import com.amplifyframework.predictions.aws.AWSPredictionsPluginConfiguration;
 import com.amplifyframework.predictions.aws.models.AWSVoiceType;
+import com.amplifyframework.predictions.models.IdentifyAction;
 import com.amplifyframework.predictions.models.LabelType;
 import com.amplifyframework.predictions.models.LanguageType;
 import com.amplifyframework.predictions.models.TextFormatType;
@@ -42,6 +43,7 @@ import java.nio.ByteBuffer;
  */
 public final class AWSPredictionsService {
 
+    private final AWSPredictionsPluginConfiguration configuration;
     private final AWSPollyService pollyService;
     private final AWSTranslateService translateService;
     private final AWSRekognitionService rekognitionService;
@@ -53,6 +55,7 @@ public final class AWSPredictionsService {
      * @param configuration the configuration for AWS Predictions Plugin
      */
     public AWSPredictionsService(@NonNull AWSPredictionsPluginConfiguration configuration) {
+        this.configuration = configuration;
         this.pollyService = new AWSPollyService(configuration);
         this.translateService = new AWSTranslateService(configuration);
         this.rekognitionService = new AWSRekognitionService(configuration);
@@ -104,12 +107,19 @@ public final class AWSPredictionsService {
      * @param onError triggered upon encountering error
      */
     public void detectLabels(
-            @NonNull LabelType type,
+            @NonNull IdentifyAction type,
             @NonNull ByteBuffer imageData,
             @NonNull Consumer<IdentifyResult> onSuccess,
             @NonNull Consumer<PredictionsException> onError
     ) {
-        rekognitionService.detectLabels(type, imageData, onSuccess, onError);
+        final LabelType labelType;
+        try {
+            labelType = getLabelType(type);
+        } catch (PredictionsException error) {
+            onError.accept(error);
+            return;
+        }
+        rekognitionService.detectLabels(labelType, imageData, onSuccess, onError);
     }
 
     /**
@@ -141,33 +151,34 @@ public final class AWSPredictionsService {
     }
 
     /**
-     * Delegate to {@link AWSRekognitionService} to detect plain text.
-     * @param imageData the image data
-     * @param onSuccess triggered upon successful result
-     * @param onError triggered upon encountering error
-     */
-    public void detectPlainText(
-            @NonNull ByteBuffer imageData,
-            @NonNull Consumer<IdentifyResult> onSuccess,
-            @NonNull Consumer<PredictionsException> onError
-    ) {
-        rekognitionService.detectPlainText(imageData, onSuccess, onError);
-    }
-
-    /**
-     * Delegate to {@link AWSTextractService} to detect document text.
+     * Delegate to {@link AWSRekognitionService} to detect plain text
+     * or to {@link AWSTextractService} to detect document text.
      * @param type the type of text format to detect
      * @param imageData the image data
      * @param onSuccess triggered upon successful result
      * @param onError triggered upon encountering error
      */
-    public void detectDocumentText(
-            @NonNull TextFormatType type,
+    public void detectText(
+            @NonNull IdentifyAction type,
             @NonNull ByteBuffer imageData,
             @NonNull Consumer<IdentifyResult> onSuccess,
             @NonNull Consumer<PredictionsException> onError
     ) {
-        textractService.detectDocumentText(type, imageData, onSuccess, onError);
+        final TextFormatType textType;
+        try {
+            textType = getTextFormatType(type);
+        } catch (PredictionsException error) {
+            onError.accept(error);
+            return;
+        }
+
+        if (TextFormatType.PLAIN.equals(textType)) {
+            // Delegate to Amazon Rekognition for plain text detection
+            rekognitionService.detectPlainText(imageData, onSuccess, onError);
+        } else {
+            // Delegate to Amazon Textract for document text detection
+            textractService.detectDocumentText(textType, imageData, onSuccess, onError);
+        }
     }
 
     /**
@@ -182,6 +193,32 @@ public final class AWSPredictionsService {
             @NonNull Consumer<PredictionsException> onError
     ) {
         comprehendService.comprehend(text, onSuccess, onError);
+    }
+
+    /**
+     * If {@link IdentifyAction} is an instance of {@link LabelType} and
+     * cast if true. Otherwise check configuration for default action type.
+     * Throw if label detection is not configured.
+     */
+    private LabelType getLabelType(IdentifyAction actionType) throws PredictionsException {
+        try {
+            return (LabelType) actionType;
+        } catch (ClassCastException error) {
+            return configuration.getIdentifyLabelsConfiguration().getType();
+        }
+    }
+
+    /**
+     * If {@link IdentifyAction} is an instance of {@link TextFormatType} and
+     * cast if true. Otherwise check configuration for default action type.
+     * Throw if text detection is not configured.
+     */
+    private TextFormatType getTextFormatType(IdentifyAction actionType) throws PredictionsException {
+        try {
+            return (TextFormatType) actionType;
+        } catch (ClassCastException error) {
+            return configuration.getIdentifyTextConfiguration().getFormat();
+        }
     }
 
     /**

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSRekognitionService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSRekognitionService.java
@@ -133,9 +133,19 @@ final class AWSRekognitionService {
             @NonNull Consumer<IdentifyResult> onSuccess,
             @NonNull Consumer<PredictionsException> onError
     ) {
+        final IdentifyEntitiesConfiguration config;
         try {
-            List<CelebrityDetails> celebrities = detectCelebrities(imageData);
-            onSuccess.accept(IdentifyCelebritiesResult.fromCelebrities(celebrities));
+            config = pluginConfiguration.getIdentifyEntitiesConfiguration();
+            if (config.isCelebrityDetectionEnabled()) {
+                List<CelebrityDetails> celebrities = detectCelebrities(imageData);
+                onSuccess.accept(IdentifyCelebritiesResult.fromCelebrities(celebrities));
+            } else {
+                onError.accept(new PredictionsException("Celebrity detection is disabled.",
+                        "Please enable celebrity detection via Amplify CLI. This feature " +
+                                "should be accessible by running `amplify update predictions` " +
+                                "in the console and updating entities detection resource with " +
+                                "advanced configuration setting."));
+            }
         } catch (PredictionsException exception) {
             onError.accept(exception);
         }

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/AWSPredictionsPluginConfigurationTest.java
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/AWSPredictionsPluginConfigurationTest.java
@@ -17,9 +17,14 @@ package com.amplifyframework.predictions.aws;
 
 import com.amplifyframework.predictions.PredictionsException;
 import com.amplifyframework.predictions.aws.configuration.IdentifyEntitiesConfiguration;
+import com.amplifyframework.predictions.aws.configuration.IdentifyLabelsConfiguration;
+import com.amplifyframework.predictions.aws.configuration.IdentifyTextConfiguration;
 import com.amplifyframework.predictions.aws.configuration.InterpretTextConfiguration;
+import com.amplifyframework.predictions.aws.configuration.SpeechGeneratorConfiguration;
 import com.amplifyframework.predictions.aws.configuration.TranslateTextConfiguration;
+import com.amplifyframework.predictions.models.LabelType;
 import com.amplifyframework.predictions.models.LanguageType;
+import com.amplifyframework.predictions.models.TextFormatType;
 import com.amplifyframework.testutils.Resources;
 
 import com.amazonaws.regions.Region;
@@ -92,6 +97,24 @@ public final class AWSPredictionsPluginConfigurationTest {
     }
 
     /**
+     * Test that configuration with explicit "speechGenerator" section creates
+     * customized text-to-speech configuration instance.
+     * @throws Exception if configuration fails
+     */
+    @Test
+    public void testSpeechGeneratorConfiguration() throws Exception {
+        JSONObject json = Resources.readAsJson("configuration-with-text-to-speech.json");
+        AWSPredictionsPluginConfiguration pluginConfig = AWSPredictionsPluginConfiguration.fromJson(json);
+
+        // Custom text-to-speech configuration
+        SpeechGeneratorConfiguration speechGeneratorConfig = pluginConfig.getSpeechGeneratorConfiguration();
+        assertNotNull(speechGeneratorConfig);
+        assertEquals("Aditi", speechGeneratorConfig.getVoice());
+        assertEquals("en-IN", speechGeneratorConfig.getLanguage());
+        assertEquals(NetworkPolicy.AUTO, speechGeneratorConfig.getNetworkPolicy());
+    }
+
+    /**
      * Test that configuration with explicit "translateText" section creates
      * customized translate configuration instance.
      * @throws Exception if configuration fails
@@ -124,6 +147,23 @@ public final class AWSPredictionsPluginConfigurationTest {
         assertNotNull(interpretConfig);
         assertEquals(InterpretTextConfiguration.InterpretType.SENTIMENT, interpretConfig.getType());
         assertEquals(NetworkPolicy.OFFLINE, interpretConfig.getNetworkPolicy());
+    }
+
+    /**
+     * Test that configuration with explicit "identifyLabels" section creates
+     * customized label detection configuration instance.
+     * @throws Exception if configuration fails
+     */
+    @Test
+    public void testIdentifyLabelsConfiguration() throws Exception {
+        JSONObject json = Resources.readAsJson("configuration-with-identify-labels.json");
+        AWSPredictionsPluginConfiguration pluginConfig = AWSPredictionsPluginConfiguration.fromJson(json);
+
+        // Custom identify labels configuration
+        IdentifyLabelsConfiguration identifyConfig = pluginConfig.getIdentifyLabelsConfiguration();
+        assertNotNull(identifyConfig);
+        assertEquals(LabelType.LABELS, identifyConfig.getType());
+        assertEquals(NetworkPolicy.AUTO, identifyConfig.getNetworkPolicy());
     }
 
     /**
@@ -166,5 +206,22 @@ public final class AWSPredictionsPluginConfigurationTest {
         assertEquals(10, identifyConfig.getMaxEntities());
         assertEquals("some-collection-id", identifyConfig.getCollectionId());
         assertFalse(identifyConfig.isGeneralEntityDetection());
+    }
+
+    /**
+     * Test that configuration with explicit "identifyText" section creates
+     * customized text detection configuration instance.
+     * @throws Exception if configuration fails
+     */
+    @Test
+    public void testIdentifyTextConfiguration() throws Exception {
+        JSONObject json = Resources.readAsJson("configuration-with-identify-text.json");
+        AWSPredictionsPluginConfiguration pluginConfig = AWSPredictionsPluginConfiguration.fromJson(json);
+
+        // Custom identify labels configuration
+        IdentifyTextConfiguration identifyConfig = pluginConfig.getIdentifyTextConfiguration();
+        assertNotNull(identifyConfig);
+        assertEquals(TextFormatType.ALL, identifyConfig.getFormat());
+        assertEquals(NetworkPolicy.AUTO, identifyConfig.getNetworkPolicy());
     }
 }

--- a/aws-predictions/src/test/resources/configuration-with-identify-labels.json
+++ b/aws-predictions/src/test/resources/configuration-with-identify-labels.json
@@ -1,0 +1,10 @@
+{
+  "defaultRegion": "us-west-1",
+  "identify": {
+    "identifyLabels": {
+      "region": "us-west-2",
+      "type": "LABELS",
+      "defaultNetworkPolicy": "auto"
+    }
+  }
+}

--- a/aws-predictions/src/test/resources/configuration-with-identify-text.json
+++ b/aws-predictions/src/test/resources/configuration-with-identify-text.json
@@ -1,0 +1,10 @@
+{
+  "defaultRegion": "us-west-1",
+  "identify": {
+    "identifyText": {
+      "format": "ALL",
+      "region": "us-west-2",
+      "defaultNetworkPolicy": "auto"
+    }
+  }
+}

--- a/aws-predictions/src/test/resources/configuration-with-text-to-speech.json
+++ b/aws-predictions/src/test/resources/configuration-with-text-to-speech.json
@@ -1,0 +1,11 @@
+{
+  "defaultRegion": "us-west-1",
+  "convert": {
+    "speechGenerator": {
+      "voice": "Aditi",
+      "language": "en-IN",
+      "region": "us-west-2",
+      "defaultNetworkPolicy": "auto"
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* celebrity detection configuration is now taken into account (used to be always enabled even when explicitly turned off in the configuration)
* add "identifyText" configuration
* add "identifyLabels" configuration
* add default behavior for passing in `IdentifyActionType#DETECT_TEXT` instead of `TextFormatType` enum (previously triggered error callback)
* add default behavior for passing in `IdentifyActionType#DETECT_LABELS` instead of `LabelType` enum (previously triggered error callback)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
