### PR TITLE
fix(core): update com.amazonaws.amplify.core package name

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
    permissions and limitations under the License.
 -->
 
-<manifest package="com.amazonaws.amplify.core"
+<manifest package="com.amplifyframework.core"
         xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/core/src/main/java/com/amplifyframework/util/UserAgent.java
+++ b/core/src/main/java/com/amplifyframework/util/UserAgent.java
@@ -20,7 +20,7 @@ import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.amazonaws.amplify.core.BuildConfig;
+import com.amplifyframework.core.BuildConfig;
 
 /**
  * A utility to construct a User-Agent header, to be sent with all network operations.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Changed the package name com.amazonaws.amplify.core to com.amplifyframework.core, since the package com.amazonaws.amplify.core does not exist.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
