### PR TITLE
chore: Replace threeten backport dependency with java.time

### DIFF
--- a/aws-api/build.gradle
+++ b/aws-api/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation dependency.aws.mobileclient
     implementation dependency.gson
     implementation dependency.okhttp
-    implementation dependency.threetenabp
 
     testImplementation project(path: ':testutils')
     testImplementation project(path: ':testmodels')

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ ext {
             translate: "com.amazonaws:aws-android-sdk-translate:$awsSdkVersion"
         ],
 
-
         okhttp: 'com.squareup.okhttp3:okhttp:4.7.2',
         gson: 'com.google.code.gson:gson:2.8.6',
         rxandroid: 'io.reactivex.rxjava2:rxandroid:2.1.1',

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
     awsSdkVersion = '2.16.12'
     dependency = [
         android: [
-            desugar_jdk_libs: 'com.android.tools:desugar_jdk_libs:1.0.5',
+            desugartools: 'com.android.tools:desugar_jdk_libs:1.0.5',
         ],
         androidx: [
             v4support: 'androidx.legacy:legacy-support-v4:1.0.0',

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ private void configureAndroidLibrary(Project project) {
         }
 
         compileOptions {
+            coreLibraryDesugaringEnabled true
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
         }
@@ -137,5 +138,9 @@ private void configureAndroidLibrary(Project project) {
                 proguardFiles 'proguard-rules.pro'
             }
         }
+    }
+
+    project.dependencies {
+        coreLibraryDesugaring dependency.android.desugartools
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ ext {
 
     awsSdkVersion = '2.16.12'
     dependency = [
+        android: [
+            desugar_jdk_libs: 'com.android.tools:desugar_jdk_libs:1.0.5',
+        ],
         androidx: [
             v4support: 'androidx.legacy:legacy-support-v4:1.0.0',
             annotation: 'androidx.annotation:annotation:1.1.0',
@@ -75,12 +78,12 @@ ext {
             translate: "com.amazonaws:aws-android-sdk-translate:$awsSdkVersion"
         ],
 
+
         okhttp: 'com.squareup.okhttp3:okhttp:4.7.2',
         gson: 'com.google.code.gson:gson:2.8.6',
         rxandroid: 'io.reactivex.rxjava2:rxandroid:2.1.1',
         rxjava: 'io.reactivex.rxjava2:rxjava:2.2.13',
         tensorflow: 'org.tensorflow:tensorflow-lite:2.0.0',
-        threetenabp: 'com.jakewharton.threetenabp:threetenabp:1.2.4',
         uuidgen: 'com.fasterxml.uuid:java-uuid-generator:4.0.1',
 
         junit: 'junit:junit:4.13',

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,7 +20,6 @@ apply from: rootProject.file("configuration/publishing.gradle")
 dependencies {
     implementation dependency.androidx.v4support
     implementation dependency.androidx.annotation
-
     testImplementation project(path: ':testmodels')
     testImplementation(project(path: ':testutils')) {
         transitive = false
@@ -41,4 +40,3 @@ dependencies {
     androidTestImplementation dependency.androidx.test.runner
     androidTestImplementation dependency.androidx.test.junit
 }
-

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring dependency.android.desugar_jdk_libs
+    coreLibraryDesugaring dependency.android.desugartools
 
     implementation dependency.androidx.v4support
     implementation dependency.androidx.annotation

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,18 +17,9 @@ apply plugin: 'com.android.library'
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 
-android {
-    compileOptions {
-        coreLibraryDesugaringEnabled true
-    }
-}
-
 dependencies {
-    coreLibraryDesugaring dependency.android.desugartools
-
     implementation dependency.androidx.v4support
     implementation dependency.androidx.annotation
-
 
     testImplementation project(path: ':testmodels')
     testImplementation(project(path: ':testutils')) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,10 +17,18 @@ apply plugin: 'com.android.library'
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 
+android {
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+    }
+}
+
 dependencies {
+    coreLibraryDesugaring dependency.android.desugar_jdk_libs
+
     implementation dependency.androidx.v4support
     implementation dependency.androidx.annotation
-    implementation dependency.threetenabp
+
 
     testImplementation project(path: ':testmodels')
     testImplementation(project(path: ':testutils')) {

--- a/core/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
+++ b/core/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
@@ -224,8 +224,7 @@ public final class Temporal {
          * @return A Java {@link java.util.Date} representation of the {@link Temporal.DateTime}
          */
         public java.util.Date toDate() {
-            long epochSeconds = offsetDateTime.toInstant().getEpochSecond();
-            return new java.util.Date(TimeUnit.SECONDS.toMillis(epochSeconds));
+            return new java.util.Date(offsetDateTime.toInstant().toEpochMilli());
         }
 
         /**

--- a/core/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
+++ b/core/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
@@ -131,8 +131,7 @@ public final class Temporal {
         public java.util.Date toDate() {
             ZoneOffset zoneOffset = this.zoneOffset != null ? this.zoneOffset : ZoneOffset.UTC;
             OffsetDateTime oft = OffsetDateTime.of(localDate, LocalTime.MIDNIGHT, zoneOffset);
-            long epochSeconds = oft.toInstant().getEpochSecond();
-            return new java.util.Date(TimeUnit.SECONDS.toMillis(epochSeconds));
+            return new java.util.Date(oft.toInstant().toEpochMilli());
         }
 
         /**
@@ -348,8 +347,7 @@ public final class Temporal {
         public java.util.Date toDate() {
             ZoneOffset zo = zoneOffset != null ? zoneOffset : ZoneOffset.UTC;
             OffsetDateTime oft = OffsetDateTime.of(LocalDate.ofEpochDay(0), localTime, zo);
-            long epochSeconds = oft.toInstant().getEpochSecond();
-            return new java.util.Date(TimeUnit.SECONDS.toMillis(epochSeconds));
+            return new java.util.Date(oft.toInstant().toEpochMilli());
         }
 
         /**

--- a/core/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
+++ b/core/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
@@ -18,18 +18,16 @@ package com.amplifyframework.core.model.temporal;
 import androidx.annotation.NonNull;
 import androidx.core.util.ObjectsCompat;
 
-import org.threeten.bp.DateTimeUtils;
-import org.threeten.bp.Instant;
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.LocalTime;
-import org.threeten.bp.OffsetDateTime;
-import org.threeten.bp.OffsetTime;
-import org.threeten.bp.ZoneOffset;
-import org.threeten.bp.format.DateTimeFormatter;
-import org.threeten.bp.format.DateTimeFormatterBuilder;
-import org.threeten.bp.format.DateTimeParseException;
-import org.threeten.bp.temporal.ChronoField;
-
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -133,7 +131,8 @@ public final class Temporal {
         public java.util.Date toDate() {
             ZoneOffset zoneOffset = this.zoneOffset != null ? this.zoneOffset : ZoneOffset.UTC;
             OffsetDateTime oft = OffsetDateTime.of(localDate, LocalTime.MIDNIGHT, zoneOffset);
-            return DateTimeUtils.toDate(oft.toInstant());
+            long epochSeconds = oft.toInstant().getEpochSecond();
+            return new java.util.Date(TimeUnit.SECONDS.toMillis(epochSeconds));
         }
 
         /**
@@ -226,7 +225,8 @@ public final class Temporal {
          * @return A Java {@link java.util.Date} representation of the {@link Temporal.DateTime}
          */
         public java.util.Date toDate() {
-            return DateTimeUtils.toDate(offsetDateTime.toInstant());
+            long epochSeconds = offsetDateTime.toInstant().getEpochSecond();
+            return new java.util.Date(TimeUnit.SECONDS.toMillis(epochSeconds));
         }
 
         /**
@@ -348,7 +348,8 @@ public final class Temporal {
         public java.util.Date toDate() {
             ZoneOffset zo = zoneOffset != null ? zoneOffset : ZoneOffset.UTC;
             OffsetDateTime oft = OffsetDateTime.of(LocalDate.ofEpochDay(0), localTime, zo);
-            return DateTimeUtils.toDate(oft.toInstant());
+            long epochSeconds = oft.toInstant().getEpochSecond();
+            return new java.util.Date(TimeUnit.SECONDS.toMillis(epochSeconds));
         }
 
         /**

--- a/core/src/test/java/com/amplifyframework/core/model/temporal/TemporalTimeTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/temporal/TemporalTimeTest.java
@@ -68,6 +68,8 @@ public final class TemporalTimeTest {
         cal.set(Calendar.HOUR_OF_DAY, 1); // 1 AM
         cal.set(Calendar.MINUTE, 2); // 1:02 AM
         cal.set(Calendar.SECOND, 3); // 1:02:03 AM
+        cal.set(Calendar.MILLISECOND, 4); // 1:02:03.004 AM
+
         Date date = cal.getTime();
         Temporal.Time temporalTime = new Temporal.Time(date);
         assertEquals(date, temporalTime.toDate());
@@ -90,6 +92,7 @@ public final class TemporalTimeTest {
         cal.set(Calendar.HOUR_OF_DAY, 1); // 1 AM
         cal.set(Calendar.MINUTE, 2); // 1:02 AM
         cal.set(Calendar.SECOND, 3); // 1:02:03 AM
+        cal.set(Calendar.MILLISECOND, 4); // 1:02:03.004 AM
 
         Date date = cal.getTime();
         long offsetInMillis = timeZone.getOffset(date.getTime());


### PR DESCRIPTION
By updating to Android Gradle Plugin 4.0.0, we can now take advantage of [Java 8+ desugaring support](https://developer.android.com/studio/write/java8-support#library-desugaring), which allows us to use `java.time`.  This PR removes the threetenabp dependency and replaces it with `java.time`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
