### PR TITLE
Move MultiDexApplication declaration from main to androidTest

### DIFF
--- a/aws-datastore/src/androidTest/AndroidManifest.xml
+++ b/aws-datastore/src/androidTest/AndroidManifest.xml
@@ -16,6 +16,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.amplifyframework.datastore">
+    <application android:name="androidx.multidex.MultiDexApplication" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/aws-datastore/src/main/AndroidManifest.xml
+++ b/aws-datastore/src/main/AndroidManifest.xml
@@ -14,7 +14,4 @@
    permissions and limitations under the License.
 -->
 
-<manifest package="com.amplifyframework.datastore"
-        xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:name="androidx.multidex.MultiDexApplication" />
-</manifest>
+<manifest package="com.amplifyframework.datastore"/>


### PR DESCRIPTION
Potential solution to https://github.com/aws-amplify/amplify-android/issues/532

This does eliminate the need for clients to add `'tools:replace="android:name"'` to the `<application>` element in their AndroidManifest.xml.  

I'm not sure if this breaks the integration tests though, because our integration tests have been failing generally for about a week now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
