### PR TITLE
[aws-datastore] fix model name plural form creation in AppSyncRequestFactory

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -91,15 +91,22 @@ final class AppSyncRequestFactory {
             throws DataStoreException {
 
         final StringBuilder doc = new StringBuilder();
-        final String capitalizedModelName = Casing.capitalizeFirst(modelClass.getSimpleName());
+
+        ModelSchema schema;
+        try {
+            schema = ModelSchema.fromModelClass(modelClass);
+        } catch (AmplifyException amplifyException) {
+            throw new DataStoreException("Failed to get fields for model.",
+                    amplifyException, "Validate your model file.");
+        }
+        final String capitalizedPluralName = Casing.capitalizeFirst(schema.getPluralName());
 
         int indent = 0;
         // Outer container, e.g. query SyncBlogPost {
-        doc.append("query Sync").append(capitalizedModelName).append("s {\n");
+        doc.append("query Sync").append(capitalizedPluralName).append(" {\n");
 
         // Inner directive, e.g. syncBlogPosts(
-        doc.append(padBy(++indent))
-            .append("sync").append(capitalizedModelName).append("s");
+        doc.append(padBy(++indent)).append("sync").append(capitalizedPluralName);
 
         // Optional param for inner directive, i.e. (lastSync: 123123)
         // (lastSync:11123123, nextToken: "asdfasdfaS")


### PR DESCRIPTION
fixes #588 

*Description of changes:*
AppSyncRequestFactory uses "simple" plural form creation instead of making use of ModelSchema.pluralName

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
