### PR TITLE
chore(predictions): Fix testIdentifyEntities by adding a buffer to the ageRange check

### DIFF
--- a/aws-predictions/src/androidTest/java/com/amplifyframework/predictions/aws/AWSPredictionsIdentifyEntitiesTest.java
+++ b/aws-predictions/src/androidTest/java/com/amplifyframework/predictions/aws/AWSPredictionsIdentifyEntitiesTest.java
@@ -89,6 +89,16 @@ public final class AWSPredictionsIdentifyEntitiesTest {
         FeatureAssert.assertMatches(GenderBinaryType.MALE, entity.getGender());
         FeatureAssert.assertMatches(EmotionType.HAPPY, Collections.max(entity.getEmotions()));
         assertNotNull(entity.getAgeRange());
-        assertTrue(entity.getAgeRange().contains(56));
+
+        int jeffAge = 56;
+
+        // When this test was created, Rekognition returned an age range containing Jeff's age.  The algorithm
+        // recently changed to predict an age range of 37-55.  The goal of this test is to verify a sane response,
+        // not verify the accurate of Rekognition, so we will add a 20 year buffer to the age range (e.g. if age range
+        // is 37 to 55, the test will pass because 56 is still between 37-20 (17) and 55+20 (75)).
+        int buffer = 20;
+
+        assertTrue(jeffAge <= entity.getAgeRange().getHigh() + buffer);
+        assertTrue(jeffAge >= entity.getAgeRange().getLow() - buffer);
     }
 }


### PR DESCRIPTION
In regards to our discussion about whether our integration tests should call real services, or instead, mock the responses, I think there is value to both approaches.  Tests that mock responses should be sufficient to verify we don't cause regressions in our Amplify code.  On the other hand, tests that call real services verify that Amplify is useful to customers, and are useful to reference when answering usage questions for customers.

That said, this PR fixes `testIdentifyEntities` in `aws-predictions`, which is an integration test which calls a real service.  The test submits a photo of Jeff Bezos to Rekognition, and verifies that his age (56) is within the predicted range.  Recently, the algorithm must have changed, and the predicted range is now 37-55.   To reduce our reliance on the accuracy of the Rekognition service itself, I've added a 20 year buffer on each side, so now the test simply verifies that ageRange.getLow() <= 76 and ageRange.getHigh() >= 36.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
