### PR TITLE
[aws-api] Fix POST requests with non-empty body

### DIFF
--- a/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
@@ -122,6 +122,22 @@ public final class RestRequestFactoryTest {
     }
 
     /**
+     * Test creates a POST request with a body.
+     * @throws MalformedURLException Throws when the URL is invalid.
+     */
+    @Test
+    public void createPostRequestWithBody() throws MalformedURLException {
+        URL url = RestRequestFactory.createURL("http://amplify-android.com",
+                "path/to/path",
+                null);
+        Request request = RestRequestFactory.createRequest(url,
+                "{}".getBytes(),
+                null,
+                HttpMethod.POST);
+        assertNotNull("Request should not be null", request);
+    }
+
+    /**
      * Test creates a POST request with headers.
      * @throws MalformedURLException Throws when the URL is invalid.
      */


### PR DESCRIPTION
AppSyncSigV4SignerInterceptor uses ByteArrayInputStream for both empty and non-empty request body.

Resolves: #379

Issue #, if available:
#379

Description of changes:
AbstractAWSSigner is checking to see if markSupported, but okio Buffer (which is used to copy the bytes into DefaultRequest in https://github.com/awslabs/aws-mobile-appsync-sdk-android/blame/master/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/sigv4/AppSyncSigV4SignerInterceptor.java#L120) does not override the default InputStream definition of return false. This change uses ByteArrayInputStream (which returns true for markSupported) for both empty and non-empty body paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.