### PR TITLE
feat(DataStore) add sorting

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -28,6 +28,7 @@ import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.PrimaryKey;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.QueryPaginationInput;
+import com.amplifyframework.core.model.query.QuerySortBy;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
@@ -250,6 +251,27 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                     .append("?");
             bindings.add(paginationInput.getLimit());
             bindings.add(paginationInput.getPage() * paginationInput.getLimit());
+        }
+
+        // Append order by
+        final List<QuerySortBy> sortByList = options.getSortBy();
+        if (sortByList != null) {
+            rawQuery.append(SqlKeyword.DELIMITER)
+                    .append(SqlKeyword.ORDER_BY)
+                    .append(SqlKeyword.DELIMITER);
+            Iterator<QuerySortBy> sortByIterator = sortByList.iterator();
+            while (sortByIterator.hasNext()) {
+                final QuerySortBy sortBy = sortByIterator.next();
+                SQLiteColumn column = table.getColumn(sortBy.getField());
+                rawQuery.append(Wrap.inBackticks(column.getAliasedName()))
+                        .append(SqlKeyword.DELIMITER)
+                        .append(SqlKeyword.fromQuerySortOrder(sortBy.getSortOrder()));
+
+                if (sortByIterator.hasNext()) {
+                    rawQuery.append(",")
+                            .append(SqlKeyword.DELIMITER);
+                }
+            }
         }
 
         rawQuery.append(";");

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -372,7 +372,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             try (Cursor cursor = getQueryAllCursor(itemClass.getSimpleName(), options)) {
                 LOG.debug("Querying item for: " + itemClass.getSimpleName());
 
-                final Set<T> models = new HashSet<>();
+                final List<T> models = new ArrayList<>();
                 final ModelSchema modelSchema =
                     modelSchemaRegistry.getModelSchemaForModelClass(itemClass.getSimpleName());
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.storage.sqlite;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.core.model.query.QuerySortOrder;
 import com.amplifyframework.core.model.query.predicate.QueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup;
 
@@ -149,10 +150,26 @@ public enum SqlKeyword {
     /**
      * SQL keyword to specify a size limit of the result set (used for paginating results).
      */
-    LIMIT("LIMIT");
+    LIMIT("LIMIT"),
+
+    /**
+     * SQL keyword to specify a column to sort the results by.
+     */
+    ORDER_BY("ORDER BY"),
+
+    /**
+     * SQL keyword meaning to sort in ascending order, for use with ORDER_BY.
+     */
+    ASC("ASC"),
+
+    /**
+     * SQL keyword meaning to sort in descending order, for use with ORDER_BY.
+     */
+    DESC("DESC");
 
     private static final Map<QueryOperator.Type, SqlKeyword> QUERY_OPERATOR_TO_SQL = new HashMap<>();
     private static final Map<QueryPredicateGroup.Type, SqlKeyword> QUERY_PREDICATE_GROUP_TO_SQL = new HashMap<>();
+    private static final Map<QuerySortOrder, SqlKeyword> QUERY_SORT_BY_TO_SQL = new HashMap<>();
 
     private final String stringValue;
 
@@ -167,6 +184,9 @@ public enum SqlKeyword {
         QUERY_PREDICATE_GROUP_TO_SQL.put(QueryPredicateGroup.Type.AND, SqlKeyword.AND);
         QUERY_PREDICATE_GROUP_TO_SQL.put(QueryPredicateGroup.Type.OR, SqlKeyword.OR);
         QUERY_PREDICATE_GROUP_TO_SQL.put(QueryPredicateGroup.Type.NOT, SqlKeyword.NOT);
+
+        QUERY_SORT_BY_TO_SQL.put(QuerySortOrder.ASCENDING, SqlKeyword.ASC);
+        QUERY_SORT_BY_TO_SQL.put(QuerySortOrder.DESCENDING, SqlKeyword.DESC);
     }
 
     SqlKeyword(String stringValue) {
@@ -198,6 +218,21 @@ public enum SqlKeyword {
         if (null == sqlKeyword) {
             throw new IllegalArgumentException(
                     "No SQL keyword mapping defined for query predicate group type = " + groupType.toString()
+            );
+        }
+        return sqlKeyword;
+    }
+
+    /**
+     * Retrieve the SQL specific keyword for the query sort order type.
+     * @param sortOrder the query sort order type
+     * @return the SQL specific keyword
+     */
+    public static SqlKeyword fromQuerySortOrder(@NonNull QuerySortOrder sortOrder) {
+        final SqlKeyword sqlKeyword = QUERY_SORT_BY_TO_SQL.get(Objects.requireNonNull(sortOrder));
+        if (null == sqlKeyword) {
+            throw new IllegalArgumentException(
+                    "No SQL keyword mapping defined for query sort order type = " + sortOrder.toString()
             );
         }
         return sqlKeyword;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
@@ -198,6 +198,7 @@ public enum SqlKeyword {
      * @param queryOperatorType the query operator type
      * @return the SQL specific keyword
      */
+    @NonNull
     public static SqlKeyword fromQueryOperator(@NonNull QueryOperator.Type queryOperatorType) {
         final SqlKeyword sqlKeyword = QUERY_OPERATOR_TO_SQL.get(Objects.requireNonNull(queryOperatorType));
         if (null == sqlKeyword) {
@@ -213,6 +214,7 @@ public enum SqlKeyword {
      * @param groupType the query predicate group type
      * @return the SQL specific keyword
      */
+    @NonNull
     public static SqlKeyword fromQueryPredicateGroup(@NonNull QueryPredicateGroup.Type groupType) {
         final SqlKeyword sqlKeyword = QUERY_PREDICATE_GROUP_TO_SQL.get(Objects.requireNonNull(groupType));
         if (null == sqlKeyword) {
@@ -228,6 +230,7 @@ public enum SqlKeyword {
      * @param sortOrder the query sort order type
      * @return the SQL specific keyword
      */
+    @NonNull
     public static SqlKeyword fromQuerySortOrder(@NonNull QuerySortOrder sortOrder) {
         final SqlKeyword sqlKeyword = QUERY_SORT_BY_TO_SQL.get(Objects.requireNonNull(sortOrder));
         if (null == sqlKeyword) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
@@ -176,9 +176,9 @@ public final class SQLiteTable {
     }
 
     /**
-     * Returns the SQLiteColumn for the provided columnName.
-     * @param columnName columnName of the column
-     * @return the SQLiteColumn for the provided columnName.
+     * Returns the SQLiteColumn for the provided column name.
+     * @param columnName name of the column
+     * @return the SQLiteColumn for the provided column name.
      * @throws DataStoreException if no column is found for the provided columnName.
      */
     @NonNull

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
@@ -19,10 +19,12 @@ import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.ModelAssociation;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.PrimaryKey;
+import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.sqlite.SQLiteDataType;
 import com.amplifyframework.datastore.storage.sqlite.TypeConverter;
 import com.amplifyframework.util.Immutable;
@@ -171,6 +173,22 @@ public final class SQLiteTable {
             }
         }
         return Immutable.of(foreignKeys);
+    }
+
+    /**
+     * Returns the SQLiteColumn for the provided columnName.
+     * @param columnName columnName of the column
+     * @return the SQLiteColumn for the provided columnName.
+     * @throws DataStoreException if no column is found for the provided columnName.
+     */
+    @NonNull
+    public SQLiteColumn getColumn(@NonNull String columnName) throws DataStoreException {
+        SQLiteColumn column = columns.get(Objects.requireNonNull(columnName));
+        if (column == null) {
+            throw new DataStoreException("Column with columnName " + columnName + " not found in " + name,
+                    AmplifyException.TODO_RECOVERY_SUGGESTION);
+        }
+        return column;
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -25,6 +25,8 @@ import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.query.Page;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.QueryPaginationInput;
+import com.amplifyframework.core.model.query.QuerySortBy;
+import com.amplifyframework.core.model.query.QuerySortOrder;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.syncengine.PendingMutation;
@@ -219,6 +221,27 @@ public class SqlCommandTest {
         assertEquals(2, bindings.size());
         assertEquals(1, bindings.get(0));
         assertEquals(0, bindings.get(1));
+    }
+
+    /**
+     * Validates that a query, with an order by clause is generated correctly.
+     * @throws DataStoreException From {@link SQLCommandFactory#queryFor(ModelSchema, QueryOptions)}
+     */
+    @Test
+    public void queryWithSortBy() throws DataStoreException {
+        final ModelSchema personSchema = getPersonModelSchema();
+        final SqlCommand sqlCommand = sqlCommandFactory.queryFor(
+                personSchema,
+                Where.matchesAll().sorted(
+                        new QuerySortBy("lastName", QuerySortOrder.ASCENDING),
+                        new QuerySortBy("firstName", QuerySortOrder.DESCENDING))
+        );
+        assertNotNull(sqlCommand);
+        assertEquals(
+                PERSON_BASE_QUERY + " ORDER BY `Person_lastName` ASC, `Person_firstName` DESC;",
+                sqlCommand.sqlStatement()
+        );
+        assertEquals(0, sqlCommand.getBindings().size());
     }
 
     private static ModelSchema getPersonModelSchema() {

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -21,7 +21,9 @@ import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
+import com.amplifyframework.util.Immutable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -60,8 +62,7 @@ public final class QueryOptions {
      */
     @NonNull
     public QueryOptions matches(@NonNull final QueryPredicate queryPredicate) {
-        this.queryPredicate = queryPredicate;
-        return this;
+        return new QueryOptions(queryPredicate, paginationInput, sortBy);
     }
 
     /**
@@ -74,19 +75,19 @@ public final class QueryOptions {
      */
     @NonNull
     public QueryOptions paginated(@NonNull final QueryPaginationInput paginationInput) {
-        this.paginationInput = paginationInput;
-        return this;
+        return new QueryOptions(queryPredicate, paginationInput, sortBy);
     }
 
     /**
-     * Updates the current options with a given {@code sortBy}.
+     * Appends the given {@code sortBy} arguments to the list of {@link QuerySortBy} elements.
      *
-     * @param sortBy sorting information
+     * @param querySortBy sorting information
      * @return current options with an updated {@code sortBy}.
      */
-    public QueryOptions sorted(@NonNull final QuerySortBy... sortBy) {
-        this.sortBy = Arrays.asList(sortBy);
-        return this;
+    public QueryOptions sorted(@NonNull final QuerySortBy... querySortBy) {
+        List<QuerySortBy> augmentedList = this.sortBy != null ? new ArrayList<>(this.sortBy) : new ArrayList<>();
+        augmentedList.addAll(Immutable.of(Arrays.asList(querySortBy)));
+        return new QueryOptions(queryPredicate, paginationInput, Immutable.of(augmentedList));
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -108,8 +108,8 @@ public final class QueryOptions {
     }
 
     /**
-     * Returns the {@code sortInput} property.
-     * @return the {@code sortInput} property.
+     * Returns the {@code sortBy} property.
+     * @return the {@code sortBy} property.
      */
     @Nullable
     public List<QuerySortBy> getSortBy() {

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -83,7 +83,7 @@ public final class QueryOptions {
      * @return current options with an updated {@code sortBy}.
      */
     public QueryOptions sorted(@NonNull final QuerySortBy... querySortBy) {
-        return new QueryOptions(queryPredicate, paginationInput, Arrays.asList(querySortBy));
+        return new QueryOptions(queryPredicate, paginationInput, Arrays.asList(Objects.requireNonNull(querySortBy)));
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -21,9 +21,7 @@ import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
-import com.amplifyframework.util.Immutable;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -55,7 +53,7 @@ public final class QueryOptions {
     }
 
     /**
-     * Update the current options with a given {@code queryPredicate}.
+     * Returns an immutable copy of the current query options with the given {@code queryPredicate}.
      *
      * @param queryPredicate predicate.
      * @return current options with an updated {@code queryPredicate}.
@@ -66,7 +64,7 @@ public final class QueryOptions {
     }
 
     /**
-     * Updates the current options with a given {@code paginationInput}.
+     * Returns an immutable copy of the current query options with the given {@code paginationInput}.
      *
      * @param paginationInput pagination information.
      * @return current options with an updated {@code paginationInput}.
@@ -79,15 +77,13 @@ public final class QueryOptions {
     }
 
     /**
-     * Appends the given {@code sortBy} arguments to the list of {@link QuerySortBy} elements.
+     * Returns an immutable copy of the current query options with the the given {@code sortBy} arguments.
      *
-     * @param querySortBy sorting information
+     * @param querySortBy sorting information.
      * @return current options with an updated {@code sortBy}.
      */
     public QueryOptions sorted(@NonNull final QuerySortBy... querySortBy) {
-        List<QuerySortBy> augmentedList = this.sortBy != null ? new ArrayList<>(this.sortBy) : new ArrayList<>();
-        augmentedList.addAll(Immutable.of(Arrays.asList(querySortBy)));
-        return new QueryOptions(queryPredicate, paginationInput, Immutable.of(augmentedList));
+        return new QueryOptions(queryPredicate, paginationInput, Arrays.asList(querySortBy));
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -22,6 +22,9 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * A data structure that provides a query construction mechanism that consolidates all query-related
  * options (e.g. predicates, pagination, etc) and allows consumers to build queries in a fluent way.
@@ -29,6 +32,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 public final class QueryOptions {
     private QueryPredicate queryPredicate;
     private QueryPaginationInput paginationInput;
+    private List<QuerySortBy> sortBy;
 
     /**
      * This class should be created using the factory methods such as {@link Where#matchesAll()}
@@ -36,14 +40,28 @@ public final class QueryOptions {
      */
     QueryOptions(
             @Nullable QueryPredicate queryPredicate,
-            @Nullable QueryPaginationInput paginationInput
+            @Nullable QueryPaginationInput paginationInput,
+            @Nullable List<QuerySortBy> sortBy
     ) {
         this.queryPredicate = queryPredicate == null ? QueryPredicates.all() : queryPredicate;
         this.paginationInput = paginationInput;
+        this.sortBy = sortBy;
     }
 
     QueryOptions() {
-        this(null, null);
+        this(null, null, null);
+    }
+
+    /**
+     * Update the current options with a given {@code queryPredicate}.
+     *
+     * @param queryPredicate predicate.
+     * @return current options with an updated {@code queryPredicate}.
+     */
+    @NonNull
+    public QueryOptions matches(@NonNull final QueryPredicate queryPredicate) {
+        this.queryPredicate = queryPredicate;
+        return this;
     }
 
     /**
@@ -57,6 +75,17 @@ public final class QueryOptions {
     @NonNull
     public QueryOptions paginated(@NonNull final QueryPaginationInput paginationInput) {
         this.paginationInput = paginationInput;
+        return this;
+    }
+
+    /**
+     * Updates the current options with a given {@code sortBy}.
+     *
+     * @param sortBy sorting information
+     * @return current options with an updated {@code sortBy}.
+     */
+    public QueryOptions sorted(@NonNull final QuerySortBy... sortBy) {
+        this.sortBy = Arrays.asList(sortBy);
         return this;
     }
 
@@ -78,6 +107,15 @@ public final class QueryOptions {
         return paginationInput;
     }
 
+    /**
+     * Returns the {@code sortInput} property.
+     * @return the {@code sortInput} property.
+     */
+    @Nullable
+    public List<QuerySortBy> getSortBy() {
+        return sortBy;
+    }
+
     @Override
     public boolean equals(@Nullable Object object) {
         if (this == object) {
@@ -88,12 +126,13 @@ public final class QueryOptions {
         }
         QueryOptions that = (QueryOptions) object;
         return ObjectsCompat.equals(queryPredicate, that.queryPredicate) &&
-                ObjectsCompat.equals(paginationInput, that.paginationInput);
+                ObjectsCompat.equals(paginationInput, that.paginationInput) &&
+                ObjectsCompat.equals(sortBy, that.sortBy);
     }
 
     @Override
     public int hashCode() {
-        return ObjectsCompat.hash(queryPredicate, paginationInput);
+        return ObjectsCompat.hash(queryPredicate, paginationInput, sortBy);
     }
 
     @NonNull
@@ -102,6 +141,7 @@ public final class QueryOptions {
         return "QueryOptions{" +
                 "queryPredicate=" + queryPredicate +
                 ", paginationInput=" + paginationInput +
+                ", sortInput=" + sortBy +
                 '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -77,7 +77,7 @@ public final class QueryOptions {
     }
 
     /**
-     * Returns an immutable copy of the current query options with the the given {@code sortBy} arguments.
+     * Returns an immutable copy of the current query options with the given {@code sortBy} arguments.
      *
      * @param querySortBy sorting information.
      * @return current options with an updated {@code sortBy}.

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -141,7 +141,7 @@ public final class QueryOptions {
         return "QueryOptions{" +
                 "queryPredicate=" + queryPredicate +
                 ", paginationInput=" + paginationInput +
-                ", sortInput=" + sortBy +
+                ", sortBy=" + sortBy +
                 '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QueryOptions.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A data structure that provides a query construction mechanism that consolidates all query-related
@@ -60,7 +61,7 @@ public final class QueryOptions {
      */
     @NonNull
     public QueryOptions matches(@NonNull final QueryPredicate queryPredicate) {
-        return new QueryOptions(queryPredicate, paginationInput, sortBy);
+        return new QueryOptions(Objects.requireNonNull(queryPredicate), paginationInput, sortBy);
     }
 
     /**
@@ -73,7 +74,7 @@ public final class QueryOptions {
      */
     @NonNull
     public QueryOptions paginated(@NonNull final QueryPaginationInput paginationInput) {
-        return new QueryOptions(queryPredicate, paginationInput, sortBy);
+        return new QueryOptions(queryPredicate, Objects.requireNonNull(paginationInput), sortBy);
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
@@ -18,7 +18,7 @@ package com.amplifyframework.core.model.query;
 /**
  * A simple data structure that holds sort information that can be applied queries.
  */
-public class QuerySortBy {
+public final class QuerySortBy {
     private final String field;
     private final QuerySortOrder sortOrder;
 
@@ -31,5 +31,21 @@ public class QuerySortBy {
     public QuerySortBy(String field, QuerySortOrder sortOrder) {
         this.field = field;
         this.sortOrder = sortOrder;
+    }
+
+    /**
+     * Returns the field to sort by.
+     * @return the field to sort by.
+     */
+    public String getField() {
+        return field;
+    }
+
+    /**
+     * Returns the order to sort by, either ASCENDING or DESCENDING.
+     * @return the order to sort by, either ASCENDING or DESCENDING.
+     */
+    public QuerySortOrder getSortOrder() {
+        return sortOrder;
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * A data structure representing a model field and an order to sort by (ascending or descending), used to specify the
  * order of results from {@link DataStoreCategoryBehavior#query(Class, QueryOptions, Consumer, Consumer)}.
  *
- * The preferred way to create a QuerySortBy is with the @{@link QueryField#ascending()} and
+ * The preferred way to create a QuerySortBy is with the {@link QueryField#ascending()} and
  * {@link QueryField#descending()} helper methods (e.g. Todo.DESCRIPTION.ascending() or Todo.DESCRIPTION.descending())
  */
 public final class QuerySortBy {

--- a/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model.query;
+
+/**
+ * A simple data structure that holds sort information that can be applied queries.
+ */
+public class QuerySortBy {
+    private final String field;
+    private final QuerySortOrder sortOrder;
+
+    /**
+     * Constructor for {@code QuerySortBy}.
+     *
+     * @param field name of field to sort by.
+     * @param sortOrder order to sort by, either ASCENDING or DESCENDING.
+     */
+    public QuerySortBy(String field, QuerySortOrder sortOrder) {
+        this.field = field;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
@@ -15,8 +15,21 @@
 
 package com.amplifyframework.core.model.query;
 
+import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+import com.amplifyframework.datastore.DataStoreCategoryBehavior;
+
+import java.util.Objects;
+
 /**
- * A simple data structure that holds sort information that can be applied queries.
+ * A data structure representing a model field and an order to sort by (ascending or descending), used to specify the
+ * order of results from {@link DataStoreCategoryBehavior#query(Class, QueryOptions, Consumer, Consumer)}.
+ *
+ * The preferred way to create a QuerySortBy is with the @{@link QueryField#ascending()} and
+ * {@link QueryField#descending()} helper methods (e.g. Todo.DESCRIPTION.ascending() or Todo.DESCRIPTION.descending())
  */
 public final class QuerySortBy {
     private final String field;
@@ -28,9 +41,9 @@ public final class QuerySortBy {
      * @param field name of field to sort by.
      * @param sortOrder order to sort by, either ASCENDING or DESCENDING.
      */
-    public QuerySortBy(String field, QuerySortOrder sortOrder) {
-        this.field = field;
-        this.sortOrder = sortOrder;
+    public QuerySortBy(@NonNull String field, @NonNull QuerySortOrder sortOrder) {
+        this.field = Objects.requireNonNull(field);
+        this.sortOrder = Objects.requireNonNull(sortOrder);
     }
 
     /**
@@ -47,5 +60,33 @@ public final class QuerySortBy {
      */
     public QuerySortOrder getSortOrder() {
         return sortOrder;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        QuerySortBy that = (QuerySortBy) object;
+        return ObjectsCompat.equals(field, that.field) &&
+                ObjectsCompat.equals(sortOrder, that.sortOrder);
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(field, sortOrder);
+    }
+
+    @Override
+    public String toString() {
+        return "QuerySortBy{" +
+                "field='" + field + '\'' +
+                ", sortOrder=" + sortOrder +
+                '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/QuerySortOrder.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QuerySortOrder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model.query;
+
+/**
+ * Enum used to specify whether to sort ascending or descending when performing a query.
+ */
+public enum QuerySortOrder {
+    /**
+     * Sort ascending.
+     */
+    ASCENDING,
+
+    /**
+     * Sort descending.
+     */
+    DESCENDING;
+}

--- a/core/src/main/java/com/amplifyframework/core/model/query/Where.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/Where.java
@@ -21,6 +21,7 @@ import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Query DSL for query predicates.
@@ -44,7 +45,7 @@ public final class Where {
      * @return options with a given predicate.
      */
     public static QueryOptions matches(@NonNull final QueryPredicate queryPredicate) {
-        return new QueryOptions(queryPredicate, null, null);
+        return new QueryOptions(Objects.requireNonNull(queryPredicate), null, null);
     }
 
     /**
@@ -55,7 +56,7 @@ public final class Where {
      * @return options with proper predicate and pagination to match a model by its id.
      */
     public static QueryOptions id(@NonNull final String modelId) {
-        return matches(QueryField.field("id").eq(modelId)).paginated(Page.firstResult());
+        return matches(QueryField.field("id").eq(Objects.requireNonNull(modelId))).paginated(Page.firstResult());
     }
 
     /**
@@ -65,7 +66,7 @@ public final class Where {
      * @return options with the given sortBy fields.
      */
     public static QueryOptions paginated(@NonNull final QueryPaginationInput paginationInput) {
-        return new QueryOptions(null, paginationInput, null);
+        return new QueryOptions(null, Objects.requireNonNull(paginationInput), null);
     }
 
     /**
@@ -75,6 +76,6 @@ public final class Where {
      * @return options with the given sortBy fields.
      */
     public static QueryOptions sorted(@NonNull final QuerySortBy... sortBy) {
-        return new QueryOptions(null, null, Arrays.asList(sortBy));
+        return new QueryOptions(null, null, Arrays.asList(Objects.requireNonNull(sortBy)));
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/Where.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/Where.java
@@ -20,6 +20,8 @@ import androidx.annotation.NonNull;
 import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 
+import java.util.Arrays;
+
 /**
  * Query DSL for query predicates.
  */
@@ -42,7 +44,7 @@ public final class Where {
      * @return options with a given predicate.
      */
     public static QueryOptions matches(@NonNull final QueryPredicate queryPredicate) {
-        return new QueryOptions(queryPredicate, null);
+        return new QueryOptions(queryPredicate, null, null);
     }
 
     /**
@@ -54,5 +56,25 @@ public final class Where {
      */
     public static QueryOptions id(@NonNull final String modelId) {
         return matches(QueryField.field("id").eq(modelId)).paginated(Page.firstResult());
+    }
+
+    /**
+     * Factory method that builds the options with the given {@link QueryPaginationInput}.
+     *
+     * @param paginationInput the pagination details
+     * @return options with the given sortBy fields.
+     */
+    public static QueryOptions paginated(@NonNull final QueryPaginationInput paginationInput) {
+        return new QueryOptions(null, paginationInput, null);
+    }
+
+    /**
+     * Factory method that builds the options with the given {@link QuerySortBy} arguments.
+     *
+     * @param sortBy a varargs list of QuerySortBy options, in the order in which they are to be applied.
+     * @return options with the given sortBy fields.
+     */
+    public static QueryOptions sorted(@NonNull final QuerySortBy... sortBy) {
+        return new QueryOptions(null, null, Arrays.asList(sortBy));
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryField.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryField.java
@@ -15,6 +15,9 @@
 
 package com.amplifyframework.core.model.query.predicate;
 
+import com.amplifyframework.core.model.query.QuerySortBy;
+import com.amplifyframework.core.model.query.QuerySortOrder;
+
 /**
  * Represents a property in a model with methods for chaining conditions.
  */
@@ -124,5 +127,23 @@ public final class QueryField {
      */
     public QueryPredicateOperation<String> contains(String value) {
         return new QueryPredicateOperation<>(fieldName, new ContainsQueryOperator(value));
+    }
+
+    /**
+     * Generates a new sort object specifying a field that should be sorted in ascending order for a query.
+     *
+     * @return a QuerySortBy object, representing a field that should be sorted in ascending order for a query.
+     */
+    public QuerySortBy ascending() {
+        return new QuerySortBy(fieldName, QuerySortOrder.ASCENDING);
+    }
+
+    /**
+     * Generates a new sort object specifying a field that should be sorted in descending order for a query.
+     *
+     * @return a QuerySortBy object, representing a field that should be sorted in descending order for a query.
+     */
+    public QuerySortBy descending() {
+        return new QuerySortBy(fieldName, QuerySortOrder.DESCENDING);
     }
 }

--- a/core/src/test/java/com/amplifyframework/util/WrapTest.java
+++ b/core/src/test/java/com/amplifyframework/util/WrapTest.java
@@ -25,6 +25,23 @@ import static org.junit.Assert.assertNull;
  */
 public final class WrapTest {
     /**
+     * Validate wrapping a string in back ticks.
+     */
+    @Test
+    public void wrapInBackTicksReturnsBackTickedString() {
+        assertEquals("`Hamburger`", Wrap.inBackticks("Hamburger"));
+    }
+
+    /**
+     * Don't try wrapping null into back ticks, just return null.
+     */
+    @Test
+    public void passThroughNullWithoutBackTicks() {
+        //noinspection ConstantConditions
+        assertNull(Wrap.inBackticks(null));
+    }
+
+    /**
      * Validate wrapping a string in single quotes.
      */
     @Test

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/BlogOwner.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/BlogOwner.java
@@ -1,18 +1,15 @@
 package com.amplifyframework.testmodels.commentsblog;
 
-import com.amplifyframework.core.model.annotations.HasOne;
-
-import java.util.List;
-import java.util.UUID;
-import java.util.Objects;
-
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.model.Model;
-import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.HasOne;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
 import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import java.util.Objects;
+import java.util.UUID;
 
 import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 
@@ -72,8 +69,18 @@ public final class BlogOwner implements Model {
       .toString()
       .hashCode();
   }
-  
-  public static NameStep builder() {
+
+    @Override
+    public String toString() {
+        return "BlogOwner{" +
+                "name='" + name + '\'' +
+                ", id='" + id + '\'' +
+                ", blog=" + blog +
+                ", wea='" + wea + '\'' +
+                '}';
+    }
+
+    public static NameStep builder() {
       return new Builder();
   }
   


### PR DESCRIPTION
### Summary 
 - This PR adds support for sorting on the `DataStore.query` API.  
 - Also, currently customers can only query for pagination if they also provide a predicate.  This PR adds a new `paginated` method on the `Where` builder so that a customer can specify just pagination if desired (`Where.paginated(Page.firstPage())`).

Sample DX:
```
        Amplify.DataStore.query(Todo.class,
                Where
                        .matches(Todo.NAME.beginsWith("foo").and(Todo.DESCRIPTION.beginsWith("bar")))
                        .paginated(Page.firstPage())
                        .sorted(Todo.NAME.ascending(), Todo.DESCRIPTION.descending(), Todo.ID.ascending()),
                response -> { },
                error -> { });
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
