### PR TITLE
fix(core): use sentinel for null query predicate

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -37,6 +37,7 @@ import com.amplifyframework.core.model.query.predicate.QueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.util.Casing;
 import com.amplifyframework.util.FieldFinder;
 import com.amplifyframework.util.Immutable;
@@ -170,6 +171,8 @@ public final class AppSyncGraphQLRequestFactory {
             ModelSchema schema = ModelSchema.fromModelClass(modelClass);
             String graphQlTypeName = schema.getName();
 
+            boolean includePredicate = !QueryPredicates.matchAll().equals(predicate);
+
             doc.append("query ")
                     .append("List")
                     .append(Casing.capitalizeFirst(graphQlTypeName))
@@ -183,7 +186,7 @@ public final class AppSyncGraphQLRequestFactory {
                     .append(getModelFields(modelClass, DEFAULT_LEVEL_DEPTH))
                     .append("} nextToken }}");
 
-            if (predicate != null) {
+            if (includePredicate) {
                 variables.put("filter", parsePredicate(predicate));
             }
             if (nextToken != null) {
@@ -231,6 +234,8 @@ public final class AppSyncGraphQLRequestFactory {
             String typeStr = type.toString();
             String graphQlTypeName = schema.getName();
 
+            boolean includePredicate = !QueryPredicates.matchAll().equals(predicate);
+
             doc.append("mutation ")
                     .append(Casing.capitalize(typeStr))
                     .append(Casing.capitalizeFirst(graphQlTypeName))
@@ -239,7 +244,7 @@ public final class AppSyncGraphQLRequestFactory {
                     .append(Casing.capitalizeFirst(graphQlTypeName))
                     .append("Input!");
 
-            if (predicate != null) {
+            if (includePredicate) {
                 doc.append(", $condition: Model")
                         .append(graphQlTypeName)
                         .append("ConditionInput");
@@ -250,7 +255,7 @@ public final class AppSyncGraphQLRequestFactory {
                     .append(Casing.capitalizeFirst(graphQlTypeName))
                     .append("(input: $input");
 
-            if (predicate != null) {
+            if (includePredicate) {
                 doc.append(", condition: $condition");
             }
 
@@ -273,7 +278,7 @@ public final class AppSyncGraphQLRequestFactory {
                 }
             }
 
-            if (predicate != null) {
+            if (includePredicate) {
                 variables.put("condition", parsePredicate(predicate));
             }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -171,7 +171,7 @@ public final class AppSyncGraphQLRequestFactory {
             ModelSchema schema = ModelSchema.fromModelClass(modelClass);
             String graphQlTypeName = schema.getName();
 
-            boolean includePredicate = !QueryPredicates.matchAll().equals(predicate);
+            boolean includePredicate = !QueryPredicates.all().equals(predicate);
 
             doc.append("query ")
                     .append("List")
@@ -234,7 +234,7 @@ public final class AppSyncGraphQLRequestFactory {
             String typeStr = type.toString();
             String graphQlTypeName = schema.getName();
 
-            boolean includePredicate = !QueryPredicates.matchAll().equals(predicate);
+            boolean includePredicate = !QueryPredicates.all().equals(predicate);
 
             doc.append("mutation ")
                     .append(Casing.capitalize(typeStr))

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelMutation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelMutation.java
@@ -22,6 +22,7 @@ import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 
 /**
  * Helper class that provides methods to create {@link GraphQLRequest} from {@link Model}.
@@ -40,7 +41,7 @@ public final class ModelMutation {
      * @see MutationType#CREATE
      */
     public static <M extends Model> GraphQLRequest<M> create(@NonNull M model) {
-        return AppSyncGraphQLRequestFactory.buildMutation(model, null, MutationType.CREATE);
+        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.matchAll(), MutationType.CREATE);
     }
 
     /**
@@ -67,7 +68,7 @@ public final class ModelMutation {
      * @see #update(Model, QueryPredicate)
      */
     public static <M extends Model> GraphQLRequest<M> update(@NonNull M model) {
-        return AppSyncGraphQLRequestFactory.buildMutation(model, null, MutationType.UPDATE);
+        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.matchAll(), MutationType.UPDATE);
     }
 
     /**
@@ -94,7 +95,7 @@ public final class ModelMutation {
      * @see #delete(Model, QueryPredicate)
      */
     public static <M extends Model> GraphQLRequest<M> delete(@NonNull M model) {
-        return AppSyncGraphQLRequestFactory.buildMutation(model, null, MutationType.DELETE);
+        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.matchAll(), MutationType.DELETE);
     }
 
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelMutation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelMutation.java
@@ -28,10 +28,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicates;
  * Helper class that provides methods to create {@link GraphQLRequest} from {@link Model}.
  */
 public final class ModelMutation {
-
-    /** This class should not be instantiated. */
-    private ModelMutation() {
-    }
+    private ModelMutation() {}
 
     /**
      * Creates a {@link GraphQLRequest} that represents a create mutation for a given {@code model} instance.
@@ -41,7 +38,7 @@ public final class ModelMutation {
      * @see MutationType#CREATE
      */
     public static <M extends Model> GraphQLRequest<M> create(@NonNull M model) {
-        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.matchAll(), MutationType.CREATE);
+        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.all(), MutationType.CREATE);
     }
 
     /**
@@ -68,7 +65,7 @@ public final class ModelMutation {
      * @see #update(Model, QueryPredicate)
      */
     public static <M extends Model> GraphQLRequest<M> update(@NonNull M model) {
-        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.matchAll(), MutationType.UPDATE);
+        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.all(), MutationType.UPDATE);
     }
 
     /**
@@ -95,7 +92,6 @@ public final class ModelMutation {
      * @see #delete(Model, QueryPredicate)
      */
     public static <M extends Model> GraphQLRequest<M> delete(@NonNull M model) {
-        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.matchAll(), MutationType.DELETE);
+        return AppSyncGraphQLRequestFactory.buildMutation(model, QueryPredicates.all(), MutationType.DELETE);
     }
-
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelQuery.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelQuery.java
@@ -78,7 +78,7 @@ public final class ModelQuery {
      * @see #list(Class, QueryPredicate)
      */
     public static <M extends Model> GraphQLRequest<Iterable<M>> list(@NonNull Class<M> modelType) {
-        return list(modelType, QueryPredicates.matchAll());
+        return list(modelType, QueryPredicates.all());
     }
 
     /**

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelQuery.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelQuery.java
@@ -16,13 +16,15 @@
 package com.amplifyframework.api.graphql.model;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.amplifyframework.api.aws.AppSyncGraphQLRequestFactory;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.PaginatedResult;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
+
+import java.util.Objects;
 
 /**
  * Helper class that provides methods to create {@link GraphQLRequest} for queries
@@ -60,8 +62,10 @@ public final class ModelQuery {
      */
     public static <M extends Model> GraphQLRequest<Iterable<M>> list(
             @NonNull Class<M> modelType,
-            @Nullable QueryPredicate predicate
+            @NonNull QueryPredicate predicate
     ) {
+        Objects.requireNonNull(modelType);
+        Objects.requireNonNull(predicate);
         return AppSyncGraphQLRequestFactory.buildQuery(modelType, predicate);
     }
 
@@ -74,7 +78,7 @@ public final class ModelQuery {
      * @see #list(Class, QueryPredicate)
      */
     public static <M extends Model> GraphQLRequest<Iterable<M>> list(@NonNull Class<M> modelType) {
-        return list(modelType, (QueryPredicate) null);
+        return list(modelType, QueryPredicates.matchAll());
     }
 
     /**

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
@@ -20,6 +20,7 @@ import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.api.graphql.SubscriptionType;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.testmodels.meeting.Meeting;
 import com.amplifyframework.testmodels.personcar.MaritalStatus;
@@ -156,7 +157,7 @@ public final class AppSyncGraphQLRequestFactoryTest {
 
         // Act: build a mutation to create a Meeting
         GraphQLRequest<Meeting> requestToCreateMeeting1 =
-                AppSyncGraphQLRequestFactory.buildMutation(meeting1, null, MutationType.CREATE);
+                AppSyncGraphQLRequestFactory.buildMutation(meeting1, QueryPredicates.matchAll(), MutationType.CREATE);
 
         // Assert: expected is actual
         JSONAssert.assertEquals(Resources.readAsString("create-meeting1.txt"),

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
@@ -157,7 +157,7 @@ public final class AppSyncGraphQLRequestFactoryTest {
 
         // Act: build a mutation to create a Meeting
         GraphQLRequest<Meeting> requestToCreateMeeting1 =
-                AppSyncGraphQLRequestFactory.buildMutation(meeting1, QueryPredicates.matchAll(), MutationType.CREATE);
+                AppSyncGraphQLRequestFactory.buildMutation(meeting1, QueryPredicates.all(), MutationType.CREATE);
 
         // Assert: expected is actual
         JSONAssert.assertEquals(Resources.readAsString("create-meeting1.txt"),

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/appsync/SynchronousAppSync.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/appsync/SynchronousAppSync.java
@@ -22,6 +22,7 @@ import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testutils.Await;
 
@@ -33,7 +34,10 @@ import io.reactivex.Observable;
  * A synchronous wrapper around an AppSync client, useful in test, so you can just
  * wait for the results of network operations.
  */
-@SuppressWarnings("unused") // Oh, that it might be, someday, though!
+@SuppressWarnings({
+    "unused", // Some of the behaviors aren't, currently, true.
+    "WeakerAccess"
+})
 public final class SynchronousAppSync {
     private final AppSync appSync;
 
@@ -93,8 +97,8 @@ public final class SynchronousAppSync {
      */
     @NonNull
     public <T extends Model> GraphQLResponse<ModelWithMetadata<T>> update(
-        @NonNull T model, @NonNull Integer version) throws DataStoreException {
-        return update(model, version, null);
+            @NonNull T model, @NonNull Integer version) throws DataStoreException {
+        return update(model, version, QueryPredicates.matchAll());
     }
 
     /**
@@ -108,7 +112,7 @@ public final class SynchronousAppSync {
      */
     @NonNull
     public <T extends Model> GraphQLResponse<ModelWithMetadata<T>> update(
-        @NonNull T model, @NonNull Integer version, @Nullable QueryPredicate predicate) throws DataStoreException {
+            @NonNull T model, @NonNull Integer version, @NonNull QueryPredicate predicate) throws DataStoreException {
         return Await.<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException>result(((onResult, onError) ->
             appSync.update(model, version, predicate, onResult, onError)
         ));
@@ -126,7 +130,7 @@ public final class SynchronousAppSync {
     @NonNull
     <T extends Model> GraphQLResponse<ModelWithMetadata<T>> delete(
         @NonNull Class<T> clazz, @NonNull String objectId, @NonNull Integer version) throws DataStoreException {
-        return delete(clazz, objectId, version, null);
+        return delete(clazz, objectId, version, QueryPredicates.matchAll());
     }
 
     /**
@@ -144,7 +148,7 @@ public final class SynchronousAppSync {
             @NonNull Class<T> clazz,
             @NonNull String objectId,
             @NonNull Integer version,
-            @Nullable QueryPredicate predicate) throws DataStoreException {
+            @NonNull QueryPredicate predicate) throws DataStoreException {
         return Await.<GraphQLResponse<ModelWithMetadata<T>>, DataStoreException>result((onResult, onError) ->
             appSync.delete(clazz, objectId, version, predicate, onResult, onError)
         );

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/appsync/SynchronousAppSync.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/appsync/SynchronousAppSync.java
@@ -98,7 +98,7 @@ public final class SynchronousAppSync {
     @NonNull
     public <T extends Model> GraphQLResponse<ModelWithMetadata<T>> update(
             @NonNull T model, @NonNull Integer version) throws DataStoreException {
-        return update(model, version, QueryPredicates.matchAll());
+        return update(model, version, QueryPredicates.all());
     }
 
     /**
@@ -130,7 +130,7 @@ public final class SynchronousAppSync {
     @NonNull
     <T extends Model> GraphQLResponse<ModelWithMetadata<T>> delete(
         @NonNull Class<T> clazz, @NonNull String objectId, @NonNull Integer version) throws DataStoreException {
-        return delete(clazz, objectId, version, QueryPredicates.matchAll());
+        return delete(clazz, objectId, version, QueryPredicates.all());
     }
 
     /**

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testutils.Await;
 
@@ -111,15 +112,14 @@ public final class SynchronousStorageAdapter {
      * @throws DataStoreException On any failure to save model into storage adapter
      */
     public <T extends Model> void save(@NonNull T model) throws DataStoreException {
-        //noinspection ConstantConditions
-        save(model, null);
+        save(model, QueryPredicates.matchAll());
     }
 
     /**
      * Save a model.
      * @param model Model to save
      * @param predicate An existing instance of the model in the storage adapter must meet these criteria
-     *                  in order for the save to succeed. If null, no criteria are considered
+     *                  in order for the save to succeed.
      * @param <T> Type of model being saved
      * @throws DataStoreException On any failure to save the model
      */
@@ -145,8 +145,7 @@ public final class SynchronousStorageAdapter {
      * @return The exception that was raised while attempting to save the model
      */
     public <T extends Model> DataStoreException saveExpectingError(@NonNull T model) {
-        //noinspection ConstantConditions
-        return saveExpectingError(model, null);
+        return saveExpectingError(model, QueryPredicates.matchAll());
     }
 
     /**
@@ -213,8 +212,7 @@ public final class SynchronousStorageAdapter {
      * @throws DataStoreException On any failure to delete model
      */
     public <T extends Model> void delete(@NonNull T model) throws DataStoreException {
-        //noinspection ConstantConditions
-        delete(model, null);
+        delete(model, QueryPredicates.matchAll());
     }
 
     /**
@@ -249,8 +247,7 @@ public final class SynchronousStorageAdapter {
      */
     @SuppressWarnings("unused")
     public <T extends Model> DataStoreException deleteExpectingError(@NonNull T model) {
-        //noinspection ConstantConditions
-        return deleteExpectingError(model, null);
+        return deleteExpectingError(model, QueryPredicates.matchAll());
     }
 
     /**
@@ -294,10 +291,8 @@ public final class SynchronousStorageAdapter {
      */
     public void clear() {
         //noinspection ResultOfMethodCallIgnored
-        Completable.fromSingle(single -> {
-            asyncDelegate.clear(() -> {
-                single.onSuccess(true);
-            }, single::onError);
-        }).blockingAwait(DEFAULT_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        Completable.create(emitter ->
+            asyncDelegate.clear(emitter::onComplete, emitter::onError)
+        ).blockingAwait(DEFAULT_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -112,7 +112,7 @@ public final class SynchronousStorageAdapter {
      * @throws DataStoreException On any failure to save model into storage adapter
      */
     public <T extends Model> void save(@NonNull T model) throws DataStoreException {
-        save(model, QueryPredicates.matchAll());
+        save(model, QueryPredicates.all());
     }
 
     /**
@@ -145,7 +145,7 @@ public final class SynchronousStorageAdapter {
      * @return The exception that was raised while attempting to save the model
      */
     public <T extends Model> DataStoreException saveExpectingError(@NonNull T model) {
-        return saveExpectingError(model, QueryPredicates.matchAll());
+        return saveExpectingError(model, QueryPredicates.all());
     }
 
     /**
@@ -212,7 +212,7 @@ public final class SynchronousStorageAdapter {
      * @throws DataStoreException On any failure to delete model
      */
     public <T extends Model> void delete(@NonNull T model) throws DataStoreException {
-        delete(model, QueryPredicates.matchAll());
+        delete(model, QueryPredicates.all());
     }
 
     /**
@@ -247,7 +247,7 @@ public final class SynchronousStorageAdapter {
      */
     @SuppressWarnings("unused")
     public <T extends Model> DataStoreException deleteExpectingError(@NonNull T model) {
-        return deleteExpectingError(model, QueryPredicates.matchAll());
+        return deleteExpectingError(model, QueryPredicates.all());
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -36,6 +36,7 @@ import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.appsync.AppSyncClient;
 import com.amplifyframework.datastore.model.ModelProviderLocator;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
@@ -239,7 +240,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull T item,
             @NonNull Consumer<DataStoreItemChange<T>> onItemSaved,
             @NonNull Consumer<DataStoreException> onFailureToSave) {
-        save(item, null, onItemSaved, onFailureToSave);
+        save(item, QueryPredicates.matchAll(), onItemSaved, onFailureToSave);
     }
 
     /**
@@ -248,7 +249,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     @Override
     public <T extends Model> void save(
             @NonNull T item,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<DataStoreItemChange<T>> onItemSaved,
             @NonNull Consumer<DataStoreException> onFailureToSave) {
         beforeOperation(() -> sqliteStorageAdapter.save(
@@ -274,7 +275,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull T item,
             @NonNull Consumer<DataStoreItemChange<T>> onItemDeleted,
             @NonNull Consumer<DataStoreException> onFailureToDelete) {
-        delete(item, null, onItemDeleted, onFailureToDelete);
+        delete(item, QueryPredicates.matchAll(), onItemDeleted, onFailureToDelete);
     }
 
     /**
@@ -283,7 +284,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     @Override
     public <T extends Model> void delete(
             @NonNull T item,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<DataStoreItemChange<T>> onItemDeleted,
             @NonNull Consumer<DataStoreException> onFailureToDelete) {
         beforeOperation(() -> sqliteStorageAdapter.delete(

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -240,7 +240,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull T item,
             @NonNull Consumer<DataStoreItemChange<T>> onItemSaved,
             @NonNull Consumer<DataStoreException> onFailureToSave) {
-        save(item, QueryPredicates.matchAll(), onItemSaved, onFailureToSave);
+        save(item, QueryPredicates.all(), onItemSaved, onFailureToSave);
     }
 
     /**
@@ -275,7 +275,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull T item,
             @NonNull Consumer<DataStoreItemChange<T>> onItemDeleted,
             @NonNull Consumer<DataStoreException> onFailureToDelete) {
-        delete(item, QueryPredicates.matchAll(), onItemDeleted, onFailureToDelete);
+        delete(item, QueryPredicates.all(), onItemDeleted, onFailureToDelete);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSync.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSync.java
@@ -107,7 +107,7 @@ public interface AppSync {
     <T extends Model> Cancelable update(
             @NonNull T model,
             @NonNull Integer version,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure
     );
@@ -147,7 +147,7 @@ public interface AppSync {
             @NonNull Class<T> clazz,
             @NonNull String objectId,
             @NonNull Integer version,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure
     );

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
@@ -165,7 +165,7 @@ public final class AppSyncClient implements AppSync {
             @NonNull Integer version,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
-        return update(model, version, QueryPredicates.matchAll(), onResponse, onFailure);
+        return update(model, version, QueryPredicates.all(), onResponse, onFailure);
     }
 
     @SuppressWarnings("unchecked") // (Class<T>)
@@ -178,7 +178,7 @@ public final class AppSyncClient implements AppSync {
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
         try {
-            final boolean includePredicate = !QueryPredicates.matchAll().equals(predicate);
+            final boolean includePredicate = !QueryPredicates.all().equals(predicate);
             final String doc = AppSyncRequestFactory.buildUpdateDoc(model.getClass(), includePredicate);
 
             Class<T> modelClass = (Class<T>) model.getClass();
@@ -221,7 +221,7 @@ public final class AppSyncClient implements AppSync {
             @NonNull Integer version,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
-        return delete(clazz, objectId, version, QueryPredicates.matchAll(), onResponse, onFailure);
+        return delete(clazz, objectId, version, QueryPredicates.all(), onResponse, onFailure);
     }
 
     @NonNull
@@ -234,7 +234,7 @@ public final class AppSyncClient implements AppSync {
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
         try {
-            final boolean includePredicate = !QueryPredicates.matchAll().equals(predicate);
+            final boolean includePredicate = !QueryPredicates.all().equals(predicate);
             final String doc = AppSyncRequestFactory.buildDeletionDoc(clazz, includePredicate);
 
             final Map<String, Object> deleteInput = new HashMap<>();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
@@ -32,6 +32,7 @@ import com.amplifyframework.core.async.NoOpCancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 
 import com.google.gson.reflect.TypeToken;
@@ -164,7 +165,7 @@ public final class AppSyncClient implements AppSync {
             @NonNull Integer version,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
-        return update(model, version, null, onResponse, onFailure);
+        return update(model, version, QueryPredicates.matchAll(), onResponse, onFailure);
     }
 
     @SuppressWarnings("unchecked") // (Class<T>)
@@ -173,11 +174,12 @@ public final class AppSyncClient implements AppSync {
     public <T extends Model> Cancelable update(
             @NonNull T model,
             @NonNull Integer version,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
         try {
-            final String doc = AppSyncRequestFactory.buildUpdateDoc(model.getClass(), predicate != null);
+            final boolean includePredicate = !QueryPredicates.matchAll().equals(predicate);
+            final String doc = AppSyncRequestFactory.buildUpdateDoc(model.getClass(), includePredicate);
 
             Class<T> modelClass = (Class<T>) model.getClass();
             ModelSchema schema = ModelSchema.fromModelClass(modelClass);
@@ -186,7 +188,7 @@ public final class AppSyncClient implements AppSync {
             updateInput.put("_version", version);
 
             final Map<String, Object> variables = Collections.singletonMap("input", updateInput);
-            if (predicate != null) {
+            if (includePredicate) {
                 variables.put("condition", AppSyncRequestFactory.parsePredicate(predicate));
             }
 
@@ -219,7 +221,7 @@ public final class AppSyncClient implements AppSync {
             @NonNull Integer version,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
-        return delete(clazz, objectId, version, null, onResponse, onFailure);
+        return delete(clazz, objectId, version, QueryPredicates.matchAll(), onResponse, onFailure);
     }
 
     @NonNull
@@ -228,18 +230,19 @@ public final class AppSyncClient implements AppSync {
             @NonNull Class<T> clazz,
             @NonNull String objectId,
             @NonNull Integer version,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
         try {
-            final String doc = AppSyncRequestFactory.buildDeletionDoc(clazz, predicate != null);
+            final boolean includePredicate = !QueryPredicates.matchAll().equals(predicate);
+            final String doc = AppSyncRequestFactory.buildDeletionDoc(clazz, includePredicate);
 
             final Map<String, Object> deleteInput = new HashMap<>();
             deleteInput.put("id", objectId);
             deleteInput.put("_version", version);
 
             final Map<String, Object> variables = Collections.singletonMap("input", deleteInput);
-            if (predicate != null) {
+            if (includePredicate) {
                 variables.put("condition", AppSyncRequestFactory.parsePredicate(predicate));
             }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/model/PredicateInterfaceAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/model/PredicateInterfaceAdapter.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.datastore.model;
 
+import com.amplifyframework.core.model.query.predicate.MatchAllQueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
@@ -40,7 +41,8 @@ public final class PredicateInterfaceAdapter implements
 
     private enum PredicateType {
         OPERATION,
-        GROUP
+        GROUP,
+        ALL
     }
 
     /**
@@ -63,6 +65,8 @@ public final class PredicateInterfaceAdapter implements
                 return context.deserialize(json, QueryPredicateOperation.class);
             case GROUP:
                 return context.deserialize(json, QueryPredicateGroup.class);
+            case ALL:
+                return context.deserialize(json, MatchAllQueryPredicate.class);
             default:
                 throw new JsonParseException("Unable to deserialize " +
                         json.toString() + " to QueryPredicate instance.");
@@ -80,7 +84,10 @@ public final class PredicateInterfaceAdapter implements
     ) throws JsonParseException {
         JsonElement json;
         PredicateType predicateType;
-        if (predicate instanceof QueryPredicateOperation) {
+        if (predicate instanceof MatchAllQueryPredicate) {
+            predicateType = PredicateType.ALL;
+            json = context.serialize(predicate, MatchAllQueryPredicate.class);
+        } else if (predicate instanceof QueryPredicateOperation) {
             json = context.serialize(predicate, QueryPredicateOperation.class);
             predicateType = PredicateType.OPERATION;
         } else if (predicate instanceof QueryPredicateGroup) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -17,7 +17,6 @@ package com.amplifyframework.datastore.storage;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
@@ -96,7 +95,7 @@ public interface LocalStorageAdapter {
     <T extends Model> void save(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<StorageItemChange<T>> onSuccess,
             @NonNull Consumer<DataStoreException> onError
     );
@@ -158,7 +157,7 @@ public interface LocalStorageAdapter {
     <T extends Model> void delete(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<StorageItemChange<T>> onSuccess,
             @NonNull Consumer<DataStoreException> onError
     );

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
@@ -17,7 +17,6 @@ package com.amplifyframework.datastore.storage;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
@@ -85,7 +84,7 @@ public final class StorageItemChange<T extends Model> {
      * Gets the predicate that was applied before this item change.
      * @return Predicate applied for this item change
      */
-    @Nullable
+    @NonNull
     public QueryPredicate predicate() {
         return predicate;
     }
@@ -140,7 +139,7 @@ public final class StorageItemChange<T extends Model> {
         if (type != that.type) {
             return false;
         }
-        if (!ObjectsCompat.equals(predicate, that.predicate)) {
+        if (!predicate.equals(that.predicate)) {
             return false;
         }
         if (!item.equals(that.item)) {
@@ -154,7 +153,7 @@ public final class StorageItemChange<T extends Model> {
         int result = changeId.hashCode();
         result = 31 * result + initiator.hashCode();
         result = 31 * result + type.hashCode();
-        result = 31 * result + (predicate != null ? predicate.hashCode() : 0);
+        result = 31 * result + predicate.hashCode();
         result = 31 * result + item.hashCode();
         result = 31 * result + itemClass.hashCode();
         return result;
@@ -238,8 +237,8 @@ public final class StorageItemChange<T extends Model> {
          * @return Current Builder instance for fluent configuration chainging
          */
         @NonNull
-        public Builder<T> predicate(@Nullable QueryPredicate predicate) {
-            this.predicate = predicate;
+        public Builder<T> predicate(@NonNull QueryPredicate predicate) {
+            this.predicate = Objects.requireNonNull(predicate);
             return this;
         }
 
@@ -279,7 +278,7 @@ public final class StorageItemChange<T extends Model> {
                 Objects.requireNonNull(usedId),
                 Objects.requireNonNull(initiator),
                 Objects.requireNonNull(type),
-                predicate, // Nullable
+                Objects.requireNonNull(predicate),
                 Objects.requireNonNull(item),
                 Objects.requireNonNull(itemClass)
             );

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -227,7 +227,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         // Append predicates.
         // WHERE condition
         final QueryPredicate predicate = options.getQueryPredicate();
-        if (!QueryPredicates.matchAll().equals(predicate)) {
+        if (!QueryPredicates.all().equals(predicate)) {
             final SQLPredicate sqlPredicate = new SQLPredicate(predicate);
             bindings.addAll(sqlPredicate.getBindings());
             rawQuery.append(SqlKeyword.DELIMITER)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -29,6 +29,7 @@ import com.amplifyframework.core.model.PrimaryKey;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.QueryPaginationInput;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLPredicate;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteColumn;
@@ -226,7 +227,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         // Append predicates.
         // WHERE condition
         final QueryPredicate predicate = options.getQueryPredicate();
-        if (predicate != null) {
+        if (!QueryPredicates.matchAll().equals(predicate)) {
             final SQLPredicate sqlPredicate = new SQLPredicate(predicate);
             bindings.addAll(sqlPredicate.getBindings());
             rawQuery.append(SqlKeyword.DELIMITER)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -39,6 +39,7 @@ import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.model.CompoundModelProvider;
 import com.amplifyframework.datastore.model.SystemModelsProviderFactory;
@@ -263,7 +264,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         Objects.requireNonNull(initiator);
         Objects.requireNonNull(onSuccess);
         Objects.requireNonNull(onError);
-        save(item, initiator, null, onSuccess, onError);
+        save(item, initiator, QueryPredicates.matchAll(), onSuccess, onError);
     }
 
     /**
@@ -273,12 +274,12 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     public <T extends Model> void save(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<StorageItemChange<T>> onSuccess,
             @NonNull Consumer<DataStoreException> onError) {
         Objects.requireNonNull(item);
         Objects.requireNonNull(initiator);
-        // Objects.requireNonNull(predicate); Not required!
+        Objects.requireNonNull(predicate);
         Objects.requireNonNull(onSuccess);
         Objects.requireNonNull(onError);
 
@@ -299,7 +300,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     // update always checks for ID first
                     final QueryPredicateOperation<?> idCheck =
                         QueryField.field(primaryKeyName).eq(item.getId());
-                    final QueryPredicate condition = predicate != null
+                    final QueryPredicate condition = !QueryPredicates.matchAll().equals(predicate)
                         ? idCheck.and(predicate)
                         : idCheck;
                     sqlCommand = sqlCommandFactory.updateFor(modelSchema, item, condition);
@@ -427,18 +428,18 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             @NonNull Consumer<StorageItemChange<T>> onSuccess,
             @NonNull Consumer<DataStoreException> onError
     ) {
-        delete(item, initiator, null, onSuccess, onError);
+        delete(item, initiator, QueryPredicates.matchAll(), onSuccess, onError);
     }
 
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings({"unchecked", "ConstantConditions"}) // item.getClass() has Class<?>, but we assume Class<T>
+    @SuppressWarnings("unchecked") // item.getClass() has Class<?>, but we assume Class<T>
     @Override
     public <T extends Model> void delete(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @Nullable QueryPredicate predicate,
+            @NonNull QueryPredicate predicate,
             @NonNull Consumer<StorageItemChange<T>> onSuccess,
             @NonNull Consumer<DataStoreException> onError
     ) {
@@ -459,7 +460,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 // delete always checks for ID first
                 final QueryPredicateOperation<?> idCheck =
                     QueryField.field(primaryKeyName).eq(item.getId());
-                final QueryPredicate condition = predicate != null
+                final QueryPredicate condition = !QueryPredicates.matchAll().equals(predicate)
                     ? idCheck.and(predicate)
                     : idCheck;
                 final SqlCommand sqlCommand = sqlCommandFactory.deleteFor(modelSchema, item, condition);
@@ -601,13 +602,12 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         LOG.debug("DataStore cleared. Re-initializing storage adapter.");
 
         //Re-initialize the adapter.
-        initialize(context, schemaList -> {
-            onComplete.call();
-        }, exception -> {
-                onError.accept(new DataStoreException(
-                    "Error occurred whilte trying to re-initialize the storage adapter",
-                    exception.getMessage()));
-            }
+        initialize(context,
+            schemaList -> onComplete.call(),
+            exception -> onError.accept(new DataStoreException(
+                "Error occurred while trying to re-initialize the storage adapter",
+                String.valueOf(exception.getMessage())
+            ))
         );
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -264,7 +264,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         Objects.requireNonNull(initiator);
         Objects.requireNonNull(onSuccess);
         Objects.requireNonNull(onError);
-        save(item, initiator, QueryPredicates.matchAll(), onSuccess, onError);
+        save(item, initiator, QueryPredicates.all(), onSuccess, onError);
     }
 
     /**
@@ -300,7 +300,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     // update always checks for ID first
                     final QueryPredicateOperation<?> idCheck =
                         QueryField.field(primaryKeyName).eq(item.getId());
-                    final QueryPredicate condition = !QueryPredicates.matchAll().equals(predicate)
+                    final QueryPredicate condition = !QueryPredicates.all().equals(predicate)
                         ? idCheck.and(predicate)
                         : idCheck;
                     sqlCommand = sqlCommandFactory.updateFor(modelSchema, item, condition);
@@ -428,7 +428,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             @NonNull Consumer<StorageItemChange<T>> onSuccess,
             @NonNull Consumer<DataStoreException> onError
     ) {
-        delete(item, initiator, QueryPredicates.matchAll(), onSuccess, onError);
+        delete(item, initiator, QueryPredicates.all(), onSuccess, onError);
     }
 
     /**
@@ -460,7 +460,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 // delete always checks for ID first
                 final QueryPredicateOperation<?> idCheck =
                     QueryField.field(primaryKeyName).eq(item.getId());
-                final QueryPredicate condition = !QueryPredicates.matchAll().equals(predicate)
+                final QueryPredicate condition = !QueryPredicates.all().equals(predicate)
                     ? idCheck.and(predicate)
                     : idCheck;
                 final SqlCommand sqlCommand = sqlCommandFactory.deleteFor(modelSchema, item, condition);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.model.annotations.Index;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 
@@ -38,6 +39,7 @@ import java.util.UUID;
  * logic onto them, before ultimately uploading to a remote endpoint.
  * @param <T> Type of model that has experienced a mutation
  */
+@SuppressWarnings("SameParameterValue")
 public final class PendingMutation<T extends Model> implements Comparable<PendingMutation<? extends Model>> {
     private final T mutatedItem;
     private final Class<T> classOfMutatedItem;
@@ -74,13 +76,13 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
             @NonNull T mutatedItem,
             @NonNull Class<T> classOfMutatedItem,
             @NonNull Type mutationType,
-            @Nullable QueryPredicate predicate) {
+            @NonNull QueryPredicate predicate) {
         return new PendingMutation<>(
             Objects.requireNonNull(mutationId),
             Objects.requireNonNull(mutatedItem),
             Objects.requireNonNull(classOfMutatedItem),
             Objects.requireNonNull(mutationType),
-            predicate
+            Objects.requireNonNull(predicate)
         );
     }
 
@@ -95,9 +97,9 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      */
     @NonNull
     static <T extends Model> PendingMutation<T> instance(@NonNull T mutatedItem,
-                                                         @NonNull Class<T> classOfMutatedItem,
-                                                         @NonNull Type mutationType,
-                                                         @Nullable QueryPredicate predicate) {
+                                                          @NonNull Class<T> classOfMutatedItem,
+                                                          @NonNull Type mutationType,
+                                                          @NonNull QueryPredicate predicate) {
         return instance(TimeBasedUuid.create(), mutatedItem, classOfMutatedItem, mutationType, predicate);
     }
 
@@ -110,7 +112,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      */
     @NonNull
     static <T extends Model> PendingMutation<T> creation(@NonNull T createdItem, @NonNull Class<T> classOfCreatedItem) {
-        return instance(createdItem, classOfCreatedItem, Type.CREATE, null);
+        return instance(createdItem, classOfCreatedItem, Type.CREATE, QueryPredicates.matchAll());
     }
 
     /**
@@ -123,7 +125,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     @NonNull
     static <T extends Model> PendingMutation<T> update(@NonNull T updatedItem,
                                                        @NonNull Class<T> classOfUpdatedItem) {
-        return instance(updatedItem, classOfUpdatedItem, Type.UPDATE, null);
+        return instance(updatedItem, classOfUpdatedItem, Type.UPDATE, QueryPredicates.matchAll());
     }
 
     /**
@@ -137,7 +139,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     @NonNull
     static <T extends Model> PendingMutation<T> update(@NonNull T updatedItem,
                                                        @NonNull Class<T> classOfUpdatedItem,
-                                                       @Nullable QueryPredicate predicate) {
+                                                       @NonNull QueryPredicate predicate) {
         return instance(updatedItem, classOfUpdatedItem, Type.UPDATE, predicate);
     }
 
@@ -151,7 +153,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     @NonNull
     static <T extends Model> PendingMutation<T> deletion(@NonNull T deletedItem,
                                                          @NonNull Class<T> classOfDeletedItem) {
-        return instance(deletedItem, classOfDeletedItem, Type.DELETE, null);
+        return instance(deletedItem, classOfDeletedItem, Type.DELETE, QueryPredicates.matchAll());
     }
 
     /**
@@ -165,7 +167,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     @NonNull
     static <T extends Model> PendingMutation<T> deletion(@NonNull T deletedItem,
                                                          @NonNull Class<T> classOfDeletedItem,
-                                                         @Nullable QueryPredicate predicate) {
+                                                         @NonNull QueryPredicate predicate) {
         return instance(deletedItem, classOfDeletedItem, Type.DELETE, predicate);
     }
 
@@ -205,7 +207,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
         return mutationType;
     }
 
-    @Nullable
+    @NonNull
     QueryPredicate getPredicate() {
         return predicate;
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
@@ -112,7 +112,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
      */
     @NonNull
     static <T extends Model> PendingMutation<T> creation(@NonNull T createdItem, @NonNull Class<T> classOfCreatedItem) {
-        return instance(createdItem, classOfCreatedItem, Type.CREATE, QueryPredicates.matchAll());
+        return instance(createdItem, classOfCreatedItem, Type.CREATE, QueryPredicates.all());
     }
 
     /**
@@ -125,7 +125,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     @NonNull
     static <T extends Model> PendingMutation<T> update(@NonNull T updatedItem,
                                                        @NonNull Class<T> classOfUpdatedItem) {
-        return instance(updatedItem, classOfUpdatedItem, Type.UPDATE, QueryPredicates.matchAll());
+        return instance(updatedItem, classOfUpdatedItem, Type.UPDATE, QueryPredicates.all());
     }
 
     /**
@@ -153,7 +153,7 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     @NonNull
     static <T extends Model> PendingMutation<T> deletion(@NonNull T deletedItem,
                                                          @NonNull Class<T> classOfDeletedItem) {
-        return instance(deletedItem, classOfDeletedItem, Type.DELETE, QueryPredicates.matchAll());
+        return instance(deletedItem, classOfDeletedItem, Type.DELETE, QueryPredicates.all());
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -333,9 +333,9 @@ final class PersistentMutationOutbox implements MutationOutbox {
                     // Update after the create -> replace item of the create mutation (and keep it as a create).
                     // No condition needs to be provided, because as far as the remote store is concerned,
                     // we're simply performing the create (with the updated item item contents)
-                    return overwriteExistingAndNotify(PendingMutation.Type.CREATE, QueryPredicates.matchAll());
+                    return overwriteExistingAndNotify(PendingMutation.Type.CREATE, QueryPredicates.all());
                 case UPDATE:
-                    if (QueryPredicates.matchAll().equals(incoming.getPredicate())) {
+                    if (QueryPredicates.all().equals(incoming.getPredicate())) {
                         // If the incoming update does not have a condition, we want to delete any
                         // existing mutations for the modelId before saving the incoming one.
                         return remove(existing.getMutationId()).andThen(saveIncomingAndNotify());

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -66,6 +66,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("SameParameterValue")
 @RunWith(RobolectricTestRunner.class)
 public final class AWSDataStorePluginTest {
     private static final String MOCK_API_PLUGIN_NAME = "MockApiPlugin";
@@ -263,10 +264,6 @@ public final class AWSDataStorePluginTest {
             .stream()
             .noneMatch(invocation -> invocation.getLocation().getSourceFile().contains("SyncProcessor"));
         assertTrue(syncProcessorNotInvoked);
-    }
-
-    private static ApiCategory mockApiCategoryWithoutPlugins() throws JSONException {
-        return spy(ApiCategory.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -73,7 +73,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull final Consumer<StorageItemChange<T>> onSuccess,
             @NonNull final Consumer<DataStoreException> onError
     ) {
-        save(item, initiator, QueryPredicates.matchAll(), onSuccess, onError);
+        save(item, initiator, QueryPredicates.all(), onSuccess, onError);
     }
 
     @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.
@@ -146,7 +146,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull final Consumer<StorageItemChange<T>> onSuccess,
             @NonNull final Consumer<DataStoreException> onError
     ) {
-        delete(item, initiator, QueryPredicates.matchAll(), onSuccess, onError);
+        delete(item, initiator, QueryPredicates.all(), onSuccess, onError);
     }
 
     @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -23,6 +23,7 @@ import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testutils.Await;
 
@@ -86,15 +87,14 @@ public final class SynchronousStorageAdapter {
      * @throws DataStoreException On any failure to save model into storage adapter
      */
     public <T extends Model> void save(@NonNull T model) throws DataStoreException {
-        //noinspection ConstantConditions
-        save(model, null);
+        save(model, QueryPredicates.matchAll());
     }
 
     /**
      * Save a model.
      * @param model Model to save
      * @param predicate An existing instance of the model in the storage adapter must meet these criteria
-     *                  in order for the save to succeed. If null, no criteria are considered
+     *                  in order for the save to succeed.
      * @param <T> Type of model being saved
      * @throws DataStoreException On any failure to save the model
      */
@@ -184,8 +184,7 @@ public final class SynchronousStorageAdapter {
      * @throws DataStoreException On any failure to delete model
      */
     public <T extends Model> void delete(@NonNull T model) throws DataStoreException {
-        //noinspection ConstantConditions
-        delete(model, null);
+        delete(model, QueryPredicates.matchAll());
     }
 
     /**
@@ -226,7 +225,7 @@ public final class SynchronousStorageAdapter {
                 asyncDelegate.delete(
                     model,
                     StorageItemChange.Initiator.DATA_STORE_API,
-                    null,
+                    QueryPredicates.matchAll(),
                     onResult,
                     onError
                 )

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -87,7 +87,7 @@ public final class SynchronousStorageAdapter {
      * @throws DataStoreException On any failure to save model into storage adapter
      */
     public <T extends Model> void save(@NonNull T model) throws DataStoreException {
-        save(model, QueryPredicates.matchAll());
+        save(model, QueryPredicates.all());
     }
 
     /**
@@ -184,7 +184,7 @@ public final class SynchronousStorageAdapter {
      * @throws DataStoreException On any failure to delete model
      */
     public <T extends Model> void delete(@NonNull T model) throws DataStoreException {
-        delete(model, QueryPredicates.matchAll());
+        delete(model, QueryPredicates.all());
     }
 
     /**
@@ -225,7 +225,7 @@ public final class SynchronousStorageAdapter {
                 asyncDelegate.delete(
                     model,
                     StorageItemChange.Initiator.DATA_STORE_API,
-                    QueryPredicates.matchAll(),
+                    QueryPredicates.all(),
                     onResult,
                     onError
                 )

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
@@ -202,7 +202,7 @@ public final class MergerTest {
         storageAdapter.save(blogOwner, localMetadata);
 
         PendingMutation<BlogOwner> pendingMutation = PendingMutation.instance(
-            blogOwner, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.matchAll()
+            blogOwner, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.all()
         );
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(pendingMutation).test();
         enqueueObserver.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.datastore.syncengine;
 
 import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
@@ -200,8 +201,9 @@ public final class MergerTest {
             new ModelMetadata(blogOwner.getId(), false, 1, Time.now());
         storageAdapter.save(blogOwner, localMetadata);
 
-        PendingMutation<BlogOwner> pendingMutation =
-            PendingMutation.instance(blogOwner, BlogOwner.class, PendingMutation.Type.CREATE, null);
+        PendingMutation<BlogOwner> pendingMutation = PendingMutation.instance(
+            blogOwner, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.matchAll()
+        );
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(pendingMutation).test();
         enqueueObserver.awaitTerminalEvent(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS);
         enqueueObserver.assertNoErrors().assertComplete();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -207,7 +207,7 @@ public final class PersistentMutationOutboxTest {
             .build();
         TimeBasedUuid mutationId = TimeBasedUuid.create();
         PendingMutation<BlogOwner> pendingMutation = PendingMutation.instance(
-            mutationId, joe, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.matchAll()
+            mutationId, joe, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.all()
         );
         mutationOutbox.enqueue(pendingMutation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
@@ -236,7 +236,7 @@ public final class PersistentMutationOutboxTest {
         TimeBasedUuid mutationId = TimeBasedUuid.create();
         @SuppressWarnings("unused") // This is the point of this field.
         PendingMutation<BlogOwner> unrelatedMutation = PendingMutation.instance(
-            mutationId, joe, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.matchAll()
+            mutationId, joe, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.all()
         );
 
         assertFalse(mutationOutbox.hasPendingMutation(joeId));
@@ -575,7 +575,7 @@ public final class PersistentMutationOutboxTest {
                 modelInIncomingMutation,
                 BlogOwner.class,
                 PendingMutation.Type.CREATE,
-                QueryPredicates.matchAll()
+                QueryPredicates.all()
             ),
             mutationOutbox.peek()
         );
@@ -651,7 +651,7 @@ public final class PersistentMutationOutboxTest {
                 joe,
                 BlogOwner.class,
                 PendingMutation.Type.DELETE,
-                QueryPredicates.matchAll()
+                QueryPredicates.all()
             ),
             mutationOutbox.peek()
         );

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.syncengine;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
 import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
@@ -177,7 +178,7 @@ public final class PersistentMutationOutboxTest {
         BlogOwner bill = BlogOwner.builder()
             .name("Bill Gates")
             .build();
-        PendingMutation<BlogOwner> deleteBillGates = PendingMutation.deletion(bill, BlogOwner.class, null);
+        PendingMutation<BlogOwner> deleteBillGates = PendingMutation.deletion(bill, BlogOwner.class);
         storage.save(converter.toRecord(deleteBillGates));
         mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
@@ -205,8 +206,9 @@ public final class PersistentMutationOutboxTest {
             .id(modelId)
             .build();
         TimeBasedUuid mutationId = TimeBasedUuid.create();
-        PendingMutation<BlogOwner> pendingMutation =
-            PendingMutation.instance(mutationId, joe, BlogOwner.class, PendingMutation.Type.CREATE, null);
+        PendingMutation<BlogOwner> pendingMutation = PendingMutation.instance(
+            mutationId, joe, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.matchAll()
+        );
         mutationOutbox.enqueue(pendingMutation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
         assertTrue(mutationOutbox.hasPendingMutation(modelId));
@@ -233,8 +235,9 @@ public final class PersistentMutationOutboxTest {
 
         TimeBasedUuid mutationId = TimeBasedUuid.create();
         @SuppressWarnings("unused") // This is the point of this field.
-        PendingMutation<BlogOwner> unrelatedMutation =
-            PendingMutation.instance(mutationId, joe, BlogOwner.class, PendingMutation.Type.CREATE, null);
+        PendingMutation<BlogOwner> unrelatedMutation = PendingMutation.instance(
+            mutationId, joe, BlogOwner.class, PendingMutation.Type.CREATE, QueryPredicates.matchAll()
+        );
 
         assertFalse(mutationOutbox.hasPendingMutation(joeId));
         assertFalse(mutationOutbox.hasPendingMutation(mutationId.toString()));
@@ -482,7 +485,7 @@ public final class PersistentMutationOutboxTest {
             .name("Papa Tony")
             .build();
         PendingMutation<BlogOwner> existingUpdate =
-            PendingMutation.update(modelInExistingMutation, BlogOwner.class, null);
+            PendingMutation.update(modelInExistingMutation, BlogOwner.class);
         String existingUpdateId = existingUpdate.getMutationId().toString();
         mutationOutbox.enqueue(existingUpdate).blockingAwait();
 
@@ -491,7 +494,7 @@ public final class PersistentMutationOutboxTest {
             .name("Tony Jr.")
             .build();
         PendingMutation<BlogOwner> incomingUpdate =
-            PendingMutation.update(modelInIncomingMutation, BlogOwner.class, null);
+            PendingMutation.update(modelInIncomingMutation, BlogOwner.class);
         String incomingUpdateId = incomingUpdate.getMutationId().toString();
         TestObserver<Void> enqueueObserver = mutationOutbox.enqueue(incomingUpdate).test();
 
@@ -572,7 +575,7 @@ public final class PersistentMutationOutboxTest {
                 modelInIncomingMutation,
                 BlogOwner.class,
                 PendingMutation.Type.CREATE,
-                null
+                QueryPredicates.matchAll()
             ),
             mutationOutbox.peek()
         );
@@ -648,7 +651,7 @@ public final class PersistentMutationOutboxTest {
                 joe,
                 BlogOwner.class,
                 PendingMutation.Type.DELETE,
-                null
+                QueryPredicates.matchAll()
             ),
             mutationOutbox.peek()
         );

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -20,13 +20,13 @@ import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 
 /**
  * A data structure that provides a query construction mechanism that consolidates all query-related
  * options (e.g. predicates, pagination, etc) and allows consumers to build queries in a fluent way.
  */
 public final class QueryOptions {
-
     private QueryPredicate queryPredicate;
     private QueryPaginationInput paginationInput;
 
@@ -38,7 +38,7 @@ public final class QueryOptions {
             @Nullable QueryPredicate queryPredicate,
             @Nullable QueryPaginationInput paginationInput
     ) {
-        this.queryPredicate = queryPredicate;
+        this.queryPredicate = queryPredicate == null ? QueryPredicates.matchAll() : queryPredicate;
         this.paginationInput = paginationInput;
     }
 
@@ -64,7 +64,7 @@ public final class QueryOptions {
      * Returns the {@code queryPredicate} property.
      * @return the {@code queryPredicate} property.
      */
-    @Nullable
+    @NonNull
     public QueryPredicate getQueryPredicate() {
         return queryPredicate;
     }
@@ -79,7 +79,7 @@ public final class QueryOptions {
     }
 
     @Override
-    public boolean equals(Object object) {
+    public boolean equals(@Nullable Object object) {
         if (this == object) {
             return true;
         }
@@ -96,6 +96,7 @@ public final class QueryOptions {
         return ObjectsCompat.hash(queryPredicate, paginationInput);
     }
 
+    @NonNull
     @Override
     public String toString() {
         return "QueryOptions{" +
@@ -103,5 +104,4 @@ public final class QueryOptions {
                 ", paginationInput=" + paginationInput +
                 '}';
     }
-
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -38,7 +38,7 @@ public final class QueryOptions {
             @Nullable QueryPredicate queryPredicate,
             @Nullable QueryPaginationInput paginationInput
     ) {
-        this.queryPredicate = queryPredicate == null ? QueryPredicates.matchAll() : queryPredicate;
+        this.queryPredicate = queryPredicate == null ? QueryPredicates.all() : queryPredicate;
         this.paginationInput = paginationInput;
     }
 

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/MatchAllQueryPredicate.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/MatchAllQueryPredicate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model.query.predicate;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * A {@link QueryPredicate} that matches any/all objects passed to it.
+ */
+public final class MatchAllQueryPredicate implements QueryPredicate {
+    private MatchAllQueryPredicate() {}
+
+    /**
+     * Creates a new instance of a {@link MatchAllQueryPredicate}.
+     * @return A match-all query predicate
+     */
+    @NonNull
+    public static MatchAllQueryPredicate instance() {
+        return new MatchAllQueryPredicate();
+    }
+
+    @Override
+    public boolean evaluate(@Nullable Object target) {
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return MatchAllQueryPredicate.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return obj instanceof MatchAllQueryPredicate;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return MatchAllQueryPredicate.class.getSimpleName();
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicates.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicates.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model.query.predicate;
+
+/**
+ * A factory class for building {@link QueryPredicate}s.
+ */
+public final class QueryPredicates {
+    private QueryPredicates() {}
+
+    /**
+     * Creates a {@link QueryPredicate} which matches any object it is asked to evaluate.
+     * @return A query predicate that matches everything.
+     */
+    public static MatchAllQueryPredicate matchAll() {
+        return MatchAllQueryPredicate.instance();
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicates.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicates.java
@@ -25,7 +25,7 @@ public final class QueryPredicates {
      * Creates a {@link QueryPredicate} which matches any object it is asked to evaluate.
      * @return A query predicate that matches everything.
      */
-    public static MatchAllQueryPredicate matchAll() {
+    public static MatchAllQueryPredicate all() {
         return MatchAllQueryPredicate.instance();
     }
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousApi.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousApi.java
@@ -30,6 +30,7 @@ import com.amplifyframework.api.rest.RestResponse;
 import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.testutils.AmplifyDisposables;
 import com.amplifyframework.testutils.Await;
 import com.amplifyframework.util.Immutable;
@@ -128,9 +129,9 @@ public final class SynchronousApi {
     @NonNull
     public <T extends Model> T update(
             @NonNull String apiName, @NonNull T model, @NonNull QueryPredicate predicate) throws ApiException {
-        return awaitResponseData((onResponse, onFailure) -> {
-            asyncDelegate.mutate(apiName, ModelMutation.update(model, predicate), onResponse, onFailure);
-        });
+        return awaitResponseData((onResponse, onFailure) ->
+            asyncDelegate.mutate(apiName, ModelMutation.update(model, predicate), onResponse, onFailure)
+        );
     }
 
     /**
@@ -162,9 +163,9 @@ public final class SynchronousApi {
     @NonNull
     public <T extends Model> List<GraphQLResponse.Error> updateExpectingErrors(
             @NonNull String apiName, @NonNull T model, @NonNull QueryPredicate predicate) throws ApiException {
-        return this.<T>awaitResponseErrors((onResponse, onFailure) -> {
-            asyncDelegate.mutate(apiName, ModelMutation.update(model, predicate), onResponse, onFailure);
-        });
+        return this.<T>awaitResponseErrors((onResponse, onFailure) ->
+            asyncDelegate.mutate(apiName, ModelMutation.update(model, predicate), onResponse, onFailure)
+        );
     }
 
     /**
@@ -242,10 +243,10 @@ public final class SynchronousApi {
     public <T extends Model> List<T> list(
             @NonNull String apiName,
             @NonNull Class<T> clazz,
-            @SuppressWarnings("NullableProblems") @NonNull QueryPredicate predicate) throws ApiException {
-        final Iterable<T> queryResults = awaitResponseData((onResponse, onFailure) -> {
-            asyncDelegate.query(apiName, ModelQuery.list(clazz, predicate), onResponse, onFailure);
-        });
+            @NonNull QueryPredicate predicate) throws ApiException {
+        final Iterable<T> queryResults = awaitResponseData((onResponse, onFailure) ->
+            asyncDelegate.query(apiName, ModelQuery.list(clazz, predicate), onResponse, onFailure)
+        );
         final List<T> results = new ArrayList<>();
         for (T item : queryResults) {
             results.add(item);
@@ -264,8 +265,7 @@ public final class SynchronousApi {
      */
     @NonNull
     public <T extends Model> List<T> list(@NonNull String apiName, @NonNull Class<T> clazz) throws ApiException {
-        //noinspection ConstantConditions To save boiler plate, we do this internally.
-        return list(apiName, clazz, null);
+        return list(apiName, clazz, QueryPredicates.matchAll());
     }
 
     /**

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousApi.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousApi.java
@@ -265,7 +265,7 @@ public final class SynchronousApi {
      */
     @NonNull
     public <T extends Model> List<T> list(@NonNull String apiName, @NonNull Class<T> clazz) throws ApiException {
-        return list(apiName, clazz, QueryPredicates.matchAll());
+        return list(apiName, clazz, QueryPredicates.all());
     }
 
     /**


### PR DESCRIPTION
Around the code-base, a `null` value for a `QueryPredicate` has the
meaning of "don't apply any filter," or, "match everything."

That's sort of clear, maybe.

Instead of having a meaningful `null` value, use a sentinel, instead,
which declares its purpose as `QueryPredicates.matchAll()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
