### PR TITLE
Sends proper user agent for Auth

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -124,10 +124,12 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     ) throws AuthException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Exception> asyncException = new AtomicReference<>();
+        JSONObject mobileClientConfig;
         LogFactory.setLevel(LogFactory.Level.OFF);
 
         try {
-            pluginConfiguration.put("UserAgentOverride", UserAgent.string());
+            mobileClientConfig = new JSONObject(pluginConfiguration.toString());
+            mobileClientConfig.put("UserAgentOverride", UserAgent.string());
         } catch (JSONException exception) {
             throw new AuthException("Failed to set user agent string",
                     exception,
@@ -136,7 +138,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
         awsMobileClient.initialize(
             context,
-            new AWSConfiguration(pluginConfiguration),
+            new AWSConfiguration(mobileClientConfig),
             new Callback<UserStateDetails>() {
                 @Override
                 public void onResult(UserStateDetails result) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -22,6 +22,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.auth.AuthChannelEventName;
 import com.amplifyframework.auth.AuthCodeDeliveryDetails;
 import com.amplifyframework.auth.AuthException;
@@ -54,6 +55,7 @@ import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
+import com.amplifyframework.util.UserAgent;
 
 import com.amazonaws.logging.LogFactory;
 import com.amazonaws.mobile.client.AWSMobileClient;
@@ -123,6 +125,14 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Exception> asyncException = new AtomicReference<>();
         LogFactory.setLevel(LogFactory.Level.OFF);
+
+        try {
+            pluginConfiguration.put("UserAgentOverride", UserAgent.string());
+        } catch (JSONException exception) {
+            throw new AuthException("Failed to set user agent string",
+                    exception,
+                    AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION);
+        }
 
         awsMobileClient.initialize(
             context,


### PR DESCRIPTION
Currently Auth isn't sending the proper Amplify user agent because AWSMobileClient overrides it. This works in conjunction with this PR on the SDK branch to enable us to override that user agent with our own: https://github.com/aws-amplify/aws-sdk-android/pull/2024


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
