### PR TITLE
feat(rxbindings): add bindings for auth

### DIFF
--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAdapters.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAdapters.java
@@ -91,4 +91,13 @@ final class RxAdapters {
     interface CancelableStreamEmitter<S, T, E> {
         Cancelable streamTo(Consumer<S> onStart, Consumer<T> onItem, Consumer<E> onError, Action onComplete);
     }
+
+    /**
+     * Describes behavior which emits a completion notification via an {@link Action},
+     * or alternately, emits an error to a {@link Consumer}.
+     * @param <E> Type of error emitted
+     */
+    interface VoidCompletionEmitter<E> {
+        void emitTo(Action onComplete, Consumer<E> onError);
+    }
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAmplify.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAmplify.java
@@ -31,6 +31,7 @@ public final class RxAmplify {
     private RxAmplify() {}
 
     // Breaking the rules, here. Don't look.
+    @SuppressWarnings({"checkstyle:all", "unused"}) public static final RxAuthCategoryBehavior Auth = new RxAuthBinding();
     @SuppressWarnings({"checkstyle:all", "unused"}) public static final RxApiCategoryBehavior API = new RxApiBinding();
     @SuppressWarnings({"checkstyle:all", "unused"}) public static final RxDataStoreCategoryBehavior DataStore = new RxDataStoreBinding();
     @SuppressWarnings({"checkstyle:all", "unused"}) public static final RxHubCategoryBehavior Hub = new RxHubBinding();

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.rx;
+
+import android.app.Activity;
+import android.content.Intent;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import com.amplifyframework.auth.AuthCategoryBehavior;
+import com.amplifyframework.auth.AuthException;
+import com.amplifyframework.auth.AuthProvider;
+import com.amplifyframework.auth.AuthSession;
+import com.amplifyframework.auth.AuthUser;
+import com.amplifyframework.auth.options.AuthSignInOptions;
+import com.amplifyframework.auth.options.AuthSignOutOptions;
+import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.options.AuthWebUISignInOptions;
+import com.amplifyframework.auth.result.AuthResetPasswordResult;
+import com.amplifyframework.auth.result.AuthSignInResult;
+import com.amplifyframework.auth.result.AuthSignUpResult;
+import com.amplifyframework.core.Amplify;
+
+import java.util.Objects;
+
+import io.reactivex.Completable;
+import io.reactivex.Single;
+
+final class RxAuthBinding implements RxAuthCategoryBehavior {
+    private final AuthCategoryBehavior delegate;
+
+    RxAuthBinding() {
+        this(Amplify.Auth);
+    }
+
+    @VisibleForTesting
+    RxAuthBinding(@NonNull AuthCategoryBehavior delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    @Override
+    public Single<AuthSignUpResult> signUp(
+            @NonNull String username, @NonNull String password, @NonNull AuthSignUpOptions options) {
+        return toSingle((onResult, onError) ->
+            delegate.signUp(username, password, options, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignUpResult> confirmSignUp(@NonNull String username, @NonNull String confirmationCode) {
+        return toSingle((onResult, onError) ->
+            delegate.confirmSignUp(username, confirmationCode, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignUpResult> resendSignUpCode(@NonNull String username) {
+        return toSingle((onResult, onError) ->
+            delegate.resendSignUpCode(username, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> signIn(
+            @Nullable String username, @Nullable String password, @NonNull AuthSignInOptions options) {
+        return toSingle((onResult, onError) ->
+            delegate.signIn(username, password, options, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> signIn(@Nullable String username, @Nullable String password) {
+        return toSingle((onResult, onError) -> delegate.signIn(username, password, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> confirmSignIn(@NonNull String confirmationCode) {
+        return toSingle((onResult, onError) -> delegate.confirmSignIn(confirmationCode, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> signInWithSocialWebUI(
+            @NonNull AuthProvider provider, @NonNull Activity callingActivity) {
+        return toSingle((onResult, onError) ->
+            delegate.signInWithSocialWebUI(provider, callingActivity, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> signInWithSocialWebUI(
+            @NonNull AuthProvider provider,
+            @NonNull Activity callingActivity,
+            @NonNull AuthWebUISignInOptions options) {
+        return toSingle((onResult, onError) ->
+            delegate.signInWithSocialWebUI(provider, callingActivity, options, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> signInWithWebUI(@NonNull Activity callingActivity) {
+        return toSingle((onResult, onError) -> delegate.signInWithWebUI(callingActivity, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> signInWithWebUI(
+            @NonNull Activity callingActivity, @NonNull AuthWebUISignInOptions options) {
+        return toSingle((onResult, onError) ->
+            delegate.signInWithWebUI(callingActivity, options, onResult, onError));
+    }
+
+    @Override
+    public void handleWebUISignInResponse(Intent intent) {
+        delegate.handleWebUISignInResponse(intent);
+    }
+
+    @Override
+    public Single<AuthSession> fetchAuthSession() {
+        return toSingle(delegate::fetchAuthSession);
+    }
+
+    @Override
+    public Single<AuthResetPasswordResult> resetPassword(@NonNull String username) {
+        return toSingle((onResult, onError) -> delegate.resetPassword(username, onResult, onError));
+    }
+
+    @Override
+    public Completable confirmResetPassword(@NonNull String newPassword, @NonNull String confirmationCode) {
+        return toCompletable((onComplete, onError) ->
+            delegate.confirmResetPassword(newPassword, confirmationCode, onComplete, onError));
+    }
+
+    @Override
+    public Completable updatePassword(@NonNull String oldPassword, @NonNull String newPassword) {
+        return toCompletable((onComplete, onError) ->
+            delegate.updatePassword(oldPassword, newPassword, onComplete, onError));
+    }
+
+    @Override
+    public AuthUser getCurrentUser() {
+        return delegate.getCurrentUser();
+    }
+
+    @Override
+    public Completable signOut() {
+        return toCompletable(delegate::signOut);
+    }
+
+    @Override
+    public Completable signOut(@NonNull AuthSignOutOptions options) {
+        return toCompletable((onComplete, onError) -> delegate.signOut(options, onComplete, onError));
+    }
+
+    private <T> Single<T> toSingle(RxAdapters.VoidResultEmitter<T, AuthException> resultEmitter) {
+        return Single.defer(() ->
+            Single.create(emitter -> resultEmitter.emitTo(emitter::onSuccess, emitter::onError))
+        );
+    }
+
+    private Completable toCompletable(RxAdapters.VoidCompletionEmitter<AuthException> resultEmitter) {
+        return Completable.defer(() -> Completable.create(emitter ->
+            resultEmitter.emitTo(emitter::onComplete, emitter::onError)
+        ));
+    }
+}

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.rx;
+
+import android.app.Activity;
+import android.content.Intent;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.auth.AuthCategoryBehavior;
+import com.amplifyframework.auth.AuthException;
+import com.amplifyframework.auth.AuthProvider;
+import com.amplifyframework.auth.AuthSession;
+import com.amplifyframework.auth.AuthUser;
+import com.amplifyframework.auth.options.AuthSignInOptions;
+import com.amplifyframework.auth.options.AuthSignOutOptions;
+import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.options.AuthWebUISignInOptions;
+import com.amplifyframework.auth.result.AuthResetPasswordResult;
+import com.amplifyframework.auth.result.AuthSignInResult;
+import com.amplifyframework.auth.result.AuthSignUpResult;
+
+import io.reactivex.Completable;
+import io.reactivex.Single;
+
+/**
+ * An Rx-idiomatic expression of the {@link AuthCategoryBehavior}.
+ */
+public interface RxAuthCategoryBehavior {
+
+    /**
+     * Creates a new user account with the specified username and password.
+     * Can also pass in user attributes to associate with the user through
+     * the options object.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param password The user's password
+     * @param options Advanced options such as additional attributes of the user or validation data
+     * @return An Rx {@link Single} which emits an {@link AuthSignUpResult} on success, or an
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignUpResult> signUp(
+            @NonNull String username,
+            @NonNull String password,
+            @NonNull AuthSignUpOptions options
+    );
+
+    /**
+     * If you have attribute confirmation enabled, this will allow the user
+     * to enter the confirmation code they received to activate their account.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param confirmationCode The confirmation code the user received
+     * @return An Rx {@link Single} which emits an {@link AuthSignUpResult} on successful confirmation,
+     *         or an {@link AuthException} on failure
+     */
+    Single<AuthSignUpResult> confirmSignUp(@NonNull String username, @NonNull String confirmationCode);
+
+    /**
+     * If the user's code expires or they just missed it, this method can
+     * be used to send them a new one.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @return An Rx {@link Single} which emits an {@link AuthSignUpResult} on successful confirmation,
+     *         or an {@link AuthException} on failure
+     */
+    Single<AuthSignUpResult> resendSignUpCode(@NonNull String username);
+
+    /**
+     * Basic authentication to the app with a username and password or, if custom auth is setup,
+     * you can send null for those and the necessary authentication details in the options object.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param password User's password for normal signup, null if custom auth or passwordless configurations are setup
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> signIn(
+            @Nullable String username,
+            @Nullable String password,
+            @NonNull AuthSignInOptions options
+    );
+
+    /**
+     * Basic authentication to the app with a username and password.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param password User's password
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> signIn(@Nullable String username, @Nullable String password);
+
+    /**
+     * Submit the confirmation code received as part of multi-factor Authentication during sign in.
+     * @param confirmationCode The code received as part of the multi-factor authentication process
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> confirmSignIn(@NonNull String confirmationCode);
+
+    /**
+     * Launch the specified auth provider's web UI sign in experience. You should also put the
+     * {@link #handleWebUISignInResponse(Intent)} method in your activity's onNewIntent method to
+     * capture the response which comes back from the UI flow.
+     * @param provider The auth provider you want to launch the web ui for (e.g. Facebook, Google, etc.)
+     * @param callingActivity The activity in your app you are calling this from
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> signInWithSocialWebUI(
+            @NonNull AuthProvider provider,
+            @NonNull Activity callingActivity
+    );
+
+    /**
+     * Launch the specified auth provider's web UI sign in experience. You should also put the
+     * {@link #handleWebUISignInResponse(Intent)} method in your activity's onNewIntent method to
+     * capture the response which comes back from the UI flow.
+     * @param provider The auth provider you want to launch the web ui for (e.g. Facebook, Google, etc.)
+     * @param callingActivity The activity in your app you are calling this from
+     * @param options Advanced options for signing in with an auth provider's hosted web ui.
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> signInWithSocialWebUI(
+            @NonNull AuthProvider provider,
+            @NonNull Activity callingActivity,
+            @NonNull AuthWebUISignInOptions options
+    );
+
+    /**
+     * Launch a hosted web sign in UI flow. You should also put the {@link #handleWebUISignInResponse(Intent)} method in
+     * your activity's onNewIntent method to capture the response which comes back from the UI flow.
+     * @param callingActivity The activity in your app you are calling this from
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> signInWithWebUI(@NonNull Activity callingActivity);
+
+    /**
+     * Launch a hosted web sign in UI flow. You should also put the {@link #handleWebUISignInResponse(Intent)}
+     * method in your activity's onNewIntent method to capture the response which comes back from the UI flow.
+     * @param callingActivity The activity in your app you are calling this from
+     * @param options Advanced options for signing in with a hosted web ui.
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> signInWithWebUI(
+            @NonNull Activity callingActivity,
+            @NonNull AuthWebUISignInOptions options
+    );
+
+    /**
+     * Handles the response which comes back from {@link #signInWithWebUI(Activity)}.
+     * @param intent The app activity's intent
+     */
+    void handleWebUISignInResponse(Intent intent);
+
+    /**
+     * Retrieve the user's current session information - by default just whether they are signed out or in.
+     * Depending on how a plugin implements this, the resulting AuthSession can also be cast to a type specific
+     * to that plugin which contains the various security tokens and other identifying information if you want to
+     * manually use them outside the plugin. Within Amplify this should not be needed as the other categories will
+     * automatically work as long as you are signed in.
+     * @return An Rx {@link Single} which emits {@link AuthSession} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSession> fetchAuthSession();
+
+    /**
+     * Trigger password recovery for the given username.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @return An Rx {@link Single} which emits {@link AuthResetPasswordResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthResetPasswordResult> resetPassword(@NonNull String username);
+
+    /**
+     * Complete password recovery process by inputting user's desired new password and confirmation code.
+     * @param newPassword The user's desired new password
+     * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
+     * @return An Rx {@link Completable} which completes successfully if password reset is confirmed,
+     *         emits an {@link AuthException} otherwise
+     */
+    Completable confirmResetPassword(@NonNull String newPassword, @NonNull String confirmationCode);
+
+    /**
+     * Update the password of an existing user - must be signed in to perform this action.
+     * @param oldPassword The user's existing password
+     * @param newPassword The new password desired on the user account
+     * @return An Rx {@link Completable} which completes successfully if the
+     *         user's password is updated successfully; emits an {@link AuthException},
+     *         otherwise.
+     */
+    Completable updatePassword(@NonNull String oldPassword, @NonNull String newPassword);
+
+    /**
+     * Gets the currently logged in User.
+     * @return the currently logged in user with basic info and methods for fetching/updating user attributes
+     */
+    AuthUser getCurrentUser();
+
+    /**
+     * Sign out of the current device.
+     * @return An Rx {@link Completable} which completes upon successful sign-out; emits an
+     *         {@link AuthException} otherwise
+     */
+    Completable signOut();
+
+    /**
+     * Sign out with advanced options.
+     * @param options Advanced options for sign out (e.g. whether to sign out of all devices globally)
+     * @return An Rx {@link Completable} which completes upon successful sign-out;
+     *         emits an {@link AuthException} otherwise
+     */
+    Completable signOut(@NonNull AuthSignOutOptions options);
+}

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -1,0 +1,733 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.rx;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import com.amplifyframework.auth.AuthCategoryBehavior;
+import com.amplifyframework.auth.AuthCodeDeliveryDetails;
+import com.amplifyframework.auth.AuthCodeDeliveryDetails.DeliveryMedium;
+import com.amplifyframework.auth.AuthException;
+import com.amplifyframework.auth.AuthProvider;
+import com.amplifyframework.auth.AuthSession;
+import com.amplifyframework.auth.AuthUser;
+import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.result.AuthResetPasswordResult;
+import com.amplifyframework.auth.result.AuthSignInResult;
+import com.amplifyframework.auth.result.AuthSignUpResult;
+import com.amplifyframework.auth.result.step.AuthNextResetPasswordStep;
+import com.amplifyframework.auth.result.step.AuthNextSignInStep;
+import com.amplifyframework.auth.result.step.AuthNextSignUpStep;
+import com.amplifyframework.auth.result.step.AuthResetPasswordStep;
+import com.amplifyframework.auth.result.step.AuthSignInStep;
+import com.amplifyframework.auth.result.step.AuthSignUpStep;
+import com.amplifyframework.core.Action;
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.testutils.random.RandomString;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import io.reactivex.observers.TestObserver;
+
+import static com.amplifyframework.rx.Matchers.anyAction;
+import static com.amplifyframework.rx.Matchers.anyConsumer;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the {@link RxAuthBinding}.
+ */
+public final class RxAuthBindingTest {
+    private AuthCategoryBehavior delegate;
+    private RxAuthBinding auth;
+
+    /**
+     * Creates an {@link RxAuthBinding} instance to test.
+     * It is tested by arranging behaviors on its {@link AuthCategoryBehavior} delegate.
+     */
+    @Before
+    public void setup() {
+        this.delegate = mock(AuthCategoryBehavior.class);
+        this.auth = new RxAuthBinding(delegate);
+    }
+
+    /**
+     * Validates that a sign-up result are passed through the binding.
+     */
+    @Test
+    public void testSignUpSucceeds() {
+        // Arrange a response from delegate
+        String username = RandomString.string();
+        String password = RandomString.string();
+        AuthSignUpOptions options = AuthSignUpOptions.builder().build();
+
+        // Arrange a result on the result consumer
+        AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.SMS);
+        AuthSignUpStep step = AuthSignUpStep.CONFIRM_SIGN_UP_STEP;
+        AuthNextSignUpStep nextStep = new AuthNextSignUpStep(step, Collections.emptyMap(), details);
+        AuthSignUpResult result = new AuthSignUpResult(false, nextStep);
+        doAnswer(invocation -> {
+            // 0 = username, 1 = pass, 2 = options, 3 = onSuccess, 4 = onFailure
+            int positionOfSuccessConsumer = 3;
+            Consumer<AuthSignUpResult> onResult = invocation.getArgument(positionOfSuccessConsumer);
+            onResult.accept(result);
+            return (Void) null;
+        }).when(delegate).signUp(eq(username), eq(password), eq(options), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignUpResult> observer = auth.signUp(username, password, options).test();
+
+        // Assert: the result was furnished to the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertValue(result);
+    }
+
+    /**
+     * Validates that a sign-up failure are passed through the binding.
+     */
+    @Test
+    public void testSignUpFails() {
+        String username = RandomString.string();
+        String password = RandomString.string();
+        AuthSignUpOptions options = AuthSignUpOptions.builder().build();
+
+        // Arrange a callback on the failure consumer
+        AuthException failure = new AuthException("Sign up", "has failed");
+        doAnswer(invocation -> {
+            // 0 = username, 1 = pass, 2 = options, 3 = onSuccess, 4 = onFailure
+            int positionOfFailureConsumer = 4;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).signUp(eq(username), eq(password), eq(options), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignUpResult> observer = auth.signUp(username, password, options).test();
+
+        // Assert: error is furnished via Rx single.
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoValues()
+            .assertError(failure);
+    }
+
+    /**
+     * Validates that a successful call to resend the sign-up code will propagate the result
+     * back through the binding.
+     */
+    @Test
+    public void testResendSignUpCodeSucceeds() {
+        String username = RandomString.string();
+
+        // Arrange a result on the result consumer
+        AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.EMAIL);
+        AuthSignUpStep step = AuthSignUpStep.CONFIRM_SIGN_UP_STEP;
+        AuthNextSignUpStep nextStep = new AuthNextSignUpStep(step, Collections.emptyMap(), details);
+        AuthSignUpResult result = new AuthSignUpResult(false, nextStep);
+        doAnswer(invocation -> {
+            // 0 = username, 1 = onResult, 2 = onFailure
+            int positionOfResultConsumer = 1;
+            Consumer<AuthSignUpResult> onResult = invocation.getArgument(positionOfResultConsumer);
+            onResult.accept(result);
+            return (Void) null;
+        }).when(delegate).resendSignUpCode(eq(username), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignUpResult> observer = auth.resendSignUpCode(username).test();
+
+        // Assert: the result was furnished to the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertValue(result);
+    }
+
+    /**
+     * Validates that a failed call to resend the sign-up code will propagate the failure
+     * back through the binding.
+     */
+    @Test
+    public void testResendSignUpCodeFails() {
+        String username = RandomString.string();
+
+        // Arrange a failure on the failure consumer
+        AuthException failure = new AuthException("Reset sign up", " has failed.");
+        doAnswer(invocation -> {
+            // 0 = username, 1 = onResult, 2 = onFailure
+            int positionOfFailureConsumer = 2;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).resendSignUpCode(eq(username), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignUpResult> observer = auth.resendSignUpCode(username).test();
+
+        // Assert: the result was furnished to the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoValues()
+            .assertError(failure);
+    }
+
+    /**
+     * Validates that a successful call to sign-in will propagate the result
+     * back through the binding.
+     */
+    @Test
+    public void testSignInSucceeds() {
+        String username = RandomString.string();
+        String password = RandomString.string();
+
+        // Arrange a result on the result consumer
+        AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.EMAIL);
+        AuthSignInStep step = AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE;
+        AuthNextSignInStep nextStep = new AuthNextSignInStep(step, Collections.emptyMap(), details);
+        AuthSignInResult result = new AuthSignInResult(false, nextStep);
+        doAnswer(invocation -> {
+            // 0 = username, 1 = password, 2 = onResult, 3 = onFailure
+            int positionOfResultConsumer = 2;
+            Consumer<AuthSignInResult> onResult = invocation.getArgument(positionOfResultConsumer);
+            onResult.accept(result);
+            return (Void) null;
+        }).when(delegate).signIn(eq(username), eq(password), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignInResult> observer = auth.signIn(username, password).test();
+
+        // Assert: the result was furnished to the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertValue(result);
+    }
+
+    /**
+     * Validates that a failed call to sign-in will propagate the result
+     * back through the binding.
+     */
+    @Test
+    public void testSignInFails() {
+        String username = RandomString.string();
+        String password = RandomString.string();
+
+        // Arrange a failure on the failure consumer
+        AuthException failure = new AuthException("Sign in", " has failed.");
+        doAnswer(invocation -> {
+            // 0 = username, 1 = password, 2 = onResult, 3 = onFailure
+            int positionOfFailureConsumer = 3;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).signIn(eq(username), eq(password), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignInResult> observer = auth.signIn(username, password).test();
+
+        // Assert: the failure was furnished to the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoValues()
+            .assertError(failure);
+    }
+
+    /**
+     * Validates that a successful call to confirm sign-in will propagate the result
+     * back through the binding.
+     */
+    @Test
+    public void testConfirmSignInSucceeds() {
+        String confirmationCode = RandomString.string();
+
+        // Arrange a successful result.
+        AuthSignInStep step = AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE;
+        AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.UNKNOWN);
+        AuthNextSignInStep nextStep = new AuthNextSignInStep(step, Collections.emptyMap(), details);
+        AuthSignInResult expected = new AuthSignInResult(true, nextStep);
+        doAnswer(invocation -> {
+            // 0 = confirm code, 1 = onResult, 2 = onFailure
+            int positionOfResultConsumer = 1;
+            Consumer<AuthSignInResult> onResult = invocation.getArgument(positionOfResultConsumer);
+            onResult.accept(expected);
+            return (Void) null;
+        }).when(delegate).confirmSignIn(eq(confirmationCode), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignInResult> observer = auth.confirmSignIn(confirmationCode).test();
+
+        // Assert: result is furnished
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertValue(expected);
+    }
+
+    /**
+     * Validates that a failed call to confirm sign-in will propagate the failure
+     * back through the binding.
+     */
+    @Test
+    public void testConfirmSignInFails() {
+        String confirmationCode = RandomString.string();
+
+        // Arrange a failure.
+        AuthException failure = new AuthException("Confirmation of sign in", " has failed.");
+        doAnswer(invocation -> {
+            // 0 = confirm code, 1 = onResult, 2 = onFailure
+            int positionOfFailureConsumer = 2;
+            Consumer<AuthException> onResult = invocation.getArgument(positionOfFailureConsumer);
+            onResult.accept(failure);
+            return (Void) null;
+        }).when(delegate).confirmSignIn(eq(confirmationCode), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignInResult> observer = auth.confirmSignIn(confirmationCode).test();
+
+        // Assert: failure is furnished
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoValues()
+            .assertError(failure);
+    }
+
+    /**
+     * Validates that a successful call to sign-in with social web UI will propagate the result
+     * back through the binding.
+     */
+    @Test
+    public void testSignInWithSocialWebUISucceeds() {
+        AuthProvider provider = AuthProvider.amazon();
+        Activity activity = new Activity();
+
+        // Arrange a successful result
+        AuthSignInStep step = AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE;
+        AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.PHONE);
+        AuthNextSignInStep nextStep = new AuthNextSignInStep(step, Collections.emptyMap(), details);
+        AuthSignInResult result = new AuthSignInResult(false, nextStep);
+        doAnswer(invocation -> {
+            // 0 = provider, 1 = activity, 2 = result consumer, 3 = failure consumer
+            int positionOfResultConsumer = 2;
+            Consumer<AuthSignInResult> onResult = invocation.getArgument(positionOfResultConsumer);
+            onResult.accept(result);
+            return (Void) null;
+        }).when(delegate).signInWithSocialWebUI(eq(provider), eq(activity), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignInResult> observer = auth.signInWithSocialWebUI(provider, activity).test();
+
+        // Assert: result is furnished the via the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertValue(result);
+    }
+
+    /**
+     * Validates that a failed call to sign-in with social web UI will propagate the failure
+     * back through the binding.
+     */
+    @Test
+    public void testSignInWithSocialWebUIFails() {
+        AuthProvider provider = AuthProvider.amazon();
+        Activity activity = new Activity();
+
+        // Arrange a failure
+        AuthException failure = new AuthException("Sign in with social provider", " has failed");
+        doAnswer(invocation -> {
+            // 0 = provider, 1 = activity, 2 = result consumer, 3 = failure consumer
+            int positionOfFailureConsumer = 3;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).signInWithSocialWebUI(eq(provider), eq(activity), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignInResult> observer = auth.signInWithSocialWebUI(provider, activity).test();
+
+        // Assert: failure is furnished the via the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoValues()
+            .assertError(failure);
+    }
+
+    /**
+     * Validates that a successful call to sign-in with web UI will propagate the result
+     * back through the binding.
+     */
+    @Test
+    public void testSignInWithWebUISucceeds() {
+        Activity activity = new Activity();
+
+        // Arrange a result
+        AuthSignInStep step = AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE;
+        AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.PHONE);
+        AuthNextSignInStep nextStep = new AuthNextSignInStep(step, Collections.emptyMap(), details);
+        AuthSignInResult result = new AuthSignInResult(false, nextStep);
+        doAnswer(invocation -> {
+            // 0 = activity, 1 = result consumer, 2 = failure consumer
+            int positionOfResultConsumer = 1;
+            Consumer<AuthSignInResult> onResult = invocation.getArgument(positionOfResultConsumer);
+            onResult.accept(result);
+            return (Void) null;
+        }).when(delegate).signInWithWebUI(eq(activity), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignInResult> observer = auth.signInWithWebUI(activity).test();
+
+        // Assert: result is furnished the via the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertValue(result);
+    }
+
+    /**
+     * Validates that a failed call to sign-in with web UI will propagate the failure
+     * back through the binding.
+     */
+    @Test
+    public void testSignInWithWebUIFails() {
+        Activity activity = new Activity();
+
+        // Arrange a failure
+        AuthException failure = new AuthException("Sign in with web UI", " has failed");
+        doAnswer(invocation -> {
+            // 0 = activity, 1 = result consumer, 2 = failure consumer
+            int positionOfFailureConsumer = 2;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).signInWithWebUI(eq(activity), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthSignInResult> observer = auth.signInWithWebUI(activity).test();
+
+        // Assert: failure is furnished the via the Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoValues()
+            .assertError(failure);
+    }
+
+    /**
+     * Validates that a request to handle a web UI sign-in response
+     * passes the response down into the delegate.
+     */
+    @Test
+    public void testHandleWebUISignInResponse() {
+        Intent intent = new Intent();
+        auth.handleWebUISignInResponse(intent);
+        verify(delegate).handleWebUISignInResponse(eq(intent));
+    }
+
+    /**
+     * Tests that a successful call to fetch the auth session will propagate the session object
+     * back up through the binding.
+     */
+    @Test
+    public void testFetchAuthSessionSucceeds() {
+        // Arrange an auth session object to return when delegate is called
+        AuthSession expected = new AuthSession(false);
+        doAnswer(invocation -> {
+            // 0 = onResult, 1 = onFailure
+            int positionOfResultConsumer = 0;
+            Consumer<AuthSession> onResult = invocation.getArgument(positionOfResultConsumer);
+            onResult.accept(expected);
+            return (Void) null;
+        }).when(delegate).fetchAuthSession(anyConsumer(), anyConsumer());
+
+        // Act: call the Rx binding
+        TestObserver<AuthSession> observer = auth.fetchAuthSession().test();
+
+        // Assert: AuthSession is furnished to the Rx Single.
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertValue(expected);
+    }
+
+    /**
+     * Tests that a failed call to fetch the auth session will propagate the failure
+     * back up through the binding.
+     */
+    @Test
+    public void testFetchAuthSessionFails() {
+        // Arrange a failure when the delegate is called
+        AuthException failure = new AuthException("Fetch session", " has failed.");
+        doAnswer(invocation -> {
+            // 0 = onResult, 1 = onFailure
+            int positionOfFailureConsumer = 1;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).fetchAuthSession(anyConsumer(), anyConsumer());
+
+        // Act: call the Rx binding
+        TestObserver<AuthSession> observer = auth.fetchAuthSession().test();
+
+        // Assert: AuthException is furnished to the Rx Single.
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoValues()
+            .assertError(failure);
+    }
+
+    /**
+     * Tests that a successful request to reset the password will propagate a result
+     * back through the binding.
+     */
+    @Test
+    public void testResetPasswordSucceeds() {
+        String username = RandomString.string();
+
+        // Arrange delegate to furnish a result
+        AuthResetPasswordStep step = AuthResetPasswordStep.CONFIRM_RESET_PASSWORD_WITH_CODE;
+        AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.PHONE);
+        AuthNextResetPasswordStep nextStep = new AuthNextResetPasswordStep(step, Collections.emptyMap(), details);
+        AuthResetPasswordResult expected = new AuthResetPasswordResult(true, nextStep);
+        doAnswer(invocation -> {
+            // 0 = username, 1 = onResult, 2 = onFailure
+            int positionOfResultConsumer = 1;
+            Consumer<AuthResetPasswordResult> onResult = invocation.getArgument(positionOfResultConsumer);
+            onResult.accept(expected);
+            return (Void) null;
+        }).when(delegate).resetPassword(eq(username), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthResetPasswordResult> observer = auth.resetPassword(username).test();
+
+        // Assert: result was furnished via Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertValue(expected);
+    }
+
+    /**
+     * Tests that a failed request to reset the password will propagate a failure
+     * back through the binding.
+     */
+    @Test
+    public void testResetPasswordFails() {
+        String username = RandomString.string();
+
+        // Arrange delegate to furnish a failure
+        AuthException failure = new AuthException("Reset password", " has failed.");
+        doAnswer(invocation -> {
+            // 0 = username, 1 = onResult, 2 = onFailure
+            int positionOfFailureConsumer = 2;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).resetPassword(eq(username), anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthResetPasswordResult> observer = auth.resetPassword(username).test();
+
+        // Assert: failure was furnished via Rx Single
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoValues()
+            .assertError(failure);
+    }
+
+    /**
+     * Tests that a successful request to confirm password reset will propagate a completion
+     * back through the binding.
+     */
+    @Test
+    public void testConfirmResetPasswordSucceeds() {
+        String newPassword = RandomString.string();
+        String confirmationCode = RandomString.string();
+
+        // Arrange completion callback to be invoked
+        doAnswer(invocation -> {
+            // 0 = new pass, 1 = confirmation code, 2 = onComplete, 3 = onFailure
+            int positionOfCompletionAction = 2;
+            Action onComplete = invocation.getArgument(positionOfCompletionAction);
+            onComplete.call();
+            return (Void) null;
+        }).when(delegate).confirmResetPassword(eq(newPassword), eq(confirmationCode), anyAction(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<Void> observer =
+            auth.confirmResetPassword(newPassword, confirmationCode).test();
+
+        // Assert: Completable was completed successfully
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertComplete();
+    }
+
+    /**
+     * Tests that a failed request to confirm password reset will propagate a failure
+     * back through the binding.
+     */
+    @Test
+    public void testConfirmResetPasswordFails() {
+        String newPassword = RandomString.string();
+        String confirmationCode = RandomString.string();
+
+        // Arrange delegate to furnish a failure
+        AuthException failure = new AuthException("Confirm password reset ", " has failed.");
+        doAnswer(invocation -> {
+            // 0 = new pass, 1 = confirmation code, 2 = onComplete, 3 = onFailure
+            int positionOfFailureConsumer = 3;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).confirmResetPassword(eq(newPassword), eq(confirmationCode), anyAction(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<Void> observer =
+            auth.confirmResetPassword(newPassword, confirmationCode).test();
+
+        // Assert: Completable terminated with failure
+        observer.awaitTerminalEvent();
+        observer
+            .assertNotComplete()
+            .assertError(failure);
+    }
+
+    /**
+     * Tests that a successful request to update a user's password will propagate a completion
+     * back through the binding.
+     */
+    @Test
+    public void testUpdatePasswordSucceeds() {
+        String oldPassword = RandomString.string();
+        String newPassword = RandomString.string();
+
+        // Arrange an invocation of the success Action
+        doAnswer(invocation -> {
+            // 0 = old pass, 1 = new pass, 2 = onComplete, 3 = onFailure
+            int positionOfCompletionAction = 2;
+            Action onCompletion = invocation.getArgument(positionOfCompletionAction);
+            onCompletion.call();
+            return (Void) null;
+        }).when(delegate).updatePassword(eq(oldPassword), eq(newPassword), anyAction(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<Void> observer = auth.updatePassword(oldPassword, newPassword).test();
+
+        // Assert: Completable completes with success
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertComplete();
+    }
+
+    /**
+     * Tests that a failed request to update a user's password will propagate a failure
+     * back through the binding.
+     */
+    @Test
+    public void testUpdatePasswordFails() {
+        String oldPassword = RandomString.string();
+        String newPassword = RandomString.string();
+
+        // Arrange a callback on the failure consumer
+        AuthException failure = new AuthException("Update password ", "has failed");
+        doAnswer(invocation -> {
+            // 0 = old pass, 1 = new pass, 2 = onComplete, 3 = onFailure
+            int positionOfFailureConsumer = 3;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).updatePassword(eq(oldPassword), eq(newPassword), anyAction(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<Void> observer = auth.updatePassword(oldPassword, newPassword).test();
+
+        // Assert: Completable terminates with failure
+        observer.awaitTerminalEvent();
+        observer
+            .assertNotComplete()
+            .assertError(failure);
+    }
+
+    /**
+     * Getting the current user should just pass through to the delegate, to reutrn whatever
+     * it would.
+     */
+    @Test
+    public void testGetCurrentUser() {
+        AuthUser expected = new AuthUser(RandomString.string(), RandomString.string());
+        when(delegate.getCurrentUser()).thenReturn(expected);
+        assertEquals(expected, auth.getCurrentUser());
+    }
+
+    /**
+     * Validates that a successful sign-out will propagate up into the binding.
+     */
+    @Test
+    public void testSignOutSucceeds() {
+        // Arrange an invocation of the success action
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            int positionOfCompletionAction = 0;
+            Action onComplete = invocation.getArgument(positionOfCompletionAction);
+            onComplete.call();
+            return (Void) null;
+        }).when(delegate).signOut(anyAction(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<Void> observer = auth.signOut().test();
+
+        // Assert: Completable completes successfully
+        observer.awaitTerminalEvent();
+        observer
+            .assertNoErrors()
+            .assertComplete();
+    }
+
+    /**
+     * Validate that a sign-out failure is propagated up through the binding.
+     */
+    @Test
+    public void testSignOutFails() {
+        // Arrange a callback on the failure consumer
+        AuthException failure = new AuthException("Sign out", "has failed");
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            int positionOfFailureConsumer = 1;
+            Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
+            onFailure.accept(failure);
+            return (Void) null;
+        }).when(delegate).signOut(anyAction(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<Void> observer = auth.signOut().test();
+
+        // Assert: failure is furnished via Rx Completable.
+        observer.awaitTerminalEvent();
+        observer
+            .assertNotComplete()
+            .assertError(failure);
+    }
+}


### PR DESCRIPTION
Adds Rx bindings covering the entire surface of the AuthCategory

As just one example, instead of calling:

```java
Amplify.Auth.signIn(username, password,
    result -> Log.i(TAG, "Sign-in ok"),
    failure -> Log.e(TAG, "Failed to sign in.", failure)
);
```

You can get an Rx `Single`, and subscribe to it:
```java
RxAmplify.Auth.signIn(username, password)
    .subscribe(
        result -> Log.i(TAG, "Sign-in ok"),
        failure -> Log.e(TAG, "Failed to sign in.", failure)
    );
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
