### PR TITLE
Integrates Auth with Predictions, Updates Sign Out, Disables AWS Logs

### DIFF
--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -543,7 +543,7 @@ public final class AuthComponentTest {
 
         ArgumentCaptor<SignOutOptions> signOutOptionsCaptor = ArgumentCaptor.forClass(SignOutOptions.class);
         verify(mobileClient).signOut(signOutOptionsCaptor.capture(), any());
-        assertTrue(signOutOptionsCaptor.getValue().isSignOutGlobally());
+        assertFalse(signOutOptionsCaptor.getValue().isSignOutGlobally());
     }
 
     /**

--- a/aws-predictions/src/androidTest/java/com/amplifyframework/predictions/aws/TestPredictionsCategory.java
+++ b/aws-predictions/src/androidTest/java/com/amplifyframework/predictions/aws/TestPredictionsCategory.java
@@ -25,6 +25,8 @@ import com.amplifyframework.core.category.CategoryConfiguration;
 import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.predictions.PredictionsCategory;
 
+import com.amazonaws.mobile.client.AWSMobileClient;
+
 import java.util.Objects;
 
 /**
@@ -45,7 +47,7 @@ final class TestPredictionsCategory {
 
         final PredictionsCategory predictionsCategory = new PredictionsCategory();
         try {
-            predictionsCategory.addPlugin(new AWSPredictionsPlugin());
+            predictionsCategory.addPlugin(new AWSPredictionsPlugin(AWSMobileClient.getInstance()));
             CategoryConfiguration predictionsConfiguration = AmplifyConfiguration.fromConfigFile(context, resourceId)
                     .forCategoryType(CategoryType.PREDICTIONS);
             predictionsCategory.configure(predictionsConfiguration, context);

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSComprehendService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSComprehendService.java
@@ -39,7 +39,6 @@ import com.amplifyframework.util.UserAgent;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.services.comprehend.AmazonComprehendClient;
 import com.amazonaws.services.comprehend.model.DetectDominantLanguageRequest;
 import com.amazonaws.services.comprehend.model.DetectDominantLanguageResult;
@@ -67,13 +66,14 @@ final class AWSComprehendService {
     private final AmazonComprehendClient comprehend;
     private final AWSPredictionsPluginConfiguration pluginConfiguration;
 
-    AWSComprehendService(@NonNull AWSPredictionsPluginConfiguration pluginConfiguration) {
-        this.comprehend = createComprehendClient();
+    AWSComprehendService(
+            @NonNull AWSPredictionsPluginConfiguration pluginConfiguration,
+            @NonNull AWSCredentialsProvider credentialsProvider) {
+        this.comprehend = createComprehendClient(credentialsProvider);
         this.pluginConfiguration = pluginConfiguration;
     }
 
-    private AmazonComprehendClient createComprehendClient() {
-        AWSCredentialsProvider credentialsProvider = AWSMobileClient.getInstance();
+    private AmazonComprehendClient createComprehendClient(@NonNull AWSCredentialsProvider credentialsProvider) {
         ClientConfiguration configuration = new ClientConfiguration();
         configuration.setUserAgent(UserAgent.string());
         return new AmazonComprehendClient(credentialsProvider, configuration);

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSPollyService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSPollyService.java
@@ -28,7 +28,6 @@ import com.amplifyframework.util.UserAgent;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.services.polly.AmazonPollyClient;
 import com.amazonaws.services.polly.AmazonPollyPresigningClient;
 import com.amazonaws.services.polly.model.OutputFormat;
@@ -47,13 +46,13 @@ final class AWSPollyService {
     private final AmazonPollyClient polly;
     private final AWSPredictionsPluginConfiguration pluginConfiguration;
 
-    AWSPollyService(AWSPredictionsPluginConfiguration pluginConfiguration) {
-        this.polly = createPollyClient();
+    AWSPollyService(AWSPredictionsPluginConfiguration pluginConfiguration,
+                    @NonNull AWSCredentialsProvider credentialsProvider) {
+        this.polly = createPollyClient(credentialsProvider);
         this.pluginConfiguration = pluginConfiguration;
     }
 
-    private AmazonPollyClient createPollyClient() {
-        AWSCredentialsProvider credentialsProvider = AWSMobileClient.getInstance();
+    private AmazonPollyClient createPollyClient(@NonNull AWSCredentialsProvider credentialsProvider) {
         ClientConfiguration configuration = new ClientConfiguration();
         configuration.setUserAgent(UserAgent.string());
         return new AmazonPollyPresigningClient(credentialsProvider, configuration);

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSPredictionsService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSPredictionsService.java
@@ -30,6 +30,7 @@ import com.amplifyframework.predictions.result.InterpretResult;
 import com.amplifyframework.predictions.result.TextToSpeechResult;
 import com.amplifyframework.predictions.result.TranslateTextResult;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.comprehend.AmazonComprehendClient;
 import com.amazonaws.services.polly.AmazonPollyClient;
 import com.amazonaws.services.rekognition.AmazonRekognitionClient;
@@ -53,14 +54,17 @@ public final class AWSPredictionsService {
     /**
      * Constructs an instance of {@link AWSPredictionsService}.
      * @param configuration the configuration for AWS Predictions Plugin
+     * @param credentialsProvider An instance of an AWSCredentialsProvider implementation to vend auth credentials
      */
-    public AWSPredictionsService(@NonNull AWSPredictionsPluginConfiguration configuration) {
+    public AWSPredictionsService(
+            @NonNull AWSPredictionsPluginConfiguration configuration,
+            @NonNull AWSCredentialsProvider credentialsProvider) {
         this.configuration = configuration;
-        this.pollyService = new AWSPollyService(configuration);
-        this.translateService = new AWSTranslateService(configuration);
-        this.rekognitionService = new AWSRekognitionService(configuration);
-        this.textractService = new AWSTextractService(configuration);
-        this.comprehendService = new AWSComprehendService(configuration);
+        this.pollyService = new AWSPollyService(configuration, credentialsProvider);
+        this.translateService = new AWSTranslateService(configuration, credentialsProvider);
+        this.rekognitionService = new AWSRekognitionService(configuration, credentialsProvider);
+        this.textractService = new AWSTextractService(configuration, credentialsProvider);
+        this.comprehendService = new AWSComprehendService(configuration, credentialsProvider);
     }
 
     /**

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSRekognitionService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSRekognitionService.java
@@ -50,7 +50,6 @@ import com.amplifyframework.util.UserAgent;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.services.rekognition.AmazonRekognitionClient;
 import com.amazonaws.services.rekognition.model.Attribute;
 import com.amazonaws.services.rekognition.model.ComparedFace;
@@ -89,13 +88,13 @@ final class AWSRekognitionService {
     private final AmazonRekognitionClient rekognition;
     private final AWSPredictionsPluginConfiguration pluginConfiguration;
 
-    AWSRekognitionService(@NonNull AWSPredictionsPluginConfiguration pluginConfiguration) {
-        this.rekognition = createRekognitionClient();
+    AWSRekognitionService(@NonNull AWSPredictionsPluginConfiguration pluginConfiguration,
+                          @NonNull AWSCredentialsProvider credentialsProvider) {
+        this.rekognition = createRekognitionClient(credentialsProvider);
         this.pluginConfiguration = pluginConfiguration;
     }
 
-    private AmazonRekognitionClient createRekognitionClient() {
-        AWSCredentialsProvider credentialsProvider = AWSMobileClient.getInstance();
+    private AmazonRekognitionClient createRekognitionClient(@NonNull AWSCredentialsProvider credentialsProvider) {
         ClientConfiguration configuration = new ClientConfiguration();
         configuration.setUserAgent(UserAgent.string());
         return new AmazonRekognitionClient(credentialsProvider, configuration);

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSTextractService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSTextractService.java
@@ -33,7 +33,6 @@ import com.amplifyframework.util.UserAgent;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.services.textract.AmazonTextractClient;
 import com.amazonaws.services.textract.model.AnalyzeDocumentRequest;
 import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
@@ -57,13 +56,13 @@ final class AWSTextractService {
     private final AmazonTextractClient textract;
     private final AWSPredictionsPluginConfiguration pluginConfiguration;
 
-    AWSTextractService(@NonNull AWSPredictionsPluginConfiguration pluginConfiguration) {
-        this.textract = createTextractClient();
+    AWSTextractService(@NonNull AWSPredictionsPluginConfiguration pluginConfiguration,
+                       @NonNull AWSCredentialsProvider credentialsProvider) {
+        this.textract = createTextractClient(credentialsProvider);
         this.pluginConfiguration = pluginConfiguration;
     }
 
-    private AmazonTextractClient createTextractClient() {
-        AWSCredentialsProvider credentialsProvider = AWSMobileClient.getInstance();
+    private AmazonTextractClient createTextractClient(@NonNull AWSCredentialsProvider credentialsProvider) {
         ClientConfiguration configuration = new ClientConfiguration();
         configuration.setUserAgent(UserAgent.string());
         return new AmazonTextractClient(credentialsProvider, configuration);

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSTranslateService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSTranslateService.java
@@ -27,7 +27,6 @@ import com.amplifyframework.util.UserAgent;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.services.translate.AmazonTranslateClient;
 import com.amazonaws.services.translate.model.TranslateTextRequest;
 
@@ -38,13 +37,13 @@ final class AWSTranslateService {
     private final AmazonTranslateClient translate;
     private final AWSPredictionsPluginConfiguration pluginConfiguration;
 
-    AWSTranslateService(@NonNull AWSPredictionsPluginConfiguration pluginConfiguration) {
-        this.translate = createTranslateClient();
+    AWSTranslateService(@NonNull AWSPredictionsPluginConfiguration pluginConfiguration,
+                        @NonNull AWSCredentialsProvider credentialsProvider) {
+        this.translate = createTranslateClient(credentialsProvider);
         this.pluginConfiguration = pluginConfiguration;
     }
 
-    private AmazonTranslateClient createTranslateClient() {
-        AWSCredentialsProvider credentialsProvider = AWSMobileClient.getInstance();
+    private AmazonTranslateClient createTranslateClient(@NonNull AWSCredentialsProvider credentialsProvider) {
         ClientConfiguration configuration = new ClientConfiguration();
         configuration.setUserAgent(UserAgent.string());
         return new AmazonTranslateClient(credentialsProvider, configuration);

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.auth.options.AuthSignInOptions;
+import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
@@ -194,6 +195,14 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     @Override
     public void signOut(@NonNull Action onSuccess, @NonNull Consumer<AuthException> onError) {
         getSelectedPlugin().signOut(onSuccess, onError);
+    }
+
+    @Override
+    public void signOut(
+            @NonNull AuthSignOutOptions options,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError) {
+        getSelectedPlugin().signOut(options, onSuccess, onError);
     }
 }
 

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.auth.options.AuthSignInOptions;
+import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
@@ -239,12 +240,22 @@ public interface AuthCategoryBehavior {
     AuthUser getCurrentUser();
 
     /**
-     * Sign out of all devices. The current credentials cached on other devices will be valid but will not be able to
-     * be refreshed without signing in again so will expire shortly.
+     * Sign out of the current device.
      * @param onSuccess Success callback
      * @param onError Error callback
      */
     void signOut(
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError);
+
+    /**
+     * Sign out with advanced options.
+     * @param options Advanced options for sign out (e.g. whether to sign out of all devices globally)
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void signOut(
+            @NonNull AuthSignOutOptions options,
             @NonNull Action onSuccess,
             @NonNull Consumer<AuthException> onError);
 }

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthSignOutOptions.java
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthSignOutOptions.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+
+/**
+ * Advanced options for signing out.
+ */
+public class AuthSignOutOptions {
+    private final boolean globalSignOut;
+
+    /**
+     * Advanced options for signing up.
+     * @param globalSignOut Sign out of all devices
+     */
+    protected AuthSignOutOptions(
+            boolean globalSignOut
+    ) {
+        this.globalSignOut = globalSignOut;
+    }
+
+    /**
+     * Specifics if Amplify should invalidate credentials for all devices for this user or just the current one.
+     * @return True if sign out should sign out all devices and False if it should only sign out locally
+     */
+    public boolean isGlobalSignOut() {
+        return globalSignOut;
+    }
+
+    /**
+     * Get a builder to construct an instance of this object.
+     * @return a builder to construct an instance of this object.
+     */
+    @NonNull
+    public static Builder<?> builder() {
+        return new CoreBuilder();
+    }
+
+    /**
+     * When overriding, be sure to include globalSignOut in the hash.
+     * @return Hash code of this object
+     */
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                isGlobalSignOut()
+        );
+    }
+
+    /**
+     * When overriding, be sure to include globalSignOut in the comparison.
+     * @return True if the two objects are equal, false otherwise
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            AuthSignOutOptions authSignOutOptions = (AuthSignOutOptions) obj;
+            return ObjectsCompat.equals(isGlobalSignOut(), authSignOutOptions.isGlobalSignOut());
+        }
+    }
+
+    /**
+     * When overriding, be sure to include globalSignOut in the output string.
+     * @return A string representation of the object
+     */
+    @Override
+    public String toString() {
+        return "AuthSignOutOptions{" +
+                "globalSignOut=" + isGlobalSignOut() +
+                '}';
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    public abstract static class Builder<T extends Builder<T>> {
+        private boolean globalSignOut = false;
+
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        public abstract T getThis();
+
+        /**
+         * Specifics if Amplify should invalidate credentials for all devices for this user or just the current one.
+         * @return True if sign out should sign out all devices and False if it should sign out locally
+         */
+        public boolean isGlobalSignOut() {
+            return globalSignOut;
+        }
+
+        /**
+         * Specifics if Amplify should invalidate credentials for all devices for this user or just the current one.
+         * @param globalSignOut True if sign out should sign out all devices and False if it should sign out locally
+         * @return The builder object
+         */
+        public T globalSignOut(boolean globalSignOut) {
+            this.globalSignOut = globalSignOut;
+            return getThis();
+        }
+
+        /**
+         * Build an instance of AuthSignOutOptions (or one of its subclasses).
+         * @return an instance of AuthSignOutOptions (or one of its subclasses)
+         */
+        @NonNull
+        public AuthSignOutOptions build() {
+            return new AuthSignOutOptions(globalSignOut);
+        }
+    }
+
+    /**
+     * The specific implementation of builder for this as the parent class.
+     */
+    public static final class CoreBuilder extends Builder<CoreBuilder> {
+
+        @Override
+        public CoreBuilder getThis() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
- Integrates Auth with Predictions
- Updates SignOut to do local by default with an option to explicitly sign out globally which will fail if the device is offline and fall back to local if a global sign out was first done on another device.
- Disables AWS logs to remove some of the confusing clutter in LogCat (AWSMobileClient still does it's own logs which is very annoying).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
