### PR TITLE
Auth Integration for API

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/TestApiCategory.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/TestApiCategory.java
@@ -21,10 +21,13 @@ import androidx.annotation.RawRes;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategory;
+import com.amplifyframework.api.aws.sigv4.DefaultCognitoUserPoolsAuthProvider;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.AmplifyConfiguration;
 import com.amplifyframework.core.category.CategoryConfiguration;
 import com.amplifyframework.core.category.CategoryType;
+
+import com.amazonaws.mobile.client.AWSMobileClient;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 
@@ -46,7 +49,17 @@ final class TestApiCategory {
     static ApiCategory fromConfiguration(@RawRes int resourceId) throws AmplifyException {
         Context context = getApplicationContext();
         ApiCategory apiCategory = new ApiCategory();
-        apiCategory.addPlugin(new AWSApiPlugin());
+        apiCategory.addPlugin(
+                new AWSApiPlugin(
+                        ApiAuthProviders
+                                .builder()
+                                .awsCredentialsProvider(AWSMobileClient.getInstance())
+                                .cognitoUserPoolsAuthProvider(
+                                        new DefaultCognitoUserPoolsAuthProvider(AWSMobileClient.getInstance())
+                                )
+                                .build()
+                )
+        );
         CategoryConfiguration apiConfiguration =
             AmplifyConfiguration.fromConfigFile(context, resourceId)
                 .forCategoryType(CategoryType.API);

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -270,7 +270,7 @@ final class AppSyncGraphQLRequestFactory {
                 if (cognitoAuth == null) {
                     throw new ApiException(
                         "Attempted to subscribe to a model with owner based authorization without a Cognito provider",
-                        "Did you initialize AWSMobileClient before making this call?"
+                        "Did you add the AWSCognitoAuthPlugin to Amplify before configuring it?"
                     );
                 }
 

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncSigV4SignerInterceptorFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncSigV4SignerInterceptorFactoryTest.java
@@ -16,10 +16,12 @@
 package com.amplifyframework.api.aws;
 
 import com.amplifyframework.api.ApiException;
-import com.amplifyframework.api.aws.sigv4.DefaultCognitoUserPoolsAuthProvider;
+import com.amplifyframework.api.aws.sigv4.CognitoUserPoolsAuthProvider;
 
 import com.amazonaws.internal.StaticCredentialsProvider;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
@@ -36,6 +38,15 @@ import static org.junit.Assert.assertEquals;
 public final class AppSyncSigV4SignerInterceptorFactoryTest {
     private static final String X_API_KEY = "x-api-key";
     private static final String AUTHORIZATION = "authorization";
+    private CognitoUserPoolsAuthProvider authProvider;
+
+    /**
+     * Setup tests with global mock.
+     */
+    @Before
+    public void setup() {
+        this.authProvider = Mockito.mock(CognitoUserPoolsAuthProvider.class);
+    }
 
     /**
      * Test cases for when no custom provider is given
@@ -53,7 +64,7 @@ public final class AppSyncSigV4SignerInterceptorFactoryTest {
 
         ApiAuthProviders providers = ApiAuthProviders.builder()
                 .awsCredentialsProvider(new StaticCredentialsProvider(null))
-                .cognitoUserPoolsAuthProvider(new DefaultCognitoUserPoolsAuthProvider())
+                .cognitoUserPoolsAuthProvider(authProvider)
                 .oidcAuthProvider(() -> "OIDC_JWT_TOKEN")
                 .build();
         InterceptorFactory factory = new AppSyncSigV4SignerInterceptorFactory(providers);
@@ -90,7 +101,7 @@ public final class AppSyncSigV4SignerInterceptorFactoryTest {
     public void testApiKeyNotProvidedInConfiguration() throws IOException, ApiException {
         ApiAuthProviders providers = ApiAuthProviders.builder()
                 .awsCredentialsProvider(new StaticCredentialsProvider(null))
-                .cognitoUserPoolsAuthProvider(new DefaultCognitoUserPoolsAuthProvider())
+                .cognitoUserPoolsAuthProvider(authProvider)
                 .oidcAuthProvider(() -> "OIDC_JWT_TOKEN")
                 .build();
         InterceptorFactory factory = new AppSyncSigV4SignerInterceptorFactory(providers);
@@ -120,7 +131,7 @@ public final class AppSyncSigV4SignerInterceptorFactoryTest {
         ApiAuthProviders providers = ApiAuthProviders.builder()
                 .apiKeyAuthProvider(() -> "CUSTOM_API_KEY")
                 .awsCredentialsProvider(new StaticCredentialsProvider(null))
-                .cognitoUserPoolsAuthProvider(new DefaultCognitoUserPoolsAuthProvider())
+                .cognitoUserPoolsAuthProvider(authProvider)
                 .oidcAuthProvider(() -> "OIDC_JWT_TOKEN")
                 .build();
         InterceptorFactory factory = new AppSyncSigV4SignerInterceptorFactory(providers);
@@ -148,7 +159,7 @@ public final class AppSyncSigV4SignerInterceptorFactoryTest {
         ApiAuthProviders providers = ApiAuthProviders.builder()
                 .apiKeyAuthProvider(() -> "CUSTOM_API_KEY")
                 .awsCredentialsProvider(new StaticCredentialsProvider(null))
-                .cognitoUserPoolsAuthProvider(new DefaultCognitoUserPoolsAuthProvider())
+                .cognitoUserPoolsAuthProvider(authProvider)
                 .oidcAuthProvider(() -> "OIDC_JWT_TOKEN")
                 .build();
         InterceptorFactory factory = new AppSyncSigV4SignerInterceptorFactory(providers);
@@ -190,7 +201,7 @@ public final class AppSyncSigV4SignerInterceptorFactoryTest {
         ApiAuthProviders providers = ApiAuthProviders.builder()
                 .apiKeyAuthProvider(() -> "API_KEY")
                 .awsCredentialsProvider(new StaticCredentialsProvider(null))
-                .cognitoUserPoolsAuthProvider(new DefaultCognitoUserPoolsAuthProvider())
+                .cognitoUserPoolsAuthProvider(authProvider)
                 .build();
         InterceptorFactory factory = new AppSyncSigV4SignerInterceptorFactory(providers);
 
@@ -215,7 +226,7 @@ public final class AppSyncSigV4SignerInterceptorFactoryTest {
         ApiAuthProviders providers = ApiAuthProviders.builder()
                 .apiKeyAuthProvider(() -> "API_KEY")
                 .awsCredentialsProvider(new StaticCredentialsProvider(null))
-                .cognitoUserPoolsAuthProvider(new DefaultCognitoUserPoolsAuthProvider())
+                .cognitoUserPoolsAuthProvider(authProvider)
                 .oidcAuthProvider(() -> "OIDC_JWT_TOKEN")
                 .build();
         InterceptorFactory factory = new AppSyncSigV4SignerInterceptorFactory(providers);


### PR DESCRIPTION
Integrates Auth with API category in a preliminary way where AWSMobileClient is obtained from the Auth escape hatch instead of directly.

Note that integration tests still rely on AWSMobileClient directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
