### PR TITLE
[aws-datastore] Serialized observation of storage

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 
 import io.reactivex.Observable;
 import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.schedulers.Schedulers;
 
 /**
  * Observes a {@link LocalStorageAdapter} for its {@link StorageItemChange}s.
@@ -57,6 +58,8 @@ final class StorageObserver {
             Observable.<StorageItemChange<? extends Model>>create(emitter ->
                 localStorageAdapter.observe(emitter::onNext, emitter::onError, emitter::onComplete)
             )
+            .subscribeOn(Schedulers.single())
+            .observeOn(Schedulers.single())
             .doOnSubscribe(disposable ->
                 LOG.info("Now observing local storage. Local changes will be enqueued to mutation outbox.")
             )


### PR DESCRIPTION
Serialize the StorageObserver, so that it will enqueue mutations
into the MutationOutbox in the same order in which the StorageObserver
dispatches them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
