### PR TITLE
feat(API): Add AuthRule annotation to support @auth directive

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -15,8 +15,9 @@
 
 package com.amplifyframework.core.model;
 
+import androidx.core.util.ObjectsCompat;
+
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * {@link AuthRule} is used define an authorization rule for who can access and operate against a
@@ -125,17 +126,17 @@ public final class AuthRule {
         AuthRule authRule = (AuthRule) object;
 
         return allow == authRule.allow &&
-                Objects.equals(ownerField, authRule.ownerField) &&
-                Objects.equals(identityClaim, authRule.identityClaim) &&
-                Objects.equals(groupClaim, authRule.groupClaim) &&
+                ObjectsCompat.equals(ownerField, authRule.ownerField) &&
+                ObjectsCompat.equals(identityClaim, authRule.identityClaim) &&
+                ObjectsCompat.equals(groupClaim, authRule.groupClaim) &&
                 Arrays.equals(groups, authRule.groups) &&
-                Objects.equals(groupsField, authRule.groupsField) &&
+                ObjectsCompat.equals(groupsField, authRule.groupsField) &&
                 Arrays.equals(operations, authRule.operations);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(allow, ownerField, identityClaim, groupClaim, groupsField);
+        int result = ObjectsCompat.hash(allow, ownerField, identityClaim, groupClaim, groupsField);
         result = 31 * result + Arrays.hashCode(groups);
         result = 31 * result + Arrays.hashCode(operations);
         return result;

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -54,7 +54,7 @@ public final class AuthRule {
      * Returns the type of strategy for this {@link AuthRule}.
      * @return the type of strategy for this {@link AuthRule}
      */
-    public AuthStrategy allow() {
+    public AuthStrategy getAllow() {
         return this.allow;
     }
 
@@ -63,7 +63,7 @@ public final class AuthRule {
      *
      * @return name of a {@link ModelField} of type String which specifies the user which should have access
      */
-    public String ownerField() {
+    public String getOwnerField() {
         return this.ownerField;
     }
 
@@ -72,7 +72,7 @@ public final class AuthRule {
      *
      * @return identity claim
      */
-    public String identityClaim() {
+    public String getIdentityClaim() {
         return this.identityClaim;
     }
 
@@ -81,7 +81,7 @@ public final class AuthRule {
      *
      * @return group claim
      */
-    public String groupClaim() {
+    public String getGroupClaim() {
         return this.groupClaim;
     }
 
@@ -90,7 +90,7 @@ public final class AuthRule {
      *
      * @return array of groups which should have access
      */
-    public String[] groups() {
+    public String[] getGroups() {
         return this.groups;
     }
 
@@ -100,7 +100,7 @@ public final class AuthRule {
      * @return name of a {@link ModelField} of type String or array of Strings which specifies a group or list of groups
      * which should have access.
      */
-    public String groupsField() {
+    public String getGroupsField() {
         return this.groupsField;
     }
 
@@ -109,7 +109,7 @@ public final class AuthRule {
      * the list are not protected by default.
      * @return list of {@link ModelOperation}s for which this {@link AuthRule} should apply.
      */
-    public ModelOperation[] operations() {
+    public ModelOperation[] getOperations() {
         return this.operations;
     }
 

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
  * documentation.</a>
  */
 public final class AuthRule {
-    private final AuthStrategy allow;
+    private final AuthStrategy authStrategy;
     private final String ownerField;
     private final String identityClaim;
     private final String groupClaim;
@@ -41,7 +41,7 @@ public final class AuthRule {
      * @param authRule an {@link com.amplifyframework.core.model.annotations.AuthRule} annotation.
      */
     public AuthRule(com.amplifyframework.core.model.annotations.AuthRule authRule) {
-        this.allow = authRule.allow();
+        this.authStrategy = authRule.allow();
         this.ownerField = authRule.ownerField();
         this.identityClaim = authRule.identityClaim();
         this.groupClaim = authRule.groupClaim();
@@ -54,8 +54,8 @@ public final class AuthRule {
      * Returns the type of strategy for this {@link AuthRule}.
      * @return the type of strategy for this {@link AuthRule}
      */
-    public AuthStrategy getAllow() {
-        return this.allow;
+    public AuthStrategy getAuthStrategy() {
+        return this.authStrategy;
     }
 
     /**
@@ -125,7 +125,7 @@ public final class AuthRule {
 
         AuthRule authRule = (AuthRule) object;
 
-        return allow == authRule.allow &&
+        return authStrategy == authRule.authStrategy &&
                 ObjectsCompat.equals(ownerField, authRule.ownerField) &&
                 ObjectsCompat.equals(identityClaim, authRule.identityClaim) &&
                 ObjectsCompat.equals(groupClaim, authRule.groupClaim) &&
@@ -136,7 +136,7 @@ public final class AuthRule {
 
     @Override
     public int hashCode() {
-        int result = ObjectsCompat.hash(allow, ownerField, identityClaim, groupClaim, groupsField);
+        int result = ObjectsCompat.hash(authStrategy, ownerField, identityClaim, groupClaim, groupsField);
         result = 31 * result + Arrays.hashCode(groups);
         result = 31 * result + Arrays.hashCode(operations);
         return result;
@@ -145,7 +145,7 @@ public final class AuthRule {
     @Override
     public String toString() {
         return "AuthRuleImpl{" +
-                "allow=" + allow +
+                "authStrategy=" + authStrategy +
                 ", ownerField='" + ownerField + '\'' +
                 ", identityClaim='" + identityClaim + '\'' +
                 ", groupClaim='" + groupClaim + '\'' +

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * {@link AuthRule} is used define an authorization rule for who can access and operate against a
+ * {@link Model} or a {@link ModelField}.
+ *
+ * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth")>GraphQL Transformer @auth directive
+ * documentation.</a>
+ */
+public final class AuthRule {
+    private final AuthStrategy allow;
+    private final String ownerField;
+    private final String identityClaim;
+    private final String groupClaim;
+    private final String[] groups;
+    private final String groupsField;
+    private final ModelOperation[] operations;
+
+    /**
+     * Constructor to create an {@link AuthRule} from an {@link com.amplifyframework.core.model.annotations.AuthRule}
+     * annotation.
+     * @param authRule an {@link com.amplifyframework.core.model.annotations.AuthRule} annotation.
+     */
+    public AuthRule(com.amplifyframework.core.model.annotations.AuthRule authRule) {
+        this.allow = authRule.allow();
+        this.ownerField = authRule.ownerField();
+        this.identityClaim = authRule.identityClaim();
+        this.groupClaim = authRule.groupClaim();
+        this.groups = authRule.groups();
+        this.groupsField = authRule.groupsField();
+        this.operations = authRule.operations();
+    }
+
+    /**
+     * Returns the type of strategy for this {@link AuthRule}.
+     * @return the type of strategy for this {@link AuthRule}
+     */
+    public AuthStrategy allow() {
+        return this.allow;
+    }
+
+    /**
+     * Used for owner authorization.  Defaults to "owner" when using AuthStrategy.OWNER.
+     *
+     * @return name of a {@link ModelField} of type String which specifies the user which should have access
+     */
+    public String ownerField() {
+        return this.ownerField;
+    }
+
+    /**
+     * Used to specify a custom claim.  Defaults to "username" when using AuthStrategy.OWNER.
+     *
+     * @return identity claim
+     */
+    public String identityClaim() {
+        return this.identityClaim;
+    }
+
+    /**
+     * Used to specify a custom claim.   Defaults to "cognito:groups" when using AuthStrategy.GROUPS.
+     *
+     * @return group claim
+     */
+    public String groupClaim() {
+        return this.groupClaim;
+    }
+
+    /**
+     * Used for static group authorization.
+     *
+     * @return array of groups which should have access
+     */
+    public String[] groups() {
+        return this.groups;
+    }
+
+    /**
+     * Used for dynamic group authorization.  Defaults to "groups" when using AuthStrategy.GROUPS.
+     *
+     * @return name of a {@link ModelField} of type String or array of Strings which specifies a group or list of groups
+     * which should have access.
+     */
+    public String groupsField() {
+        return this.groupsField;
+    }
+
+    /**
+     * Specifies which {@link ModelOperation}s are protected by this {@link AuthRule}.  Any operations not included in
+     * the list are not protected by default.
+     * @return list of {@link ModelOperation}s for which this {@link AuthRule} should apply.
+     */
+    public ModelOperation[] operations() {
+        return this.operations;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        AuthRule authRule = (AuthRule) object;
+
+        return allow == authRule.allow &&
+                Objects.equals(ownerField, authRule.ownerField) &&
+                Objects.equals(identityClaim, authRule.identityClaim) &&
+                Objects.equals(groupClaim, authRule.groupClaim) &&
+                Arrays.equals(groups, authRule.groups) &&
+                Objects.equals(groupsField, authRule.groupsField) &&
+                Arrays.equals(operations, authRule.operations);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(allow, ownerField, identityClaim, groupClaim, groupsField);
+        result = 31 * result + Arrays.hashCode(groups);
+        result = 31 * result + Arrays.hashCode(operations);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthRuleImpl{" +
+                "allow=" + allow +
+                ", ownerField='" + ownerField + '\'' +
+                ", identityClaim='" + identityClaim + '\'' +
+                ", groupClaim='" + groupClaim + '\'' +
+                ", groups=" + Arrays.toString(groups) +
+                ", groupsField='" + groupsField + '\'' +
+                ", operations=" + Arrays.toString(operations) +
+                '}';
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
  * {@link AuthRule} is used define an authorization rule for who can access and operate against a
  * {@link Model} or a {@link ModelField}.
  *
- * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth")>GraphQL Transformer @auth directive
+ * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth">GraphQL Transformer @auth directive
  * documentation.</a>
  */
 public final class AuthRule {

--- a/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
@@ -17,7 +17,7 @@ package com.amplifyframework.core.model;
 
 /**
  *  The type of strategy for an @auth directive rule.
- * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth")>GraphQL Transformer @auth directive
+ * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth">GraphQL Transformer @auth directive
  *  * documentation.</a>
  */
 public enum AuthStrategy {

--- a/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model;
+
+/**
+ *  The type of strategy for an @auth directive rule.
+ * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth")>GraphQL Transformer @auth directive
+ *  * documentation.</a>
+ */
+public enum AuthStrategy {
+    /**
+     * Owner authorization specifies whether a user can access or operate against an object.  To use OWNER, the API
+     * must have Cognito User Pool configured.
+     */
+    OWNER,
+
+    /**
+     * Group authorization specifies whether a group can access or operate against an object.  To use GROUPS, the API
+     * must have Cognito User Pool configured.
+     */
+    GROUPS,
+
+    /**
+     * The private authorization specifies that everyone will be allowed to access the API with a valid JWT token from
+     * the configured Cognito User Pool. To use PRIVATE, the API must have Cognito User Pool configured.
+     */
+    PRIVATE,
+
+    /**
+     * The public authorization specifies that everyone will be allowed to access the API, behind the scenes the API
+     * will be protected with an API Key. To use PUBLIC, the API must have API Key configured.
+     */
+    PUBLIC,
+}

--- a/core/src/main/java/com/amplifyframework/core/model/ModelField.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelField.java
@@ -18,6 +18,9 @@ package com.amplifyframework.core.model;
 import androidx.annotation.NonNull;
 import androidx.core.util.ObjectsCompat;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Represents a field of the {@link Model} class.
  * Encapsulates all the information of a field.
@@ -48,6 +51,9 @@ public final class ModelField {
     // True if the field is an instance of model.
     private final boolean isModel;
 
+    // An array of rules for owner based authorization
+    private final List<AuthRule> authRules;
+
     /**
      * Construct the ModelField object from the builder.
      */
@@ -59,6 +65,7 @@ public final class ModelField {
         this.isArray = builder.isArray;
         this.isEnum = builder.isEnum;
         this.isModel = builder.isModel;
+        this.authRules = builder.authRules;
     }
 
     /**
@@ -136,6 +143,15 @@ public final class ModelField {
      */
     public boolean isModel() {
         return isModel;
+    }
+
+    /**
+     * Specifies an array of rules for owner based authorization.
+     *
+     * @return list of {@link AuthRule}s
+     */
+    public List<AuthRule> getAuthRules() {
+        return authRules;
     }
 
     @Override
@@ -223,6 +239,9 @@ public final class ModelField {
         // True if the field's target type is Model.
         private boolean isModel = false;
 
+        // A list of rules for owner based authorization
+        private List<AuthRule> authRules = new ArrayList<>();
+
         /**
          * Set the name of the field.
          * @param name Name of the field is the name of the instance variable of the Model class.
@@ -292,6 +311,16 @@ public final class ModelField {
          */
         public ModelFieldBuilder isModel(boolean isModel) {
             this.isModel = isModel;
+            return this;
+        }
+
+        /**
+         * Set the authRules of the {@link ModelField}.
+         * @param authRules list of authorization rules
+         * @return the builder object
+         */
+        public ModelFieldBuilder authRules(List<AuthRule> authRules) {
+            this.authRules = authRules;
             return this;
         }
 

--- a/core/src/main/java/com/amplifyframework/core/model/ModelOperation.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelOperation.java
@@ -17,7 +17,7 @@ package com.amplifyframework.core.model;
 
 /**
  * Used as a property of {@link AuthRule} to specify which operations the rule applies to.
- * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth")>GraphQL Transformer @auth directive
+ * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth">GraphQL Transformer @auth directive
  * documentation.</a>
  */
 public enum ModelOperation {

--- a/core/src/main/java/com/amplifyframework/core/model/ModelOperation.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelOperation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model;
+
+/**
+ * Used as a property of {@link AuthRule} to specify which operations the rule applies to.
+ * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth")>GraphQL Transformer @auth directive
+ * documentation.</a>
+ */
+public enum ModelOperation {
+
+    /**
+     * Relates to a create mutation.
+     */
+    CREATE,
+
+    /**
+     * Relates to an update mutation.
+     */
+    UPDATE,
+
+    /**
+     * Relates to a delete mutation.
+     */
+    DELETE,
+
+    /**
+     * Relates to API queries (`get` and `list` operations).
+     */
+    READ
+}

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -259,7 +259,7 @@ public final class ModelSchema {
      *
      * @return List of {@link AuthRule}s for this Model
      */
-    public List<AuthRule> authRules() {
+    public List<AuthRule> getAuthRules() {
         return authRules;
     }
 
@@ -269,7 +269,7 @@ public final class ModelSchema {
      */
 
     public boolean hasOwnerAuthorization() {
-        for (AuthRule rule : authRules()) {
+        for (AuthRule rule : getAuthRules()) {
             if (AuthStrategy.OWNER.equals(rule.getAllow())) {
                 return true;
             }
@@ -411,7 +411,7 @@ public final class ModelSchema {
 
             return ObjectsCompat.equals(getName(), that.getName()) &&
                 ObjectsCompat.equals(getPluralName(), that.getPluralName()) &&
-                ObjectsCompat.equals(authRules(), that.authRules()) &&
+                ObjectsCompat.equals(getAuthRules(), that.getAuthRules()) &&
                 ObjectsCompat.equals(getFields(), that.getFields()) &&
                 ObjectsCompat.equals(getAssociations(), that.getAssociations()) &&
                 ObjectsCompat.equals(getIndexes(), that.getIndexes());
@@ -423,7 +423,7 @@ public final class ModelSchema {
         return ObjectsCompat.hash(
                 getName(),
                 getPluralName(),
-                authRules(),
+                getAuthRules(),
                 getFields(),
                 getAssociations(),
                 getIndexes()

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -270,7 +270,7 @@ public final class ModelSchema {
 
     public boolean hasOwnerAuthorization() {
         for (AuthRule rule : authRules()) {
-            if (AuthStrategy.OWNER.equals(rule.allow())) {
+            if (AuthStrategy.OWNER.equals(rule.getAllow())) {
                 return true;
             }
         }

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -270,7 +270,7 @@ public final class ModelSchema {
 
     public boolean hasOwnerAuthorization() {
         for (AuthRule rule : getAuthRules()) {
-            if (AuthStrategy.OWNER.equals(rule.getAllow())) {
+            if (AuthStrategy.OWNER.equals(rule.getAuthStrategy())) {
                 return true;
             }
         }

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -452,7 +452,7 @@ public final class ModelSchema {
         private final Map<String, ModelIndex> indexes;
         private String name;
         private String pluralName;
-        private List<AuthRule> authRules;
+        private final List<AuthRule> authRules;
 
         Builder() {
             this.authRules = new ArrayList<>();
@@ -492,8 +492,10 @@ public final class ModelSchema {
          * @return the builder object
          */
         @NonNull
-        public Builder authRules(List<AuthRule> authRules) {
-            this.authRules = authRules;
+        public Builder authRules(@NonNull List<AuthRule> authRules) {
+            Objects.requireNonNull(authRules);
+            this.authRules.clear();
+            this.authRules.addAll(authRules);
             return this;
         }
 

--- a/core/src/main/java/com/amplifyframework/core/model/annotations/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/annotations/AuthRule.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  * {@link ElementType#ANNOTATION_TYPE} annotation is added to indicate {@link AuthRule} annotation can be used only on
  * other annotation types (i.e. {@link ModelConfig} or {@link ModelField}).
  *
- * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth")>GraphQL Transformer @auth directive
+ * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth">GraphQL Transformer @auth directive
  * documentation.</a>
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/com/amplifyframework/core/model/annotations/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/annotations/AuthRule.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model.annotations;
+
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.ModelOperation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@link AuthRule} is used define an authorization rule for who can access and operate against a
+ * {@link com.amplifyframework.core.model.Model} or a {@link com.amplifyframework.core.model.ModelField}.
+ *
+ * The {@link RetentionPolicy#RUNTIME} annotation is added to retain {@link AuthRule} at runtime for the reflection
+ * capabilities to work in order to check if this annotation is present within a {@link ModelConfig} annotation.
+ *
+ * {@link ElementType#ANNOTATION_TYPE} annotation is added to indicate {@link AuthRule} annotation can be used only on
+ * other annotation types (i.e. {@link ModelConfig} or {@link ModelField}).
+ *
+ * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth")>GraphQL Transformer @auth directive
+ * documentation.</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface AuthRule {
+    /**
+     * Defines the strategy for this rule.  This is the only required field.
+     *
+     * @return AuthStrategy for this {@link AuthRule}
+     */
+    AuthStrategy allow();
+
+    /**
+     * Used for owner authorization.  Defaults to "owner" when using AuthStrategy.OWNER.
+     *
+     * @return name of a {@link ModelField} of type String which specifies the user which should have access
+     */
+    String ownerField() default "";
+
+    /**
+     * Used to specify a custom claim.  Defaults to "username" when using AuthStrategy.OWNER.
+     *
+     * @return identity claim
+     */
+    String identityClaim() default "";
+
+    /**
+     * Used to specify a custom claim.   Defaults to "cognito:groups" when using AuthStrategy.GROUPS.
+     *
+     * @return group claim
+     */
+    String groupClaim() default "";
+
+    /**
+     * Used for static group authorization.
+     *
+     * @return array of groups which should have access
+     */
+    String[] groups() default {};
+
+    /**
+     * Used for dynamic group authorization.  Defaults to "groups" when using AuthStrategy.GROUPS.
+     *
+     * @return name of a {@link ModelField} of type String or array of Strings which specifies a group or list of groups
+     * which should have access.
+     */
+    String groupsField() default "";
+
+    /**
+     * Specifies which {@link ModelOperation}s are protected by this {@link AuthRule}.  Any operations not included in
+     * the list are not protected by default.
+     * @return list of {@link ModelOperation}s for which this {@link AuthRule} should apply.
+     */
+    ModelOperation[] operations() default {};
+}

--- a/core/src/main/java/com/amplifyframework/core/model/annotations/ModelConfig.java
+++ b/core/src/main/java/com/amplifyframework/core/model/annotations/ModelConfig.java
@@ -15,15 +15,15 @@
 
 package com.amplifyframework.core.model.annotations;
 
+import com.amplifyframework.core.model.Model;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * {@link ModelConfig} annotates any {@link com.amplifyframework.core.model.Model}
- * with the configuration information that is applicable to a
- * {@link com.amplifyframework.core.model.Model}.
+ * {@link ModelConfig} annotates any {@link Model} with applicable configuration information.
  *
  * The {@link RetentionPolicy#RUNTIME} annotation is added to
  * retain {@link ModelConfig} at runtime for the reflection capabilities to work
@@ -42,9 +42,8 @@ public @interface ModelConfig {
     String pluralName() default "";
 
     /**
-     * Specifies whether this model has owner based authorization.
-     * e.g. @auth(rules: [{allow: owner}]) on the model in the GraphQL Schema.
-     * @return true if the model has owner based authorization configured
+     * Specifies an array of authorization rules that should apply to this {@link Model}.
+     * @return list of {@link AuthRule} annotations.
      */
-    boolean hasOwnerAuthorization() default false;
+    AuthRule[] authRules() default {};
 }

--- a/core/src/main/java/com/amplifyframework/core/model/annotations/ModelField.java
+++ b/core/src/main/java/com/amplifyframework/core/model/annotations/ModelField.java
@@ -50,4 +50,10 @@ public @interface ModelField {
      *         in the GraphQL schema.
      */
     String targetType() default "";
+
+    /**
+     * Specifies an array of rules for owner based authorization.
+     * @return array of {@link AuthRule} annotations
+     */
+    AuthRule[] authRules() default {};
 }


### PR DESCRIPTION
This adds an `@AuthRule` annotation, so that it can be used in codegen model files.   The annotation can represent an authorization rule if any are specified in a GraphQL schema with the [@auth directive](https://docs.amplify.aws/cli/graphql-transformer/directives#auth).  `ModelConfig` and `ModelField` now include an array of @AuthRule objects.   

Note that this replaces the `boolean hasOwnerAuthorization()` method previously on `ModelConfig`, which was intended to support the basic owner based auth use case.  This PR adds support for *all* use cases allowed by the @auth directive.

Sample `schema.graphql`:
```
type Todo
  @model
  @auth(rules: [
    # Owner authorization, simplest case
    { allow: owner },

    # Owner authorization, the long form way
    { allow: owner, ownerField: "owner", operations: [create, update, delete, read] },

    # Owner authorization, allow others to read
    { allow: owner, operations: [create, delete, update] },

    # Static group authorization
    { allow: groups, groups: ["Admin"] },

    # Dynamic group authorization
    { allow: groups, groupsField: "groups" },

    # public authorization
    { allow: public },

    # public authorization with provider override
    { allow: public, provider: iam },

    # private authorization
    { allow: private },

    # private authorization with provider override
    { allow: private, provider: iam },

    # owner authorization with provider override
    { allow: owner, provider: oidc, identityClaim: "sub" }

    # custom claims (owner)
    { allow: owner, identityClaim: "user_id" },

    # custom claims (groups)
    { allow: groups, groups: ["Moderator"], groupClaim: "user_groups" }
    ])
{
  id: ID!
  name: String!
  description: String
    @auth (rules: [
    { allow: private, provider: iam, operations: [create, update] }
    ])
}
```


Sample expected codegen output: `Todo.java`:
```
package com.amplifyframework.datastore.generated.model;

import androidx.core.util.ObjectsCompat;

import com.amplifyframework.core.model.AuthStrategy;
import com.amplifyframework.core.model.Model;
import com.amplifyframework.core.model.ModelOperation;
import com.amplifyframework.core.model.annotations.AuthRule;
import com.amplifyframework.core.model.annotations.ModelConfig;
import com.amplifyframework.core.model.annotations.ModelField;
import com.amplifyframework.core.model.query.predicate.QueryField;

import java.util.Objects;
import java.util.UUID;

import static com.amplifyframework.core.model.query.predicate.QueryField.field;

/** This is an auto generated class representing the Todo type in your schema. */
@SuppressWarnings("all")
@ModelConfig(
        pluralName = "Todos",
        authRules = {
                // Owner authorization, simplest case
                @AuthRule(
                        allow = AuthStrategy.OWNER
                ),

                // Owner authorization, the long form way
                @AuthRule(
                        allow = AuthStrategy.OWNER,
                        ownerField = "owner",
                        operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }
                ),

                // Owner authorization, allow others to read
                @AuthRule(
                        allow = AuthStrategy.OWNER,
                        operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE }
                ),

                // Static group authorization
                @AuthRule(
                        allow = AuthStrategy.GROUPS,
                        groups = { "Admin" }
                ),

                // Dynamic group authorization
                @AuthRule(
                        allow = AuthStrategy.GROUPS,
                        groupsField = "groups"
                ),

                // Public authorization
                @AuthRule(
                        allow = AuthStrategy.PUBLIC
                ),

                // Public authorization with provider override (provider does not need to be specified in codegen)
                @AuthRule(
                        allow = AuthStrategy.PUBLIC
                ),

                // private authorization
                @AuthRule(
                        allow = AuthStrategy.PRIVATE
                ),

                // private authorization with provider override (provider does not need to be specified in codegen)
                @AuthRule(
                        allow = AuthStrategy.PRIVATE
                ),

                // owner authorization with provider override (provider does not need to be specified in codegen)
                @AuthRule(
                        allow = AuthStrategy.OWNER,
                        identityClaim = "sub"
                ),

                // custom claims (owner)
                @AuthRule(
                        allow = AuthStrategy.OWNER,
                        identityClaim = "user_id"
                ),

                // custom claims (groups)
                @AuthRule(
                        allow = AuthStrategy.GROUPS,
                        groups = { "Moderator" },
                        groupClaim = "user_groups"
                ),
        }
)
public final class Todo implements Model {
  public static final QueryField ID = field("id");
  public static final QueryField NAME = field("name");
  public static final QueryField DESCRIPTION = field("description");
  private final @ModelField(targetType="ID", isRequired = true) String id;
  private final @ModelField(targetType="String", isRequired = true) String name;
  private final @ModelField(
    targetType = "String",
    isRequired = true,
    authRules = {
      @AuthRule(
        allow = AuthStrategy.PRIVATE,
        operations = { ModelOperation.CREATE, ModelOperation.UPDATE }
      )
    }
  ) String description;

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
