### PR TITLE
ci: Try build and integrationtest 3 times before failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
             .circleci/copy-configs
       - run:
           name: Run integration test
+          no_output_timeout: 30m
           command: .circleci/retry.sh 3 ./gradlew cAT --no-daemon
       - store_artifacts:
           path: logcat.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Build the project
           command: |
-            bash gradlew build
+            .circleci/retry.sh 3 ./gradlew build
             .circleci/aggregate-test-results.sh ~/amplify-android-home
             .circleci/aggregate-build-artifacts.sh
       - store_test_results:
@@ -118,7 +118,7 @@ jobs:
             .circleci/copy-configs
       - run:
           name: Run integration test
-          command: ./gradlew cAT --no-daemon
+          command: .circleci/retry.sh 3 ./gradlew cAT --no-daemon
       - store_artifacts:
           path: logcat.log
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ jobs:
             .circleci/copy-configs
       - run:
           name: Run integration test
-          no_output_timeout: 30m
           command: .circleci/retry.sh 3 ./gradlew cAT --no-daemon
       - store_artifacts:
           path: logcat.log

--- a/.circleci/retry.sh
+++ b/.circleci/retry.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Usage: retry.sh <max_tries> <command to run>
 
 readonly max_tries=$1
 readonly command="${@: 2}"

--- a/.circleci/retry.sh
+++ b/.circleci/retry.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+readonly max_tries=$1
+readonly command="${@: 2}"
+attempts=0
+return_code=1
+while [[ $attempts -lt $max_tries ]]; do
+  ((attempts++))
+  if [[ attempts -gt 1 ]]; then sleep 10; fi
+  echo "RETRY: Attempt $attempts of $max_tries."
+  $command && break
+done
+
+return_code=$?
+
+if [[ $return_code == 0 ]]; then
+  echo "RETRY: Attempt $attempts succeeded."
+else
+  echo "RETRY: All $attempts attempts failed."
+fi
+
+exit $return_code

--- a/core/src/test/java/com/amplifyframework/util/QuotesTest.java
+++ b/core/src/test/java/com/amplifyframework/util/QuotesTest.java
@@ -29,7 +29,7 @@ public final class QuotesTest {
      */
     @Test
     public void wrapInSingleQuotesReturnsQuotedString() {
-        assertEquals("'Pizza'", Quotes.wrapInSingle("Hamburger"));
+        assertEquals("'Hamburger'", Quotes.wrapInSingle("Hamburger"));
     }
 
     /**

--- a/core/src/test/java/com/amplifyframework/util/QuotesTest.java
+++ b/core/src/test/java/com/amplifyframework/util/QuotesTest.java
@@ -29,7 +29,7 @@ public final class QuotesTest {
      */
     @Test
     public void wrapInSingleQuotesReturnsQuotedString() {
-        assertEquals("'Hamburger'", Quotes.wrapInSingle("Hamburger"));
+        assertEquals("'Pizza'", Quotes.wrapInSingle("Hamburger"));
     }
 
     /**


### PR DESCRIPTION
If the `build` or `integrationtest` CircleCI step fails , try up to 3 times before failing.

Here is an example of the `build` step failing on the first attempt (due to the flaky `clearStopsSyncUntilNextInteraction` test), and succeeding on the 2nd attempt: https://app.circleci.com/pipelines/github/aws-amplify/amplify-android/1830/workflows/9581c719-0eae-47ea-a645-49ac41492da6/jobs/3537/steps

Here is an example of `build` failing 3 out of 3 times, because a unit test was actually broken: https://app.circleci.com/pipelines/github/aws-amplify/amplify-android/1831/workflows/a246c99a-ec03-4f67-8cc9-b685b926bb99/jobs/3538

Here is an example of `integrationtest` failing 3 out of 3 times:
https://app.circleci.com/pipelines/github/aws-amplify/amplify-android/1834/workflows/f1ab5e60-255c-450e-bd50-7f1f26823b79/jobs/3545
Failure 1: `testDownloadLargeFile`, `queryListWithoutPredicate`
Failure 2: `queryListWithoutPredicate` 
Failure 3: `queryListWithoutPredicate`

On the topic of improving test reliability, I also came across [this article](https://support.circleci.com/hc/en-us/articles/360000028928-Testing-with-Android-emulator-on-CircleCI) which indicates CircleCI does not officially support the Android emulator (even though we are doing so).  They recommend using Firebase test lab instead, which can be initiated from CircleCI.  That's probably a good next step to further improve the integration test failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
