### PR TITLE
[aws-datastore] Mark mutations as in-flight while processing

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
@@ -60,6 +60,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      * @param <T> The type of the item that has undergone mutation
      * @return A {@link PendingMutation}
      */
+    @NonNull
     static <T extends Model> PendingMutation<T> instance(
             @NonNull TimeBasedUuid mutationId,
             @NonNull T mutatedItem,
@@ -81,6 +82,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      * @param <T> The type of the item that has undergone mutation
      * @return A {@link PendingMutation}
      */
+    @NonNull
     static <T extends Model> PendingMutation<T> instance(
             @NonNull T mutatedItem, @NonNull Class<T> classOfMutatedItem, @NonNull Type mutationType) {
         return instance(TimeBasedUuid.create(), mutatedItem, classOfMutatedItem, mutationType);
@@ -93,6 +95,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      * @param <T> The type of created model
      * @return A PendingMutation representing the model creation
      */
+    @NonNull
     static <T extends Model> PendingMutation<T> creation(@NonNull T createdItem, @NonNull Class<T> classOfCreatedItem) {
         return instance(createdItem, classOfCreatedItem, Type.CREATE);
     }
@@ -104,6 +107,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      * @param <T> The type of updated model
      * @return A PendingMutation representing the model update
      */
+    @NonNull
     static <T extends Model> PendingMutation<T> update(@NonNull T updatedItem, @NonNull Class<T> classOfUpdatedItem) {
         return instance(updatedItem, classOfUpdatedItem, Type.UPDATE);
     }
@@ -115,6 +119,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      * @param <T> The type of model that was deleted
      * @return A PendingMutation representing the model deletion
      */
+    @NonNull
     static <T extends Model> PendingMutation<T> deletion(@NonNull T deletedItem, @NonNull Class<T> classOfDeletedItem) {
         return instance(deletedItem, classOfDeletedItem, Type.DELETE);
     }
@@ -156,7 +161,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     }
 
     @Override
-    public boolean equals(Object thatObject) {
+    public boolean equals(@Nullable Object thatObject) {
         if (this == thatObject) {
             return true;
         }
@@ -181,6 +186,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
         return result;
     }
 
+    @NonNull
     @Override
     public String toString() {
         return "PendingMutation{" +
@@ -216,7 +222,6 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      * referenced model is just a Gson-serialized String version of itself -- handled external
      * to the data modeling system.
      */
-    @SuppressWarnings("unused")
     @ModelConfig(pluralName = "PersistentRecords")
     @Index(fields = "decodedModelClassName", name = "decodedModelClassNameBasedIndex")
     public static final class PersistentRecord implements Model, Comparable<PersistentRecord> {
@@ -326,6 +331,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
             return result;
         }
 
+        @NonNull
         @Override
         public String toString() {
             return "Record{" +
@@ -355,7 +361,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
          * @return -1, 0, 1 if this current mutation is smaller, same, or bigger than another
          */
         @Override
-        public int compareTo(PersistentRecord another) {
+        public int compareTo(@NonNull PersistentRecord another) {
             return TimeBasedUuid.fromString(getId())
                 .compareTo(TimeBasedUuid.fromString(another.getId()));
         }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -176,7 +176,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
                     // to get identically the thing that was saved. But we know the save succeeded.
                     // So, let's skip the unwrapping, and use the thing that was enqueued,
                     // the pendingMutation, directly.
-                    updateQueue(pendingMutation);
+                    updateExistingQueueItemOrAppendNew(pendingMutation);
                     LOG.info("Successfully enqueued " + pendingMutation);
                     semaphore.release();
                     subscriber.onComplete();
@@ -189,7 +189,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
         }));
     }
 
-    private <T extends Model> void updateQueue(PendingMutation<T> pendingMutation) {
+    private <T extends Model> void updateExistingQueueItemOrAppendNew(PendingMutation<T> pendingMutation) {
         // If there is already a mutation with same ID in the queue,
         // we'll go find it, and then update it, with this contents.
         for (int position = 0; position < mutationQueue.size(); position++) {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.datastore.syncengine;
 
+import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
@@ -29,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -38,6 +40,7 @@ import io.reactivex.observers.TestObserver;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -83,7 +86,7 @@ public final class PersistentMutationOutboxTest {
         // Enqueue an save for a Jameson BlogOwner object,
         // and make sure that it calls back onComplete().
         TestObserver<Void> saveObserver = mutationOutbox.enqueue(createJameson).test();
-        saveObserver.awaitTerminalEvent();
+        saveObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         saveObserver.assertNoErrors().assertComplete();
         saveObserver.dispose();
 
@@ -93,13 +96,12 @@ public final class PersistentMutationOutboxTest {
         queueObserver.dispose();
 
         // Assert that the storage contains the mutation
-        List<PersistentRecord> recordsInStorage =
-            storage.query(PersistentRecord.class);
-        assertEquals(1, recordsInStorage.size());
         assertEquals(
-            converter.toRecord(createJameson),
-            recordsInStorage.get(0)
+            Collections.singletonList(converter.toRecord(createJameson)),
+            storage.query(PersistentRecord.class)
         );
+        assertTrue(mutationOutbox.hasPendingMutation(jameson.getId()));
+        assertEquals(createJameson, mutationOutbox.peek());
     }
 
     /**
@@ -127,6 +129,9 @@ public final class PersistentMutationOutboxTest {
 
         // And nothing is in storage.
         assertTrue(storage.query(PersistentRecord.class).isEmpty());
+
+        // And nothing is peek()ed.
+        assertNull(mutationOutbox.peek());
     }
 
     /**
@@ -150,17 +155,20 @@ public final class PersistentMutationOutboxTest {
         TestObserver<Void> loadObserver = mutationOutbox.load().test();
 
         // Assert: load worked.
-        loadObserver.awaitTerminalEvent();
+        loadObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         loadObserver.assertNoErrors().assertComplete();
         loadObserver.dispose();
 
         // Assert: items are in the outbox.
         assertTrue(mutationOutbox.hasPendingMutation(tony.getId()));
         assertTrue(mutationOutbox.hasPendingMutation(sam.getId()));
+
+        // Tony is first, since he is the older of the two mutations.
+        assertEquals(updateTony, mutationOutbox.peek());
     }
 
     /**
-     * Tests {@link MutationOutbox#remove(PendingMutation)}.
+     * Tests {@link MutationOutbox#remove(TimeBasedUuid)}.
      * @throws DataStoreException On failure to query results, for assertions
      */
     @Test
@@ -171,14 +179,18 @@ public final class PersistentMutationOutboxTest {
             .build();
         PendingMutation<BlogOwner> deleteBillGates = PendingMutation.deletion(bill, BlogOwner.class);
         storage.save(converter.toRecord(deleteBillGates));
+        mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-        TestObserver<Void> testObserver = mutationOutbox.remove(deleteBillGates).test();
+        TestObserver<Void> testObserver = mutationOutbox.remove(deleteBillGates.getMutationId()).test();
 
-        testObserver.awaitTerminalEvent();
+        testObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         testObserver.assertNoErrors().assertComplete();
         testObserver.dispose();
 
         assertEquals(0, storage.query(PersistentRecord.class).size());
+
+        assertNull(mutationOutbox.peek());
+        assertFalse(mutationOutbox.hasPendingMutation(bill.getId()));
     }
 
     /**
@@ -255,7 +267,7 @@ public final class PersistentMutationOutboxTest {
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingCreation).test();
 
         // Assert: caused a failure.
-        enqueueObserver.awaitTerminalEvent();
+        enqueueObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         enqueueObserver.assertError(throwable -> throwable instanceof DataStoreException);
 
         // Assert: original mutation is present, but the new one isn't.
@@ -265,6 +277,7 @@ public final class PersistentMutationOutboxTest {
         assertTrue(storage.query(PersistentRecord.class, Where.id(incomingCreationId)).isEmpty());
 
         // Existing mutation still attainable as next mutation (right now, its the ONLY mutation in outbox)
+        assertTrue(mutationOutbox.hasPendingMutation(modelInExistingMutation.getId()));
         assertEquals(existingCreation, mutationOutbox.peek());
     }
 
@@ -295,7 +308,7 @@ public final class PersistentMutationOutboxTest {
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingCreation).test();
 
         // Assert: caused a failure.
-        enqueueObserver.awaitTerminalEvent();
+        enqueueObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         enqueueObserver.assertError(throwable -> throwable instanceof DataStoreException);
 
         // Assert: original mutation is present, but the new one isn't.
@@ -305,6 +318,7 @@ public final class PersistentMutationOutboxTest {
         assertTrue(storage.query(PersistentRecord.class, Where.id(incomingCreationId)).isEmpty());
 
         // Existing mutation still attainable as next mutation (right now, its the ONLY mutation in outbox)
+        assertTrue(mutationOutbox.hasPendingMutation(modelInExistingMutation.getId()));
         assertEquals(existingUpdate, mutationOutbox.peek());
     }
 
@@ -336,7 +350,7 @@ public final class PersistentMutationOutboxTest {
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingCreation).test();
 
         // Assert: caused a failure.
-        enqueueObserver.awaitTerminalEvent();
+        enqueueObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         enqueueObserver.assertError(throwable -> throwable instanceof DataStoreException);
 
         // Assert: original mutation is present, but the new one isn't.
@@ -346,6 +360,7 @@ public final class PersistentMutationOutboxTest {
         assertTrue(storage.query(PersistentRecord.class, Where.id(incomingCreationId)).isEmpty());
 
         // Existing mutation still attainable as next mutation (right now, its the ONLY mutation in outbox)
+        assertTrue(mutationOutbox.hasPendingMutation(modelInExistingMutation.getId()));
         assertEquals(existingDeletion, mutationOutbox.peek());
     }
 
@@ -376,7 +391,7 @@ public final class PersistentMutationOutboxTest {
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingUpdate).test();
 
         // Assert: caused a failure.
-        enqueueObserver.awaitTerminalEvent();
+        enqueueObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         enqueueObserver.assertError(throwable -> throwable instanceof DataStoreException);
 
         // Assert: original mutation is present, but the new one isn't.
@@ -386,6 +401,7 @@ public final class PersistentMutationOutboxTest {
         assertTrue(storage.query(PersistentRecord.class, Where.id(incomingUpdateId)).isEmpty());
 
         // Existing mutation still attainable as next mutation (right now, its the ONLY mutation in outbox)
+        assertTrue(mutationOutbox.hasPendingMutation(modelInExistingMutation.getId()));
         assertEquals(existingDeletion, mutationOutbox.peek());
     }
 
@@ -415,7 +431,7 @@ public final class PersistentMutationOutboxTest {
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingUpdate).test();
 
         // Assert: OK. The new mutation is accepted
-        enqueueObserver.awaitTerminalEvent();
+        enqueueObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         enqueueObserver.assertComplete();
 
         // Assert: the existing mutation is still there, by id ....
@@ -474,7 +490,7 @@ public final class PersistentMutationOutboxTest {
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingUpdate).test();
 
         // Assert: OK. The new mutation is accepted
-        enqueueObserver.awaitTerminalEvent();
+        enqueueObserver.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         enqueueObserver.assertComplete();
 
         // Assert: the existing mutation is still there, by id ....
@@ -508,7 +524,7 @@ public final class PersistentMutationOutboxTest {
 
     /**
      * When there is already a creation pending, and then we get a deletion for the same model ID,
-     * we should just remove the creation. It means like "nevermind, don't actually create."
+     * we should just remove the creation. It means like "never mind, don't actually create."
      * @throws DataStoreException On failure to query storage for mutations state after test action
      */
     @Test
@@ -690,5 +706,68 @@ public final class PersistentMutationOutboxTest {
             firstMutation,
             mutationOutbox.nextMutationForModelId(originalJoe.getId())
         );
+    }
+
+    /**
+     * Ordinarily, a DELETE would remote a CREATE, in front of it. But if that
+     * create is marked in flight, we can't remove it. We have to enqueue the new
+     * mutation.
+     */
+    @Test
+    public void mutationEnqueuedIfExistingMutationIsInFlight() {
+        // Arrange an existing mutation.
+        BlogOwner joe = BlogOwner.builder()
+            .name("Joe")
+            .build();
+        PendingMutation<BlogOwner> creation = PendingMutation.creation(joe, BlogOwner.class);
+        mutationOutbox.enqueue(creation)
+            // Act: mark it as in-flight, after enqueue.
+            .andThen(mutationOutbox.markInFlight(creation.getMutationId()))
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        // Now, look at what happens when we enqueue a new mutation.
+        PendingMutation<BlogOwner> deletion = PendingMutation.deletion(joe, BlogOwner.class);
+        mutationOutbox.enqueue(deletion)
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        PendingMutation<? extends Model> next = mutationOutbox.peek();
+        assertNotNull(next);
+        assertEquals(creation, next);
+        mutationOutbox.remove(next.getMutationId())
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        next = mutationOutbox.peek();
+        assertNotNull(next);
+        assertEquals(deletion, next);
+        mutationOutbox.remove(next.getMutationId())
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        assertNull(mutationOutbox.peek());
+    }
+
+    /**
+     * It is an error to mark an item as in-flight, if it isn't even in the dang queue.
+     */
+    @Test
+    public void errorWhenMarkingItemNotInQueue() {
+        // Enqueue and remove a mutation.
+        BlogOwner tabby = BlogOwner.builder()
+            .name("Tabitha Stevens of Beaver Falls, Idaho")
+            .build();
+        PendingMutation<BlogOwner> creation = PendingMutation.creation(tabby, BlogOwner.class);
+        mutationOutbox.enqueue(creation)
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        mutationOutbox.remove(creation.getMutationId())
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        // Now, if we try to make that mutation as in-flight, its an error, since its already processed.
+        TestObserver<Void> observer = mutationOutbox.markInFlight(creation.getMutationId()).test();
+        observer.awaitTerminalEvent(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        observer
+            .assertError(DataStoreException.class)
+            .assertError(error ->
+                error.getMessage() != null &&
+                    error.getMessage().contains("there was no mutation with that ID in the outbox")
+            );
     }
 }


### PR DESCRIPTION
The behavior of the Mutation Outbox is changed, to include an in-memory,
"in-flight" state for its pending mutations.

Before we start to publish a mutation to AppSync, we will mark it as
"in-flight", in the Mutation Outbox. This signifies that the mutation
will be treated as immutable for the duration of its life in-memory.

The mutation will continue to be marked as "in-process" until one of two
things happen:

 1. The mutation is removed from the mutation outbox.

 2. The system restarts, and the mutation is loaded from disk, again,
    while rebuilding the mutation outbox. While loading, it will appear
    as though this mutation did _not_ finish processing successfully,
    and so should be retried.

While enqueuing new mutations, existing, in-flight mutations will be
ignored. That is to say, new mutations will be queued behind the
in-flight ones, and the in-flight ones will not be tampered with.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
