### PR TITLE
[aws-datastore] Handle list responses without any items

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncResponseDeserializer.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncResponseDeserializer.java
@@ -66,8 +66,10 @@ final class AppSyncResponseDeserializer implements AppSyncClient.ResponseDeseria
     public <T extends Model> GraphQLResponse<Iterable<ModelWithMetadata<T>>> deserialize(
             Iterable<String> jsons, Class<T> memberClazz) {
         List<ModelWithMetadata<T>> modelWithMetadataList = new ArrayList<>();
-        for (String jsonItem : jsons) {
-            modelWithMetadataList.add(toModelWithMetadata(jsonItem, memberClazz));
+        if (jsons != null) {
+            for (String jsonItem : jsons) {
+                modelWithMetadataList.add(toModelWithMetadata(jsonItem, memberClazz));
+            }
         }
         return new GraphQLResponse<>(modelWithMetadataList, Collections.emptyList());
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When the response to a query is an empty array, the data field of the `GraphQLResponse` is null. That was causing an error in with the base sync query in DataStore. Example of the response that was causing the error:

```
{"data":{"syncTodos":{"items":[],"nextToken":null,"startedAt":1590176322207}}}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
