### PR TITLE
fix(api): Fix #538 by providing a default empty byte array for REST payload

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
@@ -117,16 +117,16 @@ public final class GraphQLInstrumentationTest {
      * @throws SynchronousMobileClient.MobileClientException On failure
      *          to sign in as a valid user
      */
-    @Test
-    public void subscriptionReceivesMutationOverCognitoUserPools() throws
-            ApiException, JSONException, SynchronousMobileClient.MobileClientException {
-        currentApiName = API_WITH_COGNITO_USER_POOLS;
-        JSONObject credentials = Resources.readAsJson(getApplicationContext(), R.raw.credentials);
-        String username = credentials.getString("username");
-        String password = credentials.getString("password");
-        mobileClient.signIn(username, password);
-        subscriptionReceivesMutation();
-    }
+//    @Test
+//    public void subscriptionReceivesMutationOverCognitoUserPools() throws
+//            ApiException, JSONException, SynchronousMobileClient.MobileClientException {
+//        currentApiName = API_WITH_COGNITO_USER_POOLS;
+//        JSONObject credentials = Resources.readAsJson(getApplicationContext(), R.raw.credentials);
+//        String username = credentials.getString("username");
+//        String password = credentials.getString("password");
+//        mobileClient.signIn(username, password);
+//        subscriptionReceivesMutation();
+//    }
 
     /**
      * Test that subscription fails when using Cognito User Pools as

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
@@ -117,16 +117,16 @@ public final class GraphQLInstrumentationTest {
      * @throws SynchronousMobileClient.MobileClientException On failure
      *          to sign in as a valid user
      */
-//    @Test
-//    public void subscriptionReceivesMutationOverCognitoUserPools() throws
-//            ApiException, JSONException, SynchronousMobileClient.MobileClientException {
-//        currentApiName = API_WITH_COGNITO_USER_POOLS;
-//        JSONObject credentials = Resources.readAsJson(getApplicationContext(), R.raw.credentials);
-//        String username = credentials.getString("username");
-//        String password = credentials.getString("password");
-//        mobileClient.signIn(username, password);
-//        subscriptionReceivesMutation();
-//    }
+    @Test
+    public void subscriptionReceivesMutationOverCognitoUserPools() throws
+            ApiException, JSONException, SynchronousMobileClient.MobileClientException {
+        currentApiName = API_WITH_COGNITO_USER_POOLS;
+        JSONObject credentials = Resources.readAsJson(getApplicationContext(), R.raw.credentials);
+        String username = credentials.getString("username");
+        String password = credentials.getString("password");
+        mobileClient.signIn(username, password);
+        subscriptionReceivesMutation();
+    }
 
     /**
      * Test that subscription fails when using Cognito User Pools as

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
@@ -62,7 +62,7 @@ public final class RestApiInstrumentationTest {
     @Ignore("Temporarily disabled due to consistent failure.")
     public void getRequestWithNoAuth() throws JSONException, ApiException {
         RestResponse response =
-            api.get("nonAuthApi", new RestOptions("simplesuccess"));
+            api.get("nonAuthApi", RestOptions.builder().addPath("simplesuccess").build());
 
         final JSONObject resultJSON = response.getData().asJSONObject();
         final JSONObject contextJSON = resultJSON.getJSONObject("context");
@@ -85,7 +85,7 @@ public final class RestApiInstrumentationTest {
     @Test
     @Ignore("Temporarily disabled due to consistent failure.")
     public void postRequestWithNoAuth() throws JSONException, ApiException {
-        final RestOptions options = new RestOptions("simplesuccess", "sample body".getBytes());
+        final RestOptions options = RestOptions.builder().addPath("simplesuccess").addBody("sample body".getBytes()).build();
         final RestResponse response = api.post("nonAuthApi", options);
 
         final JSONObject resultJSON = response.getData().asJSONObject();
@@ -110,7 +110,7 @@ public final class RestApiInstrumentationTest {
     @Ignore("Temporarily disabled due to consistent failure.")
     public void getRequestWithApiKey() throws JSONException, ApiException {
         final RestResponse response =
-            api.get("apiKeyApi", new RestOptions("simplesuccessapikey"));
+            api.get("apiKeyApi", RestOptions.builder().addPath("simplesuccessapikey").build());
 
         final JSONObject resultJSON = response.getData().asJSONObject();
         final JSONObject contextJSON = resultJSON.getJSONObject("context");

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
@@ -85,7 +85,8 @@ public final class RestApiInstrumentationTest {
     @Test
     @Ignore("Temporarily disabled due to consistent failure.")
     public void postRequestWithNoAuth() throws JSONException, ApiException {
-        final RestOptions options = RestOptions.builder().addPath("simplesuccess").addBody("sample body".getBytes()).build();
+        final RestOptions options =
+                RestOptions.builder().addPath("simplesuccess").addBody("sample body".getBytes()).build();
         final RestResponse response = api.post("nonAuthApi", options);
 
         final JSONObject resultJSON = response.getData().asJSONObject();

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -591,7 +591,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
                 operationRequest = new RestOperationRequest(
                         type,
                         options.getPath(),
-                        options.getData(),
+                        options.getData() == null ? new byte[0] : options.getData(),
                         options.getHeaders(),
                         options.getQueryParameters());
                 break;

--- a/core/src/main/java/com/amplifyframework/api/rest/RestOptions.java
+++ b/core/src/main/java/com/amplifyframework/api/rest/RestOptions.java
@@ -42,7 +42,7 @@ public final class RestOptions {
      * @param headers Headers for the request.
      * @param queryParameters Query parameters for the request. This value is nullable
      */
-    public RestOptions(String path,
+    private RestOptions(String path,
                        byte[] data,
                        Map<String, String> headers,
                        Map<String, String> queryParameters) {

--- a/core/src/main/java/com/amplifyframework/api/rest/RestOptions.java
+++ b/core/src/main/java/com/amplifyframework/api/rest/RestOptions.java
@@ -47,7 +47,7 @@ public final class RestOptions {
                        Map<String, String> headers,
                        Map<String, String> queryParameters) {
         this.path = path;
-        this.data = data == null ? new byte[0] : Arrays.copyOf(data, data.length);
+        this.data = data == null ? null : Arrays.copyOf(data, data.length);
         this.headers = headers == null ? Collections.emptyMap() : Immutable.of(headers);
         this.queryParameters = queryParameters == null ? Collections.emptyMap() : Immutable.of(queryParameters);
     }

--- a/core/src/main/java/com/amplifyframework/api/rest/RestOptions.java
+++ b/core/src/main/java/com/amplifyframework/api/rest/RestOptions.java
@@ -47,37 +47,9 @@ public final class RestOptions {
                        Map<String, String> headers,
                        Map<String, String> queryParameters) {
         this.path = path;
-        this.data = data == null ? null : Arrays.copyOf(data, data.length);
+        this.data = data == null ? new byte[0] : Arrays.copyOf(data, data.length);
         this.headers = headers == null ? Collections.emptyMap() : Immutable.of(headers);
         this.queryParameters = queryParameters == null ? Collections.emptyMap() : Immutable.of(queryParameters);
-    }
-
-    /**
-     * Construct a REST request.
-     * @param path Path for the endpoint to make the request
-     * @param data Data for the rest option
-     */
-    public RestOptions(String path,
-                       byte[] data) {
-        this(path, data, null, null);
-    }
-
-    /**
-     * Construct a REST request.
-     * @param path Path for the endpoint to make the request
-     * @param queryParameters Query parameters for the request. This value is nullable
-     */
-    public RestOptions(String path,
-                       Map<String, String> queryParameters) {
-        this(path, null, null, queryParameters);
-    }
-
-    /**
-     * Construct a REST request.
-     * @param path Path for the endpoint to make the request
-     */
-    public RestOptions(String path) {
-        this(path, null, null, null);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:* #538 

*Description of changes:*

OkHTTP converts POST/PUT requests to GET requests if the payload is null. Addresses this by sending an empty byte array as the payload if the Customer does not specify one.

Also privatizes the constructor of RestOptions since the builder is what should be used

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
