### PR TITLE
fix(datastore) add deserializers for dates

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/TemporalDeserializers.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/TemporalDeserializers.java
@@ -25,14 +25,18 @@ import com.google.gson.JsonParseException;
 import java.lang.reflect.Type;
 import java.util.concurrent.TimeUnit;
 
-final class TemporalDeserializers {
+/**
+ * Collection of deserializers for <a href="https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html">AWS
+ * AppSync temporal scalars</a>.
+ */
+public final class TemporalDeserializers {
     /**
      * Deserializer of Temporal.Date, an extended ISO-8601 Date string, with an optional timezone offset.
      *
      * Based on the <a href=https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html> AWS AppSync AWSDate
      * scalar.</a>
      */
-    static class DateDeserializer implements JsonDeserializer<Temporal.Date> {
+    public static final class DateDeserializer implements JsonDeserializer<Temporal.Date> {
         @Override
         public Temporal.Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {
@@ -46,7 +50,7 @@ final class TemporalDeserializers {
      * Based on the <a href=https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html>AWS AppSync AWSDateTime
      * scalar.</a>
      */
-    static class DateTimeDeserializer implements JsonDeserializer<Temporal.DateTime> {
+    public static final class DateTimeDeserializer implements JsonDeserializer<Temporal.DateTime> {
         @Override
         public Temporal.DateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {
@@ -60,7 +64,7 @@ final class TemporalDeserializers {
      * Based on the <a href=https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html>AWS AppSync AWSTime
      * scalar.</a>
      */
-    static class TimeDeserializer implements JsonDeserializer<Temporal.Time> {
+    public static final class TimeDeserializer implements JsonDeserializer<Temporal.Time> {
         @Override
         public Temporal.Time deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {
@@ -76,7 +80,7 @@ final class TemporalDeserializers {
      * Based on the <a href=https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html>AWS AppSync AWSTemporal
      * scalar.</a>
      */
-    static class TimestampDeserializer implements JsonDeserializer<Temporal.Timestamp> {
+    public static final class TimestampDeserializer implements JsonDeserializer<Temporal.Timestamp> {
         @Override
         public Temporal.Timestamp deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncResponseDeserializer.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncResponseDeserializer.java
@@ -19,8 +19,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.api.ApiCategoryBehavior;
+import com.amplifyframework.api.aws.TemporalDeserializers;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,6 +55,10 @@ final class AppSyncResponseDeserializer implements AppSyncClient.ResponseDeseria
     AppSyncResponseDeserializer() {
         this.gson = new GsonBuilder()
                 .registerTypeAdapter(List.class, new GsonListDeserializer())
+                .registerTypeAdapter(Temporal.Date.class, new TemporalDeserializers.DateDeserializer())
+                .registerTypeAdapter(Temporal.Time.class, new TemporalDeserializers.TimeDeserializer())
+                .registerTypeAdapter(Temporal.Timestamp.class, new TemporalDeserializers.TimestampDeserializer())
+                .registerTypeAdapter(Temporal.DateTime.class, new TemporalDeserializers.DateTimeDeserializer())
                 .create();
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncResponseDeserializerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncResponseDeserializerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.appsync;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.testmodels.meeting.Meeting;
+import com.amplifyframework.testutils.Resources;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class AppSyncResponseDeserializerTest {
+    private AppSyncResponseDeserializer appSyncResponseDeserializer;
+
+    /**
+     * Set up the object under test, an AppSyncResponseDeserializer.
+     */
+    @Before
+    public void setup() {
+        this.appSyncResponseDeserializer = new AppSyncResponseDeserializer();
+    }
+
+    /**
+     * {@link Temporal.Date}, {@link Temporal.DateTime}, {@link Temporal.Time}, and {@link Temporal.Timestamp} all
+     * have different JSON representations. It must be possible to recover the Java type which
+     * models the JSON representation of each.
+     * @throws ApiException If the response factory fails to construct a response,
+     *                      perhaps because deserialization to one of these types
+     *                      has failed.
+     */
+    @Test
+    public void awsDateTypesCanBeDeserialized() {
+        // Expect
+        String meetingId = "45a5f600-8aa8-41ac-a529-aed75036f5be";
+        Meeting meeting = Meeting.builder()
+                .name("meeting0")
+                .id(meetingId)
+                .date(new Temporal.Date("2001-02-03"))
+                .dateTime(new Temporal.DateTime("2001-02-03T01:30Z"))
+                .time(new Temporal.Time("01:22"))
+                .timestamp(new Temporal.Timestamp(1234567890000L, TimeUnit.MILLISECONDS))
+                .build();
+        Boolean deleted = false;
+        Integer version = 42;
+        Long lastChangedAt = Long.valueOf(1594858827);
+        ModelMetadata modelMetadata = new ModelMetadata(meetingId, deleted, version, lastChangedAt);
+        ModelWithMetadata<Meeting> modelWithMetadata = new ModelWithMetadata<>(meeting, modelMetadata);
+        GraphQLResponse<ModelWithMetadata<Meeting>> expected = new GraphQLResponse<>(modelWithMetadata, null);
+
+        // Act
+        final String responseString = Resources.readAsString("meeting-response.json");
+
+        final GraphQLResponse<ModelWithMetadata<Meeting>> response =
+                appSyncResponseDeserializer.deserialize(responseString, Meeting.class);
+
+        // Assert
+        assertEquals(expected, response);
+    }
+}

--- a/aws-datastore/src/test/resources/meeting-response.json
+++ b/aws-datastore/src/test/resources/meeting-response.json
@@ -1,0 +1,11 @@
+{
+  "date": "2001-02-03",
+  "dateTime": "2001-02-03T01:30:00Z",
+  "id": "45a5f600-8aa8-41ac-a529-aed75036f5be",
+  "name": "meeting0",
+  "time": "01:22:00",
+  "timestamp": 1234567890,
+  "_deleted": false,
+  "_version": 42,
+  "_lastChangedAt": 1594858827
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-android/issues/590, https://github.com/aws-amplify/amplify-android/issues/621

*Description of changes:* Adds full support for using [AWS Date scalars](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html) with DataStore.  This PR specifically adds support for deserializing them in the response.  Serialization on requests was already fixed in https://github.com/aws-amplify/amplify-android/pull/601.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
