### PR TITLE
Add equals, hashcode to VariablesSerializers

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonVariablesSerializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonVariablesSerializer.java
@@ -46,11 +46,28 @@ final class GsonVariablesSerializer implements GraphQLRequest.VariablesSerialize
         return gson.toJson(variables);
     }
 
-    /**
-     * Serializer of {@link Temporal.Date}, an extended ISO-8601 Date string, with an optional timezone offset.
-     *
-     * https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html
-     */
+    @Override
+    public boolean equals(Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+        /**
+         * Serializer of {@link Temporal.Date}, an extended ISO-8601 Date string, with an optional timezone offset.
+         *
+         * https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html
+         */
     static class TemporalDateSerializer implements JsonSerializer<Temporal.Date> {
         @Override
         public JsonElement serialize(Temporal.Date date, Type typeOfSrc, JsonSerializationContext context) {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonVariablesSerializer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonVariablesSerializer.java
@@ -63,11 +63,11 @@ final class GsonVariablesSerializer implements GraphQLRequest.VariablesSerialize
         return 0;
     }
 
-        /**
-         * Serializer of {@link Temporal.Date}, an extended ISO-8601 Date string, with an optional timezone offset.
-         *
-         * https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html
-         */
+    /**
+     * Serializer of {@link Temporal.Date}, an extended ISO-8601 Date string, with an optional timezone offset.
+     *
+     * https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html
+     */
     static class TemporalDateSerializer implements JsonSerializer<Temporal.Date> {
         @Override
         public JsonElement serialize(Temporal.Date date, Type typeOfSrc, JsonSerializationContext context) {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
@@ -189,9 +189,8 @@ public final class GsonGraphQLResponseFactoryTest {
         String nextToken = "eyJ2ZXJzaW9uIjoyLCJ0b2tlbiI6IkFRSUNBSGg5OUIvN3BjWU41eE96NDZJMW5GeGM4";
         Map<String, Object> variables = Collections.singletonMap("nextToken", nextToken);
         Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Todo.class);
-        GsonVariablesSerializer serializer = new GsonVariablesSerializer();
         GraphQLRequest<PaginatedResult<Todo>> expectedRequest =
-                new GraphQLRequest<>("document", variables, responseType, serializer);
+                new GraphQLRequest<>("document", variables, responseType, new GsonVariablesSerializer());
         final PaginatedResult<Todo> expectedPaginatedResult =
                 new AppSyncPaginatedResult<>(expectedTodos, expectedRequest);
 
@@ -220,7 +219,7 @@ public final class GsonGraphQLResponseFactoryTest {
         final String partialResponseJson = Resources.readAsString("partial-gql-response.json");
 
         final GraphQLRequest<PaginatedResult<Todo>> request =
-                new GraphQLRequest<>("document", responseType, serializer);
+                new GraphQLRequest<>("document", responseType, new GsonVariablesSerializer());
         final GraphQLResponse<PaginatedResult<Todo>> response =
                 responseFactory.buildResponse(request, partialResponseJson, responseType);
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncVariablesSerializer.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncVariablesSerializer.java
@@ -31,4 +31,21 @@ final class AppSyncVariablesSerializer implements GraphQLRequest.VariablesSerial
     public String serialize(Map<String, Object> variables) {
         return new Gson().toJson(variables);
     }
+
+    @Override
+    public boolean equals(Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
 }


### PR DESCRIPTION
`GraphQLRequest` already implements `equals`, `hashcode`, but it has a VariablesSerializer property which does not.  This adds `equals`, `hashcode` to those classes, so that `GraphQLRequest` should now work properly when checking for equality.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
