### PR TITLE
chore: use latest Gradle version 6 dot 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     parameters:
       gradle_version:
         description: "The version of Gradle to install"
-        default: "6.4.1"
+        default: "6.5"
         type: string
 
     steps:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 28 18:47:55 EDT 2020
+#Mon Jun 15 13:56:43 MDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Gradle 6.5 is the latest stable Gradle release; use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
