### PR TITLE
Remove nextToken from ModelPagination since nextToken is never exposed

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -130,7 +130,7 @@ public final class AppSyncGraphQLRequestFactory {
             QueryPredicate predicate
     ) {
         Type dataType = TypeMaker.getParameterizedType(Iterable.class, modelClass);
-        return buildQuery(modelClass, predicate, DEFAULT_QUERY_LIMIT, null, dataType);
+        return buildQuery(modelClass, predicate, DEFAULT_QUERY_LIMIT, dataType);
     }
 
     /**
@@ -143,7 +143,6 @@ public final class AppSyncGraphQLRequestFactory {
      * @param modelClass the model class.
      * @param predicate the predicate for filtering.
      * @param limit the page size/limit.
-     * @param nextToken the next page token.
      * @param <R> the response type.
      * @param <T> the concrete model type.
      * @return a valid {@link GraphQLRequest} instance.
@@ -151,18 +150,16 @@ public final class AppSyncGraphQLRequestFactory {
     public static <R, T extends Model> GraphQLRequest<R> buildPaginatedResultQuery(
             Class<T> modelClass,
             QueryPredicate predicate,
-            int limit,
-            String nextToken
+            int limit
     ) {
         Type dataType = TypeMaker.getParameterizedType(PaginatedResult.class, modelClass);
-        return buildQuery(modelClass, predicate, limit, nextToken, dataType);
+        return buildQuery(modelClass, predicate, limit, dataType);
     }
 
     static <R, T extends Model> GraphQLRequest<R> buildQuery(
             Class<T> modelClass,
             QueryPredicate predicate,
             int limit,
-            String nextToken,
             Type responseType
     ) {
         try {
@@ -188,9 +185,6 @@ public final class AppSyncGraphQLRequestFactory {
 
             if (includePredicate) {
                 variables.put("filter", parsePredicate(predicate));
-            }
-            if (nextToken != null) {
-                variables.put("nextToken", nextToken);
             }
             variables.put("limit", limit);
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncPaginatedResult.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncPaginatedResult.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.api.aws;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.api.graphql.GraphQLRequest;
@@ -27,7 +28,7 @@ final class AppSyncPaginatedResult<T extends Model> extends PaginatedResult<T> {
     private final Iterable<T> items;
 
     AppSyncPaginatedResult(@NonNull Iterable<T> items,
-                           @NonNull GraphQLRequest<PaginatedResult<T>> requestForNextResult) {
+                           @Nullable GraphQLRequest<PaginatedResult<T>> requestForNextResult) {
         this.requestForNextResult = requestForNextResult;
         this.items = items;
     }

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelPagination.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelPagination.java
@@ -29,35 +29,32 @@ public final class ModelPagination {
     private static final int DEFAULT_LIMIT = 1000;
 
     private int limit;
-    private final String nextToken;
 
     /**
-     * This class should be created using the factory methods {@link #firstPage()} and {@link #nextToken(String)}.
+     * This class should be created using the factory methods {@link #firstPage()} or {@link #limit(int)}.
      * @param limit the page size.
-     * @param nextToken the next page token.
      */
-    private ModelPagination(int limit, String nextToken) {
+    private ModelPagination(int limit) {
         this.limit = limit;
-        this.nextToken = nextToken;
     }
 
     /**
-     * Creates a reference to the first page. Same as {@link #nextToken(String)} passing {@code null}.
+     * Creates a reference to the first page.
      * @return an instance of {@link ModelPagination}.
      */
     @NonNull
     public static ModelPagination firstPage() {
-        return nextToken(null);
+        return limit(DEFAULT_LIMIT);
     }
 
     /**
-     * Creates a {@link ModelPagination} with the given {@code nextToken}.
-     * @param nextToken the value of the nextToken.
+     * Creates a {@link ModelPagination} with the given {@code limit}.
+     * @param limit the page size
      * @return an instance of {@link ModelPagination}.
      */
     @NonNull
-    public static ModelPagination nextToken(@Nullable String nextToken) {
-        return new ModelPagination(DEFAULT_LIMIT, nextToken);
+    public static ModelPagination limit(@Nullable int limit) {
+        return new ModelPagination(limit);
     }
 
     /**
@@ -77,14 +74,5 @@ public final class ModelPagination {
      */
     public int getLimit() {
         return limit;
-    }
-
-    /**
-     * Returns the {@code nextToken} property.
-     * @return the {@code nextToken} property.
-     */
-    @Nullable
-    public String getNextToken() {
-        return nextToken;
     }
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelQuery.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelQuery.java
@@ -122,7 +122,7 @@ public final class ModelQuery {
             @NonNull ModelPagination pagination
     ) {
         return AppSyncGraphQLRequestFactory.buildPaginatedResultQuery(
-                modelType, null, pagination.getLimit());
+                modelType, QueryPredicates.all(), pagination.getLimit());
     }
 
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelQuery.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelQuery.java
@@ -93,7 +93,6 @@ public final class ModelQuery {
      * @param pagination the pagination settings.
      * @param <M> the concrete model type.
      * @return a valid {@link GraphQLRequest} instance.
-     * @see ModelPagination#nextToken(String)
      * @see ModelPagination#firstPage()
      */
     public static <M extends Model> GraphQLRequest<PaginatedResult<M>> list(
@@ -102,7 +101,7 @@ public final class ModelQuery {
             @NonNull ModelPagination pagination
     ) {
         return AppSyncGraphQLRequestFactory.buildPaginatedResultQuery(
-                modelType, predicate, pagination.getLimit(), pagination.getNextToken());
+                modelType, predicate, pagination.getLimit());
     }
 
     /**
@@ -116,7 +115,6 @@ public final class ModelQuery {
      * @param pagination the pagination settings.
      * @param <M> the concrete model type.
      * @return a valid {@link GraphQLRequest} instance.
-     * @see ModelPagination#nextToken(String)
      * @see ModelPagination#firstPage()
      */
     public static <M extends Model> GraphQLRequest<PaginatedResult<M>> list(
@@ -124,7 +122,7 @@ public final class ModelQuery {
             @NonNull ModelPagination pagination
     ) {
         return AppSyncGraphQLRequestFactory.buildPaginatedResultQuery(
-                modelType, null, pagination.getLimit(), pagination.getNextToken());
+                modelType, null, pagination.getLimit());
     }
 
 }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
@@ -162,7 +162,8 @@ public final class AWSApiPluginTest {
     }
 
     /**
-     * Same as graphQlQueryRendersValidResponse, except with pagination.   Expect a PaginatedResult&lt;BlogOwner&gt;
+     * Same as {@link #graphQlQueryRendersValidResponse()}, except with pagination.
+     * Expect a PaginatedResult&lt;BlogOwner&gt;
      * instead of an Iterable&lt;BlogOwner&gt;, and verify that getRequestForNextResult is not null.
      * @throws ApiException If call to query(...) itself emits such an exception
      */
@@ -233,4 +234,3 @@ public final class AWSApiPluginTest {
         assertEquals("graphQlApi", selectedApi);
     }
 }
-

--- a/aws-api/src/test/resources/blog-owners-query-results.json
+++ b/aws-api/src/test/resources/blog-owners-query-results.json
@@ -14,7 +14,8 @@
           "id": "1b12a1f0-b772-47ba-a9fc-69ba35f449ff5",
           "name": "Larry"
         }
-      ]
+      ],
+      "nextToken" : "IkFRSUNBSGg5OUIvN3BjWU41eE96NDZJMW5GeGM4eyJ2ZXJzaW9uIjoyLCJ0b2tlbiI6"
     }
   }
 }


### PR DESCRIPTION
`nextToken` is an AppSync detail, which should not be exposed in the public interface.   There is no way to obtain it from a response directly, so we can remove it from the `ModelPagination` object.

To make a request to get a "next page" of results, customers should obtain a `GraphQLRequest` via the `getRequestForNextPage()` method on the `PaginatedResult` object.  This request object is a copy of the `GraphQLRequest` used in the previous query, but with the `nextToken` added as a variable.   Then, customers can pass this GraphQLRequest directly to `Amplify.API.query(...)`

This also adds an additional factory method, so customers can do `ModelPagination.limit(1000)`, instead of `ModelPagination.firstPage().withLimit(1000)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
