### PR TITLE
[aws-datastore] Remove mutation before merge in MutationProcessor

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -61,24 +61,12 @@ final class Merger {
      * @return A completable operation to merge the model
      */
     <T extends Model> Completable merge(ModelWithMetadata<T> modelWithMetadata) {
-        return merge(modelWithMetadata, MergeStrategy.CONSIDER_PENDING_MUTATIONS);
-    }
-
-    /**
-     * Merge an item back into the local store, using a merge strategy.
-     * @param modelWithMetadata A model, combined with metadata about it
-     * @param mergeStrategy A strategy to use while merging - check for pending mutations in outbox?
-     * @param <T> Type of model
-     * @return A completable operation to merge the item
-     */
-    <T extends Model> Completable merge(ModelWithMetadata<T> modelWithMetadata, MergeStrategy mergeStrategy) {
         ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
         boolean isDelete = Boolean.TRUE.equals(metadata.isDeleted());
         T model = modelWithMetadata.getModel();
 
         // Check if there is a pending mutation for this model, in the outbox.
-        boolean checkOutbox = !MergeStrategy.IGNORE_PENDING_MUTATIONS.equals(mergeStrategy);
-        if (checkOutbox && mutationOutbox.hasPendingMutation(model.getId())) {
+        if (mutationOutbox.hasPendingMutation(model.getId())) {
             LOG.info("Mutation outbox has pending mutation for " + model.getId() + ", refusing to merge.");
             return Completable.complete();
         }


### PR DESCRIPTION
A subtle change.

The Mutation Processor responds to changes in storage. There is always a
pending mutation in the outbox when it runs. That's why it is asked to
run.

At the same time, the Merger will check if there is a mutation for a
given model ID, before merging. It will refuse to merge, if there is at
least one.

The previous solution to this was to forcibly clobber data, based on a
"no, but really" flag, passed to the Merger.

Instead, the MutationProcessor is changed to first remove the pending
mutation, before merging it.

This new behavior is subtly different. There might _still_ be a pending
mutation for the model ID in the outbox. It just won't be one that was
just published. So, the merge can still fail, even after we remove the
pending mutation from the outbox.

However, that's _desirable_. The server will have our latest state, and we
will be sure to preserve the customer's data.

Previously, the inbound mutation might have clobbered data locally,
without considering the content of upcoming mutations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
