### PR TITLE
fix(aws-api): Fix path with leading slash breaking REST

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
@@ -61,7 +61,7 @@ public final class RestApiInstrumentationTest {
     @Test
     public void getRequestWithNoAuth() throws JSONException, ApiException {
         final RestOptions options = RestOptions.builder()
-            .addPath("simplesuccess")
+            .addPath("/simplesuccess")
             .build();
         final RestResponse response = api.get("nonAuthApi", options);
         final JSONObject resultJSON = response.getData().asJSONObject();
@@ -84,7 +84,7 @@ public final class RestApiInstrumentationTest {
     @Test
     public void postRequestWithNoAuth() throws ApiException {
         final RestOptions options = RestOptions.builder()
-                .addPath("simplesuccess")
+                .addPath("/simplesuccess")
                 .addBody("sample body".getBytes())
                 .build();
         final RestResponse response = api.post("nonAuthApi", options);
@@ -100,7 +100,7 @@ public final class RestApiInstrumentationTest {
     @Test
     public void getRequestWithApiKey() throws JSONException, ApiException {
         final RestOptions options = RestOptions.builder()
-            .addPath("simplesuccessapikey")
+            .addPath("/simplesuccessapikey")
             .build();
         final RestResponse response = api.get("apiKeyApi", options);
         final JSONObject resultJSON = response.getData().asJSONObject();
@@ -123,7 +123,7 @@ public final class RestApiInstrumentationTest {
     @Test
     public void getRequestWithIAM() throws ApiException {
         final RestOptions options = RestOptions.builder()
-            .addPath("items")
+            .addPath("/items")
             .build();
         final RestResponse response = api.get("iamAuthApi", options);
         assertNotNull("Should return non-null data", response.getData());
@@ -137,7 +137,7 @@ public final class RestApiInstrumentationTest {
     @Test
     public void getRequestWithIAMFailedAccess() throws ApiException {
         final RestOptions options = RestOptions.builder()
-            .addPath("invalidPath")
+            .addPath("/invalidPath")
             .build();
         final RestResponse response = api.get("iamAuthApi", options);
         assertNotNull("Should return non-null data", response.getData());

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
@@ -26,13 +26,13 @@ import com.amplifyframework.testutils.sync.SynchronousMobileClient;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Validates the functionality of the {@link AWSApiPlugin} for REST operations.
@@ -41,12 +41,12 @@ public final class RestApiInstrumentationTest {
     private static SynchronousApi api;
 
     /**
-     * Configure the Amplify framework, if that hasn't already happened in this process instance.
+     * Configure the Amplify framework and auth.
      * @throws AmplifyException if configuration fails
      * @throws SynchronousMobileClient.MobileClientException If AWS Mobile Client initialization fails
      */
-    @BeforeClass
-    public static void onceBeforeTests() throws AmplifyException, SynchronousMobileClient.MobileClientException {
+    @Before
+    public void setUp() throws AmplifyException, SynchronousMobileClient.MobileClientException {
         ApiCategory asyncDelegate = TestApiCategory.fromConfiguration(R.raw.amplifyconfiguration);
         api = SynchronousApi.delegatingTo(asyncDelegate);
         SynchronousMobileClient mobileClient = SynchronousMobileClient.instance();
@@ -59,11 +59,11 @@ public final class RestApiInstrumentationTest {
      * @throws ApiException On failure to obtain a valid response from API endpoint
      */
     @Test
-    @Ignore("Temporarily disabled due to consistent failure.")
     public void getRequestWithNoAuth() throws JSONException, ApiException {
-        RestResponse response =
-            api.get("nonAuthApi", RestOptions.builder().addPath("simplesuccess").build());
-
+        final RestOptions options = RestOptions.builder()
+            .addPath("simplesuccess")
+            .build();
+        final RestResponse response = api.get("nonAuthApi", options);
         final JSONObject resultJSON = response.getData().asJSONObject();
         final JSONObject contextJSON = resultJSON.getJSONObject("context");
         assertNotNull("Should contain an object called context", contextJSON);
@@ -79,27 +79,17 @@ public final class RestApiInstrumentationTest {
 
     /**
      * Test whether we can make POST api Rest call in none auth.
-     * @throws JSONException If JSON parsing of arranged data fails
      * @throws ApiException On failure to obtain a valid response from API endpoint
      */
     @Test
-    @Ignore("Temporarily disabled due to consistent failure.")
-    public void postRequestWithNoAuth() throws JSONException, ApiException {
-        final RestOptions options =
-                RestOptions.builder().addPath("simplesuccess").addBody("sample body".getBytes()).build();
+    public void postRequestWithNoAuth() throws ApiException {
+        final RestOptions options = RestOptions.builder()
+                .addPath("simplesuccess")
+                .addBody("sample body".getBytes())
+                .build();
         final RestResponse response = api.post("nonAuthApi", options);
-
-        final JSONObject resultJSON = response.getData().asJSONObject();
-        final JSONObject contextJSON = resultJSON.getJSONObject("context");
-        assertNotNull("Should contain an object called context", contextJSON);
-        assertEquals(
-                "Should return the right value",
-                "POST",
-                contextJSON.getString("http-method"));
-        assertEquals(
-                "Should return the right value",
-                "/simplesuccess",
-                contextJSON.getString("resource-path"));
+        assertNotNull("Should return non-null data", response.getData());
+        assertTrue("Response should be successful", response.getCode().isSuccessful());
     }
 
     /**
@@ -108,11 +98,11 @@ public final class RestApiInstrumentationTest {
      * @throws ApiException On failure to obtain a valid response from API endpoint
      */
     @Test
-    @Ignore("Temporarily disabled due to consistent failure.")
     public void getRequestWithApiKey() throws JSONException, ApiException {
-        final RestResponse response =
-            api.get("apiKeyApi", RestOptions.builder().addPath("simplesuccessapikey").build());
-
+        final RestOptions options = RestOptions.builder()
+            .addPath("simplesuccessapikey")
+            .build();
+        final RestResponse response = api.get("apiKeyApi", options);
         final JSONObject resultJSON = response.getData().asJSONObject();
         final JSONObject contextJSON = resultJSON.getJSONObject("context");
         assertNotNull("Should contain an object called context", contextJSON);
@@ -132,11 +122,12 @@ public final class RestApiInstrumentationTest {
      */
     @Test
     public void getRequestWithIAM() throws ApiException {
-        RestOptions options = RestOptions.builder()
+        final RestOptions options = RestOptions.builder()
             .addPath("items")
             .build();
-        RestResponse response = api.get("iamAuthApi", options);
+        final RestResponse response = api.get("iamAuthApi", options);
         assertNotNull("Should return non-null data", response.getData());
+        assertTrue("Response should be successful", response.getCode().isSuccessful());
     }
 
     /**
@@ -145,10 +136,10 @@ public final class RestApiInstrumentationTest {
      */
     @Test
     public void getRequestWithIAMFailedAccess() throws ApiException {
-        RestOptions options = RestOptions.builder()
+        final RestOptions options = RestOptions.builder()
             .addPath("invalidPath")
             .build();
-        RestResponse response = api.get("iamAuthApi", options);
+        final RestResponse response = api.get("iamAuthApi", options);
         assertNotNull("Should return non-null data", response.getData());
         assertFalse("Response should be unsuccessful", response.getCode().isSuccessful());
     }

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
@@ -70,11 +70,13 @@ public final class RestApiInstrumentationTest {
         assertEquals(
                 "Should return the right value",
                 "GET",
-                contextJSON.getString("http-method"));
+                contextJSON.getString("http-method")
+        );
         assertEquals(
                 "Should return the right value",
                 "/simplesuccess",
-                contextJSON.getString("resource-path"));
+                contextJSON.getString("resource-path")
+        );
     }
 
     /**
@@ -84,9 +86,9 @@ public final class RestApiInstrumentationTest {
     @Test
     public void postRequestWithNoAuth() throws ApiException {
         final RestOptions options = RestOptions.builder()
-                .addPath("/simplesuccess")
-                .addBody("sample body".getBytes())
-                .build();
+            .addPath("/simplesuccess")
+            .addBody("sample body".getBytes())
+            .build();
         final RestResponse response = api.post("nonAuthApi", options);
         assertNotNull("Should return non-null data", response.getData());
         assertTrue("Response should be successful", response.getCode().isSuccessful());
@@ -109,11 +111,13 @@ public final class RestApiInstrumentationTest {
         assertEquals(
                 "Should return the right value",
                 "GET",
-                contextJSON.getString("http-method"));
+                contextJSON.getString("http-method")
+        );
         assertEquals(
                 "Should return the right value",
                 "/simplesuccessapikey",
-                contextJSON.getString("resource-path"));
+                contextJSON.getString("resource-path")
+        );
     }
 
     /**

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
@@ -51,17 +51,16 @@ public final class RestRequestFactory {
             @Nullable String path,
             @Nullable Map<String, String> queryParameters
     ) throws MalformedURLException {
-        // If path isn't specified, then use empty string
-        if (path == null) {
-            path = "";
-        }
 
         URL url = new URL(endpoint);
         HttpUrl.Builder builder = new HttpUrl.Builder()
             .scheme(url.getProtocol())
             .host(url.getHost())
-            .addPathSegment(stripLeadingSlashes(url.getPath()))
-            .addPathSegments(stripLeadingSlashes(path));
+            .addPathSegment(stripLeadingSlashes(url.getPath()));
+
+        if (path != null) {
+            builder.addPathSegments(stripLeadingSlashes(path));
+        }
 
         if (queryParameters != null) {
             for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
@@ -140,7 +139,7 @@ public final class RestRequestFactory {
     // Segment separator can be either '/' or '\'.
     // HttpUrl.Builder assumes an empty URL if path segments
     // begin with either character. Strip them before appending.
-    private static String stripLeadingSlashes(String path) {
+    private static String stripLeadingSlashes(final String path) {
         return path.replaceAll("^[\\\\/]+", "");
     }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
@@ -49,14 +49,19 @@ public final class RestRequestFactory {
     public static URL createURL(
             @NonNull String endpoint,
             @Nullable String path,
-            @Nullable Map<String, String> queryParameters)
-            throws MalformedURLException {
+            @Nullable Map<String, String> queryParameters
+    ) throws MalformedURLException {
+        // If path isn't specified, then use empty string
+        if (path == null) {
+            path = "";
+        }
+
         URL url = new URL(endpoint);
         HttpUrl.Builder builder = new HttpUrl.Builder()
             .scheme(url.getProtocol())
             .host(url.getHost())
-            .addPathSegment(url.getPath().replaceFirst("/", ""))
-            .addPathSegments(path == null ? "" : path);
+            .addPathSegment(stripLeadingSlashes(url.getPath()))
+            .addPathSegments(stripLeadingSlashes(path));
 
         if (queryParameters != null) {
             for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
@@ -125,10 +130,18 @@ public final class RestRequestFactory {
     private static void populateBody(
             Request.Builder builder,
             byte[] data,
-            BodyCreationStrategy strategy) {
+            BodyCreationStrategy strategy
+    ) {
         if (data != null) {
             strategy.buildRequest(builder, data);
         }
+    }
+
+    // Segment separator can be either '/' or '\'.
+    // HttpUrl.Builder assumes an empty URL if path segments
+    // begin with either character. Strip them before appending.
+    private static String stripLeadingSlashes(String path) {
+        return path.replaceAll("^[\\\\/]+", "");
     }
 
     /**

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
@@ -40,7 +40,7 @@ public final class RestRequestFactoryTest {
     @Test
     public void createValidURL() throws MalformedURLException {
         URL url = RestRequestFactory.createURL("http://amplify-android.com",
-                "path/to/path",
+                "/path/to/path",
                 null);
         assertEquals("The url generated should match",
                 "http://amplify-android.com/path/to/path",
@@ -54,10 +54,24 @@ public final class RestRequestFactoryTest {
     @Test
     public void createValidURLWithPath() throws MalformedURLException {
         URL url = RestRequestFactory.createURL("http://amplify-android.com/beta",
-                "path/to/path",
+                "/path/to/path",
                 null);
         assertEquals("The url generated should match",
                 "http://amplify-android.com/beta/path/to/path",
+                url.toString());
+    }
+
+    /**
+     * Test if path without leading slash is still valid.
+     * @throws MalformedURLException Throws if the URL is invalid.
+     */
+    @Test
+    public void createValidURLWithPathWithoutLeadingSlash() throws MalformedURLException {
+        URL url = RestRequestFactory.createURL("http://amplify-android.com/beta",
+                "path",
+                null);
+        assertEquals("The url generated should match",
+                "http://amplify-android.com/beta/path",
                 url.toString());
     }
 
@@ -71,7 +85,7 @@ public final class RestRequestFactoryTest {
         queries.put("key1", "value1");
         queries.put("key2", "value2");
         URL url = RestRequestFactory.createURL("http://amplify-android.com",
-                "path/to/path",
+                "/path/to/path",
                 queries);
         assertEquals("The url generated should match",
                 "http://amplify-android.com/path/to/path?key1=value1&key2=value2",
@@ -83,9 +97,9 @@ public final class RestRequestFactoryTest {
      * @throws MalformedURLException Should throw since the URL is invalid.
      */
     @Test(expected = MalformedURLException.class)
-    public void createInValidURL() throws MalformedURLException {
+    public void createInvalidURL() throws MalformedURLException {
         RestRequestFactory.createURL("asd.com",
-                "path/to/path",
+                "/path/to/path",
                 null);
     }
 
@@ -96,7 +110,7 @@ public final class RestRequestFactoryTest {
     @Test
     public void createGetRequest() throws MalformedURLException {
         URL url = RestRequestFactory.createURL("http://amplify-android.com",
-                "path/to/path",
+                "/path/to/path",
                 null);
         Request request = RestRequestFactory.createRequest(url,
                 null,
@@ -112,7 +126,7 @@ public final class RestRequestFactoryTest {
     @Test
     public void createPostRequest() throws MalformedURLException {
         URL url = RestRequestFactory.createURL("http://amplify-android.com",
-                "path/to/path",
+                "/path/to/path",
                 null);
         Request request = RestRequestFactory.createRequest(url,
                 null,
@@ -128,7 +142,7 @@ public final class RestRequestFactoryTest {
     @Test
     public void createPostRequestWithBody() throws MalformedURLException {
         URL url = RestRequestFactory.createURL("http://amplify-android.com",
-                "path/to/path",
+                "/path/to/path",
                 null);
         Request request = RestRequestFactory.createRequest(url,
                 "{}".getBytes(),
@@ -144,7 +158,7 @@ public final class RestRequestFactoryTest {
     @Test
     public void createPostRequestWithHeaders() throws MalformedURLException {
         URL url = RestRequestFactory.createURL("http://amplify-android.com",
-                "path/to/path",
+                "/path/to/path",
                 null);
 
         Map<String, String> headers = new HashMap<>();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Re-enable the REST API integration tests that were previously turned off.
* REST URL constructor will now strip leading slashes in provided path to avoid the [following OkHttp behavior](https://square.github.io/okhttp/3.x/okhttp/okhttp3/HttpUrl.Builder.html#addPathSegments-java.lang.String-):
  * > If `pathSegments` starts with a slash, the resulting URL will have empty path segment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
