### PR TITLE
ci: improve integration test retry logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
             .circleci/copy-configs
       - run:
           name: Run integration test
-          command: .circleci/retry.sh 3 ./gradlew connectedDebugAndroidTest --no-daemon
+          command: .circleci/run-integration-tests.sh
       - run:
           name: Store coverage data
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,10 +91,9 @@ jobs:
       - run:
           name: Build the project
           command: |
-            .circleci/retry.sh 3 900 ./gradlew build
+            .circleci/retry.sh 3 ./gradlew build
             .circleci/aggregate-test-results.sh ~/amplify-android-home
             .circleci/aggregate-build-artifacts.sh
-          no_output_timeout: 30m
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -120,11 +119,10 @@ jobs:
       - run:
           name: Run integration test
           command: .circleci/run-integration-tests.sh
-          no_output_timeout: 30m
       - run:
           name: Store coverage data
           command: |
-              .circleci/retry.sh 3 900 ./gradlew jacocoFullReport --no-daemon
+              .circleci/retry.sh 3 ./gradlew jacocoFullReport --no-daemon
               tmp_file="$(mktemp)"
               curl -s https://codecov.io/bash > "$tmp_file"
               actual_hash="$(cat $tmp_file | cksum | cut -f 1 -d\ )"
@@ -138,7 +136,7 @@ jobs:
               chmod +x "$tmp_file"
               bash "$tmp_file"
               rm "$tmp_file"
-          no_output_timeout: 30m
+
       - store_artifacts:
           path: logcat.log
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Build the project
           command: |
-            .circleci/retry.sh 3 ./gradlew build
+            .circleci/retry.sh 3 "./gradlew build"
             .circleci/aggregate-test-results.sh ~/amplify-android-home
             .circleci/aggregate-build-artifacts.sh
       - store_test_results:
@@ -122,7 +122,7 @@ jobs:
       - run:
           name: Store coverage data
           command: |
-              .circleci/retry.sh 3 ./gradlew jacocoFullReport --no-daemon
+              .circleci/retry.sh 3 "./gradlew jacocoFullReport --no-daemon"
               tmp_file="$(mktemp)"
               curl -s https://codecov.io/bash > "$tmp_file"
               actual_hash="$(cat $tmp_file | cksum | cut -f 1 -d\ )"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
               tmp_file="$(mktemp)"
               curl -s https://codecov.io/bash > "$tmp_file"
               actual_hash="$(cat $tmp_file | cksum | cut -f 1 -d\ )"
-              expected_hash='2175291078'
+              expected_hash='261829867'
 
               if [ "$expected_hash" != "$actual_hash" ]; then
                   echo "Unexpected file contents in codecov script." >&2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,10 @@ jobs:
       - run:
           name: Build the project
           command: |
-            .circleci/retry.sh 3 ./gradlew build
+            .circleci/retry.sh 3 900 ./gradlew build
             .circleci/aggregate-test-results.sh ~/amplify-android-home
             .circleci/aggregate-build-artifacts.sh
+          no_output_timeout: 30m
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -119,10 +120,11 @@ jobs:
       - run:
           name: Run integration test
           command: .circleci/run-integration-tests.sh
+          no_output_timeout: 30m
       - run:
           name: Store coverage data
           command: |
-              .circleci/retry.sh 3 ./gradlew jacocoFullReport --no-daemon
+              .circleci/retry.sh 3 900 ./gradlew jacocoFullReport --no-daemon
               tmp_file="$(mktemp)"
               curl -s https://codecov.io/bash > "$tmp_file"
               actual_hash="$(cat $tmp_file | cksum | cut -f 1 -d\ )"
@@ -136,7 +138,7 @@ jobs:
               chmod +x "$tmp_file"
               bash "$tmp_file"
               rm "$tmp_file"
-
+          no_output_timeout: 30m
       - store_artifacts:
           path: logcat.log
 workflows:

--- a/.circleci/retry.sh
+++ b/.circleci/retry.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
-# Usage: retry.sh <max_tries> <timeout_seconds> <command to run>
-sudo apt-get update
-sudo apt-get install expect
+# Usage: retry.sh <max_tries> <command to run>
 
 readonly max_tries=$1
-readonly timeout=$2
-readonly command="${@: 3}"
+readonly command="${@: 2}"
 attempts=0
 return_code=1
 while [[ $attempts -lt $max_tries ]]; do
   ((attempts++))
   if [[ attempts -gt 1 ]]; then sleep 10; fi
   echo "RETRY: $command : Attempt $attempts of $max_tries."
-  expect -c "set timeout $timeout; spawn $command; expect timeout { exit 1 } eof { exit 0 }" && break
+  $command && break
 done
 
 return_code=$?

--- a/.circleci/retry.sh
+++ b/.circleci/retry.sh
@@ -8,16 +8,16 @@ return_code=1
 while [[ $attempts -lt $max_tries ]]; do
   ((attempts++))
   if [[ attempts -gt 1 ]]; then sleep 10; fi
-  echo "RETRY: Attempt $attempts of $max_tries."
+  echo "RETRY: $command : Attempt $attempts of $max_tries."
   $command && break
 done
 
 return_code=$?
 
 if [[ $return_code == 0 ]]; then
-  echo "RETRY: Attempt $attempts succeeded."
+  echo "RETRY: $command : Attempt $attempts succeeded."
 else
-  echo "RETRY: All $attempts attempts failed."
+  echo "RETRY: $command : All $attempts attempts failed."
 fi
 
 exit $return_code

--- a/.circleci/retry.sh
+++ b/.circleci/retry.sh
@@ -1,23 +1,25 @@
 #!/bin/bash
 # Usage: retry.sh <max_tries> <command to run>
 
+tag="RETRY"
 readonly max_tries=$1
 readonly command="${@: 2}"
 attempts=0
 return_code=1
+
 while [[ $attempts -lt $max_tries ]]; do
   ((attempts++))
   if [[ attempts -gt 1 ]]; then sleep 10; fi
-  echo "RETRY: $command : Attempt $attempts of $max_tries."
+  echo "$tag: $command : Attempt $attempts of $max_tries."
   $command && break
 done
 
 return_code=$?
 
 if [[ $return_code == 0 ]]; then
-  echo "RETRY: $command : Attempt $attempts succeeded."
+  echo "$tag: $command : Attempt $attempts succeeded."
 else
-  echo "RETRY: $command : All $attempts attempts failed."
+  echo "$tag: $command : All $attempts attempts failed."
 fi
 
 exit $return_code

--- a/.circleci/retry.sh
+++ b/.circleci/retry.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
-# Usage: retry.sh <max_tries> <command to run>
+# Usage: retry.sh <max_tries> <timeout_seconds> <command to run>
+sudo apt-get update
+sudo apt-get install expect
 
 readonly max_tries=$1
-readonly command="${@: 2}"
+readonly timeout=$2
+readonly command="${@: 3}"
 attempts=0
 return_code=1
 while [[ $attempts -lt $max_tries ]]; do
   ((attempts++))
   if [[ attempts -gt 1 ]]; then sleep 10; fi
   echo "RETRY: $command : Attempt $attempts of $max_tries."
-  $command && break
+  expect -c "set timeout $timeout; spawn $command; expect timeout { exit 1 } eof { exit 0 }" && break
 done
 
 return_code=$?

--- a/.circleci/retry.sh
+++ b/.circleci/retry.sh
@@ -3,7 +3,7 @@
 
 tag="RETRY"
 readonly max_tries=$1
-readonly command="${@: 2}"
+readonly command="${*: 2}"
 attempts=0
 return_code=1
 

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -6,19 +6,16 @@ tasks=($(./gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 
 
 # Run the integration tests for each module.  If it fails, retry.sh
 return_code=0
-summary=""
 tag="RUN_INTEGRATION_TESTS"
 for task in "${tasks[@]}"; do
   echo "$tag: $task"
   .circleci/retry.sh 3 ./gradlew $task --no-daemon
   if [[ $? == 1 ]]; then
     return_code=1
-    summary+="$task failed.\n"
+    echo "$task failed."
   else
-    summary+="$task succeeded.\n"
+    echo "$task succeeded."
   fi
 done
-echo "$tag SUMMARY:\n"
-printf $summary
 exit $return_code
 

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -7,7 +7,7 @@ tasks=($(gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1)
 # Run the integration tests for each module.  If it fails, retry.sh
 return_code=0
 for task in "${tasks[@]}"; do
-   retry.sh 3 gradlew $task --no-daemon
+   retry.sh 3 ./gradlew $task --no-daemon
    if [[ $? == 1 ]]; then
      return_code=1
    fi

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -6,12 +6,19 @@ tasks=($(./gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 
 
 # Run the integration tests for each module.  If it fails, retry.sh
 return_code=0
+summary=""
+tag="RUN_INTEGRATION_TESTS"
 for task in "${tasks[@]}"; do
+   echo "$tag: $task"
    .circleci/retry.sh 3 ./gradlew $task --no-daemon
    if [[ $? == 1 ]]; then
      return_code=1
+     summary+="$task failed.\n"
+   else
+     summary+="$task succeeded.\n"
    fi
 done
-
+echo "$tag SUMMARY:\n"
+echo $summary
 exit $return_code
 

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -2,12 +2,14 @@
 
 # List all available gradle tasks, grep for the integration test tasks, and then use cut to strip the task description
 # and just return the name of the task, one for each module (e.g. aws-api:connectedDebugAndroidTest
+pwd
+ls
 tasks=($(gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1))
 
 # Run the integration tests for each module.  If it fails, retry.sh
 return_code=0
 for task in "${tasks[@]}"; do
-   retry.sh 3 ./gradlew $task --no-daemon
+   retry.sh 3 gradlew $task --no-daemon
    if [[ $? == 1 ]]; then
      return_code=1
    fi

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -4,12 +4,12 @@
 # and just return the name of the task, one for each module (e.g. aws-api:connectedDebugAndroidTest
 pwd
 ls
-tasks=($(gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1))
+tasks=($(./gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1))
 
 # Run the integration tests for each module.  If it fails, retry.sh
 return_code=0
 for task in "${tasks[@]}"; do
-   retry.sh 3 gradlew $task --no-daemon
+   .circleci/retry.sh 3 ./gradlew $task --no-daemon
    if [[ $? == 1 ]]; then
      return_code=1
    fi

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -10,7 +10,7 @@ summary=""
 tag="RUN_INTEGRATION_TESTS"
 for task in "${tasks[@]}"; do
   echo "$tag: $task"
-  .circleci/retry.sh 3 900 ./gradlew $task --no-daemon
+  .circleci/retry.sh 3 ./gradlew $task --no-daemon
   if [[ $? == 1 ]]; then
     return_code=1
     summary+="$task failed.\n"

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -19,6 +19,6 @@ for task in "${tasks[@]}"; do
   fi
 done
 echo "$tag SUMMARY:\n"
-echo $summary
+printf $summary
 exit $return_code
 

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# List all available gradle tasks, grep for the integration test tasks, and then use cut to strip the task description
+# and just return the name of the task, one for each module (e.g. aws-api:connectedDebugAndroidTest
+tasks=($(gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1))
+
+# Run the integration tests for each module.  If it fails, retry.sh
+return_code=0
+for task in "${tasks[@]}"; do
+   retry.sh 3 gradlew $task --no-daemon
+   if [[ $? == 1 ]]; then
+     return_code=1
+   fi
+done
+
+exit $return_code
+

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -9,14 +9,14 @@ return_code=0
 summary=""
 tag="RUN_INTEGRATION_TESTS"
 for task in "${tasks[@]}"; do
-   echo "$tag: $task"
-   .circleci/retry.sh 3 ./gradlew $task --no-daemon
-   if [[ $? == 1 ]]; then
-     return_code=1
-     summary+="$task failed.\n"
-   else
-     summary+="$task succeeded.\n"
-   fi
+  echo "$tag: $task"
+  .circleci/retry.sh 3 ./gradlew $task --no-daemon
+  if [[ $? == 1 ]]; then
+    return_code=1
+    summary+="$task failed.\n"
+  else
+    summary+="$task succeeded.\n"
+  fi
 done
 echo "$tag SUMMARY:\n"
 echo $summary

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -5,12 +5,13 @@ return_code=0
 
 # List all available gradle tasks, grep for the integration test tasks, and then use cut to strip the task description
 # and just return the name of the task, one for each module (e.g. aws-api:connectedDebugAndroidTest)
-tasks=($(./gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1))
+tasks=()
+while IFS='' read -r line; do tasks+=("$line"); done < <(./gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1)
 
 # Run the integration tests for each module.  Make up to 3 attempts on each module before failing.
 for task in "${tasks[@]}"; do
   echo "$tag: Starting $task"
-  .circleci/retry.sh 3 ./gradlew $task --no-daemon
+  .circleci/retry.sh 3 "./gradlew $task --no-daemon"
   if [[ $? == 1 ]]; then
     return_code=1
     echo "$tag: $task failed."

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -10,7 +10,7 @@ summary=""
 tag="RUN_INTEGRATION_TESTS"
 for task in "${tasks[@]}"; do
   echo "$tag: $task"
-  .circleci/retry.sh 3 ./gradlew $task --no-daemon
+  .circleci/retry.sh 3 900 ./gradlew $task --no-daemon
   if [[ $? == 1 ]]; then
     return_code=1
     summary+="$task failed.\n"

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -8,13 +8,13 @@ tasks=($(./gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 
 return_code=0
 tag="RUN_INTEGRATION_TESTS"
 for task in "${tasks[@]}"; do
-  echo "$tag: $task"
+  echo "$tag: Starting $task"
   .circleci/retry.sh 3 ./gradlew $task --no-daemon
   if [[ $? == 1 ]]; then
     return_code=1
-    echo "$task failed."
+    echo "$tag: $task failed."
   else
-    echo "$task succeeded."
+    echo "$tag: $task succeeded."
   fi
 done
 exit $return_code

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+tag="RUN_INTEGRATION_TESTS"
+return_code=0
+
 # List all available gradle tasks, grep for the integration test tasks, and then use cut to strip the task description
-# and just return the name of the task, one for each module (e.g. aws-api:connectedDebugAndroidTest
+# and just return the name of the task, one for each module (e.g. aws-api:connectedDebugAndroidTest)
 tasks=($(./gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1))
 
-# Run the integration tests for each module.  If it fails, retry.sh
-return_code=0
-tag="RUN_INTEGRATION_TESTS"
+# Run the integration tests for each module.  Make up to 3 attempts on each module before failing.
 for task in "${tasks[@]}"; do
   echo "$tag: Starting $task"
   .circleci/retry.sh 3 ./gradlew $task --no-daemon

--- a/.circleci/run-integration-tests.sh
+++ b/.circleci/run-integration-tests.sh
@@ -2,8 +2,6 @@
 
 # List all available gradle tasks, grep for the integration test tasks, and then use cut to strip the task description
 # and just return the name of the task, one for each module (e.g. aws-api:connectedDebugAndroidTest
-pwd
-ls
 tasks=($(./gradlew tasks --all | grep connectedDebugAndroidTest | cut -d " " -f 1))
 
 # Run the integration tests for each module.  If it fails, retry.sh

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
@@ -199,7 +199,7 @@ public final class GraphQLInstrumentationTest {
                 new GsonVariablesSerializer()
             )
         );
-        assertEquals("It's going to be exciting!", createdComment.content());
+        assertEquals("It's going to be fun!", createdComment.content());
     }
 
     /**

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
@@ -199,7 +199,7 @@ public final class GraphQLInstrumentationTest {
                 new GsonVariablesSerializer()
             )
         );
-        assertEquals("It's going to be fun!", createdComment.content());
+        assertEquals("It's going to be exciting!", createdComment.content());
     }
 
     /**


### PR DESCRIPTION
With these changes, I was able to get a green checkmark on the `integrationtest` step 4 out of 5 times.  The [one failure](https://app.circleci.com/pipelines/github/aws-amplify/amplify-android/1915/workflows/351584cc-d22c-42e4-a9a3-bfc061a5909c/jobs/3716/steps) was because the emulator didn't start.

 - Integration tests now run one module at a time (e.g. `./gradlew aws-api:connectedDebugAndroidTest` instead of `./gradlew connectedDebugAndroidTest`, and retry logic is applied at the module level.  So, if an `aws-api` integration test fails, it only retries `aws-api`, instead of the whole suite. 
 - Updated hash for codecov.io/bash script, since there was an update to the script.

I have a hunch that the main reason for the improvement here is actually not because of modularizing retries, but because the tasks are not running in parallel anymore. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
