### PR TITLE
Implement conflict resolution rules for existing and incoming mutations for the same model

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -23,6 +23,7 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
@@ -83,19 +84,19 @@ final class PersistentMutationOutbox implements MutationOutbox {
         String modelId = incomingMutation.getMutatedItem().getId();
         @SuppressWarnings("unchecked")
         PendingMutation<T> existingMutation = (PendingMutation<T>) nextMutationForModelId(modelId);
-        if (existingMutation == null || inFlightMutations.contains(existingMutation.getMutationId())) {
-            return save(incomingMutation).andThen(notifyContentAvailable());
+        if (existingMutation == null) {
+            return save(incomingMutation)
+                .andThen(notifyContentAvailable());
+        } else {
+            return resolveConflict(existingMutation, incomingMutation);
         }
-        switch (incomingMutation.getMutationType()) {
-            case CREATE:
-                return handleCreation();
-            case UPDATE:
-                return handleUpdate(existingMutation, incomingMutation);
-            case DELETE:
-                return handleDeletion(existingMutation, incomingMutation);
-            default:
-                return unknownMutationType(incomingMutation.getMutationType());
-        }
+    }
+
+    private <T extends Model> Completable resolveConflict(@NonNull PendingMutation<T> existingMutation,
+                                                          @NonNull PendingMutation<T> incomingMutation) {
+        IncomingMutationConflictHandler<T> mutationConflictHandler =
+            new IncomingMutationConflictHandler<>(existingMutation, incomingMutation);
+        return mutationConflictHandler.resolve();
     }
 
     @VisibleForTesting
@@ -107,61 +108,6 @@ final class PersistentMutationOutbox implements MutationOutbox {
             }
         }
         return null;
-    }
-
-    private Completable handleCreation() {
-        return Completable.error(new DataStoreException(
-            "Attempted to enqueue a model creation, but there is already a pending mutation for that model ID.",
-            "Please report at https://github.com/aws-amplify/amplify-android/issues."
-        ));
-    }
-
-    private <T extends Model> Completable handleUpdate(
-            PendingMutation<T> existingMutation, PendingMutation<T> incomingMutation) {
-        switch (existingMutation.getMutationType()) {
-            case CREATE:
-            case UPDATE:
-                return overwriteExisting(existingMutation, incomingMutation, existingMutation.getMutationType());
-            case DELETE:
-                return Completable.error(new DataStoreException(
-                    "Attempted to enqueue a model mutation, but that model already had a delete mutation pending.",
-                    "This should not be possible. Please report on GitHub issues."
-                ));
-            default:
-                return unknownMutationType(existingMutation.getMutationType());
-        }
-    }
-
-    private <T extends Model> Completable handleDeletion(
-            PendingMutation<T> existingMutation, PendingMutation<T> incomingMutation) {
-        switch (existingMutation.getMutationType()) {
-            case CREATE:
-                return remove(existingMutation.getMutationId());
-            case UPDATE:
-            case DELETE:
-                return overwriteExisting(existingMutation, incomingMutation, PendingMutation.Type.DELETE);
-            default:
-                return unknownMutationType(existingMutation.getMutationType());
-        }
-    }
-
-    private Completable unknownMutationType(PendingMutation.Type unknownType) {
-        return Completable.error(new DataStoreException(
-            "Existing mutation of unknown type = " + unknownType,
-            "Please report at https://github.com/aws-amplify/amplify-android/issues."
-        ));
-    }
-
-    // Type is sometimes the existing type, sometimes the incoming type.
-    private <T extends Model> Completable overwriteExisting(
-            PendingMutation<T> existingMutation, PendingMutation<T> incomingMutation, PendingMutation.Type type) {
-        // Keep the old mutation ID, but update the contents of that mutation.
-        // Now, it will have the contents of the incoming update mutation.
-        TimeBasedUuid id = existingMutation.getMutationId();
-        T item = incomingMutation.getMutatedItem();
-        Class<T> clazz = incomingMutation.getClassOfMutatedItem();
-        return save(PendingMutation.instance(id, item, clazz, type, null))
-            .andThen(notifyContentAvailable());
     }
 
     private <T extends Model> Completable save(PendingMutation<T> pendingMutation) {
@@ -317,5 +263,159 @@ final class PersistentMutationOutbox implements MutationOutbox {
             }
         }
         return null;
+    }
+
+    /**
+     * Encapsulate the logic to determine which actions to take based on incoming and existing
+     * mutations. Non-static so we can access instance methods of the outer class. Private because
+     * we don't want this logic called from anywhere else.
+     * @param <T> the model type
+     */
+    private final class IncomingMutationConflictHandler<T extends Model> {
+        private final PendingMutation<T> existing;
+        private final PendingMutation<T> incoming;
+
+        /**
+         * Constructor for a IncomingMutationConflictHandler.
+         * @param existing The existing mutation.
+         * @param incoming The incoming mutation.
+         */
+        private IncomingMutationConflictHandler(@NonNull PendingMutation<T> existing,
+                                                @NonNull PendingMutation<T> incoming) {
+            this.existing = existing;
+            this.incoming = incoming;
+        }
+
+        /**
+         * Handle the conflict based on the incoming mutation type.
+         * @return A completable with the actions to resolve the conflict.
+         */
+        Completable resolve() {
+            switch (incoming.getMutationType()) {
+                case CREATE:
+                    return handleIncomingCreate();
+                case UPDATE:
+                    return handleIncomingUpdate();
+                case DELETE:
+                    return handleIncomingDelete();
+                default:
+                    return unknownMutationType(existing.getMutationType());
+            }
+        }
+
+        /**
+         * Determine which action to take when the incoming mutation type is {@linkplain PendingMutation.Type#CREATE}.
+         * @return A completable with the actions needed to resolve the conflict
+         */
+        private Completable handleIncomingCreate() {
+            switch (existing.getMutationType()) {
+                case CREATE:
+                    // Double create, return an different error than in the default block of the switch
+                    // statement. This way, we can differentiate between an incoming create being processed
+                    // multiple times (this case), versus outgoing mutations being processed out of order.
+                    return conflictingCreationError();
+                default:
+                    // A create mutation should never show up after an update or delete for the same modelId.
+                    return unexpectedMutationScenario();
+            }
+        }
+
+        /**
+         * Determine which action to take when the incoming mutation type is {@linkplain PendingMutation.Type#UPDATE}.
+         * @return A completable with the actions needed to resolve the conflict
+         */
+        private Completable handleIncomingUpdate() {
+            switch (existing.getMutationType()) {
+                case CREATE:
+                    // Update after the create -> replace item of the create mutation (and keep it as a create).
+                    // No condition needs to be provided, because as far as the remote store is concerned,
+                    // we're simply performing the create (with the updated item item contents)
+                    return overwriteExistingAndNotify(PendingMutation.Type.CREATE, null);
+                case UPDATE:
+                    if (incoming.getPredicate() == null) {
+                        // If the incoming update does not have a condition, we want to delete any
+                        // existing mutations for the modelId before saving the incoming one.
+                        return remove(existing.getMutationId()).andThen(saveIncomingAndNotify());
+                    } else {
+                        // If it has a condition, we want to just add it to the queue
+                        return saveIncomingAndNotify();
+                    }
+                case DELETE:
+                    // Incoming update after a delete -> throw exception
+                    return modelAlreadyScheduledForDeletion();
+                default:
+                    return unexpectedMutationScenario();
+            }
+        }
+
+        /**
+         * Determine which action to take when the incoming mutation type is {@linkplain PendingMutation.Type#DELETE}.
+         * @return A completable with the actions needed to resolve the conflict
+         */
+        private Completable handleIncomingDelete() {
+            switch (existing.getMutationType()) {
+                case CREATE:
+                    //
+                    if (inFlightMutations.contains(existing.getMutationId())) {
+                        // Existing create is already in flight, then save the delete
+                        return save(incoming);
+                    } else {
+                        // The existing create mutation hasn't made it to the remote store, so we
+                        // ignore the incoming and remove the existing create mutation from outbox.
+                        return remove(existing.getMutationId());
+                    }
+                case UPDATE:
+                case DELETE:
+                    // If there's a pending update OR delete, we want to replace it with the incoming delete.
+                    return overwriteExistingAndNotify(PendingMutation.Type.DELETE, incoming.getPredicate());
+                default:
+                    return unexpectedMutationScenario();
+            }
+        }
+
+        private Completable overwriteExistingAndNotify(@NonNull PendingMutation.Type type,
+                                                       @Nullable QueryPredicate predicate) {
+            // Keep the old mutation ID, but update the contents of that mutation.
+            // Now, it will have the contents of the incoming update mutation.
+            TimeBasedUuid id = existing.getMutationId();
+            T item = incoming.getMutatedItem();
+            Class<T> clazz = incoming.getClassOfMutatedItem();
+            return save(PendingMutation.instance(id, item, clazz, type, predicate))
+                .andThen(notifyContentAvailable());
+        }
+
+        private Completable saveIncomingAndNotify() {
+            return save(incoming)
+                .andThen(notifyContentAvailable());
+        }
+
+        private Completable conflictingCreationError() {
+            return Completable.error(new DataStoreException(
+                "Attempted to enqueue a model creation, but there is already a pending creation for that model ID.",
+                "Please report at https://github.com/aws-amplify/amplify-android/issues."
+            ));
+        }
+
+        private Completable modelAlreadyScheduledForDeletion() {
+            return Completable.error(new DataStoreException(
+                "Attempted to enqueue a model mutation, but that model already had a delete mutation pending.",
+                "This should not be possible. Please report on GitHub issues."
+            ));
+        }
+
+        private Completable unknownMutationType(PendingMutation.Type unknownType) {
+            return Completable.error(new DataStoreException(
+                "Existing mutation of unknown type = " + unknownType,
+                "Please report at https://github.com/aws-amplify/amplify-android/issues."
+            ));
+        }
+
+        private Completable unexpectedMutationScenario() {
+            return Completable.error(new DataStoreException(
+                "Unable to handle existing mutation of type = " + existing.getMutationType() +
+                " and incoming mutation of type = " + incoming.getMutationType(),
+                "Please report at https://github.com/aws-amplify/amplify-android/issues."
+            ));
+        }
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -84,7 +84,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
         String modelId = incomingMutation.getMutatedItem().getId();
         @SuppressWarnings("unchecked")
         PendingMutation<T> existingMutation = (PendingMutation<T>) nextMutationForModelId(modelId);
-        if (existingMutation == null) {
+        if (existingMutation == null || inFlightMutations.contains(existingMutation.getMutationId())) {
             return save(incomingMutation)
                 .andThen(notifyContentAvailable());
         } else {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -472,7 +472,7 @@ public final class PersistentMutationOutboxTest {
 
     /**
      * When there is an existing update mutation, and a new update mutation comes in,
-     * then we need to remove any existing mutations for that modelId and create the new one
+     * then we need to remove any existing mutations for that modelId and create the new one.
      * @throws DataStoreException On failure to query storage for current mutations state
      */
     @Test

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -406,12 +406,12 @@ public final class PersistentMutationOutboxTest {
     }
 
     /**
-     * When there is an existing update mutation, and a new update mutation comes in,
-     * then the existing one should be updated.
+     * When there is an existing update mutation, and a new update mutation with condition
+     * comes in, then the existing one should remain and the new one should be appended.
      * @throws DataStoreException On failure to query storage for current mutations state
      */
     @Test
-    public void existingUpdateIncomingUpdateRewritesExistingMutation() throws DataStoreException {
+    public void existingUpdateIncomingUpdateWithConditionAppendsMutation() throws DataStoreException {
         // Arrange an existing update mutation
         BlogOwner modelInExistingMutation = BlogOwner.builder()
             .name("Papa Tony")
@@ -426,7 +426,7 @@ public final class PersistentMutationOutboxTest {
             .name("Tony Jr.")
             .build();
         PendingMutation<BlogOwner> incomingUpdate =
-            PendingMutation.update(modelInIncomingMutation, BlogOwner.class, null);
+            PendingMutation.update(modelInIncomingMutation, BlogOwner.class, BlogOwner.NAME.eq("Papa Tony"));
         String incomingUpdateId = incomingUpdate.getMutationId().toString();
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingUpdate).test();
 
@@ -439,27 +439,81 @@ public final class PersistentMutationOutboxTest {
             storage.query(PersistentRecord.class, Where.id(existingUpdateId));
         assertEquals(1, recordsForExistingMutationId.size());
 
-        // And the new one is not, by ID...
+        // Assert: And the new one is also there
         List<PendingMutation.PersistentRecord> recordsForIncomingMutationId =
             storage.query(PersistentRecord.class, Where.id(incomingUpdateId));
-        assertEquals(0, recordsForIncomingMutationId.size());
+        assertEquals(1, recordsForIncomingMutationId.size());
 
-        // However, the original mutation has been updated to include the contents of the
-        // incoming mutation. This is true even whilst the mutation retains its original ID.
-        PendingMutation<BlogOwner> storedMutation = converter.fromRecord(recordsForExistingMutationId.get(0));
+        // The original mutation should remain as is
+        PendingMutation<BlogOwner> existingStoredMutation = converter.fromRecord(recordsForExistingMutationId.get(0));
         // This is the name from the second model, not the first!!
-        assertEquals("Tony Jr.", storedMutation.getMutatedItem().getName());
+        assertEquals(modelInExistingMutation.getName(), existingStoredMutation.getMutatedItem().getName());
 
-        // There is a mutation in the outbox, it has the original ID
-        // It is still an update. But it has the new model data.
+        PendingMutation<? extends Model> next = mutationOutbox.peek();
+        assertNotNull(next);
+        // The first one should be the existing mutation
         assertEquals(
-            PendingMutation.instance(
-                existingUpdate.getMutationId(),
-                modelInIncomingMutation,
-                BlogOwner.class,
-                PendingMutation.Type.UPDATE,
-                null
-            ),
+            existingUpdate,
+            next
+        );
+        // Remove the first one from the queue
+        mutationOutbox.remove(existingUpdate.getMutationId())
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        // Get the next one
+        next = mutationOutbox.peek();
+        assertNotNull(next);
+        // The first one should be the existing mutation
+        assertEquals(
+            incomingUpdate,
+            next
+        );
+    }
+
+    /**
+     * When there is an existing update mutation, and a new update mutation comes in,
+     * then we need to remove any existing mutations for that modelId and create the new one
+     * @throws DataStoreException On failure to query storage for current mutations state
+     */
+    @Test
+    public void existingUpdateIncomingUpdateWithoutConditionRewritesExistingMutation() throws DataStoreException {
+        // Arrange an existing update mutation
+        BlogOwner modelInExistingMutation = BlogOwner.builder()
+            .name("Papa Tony")
+            .build();
+        PendingMutation<BlogOwner> existingUpdate =
+            PendingMutation.update(modelInExistingMutation, BlogOwner.class, null);
+        String existingUpdateId = existingUpdate.getMutationId().toString();
+        mutationOutbox.enqueue(existingUpdate).blockingAwait();
+
+        // Act: try to enqueue a new update mutation when there already is one
+        BlogOwner modelInIncomingMutation = modelInExistingMutation.copyOfBuilder()
+            .name("Tony Jr.")
+            .build();
+        PendingMutation<BlogOwner> incomingUpdate =
+            PendingMutation.update(modelInIncomingMutation, BlogOwner.class, null);
+        String incomingUpdateId = incomingUpdate.getMutationId().toString();
+        TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingUpdate).test();
+
+        // Assert: OK. The new mutation is accepted
+        enqueueObserver.awaitTerminalEvent();
+        enqueueObserver.assertComplete();
+
+        // Assert: the existing mutation has been removed
+        assertRecordCountForMutationId(existingUpdateId, 0);
+
+        // And the new one has been added to the queue
+        assertRecordCountForMutationId(incomingUpdateId, 1);
+
+        // Ensure the new one is in storage.
+        PendingMutation<BlogOwner> storedMutation =
+            converter.fromRecord(getPendingMutationRecordFromStorage(incomingUpdateId).get(0));
+        // This is the name from the second model, not the first!!
+        assertEquals(modelInIncomingMutation.getName(), storedMutation.getMutatedItem().getName());
+
+        // The mutation in the outbox is the incoming one.
+        assertEquals(
+            incomingUpdate,
             mutationOutbox.peek()
         );
     }
@@ -772,5 +826,14 @@ public final class PersistentMutationOutboxTest {
                 error.getMessage() != null &&
                     error.getMessage().contains("there was no mutation with that ID in the outbox")
             );
+    }
+
+    private void assertRecordCountForMutationId(String mutationId, int expectedCount) throws DataStoreException {
+        List<PersistentRecord> recordsForExistingMutationId = getPendingMutationRecordFromStorage(mutationId);
+        assertEquals(expectedCount, recordsForExistingMutationId.size());
+    }
+
+    private List<PersistentRecord> getPendingMutationRecordFromStorage(String mutationId) throws DataStoreException {
+        return storage.query(PersistentRecord.class, Where.id(mutationId));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The PR is a follow up to #496. It contains the business logic that handles conflicts when multiple mutations for the same model and enqueued. It takes into account whether a condition was included with the update/delete.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
