### PR TITLE
fix(amplify-tools): Don't escape JSON on non-Windows platforms

### DIFF
--- a/amplify-tools/amplify-tools-gradle-plugin/src/main/groovy/com/amplifyframework/tools/gradle/plugin/AmplifyTools.groovy
+++ b/amplify-tools/amplify-tools-gradle-plugin/src/main/groovy/com/amplifyframework/tools/gradle/plugin/AmplifyTools.groovy
@@ -102,15 +102,15 @@ class AmplifyTools implements Plugin<Project> {
         project.modelgen.dependsOn('datastoreSync')
 
         project.task('amplifyPush') {
-            def AWSCLOUDFORMATIONCONFIG
+            def awsCloudFormationConfig
             if (!accessKeyId || !secretAccessKey || !region) {
-                AWSCLOUDFORMATIONCONFIG = [
+                awsCloudFormationConfig = [
                         'configLevel': 'project',
                         'useProfile' : true,
                         'profileName': profile,
                 ]
             } else {
-                AWSCLOUDFORMATIONCONFIG = [
+                awsCloudFormationConfig = [
                         'configLevel'    : 'project',
                         'useProfile'     : true,
                         'profileName'    : profile,
@@ -120,19 +120,19 @@ class AmplifyTools implements Plugin<Project> {
                 ]
             }
 
-            def AMPLIFY
+            def amplifyConfig
             if (!envName) {
-                AMPLIFY = JsonOutput.toJson([
+                amplifyConfig = JsonOutput.toJson([
                         'envName': 'amplify',
                 ])
             } else {
-                AMPLIFY = JsonOutput.toJson([
+                amplifyConfig = JsonOutput.toJson([
                         'envName': envName,
                 ])
             }
 
-            def PROVIDERS = JsonOutput.toJson([
-                    'awscloudformation': AWSCLOUDFORMATIONCONFIG,
+            def providersConfig = JsonOutput.toJson([
+                    'awscloudformation': awsCloudFormationConfig,
             ])
 
             doLast {
@@ -140,6 +140,8 @@ class AmplifyTools implements Plugin<Project> {
 
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     amplify += '.cmd'
+                    amplifyConfig = StringEscapeUtils.escapeJavaScript(amplifyConfig)
+                    providersConfig = StringEscapeUtils.escapeJavaScript(providersConfig)
                 }
 
                 if (project.file('./amplify/.config/local-env-info.json').exists()) {
@@ -149,8 +151,8 @@ class AmplifyTools implements Plugin<Project> {
                 } else {
                     project.exec {
                         commandLine amplify, 'init',
-                                '--amplify', StringEscapeUtils.escapeJavaScript(AMPLIFY),
-                                '--providers', StringEscapeUtils.escapeJavaScript(PROVIDERS),
+                                '--amplify', amplifyConfig,
+                                '--providers', providersConfig,
                                 '--yes'
                     }
                 }


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Don't escape JSON on non-Windows platforms

Windows requires double-quotes to be escaped to be passed on the command
line, but if we do the same everywhere the backslashes will be passed to
the CLI on macOS/Linux and the CLI will blow up.

This change only applies the escaping when on Windows.

- Rename variables to not be CONSTANT_CASE

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
