### PR TITLE
fix(DataStore): remove unnecessary observeOn call

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -93,7 +93,6 @@ final class SubscriptionProcessor {
         }
         ongoingOperationsDisposable.add(Observable.merge(subscriptions)
             .subscribeOn(Schedulers.io())
-            .observeOn(Schedulers.io())
             .doOnSubscribe(disposable ->
                 LOG.info(String.format(Locale.US,
                     "Began buffering subscription events for remote mutations %s to Cloud models of types %s.",

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -98,7 +98,6 @@ final class SyncProcessor {
         return Observable.fromIterable(modelProvider.models())
             // Heavy network traffic, we require this to be done on IO scheduler.
             .subscribeOn(Schedulers.io())
-            .observeOn(Schedulers.io())
             // For each model class, find the last time it was sync'd.
             .flatMapCompletable(modelClass ->
                 syncTimeRegistry.lookupLastSyncTime(modelClass)


### PR DESCRIPTION
calling observeOn with the same schedulers wont change the below rxjava stream's running thread.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
