### PR TITLE
[core] Add equals hashCode toString for Analytics data types

### DIFF
--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsBooleanProperty.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsBooleanProperty.java
@@ -16,6 +16,8 @@
 package com.amplifyframework.analytics;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import java.util.Objects;
 
@@ -48,5 +50,30 @@ public final class AnalyticsBooleanProperty implements AnalyticsPropertyBehavior
     @NonNull
     public static AnalyticsBooleanProperty from(@NonNull Boolean value) {
         return new AnalyticsBooleanProperty(Objects.requireNonNull(value));
+    }
+
+    @Override
+    public boolean equals(@Nullable Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+        AnalyticsBooleanProperty that = (AnalyticsBooleanProperty) thatObject;
+        return ObjectsCompat.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return getValue().hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AnalyticsBooleanProperty{" +
+            "value=" + value +
+            '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsDoubleProperty.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsDoubleProperty.java
@@ -16,6 +16,8 @@
 package com.amplifyframework.analytics;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import java.util.Objects;
 
@@ -48,5 +50,31 @@ public final class AnalyticsDoubleProperty implements AnalyticsPropertyBehavior<
     @NonNull
     public static AnalyticsDoubleProperty from(@NonNull Double value) {
         return new AnalyticsDoubleProperty(Objects.requireNonNull(value));
+    }
+
+    @Override
+    public boolean equals(@Nullable Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        AnalyticsDoubleProperty that = (AnalyticsDoubleProperty) thatObject;
+        return ObjectsCompat.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return getValue().hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AnalyticsDoubleProperty{" +
+            "value=" + value +
+            '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsEvent.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsEvent.java
@@ -16,6 +16,8 @@
 package com.amplifyframework.analytics;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import java.util.Objects;
 
@@ -75,6 +77,37 @@ public final class AnalyticsEvent implements AnalyticsEventBehavior {
     @NonNull
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+        AnalyticsEvent that = (AnalyticsEvent) thatObject;
+        if (!ObjectsCompat.equals(getName(), that.getName())) {
+            return false;
+        }
+        return ObjectsCompat.equals(getProperties(), that.getProperties());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getName().hashCode();
+        result = 31 * result + getProperties().hashCode();
+        return result;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AnalyticsEvent{" +
+            "name='" + name + '\'' +
+            ", properties=" + properties +
+            '}';
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsIntegerProperty.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsIntegerProperty.java
@@ -16,6 +16,8 @@
 package com.amplifyframework.analytics;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import java.util.Objects;
 
@@ -34,6 +36,7 @@ public final class AnalyticsIntegerProperty implements AnalyticsPropertyBehavior
      *
      * @return The wrapped Boolean value
      */
+    @NonNull
     @Override
     public Integer getValue() {
         return value;
@@ -48,5 +51,30 @@ public final class AnalyticsIntegerProperty implements AnalyticsPropertyBehavior
     @NonNull
     public static AnalyticsIntegerProperty from(@NonNull Integer value) {
         return new AnalyticsIntegerProperty(Objects.requireNonNull(value));
+    }
+
+    @Override
+    public boolean equals(@Nullable Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+        AnalyticsIntegerProperty that = (AnalyticsIntegerProperty) thatObject;
+        return ObjectsCompat.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return getValue().hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AnalyticsIntegerProperty{" +
+            "value=" + value +
+            '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsProperties.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsProperties.java
@@ -16,6 +16,8 @@
 package com.amplifyframework.analytics;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -70,7 +72,6 @@ public final class AnalyticsProperties implements Iterable<Map.Entry<String, Ana
      *
      * @return The number of properties
      */
-    @NonNull
     public int size() {
         return properties.size();
     }
@@ -101,6 +102,31 @@ public final class AnalyticsProperties implements Iterable<Map.Entry<String, Ana
     @NonNull
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+        AnalyticsProperties entries = (AnalyticsProperties) thatObject;
+        return ObjectsCompat.equals(properties, entries.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return properties.hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AnalyticsProperties{" +
+            "properties=" + properties +
+            '}';
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsStringProperty.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsStringProperty.java
@@ -16,6 +16,8 @@
 package com.amplifyframework.analytics;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import java.util.Objects;
 
@@ -48,5 +50,30 @@ public final class AnalyticsStringProperty implements AnalyticsPropertyBehavior<
     @NonNull
     public static AnalyticsStringProperty from(@NonNull String value) {
         return new AnalyticsStringProperty(Objects.requireNonNull(value));
+    }
+
+    @Override
+    public boolean equals(@Nullable Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+        AnalyticsStringProperty that = (AnalyticsStringProperty) thatObject;
+        return ObjectsCompat.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return getValue().hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AnalyticsStringProperty{" +
+            "value='" + value + '\'' +
+            '}';
     }
 }


### PR DESCRIPTION
An Amplify user may compare these objects, and may use them in collections.

An Amplify user will like to see a string representation of the objects, while debugging their project code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
