### PR TITLE
fix(api): now correctly signs requests with query string params

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
@@ -29,6 +29,8 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -128,6 +130,7 @@ public final class RestApiInstrumentationTest {
     public void getRequestWithIAM() throws ApiException {
         final RestOptions options = RestOptions.builder()
             .addPath("/items")
+            .addQueryParameters(Collections.singletonMap("key", "value"))
             .build();
         final RestResponse response = api.get("iamAuthApi", options);
         assertNotNull("Should return non-null data", response.getData());

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
@@ -29,7 +29,6 @@ import com.amazonaws.util.IOUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
@@ -25,12 +25,14 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.http.HttpMethodName;
 import com.amazonaws.util.IOUtils;
+import com.amazonaws.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -236,9 +238,13 @@ public final class AppSyncSigV4SignerInterceptor implements Interceptor {
 
     // Extracts query string parameters from a URL.
     // Source: https://stackoverflow.com/questions/13592236/parse-a-uri-string-into-name-value-collection
+    @NonNull
     private static Map<String, String> splitQuery(URL url) throws UnsupportedEncodingException {
         Map<String, String> queryPairs = new LinkedHashMap<>();
         String query = url.getQuery();
+        if (StringUtils.isBlank(query)) {
+            return Collections.emptyMap();
+        }
         String[] pairs = query.split("&");
         for (String pair : pairs) {
             int index = pair.indexOf("=");

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
@@ -46,7 +46,8 @@ public final class AppSyncSigV4SignerInterceptor implements Interceptor {
 
     private static final String CONTENT_TYPE = "application/json";
     private static final MediaType JSON_MEDIA_TYPE = MediaType.parse(CONTENT_TYPE);
-    private static final String SERVICE_NAME = "appsync";
+    private static final String APP_SYNC_SERVICE_NAME = "appsync";
+    private static final String API_GATEWAY_SERVICE_NAME = "apigateway";
     private static final String X_API_KEY = "x-api-key";
     private static final String AUTHORIZATION = "authorization";
 
@@ -148,7 +149,12 @@ public final class AppSyncSigV4SignerInterceptor implements Interceptor {
         Request req = chain.request();
 
         //Clone the request into a new DefaultRequest object and populate it with credentials
-        DefaultRequest<?> dr = new DefaultRequest<>(SERVICE_NAME);
+        final DefaultRequest<?> dr;
+        if (endpointType == EndpointType.GRAPHQL) {
+            dr = new DefaultRequest<>(APP_SYNC_SERVICE_NAME);
+        } else {
+            dr = new DefaultRequest<>(API_GATEWAY_SERVICE_NAME);
+        }
         //set the endpoint
         dr.setEndpoint(req.url().uri());
         //copy all the headers
@@ -219,25 +225,5 @@ public final class AppSyncSigV4SignerInterceptor implements Interceptor {
 
         //continue with chain.
         return chain.proceed(okReqBuilder.build());
-    }
-
-    // Utility method to convert string to human-readable format
-    private String toHumanReadableAscii(String str) {
-        for (int i = 0, length = str.length(), c; i < length; i += Character.charCount(c)) {
-            c = str.codePointAt(i);
-            if (c > '\u001f' && c < '\u007f') {
-                continue;
-            }
-            Buffer buffer = new Buffer();
-            buffer.writeUtf8(str, 0, i);
-            for (int j = i; j < length; j += Character.charCount(c)) {
-                c = str.codePointAt(j);
-                if (c > '\u001f' && c < '\u007f') {
-                    buffer.writeUtf8CodePoint(c);
-                }
-            }
-            return buffer.readUtf8();
-        }
-        return str;
     }
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
@@ -19,17 +19,18 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.api.aws.AuthorizationType;
 import com.amplifyframework.api.aws.EndpointType;
+import com.amplifyframework.util.Empty;
 
 import com.amazonaws.DefaultRequest;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.http.HttpMethodName;
 import com.amazonaws.util.IOUtils;
-import com.amazonaws.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.Collections;
@@ -239,15 +240,18 @@ public final class AppSyncSigV4SignerInterceptor implements Interceptor {
     // Extracts query string parameters from a URL.
     // Source: https://stackoverflow.com/questions/13592236/parse-a-uri-string-into-name-value-collection
     @NonNull
-    private static Map<String, String> splitQuery(URL url) throws UnsupportedEncodingException {
+    private static Map<String, String> splitQuery(URL url) throws IOException {
         Map<String, String> queryPairs = new LinkedHashMap<>();
         String query = url.getQuery();
-        if (StringUtils.isBlank(query)) {
+        if (Empty.check(query)) {
             return Collections.emptyMap();
         }
         String[] pairs = query.split("&");
         for (String pair : pairs) {
             int index = pair.indexOf("=");
+            if (index < 0) {
+                throw new MalformedURLException("URL query parameters are malformed.");
+            }
             queryPairs.put(
                     URLDecoder.decode(pair.substring(0, index), "UTF-8"),
                     URLDecoder.decode(pair.substring(index + 1), "UTF-8")

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
@@ -20,8 +20,10 @@ import androidx.annotation.Nullable;
 
 import com.amplifyframework.api.rest.HttpMethod;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Map;
 import java.util.Objects;
 
@@ -68,7 +70,11 @@ public final class RestRequestFactory {
             }
         }
 
-        return builder.build().url();
+        try {
+            return new URL(URLDecoder.decode(builder.build().url().toString(), "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new MalformedURLException(e.getMessage());
+        }
     }
 
     /**

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
@@ -72,8 +72,8 @@ public final class RestRequestFactory {
 
         try {
             return new URL(URLDecoder.decode(builder.build().url().toString(), "UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new MalformedURLException(e.getMessage());
+        } catch (UnsupportedEncodingException error) {
+            throw new MalformedURLException(error.getMessage());
         }
     }
 

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -90,6 +91,20 @@ public final class RestRequestFactoryTest {
         assertEquals("The url generated should match",
                 "http://amplify-android.com/path/to/path?key1=value1&key2=value2",
                 url.toString());
+    }
+
+    /**
+     * Test creating a valid URL with queries containing special chars.
+     * @throws MalformedURLException Throws if the URL is invalid.
+     */
+    @Test
+    public void createValidURLWithQueryEncoded() throws MalformedURLException {
+        URL url = RestRequestFactory.createURL("http://amplify-android.com/beta",
+                "/path",
+                Collections.singletonMap("phone_number", "+1234567890"));
+        assertEquals("The url generated should match",
+                new URL("http://amplify-android.com/beta/path?phone_number=+1234567890"),
+                url);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
#650 #644 

*Description of changes:*
* The request was being SigV4 signed without adding the query parameters. This was fixed.

*Minor changes:*
* URL is now decoded and re-encoded inside `RestRequestFactory` to ensure correct encoding.
* Signer now distinguishes AppSync and API gateway when signing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
