### PR TITLE
Fix for contains predicate

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -141,12 +141,25 @@ public final class SQLPredicate {
                         .append("?");
             case CONTAINS:
                 ContainsQueryOperator containsOp = (ContainsQueryOperator) op;
-                addBinding(containsOp.value());
-                return builder.append("?")
+                //TODO: Need to somehow the the underlying model type to determine whether the
+                //      field we're querying against is a string field of a list of primitive types
+                //
+                JavaFieldType javaType = TypeConverter.getJavaFieldTypeFromValue(containsOp.value());
+                if (JavaFieldType.STRING.equals(javaType)) {
+                    addBinding("%" + containsOp.value() + "%");
+                    return builder.append(field)
+                        .append(SqlKeyword.DELIMITER)
+                        .append(SqlKeyword.LIKE)
+                        .append(SqlKeyword.DELIMITER)
+                        .append("?");
+                } else {
+                    addBinding(containsOp.value());
+                    return builder.append("?")
                         .append(SqlKeyword.DELIMITER)
                         .append(SqlKeyword.IN)
                         .append(SqlKeyword.DELIMITER)
                         .append(field);
+                }
             case BEGINS_WITH:
                 BeginsWithQueryOperator beginsWithOp = (BeginsWithQueryOperator) op;
                 addBinding(beginsWithOp.value() + "%");

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -142,11 +142,11 @@ public final class SQLPredicate {
             case CONTAINS:
                 ContainsQueryOperator containsOp = (ContainsQueryOperator) op;
                 addBinding(containsOp.value());
-                return builder.append("instr(")
-                  .append(field)
-                  .append(",")
-                  .append("?")
-                  .append(")");
+              return builder.append("instr(")
+                        .append(field)
+                        .append(",")
+                        .append("?")
+                        .append(")");
             case BEGINS_WITH:
                 BeginsWithQueryOperator beginsWithOp = (BeginsWithQueryOperator) op;
                 addBinding(beginsWithOp.value() + "%");

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -142,7 +142,7 @@ public final class SQLPredicate {
             case CONTAINS:
                 ContainsQueryOperator containsOp = (ContainsQueryOperator) op;
                 addBinding(containsOp.value());
-              return builder.append("instr(")
+                return builder.append("instr(")
                         .append(field)
                         .append(",")
                         .append("?")

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -141,25 +141,12 @@ public final class SQLPredicate {
                         .append("?");
             case CONTAINS:
                 ContainsQueryOperator containsOp = (ContainsQueryOperator) op;
-                //TODO: Need to somehow the the underlying model type to determine whether the
-                //      field we're querying against is a string field of a list of primitive types
-                //
-                JavaFieldType javaType = TypeConverter.getJavaFieldTypeFromValue(containsOp.value());
-                if (JavaFieldType.STRING.equals(javaType)) {
-                    addBinding("%" + containsOp.value() + "%");
-                    return builder.append(field)
-                        .append(SqlKeyword.DELIMITER)
-                        .append(SqlKeyword.LIKE)
-                        .append(SqlKeyword.DELIMITER)
-                        .append("?");
-                } else {
-                    addBinding(containsOp.value());
-                    return builder.append("?")
-                        .append(SqlKeyword.DELIMITER)
-                        .append(SqlKeyword.IN)
-                        .append(SqlKeyword.DELIMITER)
-                        .append(field);
-                }
+                addBinding(containsOp.value());
+                return builder.append("instr(")
+                  .append(field)
+                  .append(",")
+                  .append("?")
+                  .append(")");
             case BEGINS_WITH:
                 BeginsWithQueryOperator beginsWithOp = (BeginsWithQueryOperator) op;
                 addBinding(beginsWithOp.value() + "%");

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -146,7 +146,11 @@ public final class SQLPredicate {
                         .append(field)
                         .append(",")
                         .append("?")
-                        .append(")");
+                        .append(")")
+                        .append(SqlKeyword.DELIMITER)
+                        .append(SqlKeyword.fromQueryOperator(QueryOperator.Type.GREATER_THAN))
+                        .append(SqlKeyword.DELIMITER)
+                        .append("0");
             case BEGINS_WITH:
                 BeginsWithQueryOperator beginsWithOp = (BeginsWithQueryOperator) op;
                 addBinding(beginsWithOp.value() + "%");

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
@@ -1,0 +1,36 @@
+package com.amplifyframework.datastore.storage.sqlite;
+
+import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.storage.sqlite.adapter.SQLPredicate;
+import com.amplifyframework.testmodels.ratingsblog.Blog;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class SQLPredicateTest {
+
+    @Test
+    public void testContainsForStringField() throws DataStoreException {
+        QueryPredicate predicate = Where.matches(Blog.NAME.contains("something")).getQueryPredicate();
+        SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+        assertEquals(1, sqlPredicate.getBindings().size());
+        assertEquals("%something%", sqlPredicate.getBindings().get(0));
+        assertEquals("name LIKE ?", sqlPredicate.toString());
+    }
+
+    @Test
+    public void testContainsForNonStringField() throws DataStoreException {
+        QueryPredicateOperation<String> predicate = Blog.TAGS.contains("something");
+        SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+        assertEquals(1, sqlPredicate.getBindings().size());
+        assertEquals("something", sqlPredicate.getBindings().get(0));
+        assertEquals("? IN tags", sqlPredicate.toString());
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amplifyframework.datastore.storage.sqlite;
 
 import com.amplifyframework.core.model.query.Where;
@@ -18,27 +33,27 @@ public class SQLPredicateTest {
 
     /**
      * Test contains in the context of a String field.
-     * @throws DataStoreException
+     * @throws DataStoreException Not thrown.
      */
     @Test
     public void testContainsForStringField() throws DataStoreException {
         QueryPredicate predicate = Where.matches(Blog.NAME.contains("something")).getQueryPredicate();
         SQLPredicate sqlPredicate = new SQLPredicate(predicate);
-        assertStringResults(sqlPredicate, "name");
+        validateSQLExpressionForContains(sqlPredicate, "name");
     }
 
     /**
      * Test contains in the context of a list.
-     * @throws DataStoreException
+     * @throws DataStoreException Not thrown.
      */
     @Test
     public void testContainsForStringList() throws DataStoreException {
         QueryPredicateOperation<String> predicate = Blog.TAGS.contains("something");
         SQLPredicate sqlPredicate = new SQLPredicate(predicate);
-        assertStringResults(sqlPredicate, "tags");
+        validateSQLExpressionForContains(sqlPredicate, "tags");
     }
 
-    private void assertStringResults(SQLPredicate sqlPredicate, String fieldName) {
+    private void validateSQLExpressionForContains(SQLPredicate sqlPredicate, String fieldName) {
         assertEquals(1, sqlPredicate.getBindings().size());
         assertEquals("something", sqlPredicate.getBindings().get(0));
         assertEquals("instr(" + fieldName + ",?) > 0", sqlPredicate.toString());

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
@@ -16,21 +16,31 @@ import static org.junit.Assert.assertEquals;
 @RunWith(RobolectricTestRunner.class)
 public class SQLPredicateTest {
 
+    /**
+     * Test contains in the context of a String field.
+     * @throws DataStoreException
+     */
     @Test
     public void testContainsForStringField() throws DataStoreException {
         QueryPredicate predicate = Where.matches(Blog.NAME.contains("something")).getQueryPredicate();
         SQLPredicate sqlPredicate = new SQLPredicate(predicate);
-        assertEquals(1, sqlPredicate.getBindings().size());
-        assertEquals("%something%", sqlPredicate.getBindings().get(0));
-        assertEquals("name LIKE ?", sqlPredicate.toString());
+        assertStringResults(sqlPredicate, "name");
     }
 
+    /**
+     * Test contains in the context of a list.
+     * @throws DataStoreException
+     */
     @Test
-    public void testContainsForNonStringField() throws DataStoreException {
+    public void testContainsForStringList() throws DataStoreException {
         QueryPredicateOperation<String> predicate = Blog.TAGS.contains("something");
         SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+        assertStringResults(sqlPredicate, "tags");
+    }
+
+    private void assertStringResults(SQLPredicate sqlPredicate, String fieldName) {
         assertEquals(1, sqlPredicate.getBindings().size());
         assertEquals("something", sqlPredicate.getBindings().get(0));
-        assertEquals("? IN tags", sqlPredicate.toString());
+        assertEquals("instr(" + fieldName + ",?)", sqlPredicate.toString());
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
@@ -41,6 +41,6 @@ public class SQLPredicateTest {
     private void assertStringResults(SQLPredicate sqlPredicate, String fieldName) {
         assertEquals(1, sqlPredicate.getBindings().size());
         assertEquals("something", sqlPredicate.getBindings().get(0));
-        assertEquals("instr(" + fieldName + ",?)", sqlPredicate.toString());
+        assertEquals("instr(" + fieldName + ",?) > 0", sqlPredicate.toString());
     }
 }


### PR DESCRIPTION
*Issue #, if available: #458 

*Description of changes:*
The issue is that the `contains` predicate assumes that the field we're querying is a list. However, when used on a String field, it results in invalid SQL syntax. So for example:

```
Blog.TAGS.contains("something");
```

yields

```sql
"something" IN tags
```  
which results in an error.

At first, I thought fixing it would just be a matter of determining whether the field we’re querying against is a List<> or a String. However, that information is not available from inside the `SQLPredicate` class as it exists today, so I need to explore some options.

## Update
Decided to go with the [instr](https://www.sqlite.org/lang_corefunc.html#instr) function to handle string pattern matching operation.

------------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
