### PR TITLE
[core] Repackage REST and GraphQL Behaviors interfaces

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -24,7 +24,7 @@ import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategory;
-import com.amplifyframework.api.GraphQlBehavior;
+import com.amplifyframework.api.graphql.GraphQLBehavior;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.Consumer;
@@ -130,7 +130,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     /**
      * Constructs an {@link AWSDataStorePlugin} which can warehouse the model types provided by the
      * supplied {@link ModelProvider}. If remote synchronization is enabled, it will be performed
-     * through the provided {@link GraphQlBehavior}.
+     * through the provided {@link GraphQLBehavior}.
      * @param modelProvider Provides the set of models to be warehouse-able by this system
      * @param api Interface to a remote system where models will be synchronized
      */

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
@@ -21,7 +21,7 @@ import androidx.annotation.Nullable;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategoryBehavior;
 import com.amplifyframework.api.ApiException;
-import com.amplifyframework.api.GraphQlBehavior;
+import com.amplifyframework.api.graphql.GraphQLBehavior;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.SubscriptionType;
@@ -49,7 +49,7 @@ import java.util.Map;
  * assumptions about the structure of data types (unique IDs, versioning information), etc.
  */
 public final class AppSyncClient implements AppSync {
-    private final GraphQlBehavior api;
+    private final GraphQLBehavior api;
     private final GraphQLRequest.VariablesSerializer variablesSerializer;
     private final ResponseDeserializer responseDeserializer;
 
@@ -57,7 +57,7 @@ public final class AppSyncClient implements AppSync {
      * Constructs a new AppSyncClient.
      * @param api The API Category, configured with a DataStore API
      */
-    private AppSyncClient(GraphQlBehavior api) {
+    private AppSyncClient(GraphQLBehavior api) {
         this.api = api;
         this.variablesSerializer = new AppSyncVariablesSerializer();
         this.responseDeserializer = new AppSyncResponseDeserializer();
@@ -70,7 +70,7 @@ public final class AppSyncClient implements AppSync {
      * @return An App Sync API instance
      */
     @NonNull
-    public static AppSyncClient via(@NonNull GraphQlBehavior api) {
+    public static AppSyncClient via(@NonNull GraphQLBehavior api) {
         return new AppSyncClient(api);
     }
 

--- a/core/src/main/java/com/amplifyframework/api/ApiCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/api/ApiCategoryBehavior.java
@@ -15,9 +15,12 @@
 
 package com.amplifyframework.api;
 
+import com.amplifyframework.api.graphql.GraphQLBehavior;
+import com.amplifyframework.api.rest.RestBehavior;
+
 /**
  * API category behaviors include REST and GraphQL operations. These
  * include the family of HTTP verbs (GET, POST, etc.), and the GraphQL
  * query/subscribe/mutate operations.
  */
-public interface ApiCategoryBehavior extends RestBehavior, GraphQlBehavior { }
+public interface ApiCategoryBehavior extends RestBehavior, GraphQLBehavior {}

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLBehavior.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLBehavior.java
@@ -13,16 +13,13 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.api;
+package com.amplifyframework.api.graphql;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.amplifyframework.api.graphql.GraphQLOperation;
-import com.amplifyframework.api.graphql.GraphQLRequest;
-import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.api.graphql.MutationType;
-import com.amplifyframework.api.graphql.SubscriptionType;
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.ApiOperation;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
@@ -32,7 +29,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicate;
  * GraphQL behaviors include varying approaches to perform the query,
  * subscribe and mutate GraphQL operations.
  */
-public interface GraphQlBehavior {
+public interface GraphQLBehavior {
 
     /**
      * This is a special helper method for easily calling a list query for

--- a/core/src/main/java/com/amplifyframework/api/rest/RestBehavior.java
+++ b/core/src/main/java/com/amplifyframework/api/rest/RestBehavior.java
@@ -13,14 +13,13 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.api;
+package com.amplifyframework.api.rest;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.amplifyframework.api.rest.RestOperation;
-import com.amplifyframework.api.rest.RestOptions;
-import com.amplifyframework.api.rest.RestResponse;
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.ApiOperation;
 import com.amplifyframework.core.Consumer;
 
 /**

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxGraphQlBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxGraphQlBehavior.java
@@ -19,7 +19,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.api.ApiException;
-import com.amplifyframework.api.GraphQlBehavior;
+import com.amplifyframework.api.graphql.GraphQLBehavior;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.MutationType;
@@ -32,7 +32,7 @@ import io.reactivex.Single;
 import io.reactivex.disposables.Disposable;
 
 /**
- * An Rx-idiomatic expression of Amplify's {@link GraphQlBehavior}.
+ * An Rx-idiomatic expression of Amplify's {@link GraphQLBehavior}.
  */
 @SuppressWarnings("unused") // This is a public API
 public interface RxGraphQlBehavior {

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxRestBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxRestBehavior.java
@@ -18,7 +18,7 @@ package com.amplifyframework.rx;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.api.ApiException;
-import com.amplifyframework.api.RestBehavior;
+import com.amplifyframework.api.rest.RestBehavior;
 import com.amplifyframework.api.rest.RestOptions;
 import com.amplifyframework.api.rest.RestResponse;
 


### PR DESCRIPTION
1. GraphQlBehavior is renamed to GraphQLBehavior, with a capitol 'L', to
   match other such classes.

2. RestBehavior and GraphQLBehavior are moved into .rest and .graphql,
   respectively, to live alongside the rest of their component entities.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
