### PR TITLE
chore: update api levels and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Guide](https://docs.amplify.aws/start/q/integration/android).
 
 ## Platform Support
 
-The Amplify Framework supports Android API level 16 (Android 4.1) and above.
+The Amplify Framework supports Android API level 21 (Android 5.0) and above.
 
 ## Using Amplify from Your App
 

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/UserAgentTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/UserAgentTest.java
@@ -95,8 +95,8 @@ public final class UserAgentTest {
      *          waiting for request
      */
     @Test
-    @Config(sdk = 16)
-    public void testUserAgentWithApi16() throws Exception {
+    @Config(sdk = 21)
+    public void testUserAgentWithApi21() throws Exception {
         String userAgent = checkUserAgent();
 
         // Assert the correct format and content
@@ -105,7 +105,7 @@ public final class UserAgentTest {
         assertTrue(regexMatcher.matches());
         assertEquals("amplify-android", regexMatcher.group("libraryName"));
         assertEquals("Android", regexMatcher.group("systemName"));
-        assertEquals("4.1.2", regexMatcher.group("systemVersion"));
+        assertEquals("5.0.2", regexMatcher.group("systemVersion"));
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageHelper.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.core.util.ObjectsCompat;
 
@@ -80,9 +79,7 @@ final class SQLiteStorageHelper extends SQLiteOpenHelper implements ModelUpdateS
     @Override
     public void onConfigure(SQLiteDatabase sqliteDatabase) {
         super.onConfigure(sqliteDatabase);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            sqliteDatabase.setForeignKeyConstraintsEnabled(true);
-        }
+        sqliteDatabase.setForeignKeyConstraintsEnabled(true);
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -44,13 +44,13 @@ task clean(type: Delete) {
 ext {
     buildToolsVersion = "29.0.2"
     compileSdkVersion = 29
-    minSdkVersion = 16
+    minSdkVersion = 21
     targetSdkVersion = 29
 
     awsSdkVersion = '2.16.12'
     dependency = [
         android: [
-            desugartools: 'com.android.tools:desugar_jdk_libs:1.0.5',
+            desugartools: 'com.android.tools:desugar_jdk_libs:1.0.9',
         ],
         androidx: [
             v4support: 'androidx.legacy:legacy-support-v4:1.0.0',


### PR DESCRIPTION
desugaring tools -> 1.0.9

The library will not currently run on API levels below 21. Reflect this
reality in the minSdkVersion as well as in the project README.md.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
