### PR TITLE
fix(Auth): Adds invalidateTokens param to properly signout HostedUI

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -655,28 +655,31 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     }
 
     private void signOutLocally(@NonNull Action onSuccess, @NonNull Consumer<AuthException> onError) {
-        awsMobileClient.signOut(SignOutOptions.builder().signOutGlobally(false).build(), new Callback<Void>() {
-            @Override
-            public void onResult(Void result) {
-                onSuccess.call();
-            }
+        awsMobileClient.signOut(
+                SignOutOptions.builder().signOutGlobally(false).invalidateTokens(true).build(),
+                new Callback<Void>() {
+                    @Override
+                    public void onResult(Void result) {
+                        onSuccess.call();
+                    }
 
-            @Override
-            public void onError(Exception error) {
-                if (error != null && error.getMessage() != null && error.getMessage().contains("signed-out")) {
-                    onError.accept(new AuthException(
-                            "Failed to sign out since Auth is already signed out",
-                            "No need to sign out - you already are!"
-                    ));
-                } else {
-                    onError.accept(new AuthException(
-                            "Failed to sign out",
-                            error,
-                            "See attached exception for more details"
-                    ));
-                }
+                    @Override
+                    public void onError(Exception error) {
+                        if (error != null && error.getMessage() != null && error.getMessage().contains("signed-out")) {
+                            onError.accept(new AuthException(
+                                    "Failed to sign out since Auth is already signed out",
+                                    "No need to sign out - you already are!"
+                            ));
+                        } else {
+                            onError.accept(new AuthException(
+                                    "Failed to sign out",
+                                    error,
+                                    "See attached exception for more details"
+                            ));
+                        }
+                    }
             }
-        });
+        );
     }
 
     private void signInWithWebUIHelper(

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -544,6 +544,7 @@ public final class AuthComponentTest {
         ArgumentCaptor<SignOutOptions> signOutOptionsCaptor = ArgumentCaptor.forClass(SignOutOptions.class);
         verify(mobileClient).signOut(signOutOptionsCaptor.capture(), any());
         assertFalse(signOutOptionsCaptor.getValue().isSignOutGlobally());
+        assertTrue(signOutOptionsCaptor.getValue().isInvalidateTokens());
     }
 
     /**


### PR DESCRIPTION
Currently if the user has signed in with HostedUI, signs out, and then tries to sign in again, it doesn't allow them to choose an account, it just signs them back into the same account they were signed in to before. This addresses that.

Here is the issue filed against iOS: https://github.com/aws-amplify/amplify-ios/issues/484 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
