### PR TITLE
fix: update default release version name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx3g
 org.gradle.parallel=true
 
 GROUP=com.amplifyframework
-VERSION_NAME=master
+VERSION_NAME=main
 VERSION_CODE=1
 
 POM_URL=https://github.com/aws-amplify/amplify-android


### PR DESCRIPTION
The "master" branch is deleted, and this term is no longer being used.

We missed the update in gradle.properties, where the default release
name is kept.

The default branch is "main", and the default release name should match, and be "main", too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
