### PR TITLE
Add AmplifyDisposables utility to each modules using Rx

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
@@ -47,8 +47,6 @@ import java.util.Date;
 import java.util.List;
 
 import io.reactivex.Observable;
-import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposables;
 import io.reactivex.observers.TestObserver;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
@@ -315,11 +313,10 @@ public final class AppSyncClientInstrumentationTest {
         return response.getErrors();
     }
 
+    @SuppressWarnings({"CodeBlock2Expr", "SameParameterValue"})
     private <T extends Model> Observable<GraphQLResponse<ModelWithMetadata<T>>> onCreate(
-            @SuppressWarnings("SameParameterValue") @NonNull Class<T> clazz) {
+            @NonNull Class<T> clazz) {
         return Observable.create(emitter -> {
-            CompositeDisposable disposable = new CompositeDisposable();
-            emitter.setDisposable(disposable);
             Await.result((onSubscriptionStarted, ignored) -> {
                 Cancelable cancelable = api.onCreate(
                     clazz,
@@ -328,7 +325,7 @@ public final class AppSyncClientInstrumentationTest {
                     emitter::onError,
                     emitter::onComplete
                 );
-                disposable.add(Disposables.fromAction(cancelable::cancel));
+                emitter.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
             });
         });
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AmplifyDisposables.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AmplifyDisposables.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.core.async.Cancelable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * A utility for building Rx {@link Disposable}s from Amplify entities,
+ * e.g. the {@link Cancelable}.
+ */
+public final class AmplifyDisposables {
+    private AmplifyDisposables() {}
+
+    /**
+     * Builds an Rx {@link Disposable} around an Amplify {@link Cancelable}.
+     * @param cancelable An Amplify Cancelable
+     * @return An Rx Disposable
+     */
+    @NonNull
+    public static Disposable fromCancelable(@Nullable Cancelable cancelable) {
+        if (cancelable == null) {
+            return io.reactivex.disposables.Disposables.empty();
+        }
+        return new Disposable() {
+            private final AtomicReference<Boolean> isCanceled = new AtomicReference<>(false);
+            @Override
+            public void dispose() {
+                synchronized (isCanceled) {
+                    if (!isCanceled.get()) {
+                        cancelable.cancel();
+                        isCanceled.set(true);
+                    }
+                }
+            }
+
+            @Override
+            public boolean isDisposed() {
+                synchronized (isCanceled) {
+                    return isCanceled.get();
+                }
+            }
+        };
+    }
+}

--- a/rxbindings/src/main/java/com/amplifyframework/rx/AmplifyDisposables.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/AmplifyDisposables.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.rx;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.core.async.Cancelable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * A utility for building Rx {@link Disposable}s from Amplify entities,
+ * e.g. the {@link Cancelable}.
+ */
+final class AmplifyDisposables {
+    private AmplifyDisposables() {}
+
+    /**
+     * Builds an Rx {@link Disposable} around an Amplify {@link Cancelable}.
+     * @param cancelable An Amplify Cancelable
+     * @return An Rx Disposable
+     */
+    @NonNull
+    static Disposable fromCancelable(@Nullable Cancelable cancelable) {
+        if (cancelable == null) {
+            return io.reactivex.disposables.Disposables.empty();
+        }
+        return new Disposable() {
+            private final AtomicReference<Boolean> isCanceled = new AtomicReference<>(false);
+            @Override
+            public void dispose() {
+                synchronized (isCanceled) {
+                    if (!isCanceled.get()) {
+                        cancelable.cancel();
+                        isCanceled.set(true);
+                    }
+                }
+            }
+
+            @Override
+            public boolean isDisposed() {
+                synchronized (isCanceled) {
+                    return isCanceled.get();
+                }
+            }
+        };
+    }
+}

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxHubBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxHubBinding.java
@@ -27,7 +27,6 @@ import com.amplifyframework.hub.SubscriptionToken;
 
 import io.reactivex.Completable;
 import io.reactivex.Observable;
-import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposables;
 
 final class RxHubBinding implements RxHubCategoryBehavior {
@@ -38,6 +37,7 @@ final class RxHubBinding implements RxHubCategoryBehavior {
         this(Amplify.Hub);
     }
 
+    @SuppressWarnings("WeakerAccess")
     @VisibleForTesting
     RxHubBinding(HubCategory hub) {
         this.hub = hub;
@@ -53,13 +53,8 @@ final class RxHubBinding implements RxHubCategoryBehavior {
     @Override
     public Observable<HubEvent<?>> on(@NonNull HubChannel hubChannel) {
         return Observable.defer(() -> Observable.create(emitter -> {
-            final CompositeDisposable disposable = new CompositeDisposable();
-            emitter.setDisposable(disposable);
             SubscriptionToken token = hub.subscribe(hubChannel, emitter::onNext);
-            disposable.add(Disposables.fromAction(() -> {
-                hub.unsubscribe(token);
-                emitter.onComplete();
-            }));
+            emitter.setDisposable(Disposables.fromAction(() -> hub.unsubscribe(token)));
         }));
     }
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/AmplifyDisposables.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/AmplifyDisposables.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.core.async.Cancelable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * A utility for building Rx {@link Disposable}s from Amplify entities,
+ * e.g. the {@link Cancelable}.
+ */
+public final class AmplifyDisposables {
+    private AmplifyDisposables() {}
+
+    /**
+     * Builds an Rx {@link Disposable} around an Amplify {@link Cancelable}.
+     * @param cancelable An Amplify Cancelable
+     * @return An Rx Disposable
+     */
+    @NonNull
+    public static Disposable fromCancelable(@Nullable Cancelable cancelable) {
+        if (cancelable == null) {
+            return io.reactivex.disposables.Disposables.empty();
+        }
+        return new Disposable() {
+            private final AtomicReference<Boolean> isCanceled = new AtomicReference<>(false);
+            @Override
+            public void dispose() {
+                synchronized (isCanceled) {
+                    if (!isCanceled.get()) {
+                        cancelable.cancel();
+                        isCanceled.set(true);
+                    }
+                }
+            }
+
+            @Override
+            public boolean isDisposed() {
+                synchronized (isCanceled) {
+                    return isCanceled.get();
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
`AmplifyDisposables` is a factory class that generates Rx `Disposable` from
an input Amplify `Cancelable`.

Three copies of this file are added. Unfortunately this is necessary
since `testutils`, `rxbinings`, and `aws-datastore` only share `core` as a
common dependency module. However, `core` does not take a dependency on
Rx, by design. So, this class could not compile, in `core`, nor is `core` an ideal
place for miscellaneous utility code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
