### PR TITLE
Show build outputs and unit test results in CircleCI Web UI

### DIFF
--- a/.circleci/aggregate-build-artifacts.sh
+++ b/.circleci/aggregate-build-artifacts.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e 
+
+modules_with_build_trees() {
+   for item in *; do
+       if [ -d "$item/build" ]; then
+           echo "$item"
+       fi
+   done
+}
+readonly modules=($(modules_with_build_trees))
+readonly current_dir="$(pwd)"
+readonly aggregation_dir="build-artifacts"
+
+if [ ! -d "$aggregation_dir" ]; then
+    mkdir "$aggregation_dir"
+fi
+cd "$aggregation_dir"
+
+for item in ${modules[@]}; do
+    [ ! -d "$item" ] && mkdir "$item"
+    echo "Aggregating build artifacts for CircleCI [$item]..."
+    cp -a "$current_dir/$item/build" "$item"
+done
+
+cd "$current_dir"
+
+tar czf build-artifacts.tar.gz "$aggregation_dir"
+echo "Aggregating build artifacts completed: see build-artifacts.tar.gz."
+

--- a/.circleci/aggregate-build-artifacts.sh
+++ b/.circleci/aggregate-build-artifacts.sh
@@ -13,13 +13,10 @@ readonly modules=($(modules_with_build_trees))
 readonly current_dir="$(pwd)"
 readonly aggregation_dir="build-artifacts"
 
-if [ ! -d "$aggregation_dir" ]; then
-    mkdir "$aggregation_dir"
-fi
-cd "$aggregation_dir"
+mkdir -p "$aggregation_dir" && cd "$aggregation_dir"
 
 for item in ${modules[@]}; do
-    [ ! -d "$item" ] && mkdir "$item"
+    mkdir -p "$item"
     echo "Aggregating build artifacts for CircleCI [$item]..."
     cp -a "$current_dir/$item/build" "$item"
 done

--- a/.circleci/aggregate-test-results.sh
+++ b/.circleci/aggregate-test-results.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+readonly circle_ci_storage_dir='test-results'
+readonly cur_dir=$(pwd)
+readonly junit_xmls_path='build/test-results/testDebugUnitTest'
+
+[ -z "$1" ] && echo "Usage: $0 <workdir_path>" >&2 && exit 1
+
+module_test_results() {
+    for item in *; do
+        if [ -d "$item/$junit_xmls_path" ]; then
+            echo $item
+        fi
+    done
+}
+readonly test_results_dirs=($(module_test_results))
+
+if [ ! -d $circle_ci_storage_dir ]; then
+    mkdir $circle_ci_storage_dir
+fi
+cd $circle_ci_storage_dir
+
+for item in ${test_results_dirs[@]}; do
+    echo "Aggregating test results for CircleCI [$item]..."
+    find "$cur_dir/$item/$junit_xmls_path" -name "*.xml" \
+        -exec cp {} . \;
+done
+
+cd $cur_dir
+

--- a/.circleci/aggregate-test-results.sh
+++ b/.circleci/aggregate-test-results.sh
@@ -17,10 +17,7 @@ module_test_results() {
 }
 readonly test_results_dirs=($(module_test_results))
 
-if [ ! -d $circle_ci_storage_dir ]; then
-    mkdir $circle_ci_storage_dir
-fi
-cd $circle_ci_storage_dir
+mkdir -p $circle_ci_storage_dir && cd $circle_ci_storage_dir
 
 for item in ${test_results_dirs[@]}; do
     echo "Aggregating test results for CircleCI [$item]..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,12 +90,14 @@ jobs:
       - generate_gradle_wrapper
       - run:
           name: Build the project
-          command: bash gradlew build
-      - run:
-          name: Publish the project to local maven
-          command: bash gradlew publishToMavenLocal
+          command: |
+            bash gradlew build
+            .circleci/aggregate-test-results.sh ~/amplify-android-home
+            .circleci/aggregate-build-artifacts.sh
       - store_test_results:
           path: test-results
+      - store_artifacts:
+          path: build-artifacts.tar.gz
 
   integrationtest:
     working_directory: ~/amplify-android-home

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ node_modules/
 aws-exports.js
 awsconfiguration.json
 amplifyconfiguration.json
+
+test-results/
+build-artifacts/
+build-artifacts.tar.gz


### PR DESCRIPTION
### Now, there is content in the CircleCI run's ["Tests"  tab](https://app.circleci.com/pipelines/github/aws-amplify/amplify-android/1761/workflows/86718868-f4d4-4295-b2ef-67e61c552796/jobs/3371/tests):
<img width="1100" alt="Screen Shot 2020-05-26 at 9 51 12 PM" src="https://user-images.githubusercontent.com/899569/82968363-294ed180-9f9b-11ea-9f20-0f24d66bcf2f.png">

### Now, there is content in the CircleCI ["Artifacts" Tab](https://app.circleci.com/pipelines/github/aws-amplify/amplify-android/1761/workflows/86718868-f4d4-4295-b2ef-67e61c552796/jobs/3371/artifacts):
<img width="1125" alt="Screen Shot 2020-05-26 at 9 51 36 PM" src="https://user-images.githubusercontent.com/899569/82968378-323fa300-9f9b-11ea-89fe-adc46ce867de.png">

------------------------
Currently we are not able to see the outputs of unit tests that run in CircleCI.

To enable this, we need to package test results into a fake directory structure that CircleCI expects.

------------------------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
