### PR TITLE
Return empty array instead of null for empty items in response

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/IterableDeserializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/IterableDeserializer.java
@@ -61,11 +61,7 @@ final class IterableDeserializer implements JsonDeserializer<Iterable<Object>> {
             // ...and it is in the format we expect from AppSync for a list of objects in a relationship
             if (jsonObject.has(APP_SYNC_ITEMS_KEY) && jsonObject.get(APP_SYNC_ITEMS_KEY).isJsonArray()) {
                 JsonArray items = jsonObject.get(APP_SYNC_ITEMS_KEY).getAsJsonArray();
-                if (items.size() == 0) {
-                    return null;
-                } else {
-                    return toList(items, templateClassType, context);
-                }
+                return toList(items, templateClassType, context);
             } else {
                 throw new JsonParseException(
                     "Got JSON from an API call which was supposed to go with a List " +


### PR DESCRIPTION
Before the refactor of GsonGraphQLResponseFactory in https://github.com/aws-amplify/amplify-android/pull/488, there were two ways of deserializing Lists:

1. Lists at the top level were deserialized by GsonGraphQLResponseFactory with something like this:

```
private <T> Iterable<T> parseDataAsList(JsonElement jsonData, Class<T> classToCast) {
    ArrayList<T> dataAsList = new ArrayList<>();
    for (JsonElement current : jsonData.getAsJsonArray()) {
        dataAsList.add(gson.fromJson(current, classToCast));
    }
    return dataAsList;
}
```

2. Lists of objects below the top level (like an array of `Post` objects on a `Blog` object) were parsed with the `GsonListDeserializer`, and for some reason returned null if the list is empty:

```
GsonListDeserializer.java:

if (items.size() == 0) {
      return null;
} else {
    for (JsonElement item : items) {
        response.add(context.deserialize(item, templateClassType));  
    }
    return response;
}
```

With the refactor introduced in https://github.com/aws-amplify/amplify-android/pull/488, all lists are deserialized in the same way with the new `IterableDeserializer`, so I had to choose one of the two approaches above.    For no particular reason, I chose to return `null` if the array is empty to try and not break existing behavior, but in retrospect, it makes more sense to return an empty array when items is an empty array (see https://github.com/aws-amplify/amplify-android/pull/515 for an example of where the refactor actually caused an NPE into datastore)

I can't see a reason why an empty List should be deserialized as null (and all of the tests still pass), but curious if others may have context for why this was the previous implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
