### PR TITLE
[aws-datastore] Consider the model version before merging

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -43,14 +43,19 @@ import io.reactivex.Completable;
 final class Merger {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
     private final MutationOutbox mutationOutbox;
+    private final VersionRepository versionRepository;
     private final LocalStorageAdapter localStorageAdapter;
 
     /**
      * Constructs a Merger.
      * @param localStorageAdapter A local storage adapter
      */
-    Merger(@NonNull MutationOutbox mutationOutbox, @NonNull LocalStorageAdapter localStorageAdapter) {
+    Merger(
+            @NonNull MutationOutbox mutationOutbox,
+            @NonNull VersionRepository versionRepository,
+            @NonNull LocalStorageAdapter localStorageAdapter) {
         this.mutationOutbox = Objects.requireNonNull(mutationOutbox);
+        this.versionRepository = Objects.requireNonNull(versionRepository);
         this.localStorageAdapter = Objects.requireNonNull(localStorageAdapter);
     }
 
@@ -63,6 +68,7 @@ final class Merger {
     <T extends Model> Completable merge(ModelWithMetadata<T> modelWithMetadata) {
         ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
         boolean isDelete = Boolean.TRUE.equals(metadata.isDeleted());
+        int incomingVersion = metadata.getVersion() == null ? -1 : metadata.getVersion();
         T model = modelWithMetadata.getModel();
 
         // Check if there is a pending mutation for this model, in the outbox.
@@ -70,9 +76,20 @@ final class Merger {
             LOG.info("Mutation outbox has pending mutation for " + model.getId() + ", refusing to merge.");
             return Completable.complete();
         }
-        return (isDelete ? delete(model) : save(model))
-            // Update the metadata for it
-            .andThen(save(metadata))
+
+        return versionRepository.findModelVersion(model)
+            .onErrorReturnItem(-1)
+            // If the incoming version is strictly less than the current version, it's "out of date,"
+            // so don't merge it.
+            // If the incoming version is exactly equal, it might clobber our local changes. So we
+            // *still* won't merge it. Instead, the MutationProcessor would publish the current content,
+            // and the version would get bumped up.
+            .filter(currentVersion -> currentVersion == -1 || incomingVersion > currentVersion)
+            // If we should merge, then do so now, starting with the model data.
+            .flatMapCompletable(shouldMerge ->
+                (isDelete ? delete(model) : save(model))
+                    .andThen(save(metadata))
+            )
             // Let the world know that we've done a good thing.
             .doOnComplete(() -> {
                 announceSuccessfulMerge(modelWithMetadata);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -77,8 +77,8 @@ public final class Orchestrator {
         Objects.requireNonNull(localStorageAdapter);
 
         this.mutationOutbox = new PersistentMutationOutbox(localStorageAdapter);
-        Merger merger = new Merger(mutationOutbox, localStorageAdapter);
         VersionRepository versionRepository = new VersionRepository(localStorageAdapter);
+        Merger merger = new Merger(mutationOutbox, versionRepository, localStorageAdapter);
         SyncTimeRegistry syncTimeRegistry = new SyncTimeRegistry(localStorageAdapter);
 
         this.mutationProcessor = new MutationProcessor(merger, versionRepository, mutationOutbox, appSync);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
@@ -110,8 +110,8 @@ public final class MergerTest {
         BlogOwner blogOwner = BlogOwner.builder()
             .name("Jameson")
             .build();
-        // Note that putInStore does NOT happen!
-        // putInStore(blogOwner, new ModelMetadata(blogOwner.getId(), false, 1, Time.now()));
+        // Note that storageAdapter.save(...) does NOT happen!
+        // storageAdapter.save(blogOwner, new ModelMetadata(blogOwner.getId(), false, 1, Time.now()));
 
         // Act: try to merge a deletion that refers to an item not in the store
         ModelMetadata deletionMetadata =
@@ -137,7 +137,7 @@ public final class MergerTest {
             .name("Jameson")
             .build();
         ModelMetadata metadata = new ModelMetadata(blogOwner.getId(), false, 1, Time.now());
-        // Note that putInStore is NOT called!
+        // Note that storageAdapter.save(...) is NOT called!
         // storageAdapter.save(blogOwner, metadata);
 
         // Act: merge a creation for an item

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -60,8 +60,8 @@ public final class MutationProcessorTest {
         LocalStorageAdapter localStorageAdapter = InMemoryStorageAdapter.create();
         this.synchronousStorageAdapter = SynchronousStorageAdapter.delegatingTo(localStorageAdapter);
         this.mutationOutbox = new PersistentMutationOutbox(localStorageAdapter);
-        Merger merger = new Merger(mutationOutbox, localStorageAdapter);
         VersionRepository versionRepository = new VersionRepository(localStorageAdapter);
+        Merger merger = new Merger(mutationOutbox, versionRepository, localStorageAdapter);
         this.appSync = mock(AppSync.class);
         this.mutationProcessor = new MutationProcessor(merger, versionRepository, mutationOutbox, appSync);
     }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -96,7 +96,8 @@ public final class SyncProcessorTest {
 
         final SyncTimeRegistry syncTimeRegistry = new SyncTimeRegistry(inMemoryStorageAdapter);
         final MutationOutbox mutationOutbox = new PersistentMutationOutbox(inMemoryStorageAdapter);
-        final Merger merger = new Merger(mutationOutbox, inMemoryStorageAdapter);
+        final VersionRepository versionRepository = new VersionRepository(inMemoryStorageAdapter);
+        final Merger merger = new Merger(mutationOutbox, versionRepository, inMemoryStorageAdapter);
 
         DataStoreConfiguration dataStoreConfiguration = DataStoreConfiguration
             .builder()


### PR DESCRIPTION
Upon merging a model from sync, mutation response, subscription data,
inspect the model version. If the version is equal to or less than the
current version in the system, refuse to merge.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
