### PR TITLE
[aws-datastore] Clarify field naming in PersistentRecord

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverter.java
@@ -58,10 +58,10 @@ public final class GsonPendingMutationConverter implements PendingMutation.Conve
     @Override
     public <T extends Model> PendingMutation.PersistentRecord toRecord(@NonNull PendingMutation<T> mutation) {
         return PendingMutation.PersistentRecord.builder()
-            .decodedModelId(mutation.getMutatedItem().getId())
-            .decodedModelClassName(mutation.getClassOfMutatedItem().getName())
-            .encodedModelData(gson.toJson(mutation))
-            .recordId(mutation.getMutationId())
+            .containedModelId(mutation.getMutatedItem().getId())
+            .containedModelClassName(mutation.getClassOfMutatedItem().getName())
+            .serializedMutationData(gson.toJson(mutation))
+            .mutationId(mutation.getMutationId())
             .build();
     }
 
@@ -71,17 +71,17 @@ public final class GsonPendingMutationConverter implements PendingMutation.Conve
             @NonNull PendingMutation.PersistentRecord record) throws DataStoreException {
         final Class<?> itemClass;
         try {
-            itemClass = Class.forName(record.getDecodedModelClassName());
+            itemClass = Class.forName(record.getContainedModelClassName());
         } catch (ClassNotFoundException classNotFoundException) {
             throw new DataStoreException(
-                "Could not find a class with the name " + record.getDecodedModelClassName(),
+                "Could not find a class with the name " + record.getContainedModelClassName(),
                 classNotFoundException,
                 "Verify that you have built this model into your project."
             );
         }
         final Type itemType =
             TypeToken.getParameterized(PendingMutation.class, itemClass).getType();
-        return gson.fromJson(record.getEncodedModelData(), itemType);
+        return gson.fromJson(record.getSerializedMutationData(), itemType);
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/PendingMutationPersistentRecordTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/PendingMutationPersistentRecordTest.java
@@ -52,19 +52,19 @@ public class PendingMutationPersistentRecordTest {
                 .type(String.class)
                 .build(),
             ModelField.builder()
-                .name("decodedModelId")
+                .name("containedModelId")
                 .targetType("String")
                 .isRequired(true)
                 .type(String.class)
                 .build(),
             ModelField.builder()
-                .name("encodedModelData")
+                .name("serializedMutationData")
                 .targetType("String")
                 .isRequired(true)
                 .type(String.class)
                 .build(),
             ModelField.builder()
-                .name("decodedModelClassName")
+                .name("containedModelClassName")
                 .targetType("String")
                 .isRequired(true)
                 .type(String.class)
@@ -77,8 +77,8 @@ public class PendingMutationPersistentRecordTest {
         }
 
         final ModelIndex index = ModelIndex.builder()
-            .indexFieldNames(Collections.singletonList("decodedModelClassName"))
-            .indexName("decodedModelClassNameBasedIndex")
+            .indexFieldNames(Collections.singletonList("containedModelClassName"))
+            .indexName("containedModelClassNameBasedIndex")
             .build();
 
         assertEquals(
@@ -87,7 +87,7 @@ public class PendingMutationPersistentRecordTest {
                 .name("PersistentRecord")
                 .pluralName("PersistentRecords")
                 .fields(expectedFieldsMap)
-                .indexes(Collections.singletonMap("decodedModelClassNameBasedIndex", index))
+                .indexes(Collections.singletonMap("containedModelClassNameBasedIndex", index))
                 .build(),
             // Actual
             ModelSchema.fromModelClass(PendingMutation.PersistentRecord.class)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -143,8 +143,8 @@ public class SqlCommandTest {
             // expected
             new SqlCommand(
                 "PersistentRecord",
-                "CREATE INDEX IF NOT EXISTS decodedModelClassNameBasedIndex " +
-                    "ON PersistentRecord (decodedModelClassName);"
+                "CREATE INDEX IF NOT EXISTS containedModelClassNameBasedIndex " +
+                    "ON PersistentRecord (containedModelClassName);"
             ),
             // actual
             sqlCommandIterator.next()


### PR DESCRIPTION
The `PersistentRecord` was documented as storing a serialized form of the
_`Model`_ itself. However, that is not the case. The `PersistentRecord` stores
a Gson-serialized form of a `PendingMutation`.

This distinction is made more clear by improving the documentation,
method names, and identifiers, to clarify the user of the record fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
