### PR TITLE
[Gradle plugin] Add task to create javadoc jar

### DIFF
--- a/amplify-tools/publishing.gradle
+++ b/amplify-tools/publishing.gradle
@@ -205,14 +205,29 @@ afterEvaluate { project ->
             classifier = 'sources'
             from sourceSets.main.allSource
         }
+
+        task javadocJar(type: Jar, dependsOn: javadoc) {
+            classifier = 'javadoc'
+            from javadoc.destinationDir
+        }
+    }
+
+    if (JavaVersion.current().isJava8Compatible()) {
+        allprojects {
+            tasks.withType(Javadoc) {
+                options.addStringOption('Xdoclint:none', '-quiet')
+            }
+        }
     }
 
     artifacts {
         if (project.getPlugins().hasPlugin('com.android.application') ||
                 project.getPlugins().hasPlugin('com.android.library')) {
             archives androidSourcesJar
+            archives androidJavadocsJar
         } else {
             archives sourcesJar
+            archives javadocJar
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Amplify gradle tools does not generate javadoc jar in the release process which seems to be required by Sonatype for publishing to maven. Adding task for javadoc generation.
There is potential for further enhancements to the script such as merging it with [central publishing script](https://github.com/aws-amplify/amplify-android/blob/master/configuration/publishing.gradle) and [reducing this if case](https://github.com/aws-amplify/amplify-android/blob/roshan/plugin-javadoc-task/amplify-tools/publishing.gradle#L224) since this script currently applies only to plugin module. Will test these changes with today's release and update the PR.
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
