### PR TITLE
fix(datastore) Set orchestrator status when no API configured

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -491,6 +491,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
 
     private Completable initializeOrchestrator() {
         if (api.getPlugins().isEmpty()) {
+            isOrchestratorReady.set(true);
             return Completable.complete();
         } else {
             // Let's prevent the orchestrator startup from possibly running in main.


### PR DESCRIPTION
If there is no API configured (i.e. DataStore is operating in local-only mode), calls to the DataStore end up timing out. This PR addresses this issue and modified tests to account for the scenario.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
