### PR TITLE
[aws-datastore] Permit multiple mutations per model ID

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -678,8 +678,8 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> firstMutation = PendingMutation.update(originalJoe, BlogOwner.class);
         storage.save(originalJoe, converter.toRecord(firstMutation));
 
-        BlogOwner updatedJoe = BlogOwner.builder()
-            .name("Susan Now Owns the Blog")
+        BlogOwner updatedJoe = originalJoe.copyOfBuilder()
+            .name("Joe Swanson, MD. (He finished med school, I guess?)")
             .build();
         PendingMutation<BlogOwner> secondMutation = PendingMutation.update(updatedJoe, BlogOwner.class);
         storage.save(updatedJoe, converter.toRecord(secondMutation));


### PR DESCRIPTION
In order to support conditional outgoing mutations, we need to allow
multiple mutations to exist in the queue at the same time.

This means there is no longer a notion of a single "pre-existing
mutation" for a model ID, there are n-many such.

All the same, we will concern the _first_ match in the queue, when we
enact business logic about the outbox state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
