### PR TITLE
fix: start orchestrator before any datastore operations

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -109,14 +109,6 @@ final class MutationProcessor {
     }
 
     /**
-     * Checks if the mutation processor is actively observing the mutation outbox.
-     * @return True if the mutation processor is subscribed the mutation outbox.
-     */
-    boolean isDrainingMutationOutbox() {
-        return ongoingOperationsDisposable.size() > 0;
-    }
-
-    /**
      * Process an item in the mutation outbox.
      * @param mutationOutboxItem An item in the mutation outbox
      * @param <T> Type of model

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -17,12 +17,14 @@ package com.amplifyframework.datastore.syncengine;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+import androidx.core.util.Supplier;
 
 import com.amplifyframework.AmplifyException;
-import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
+import com.amplifyframework.datastore.AWSDataStorePlugin;
 import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.DataStoreConfigurationProvider;
 import com.amplifyframework.datastore.DataStoreException;
@@ -34,33 +36,32 @@ import com.amplifyframework.logging.Logger;
 
 import org.json.JSONObject;
 
+import java.util.Locale;
 import java.util.Objects;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.Completable;
+import io.reactivex.Scheduler;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.schedulers.Schedulers;
 
 /**
- * Synchronizes changed data between the {@link LocalStorageAdapter}
- * and {@link AppSync}.
+ * Synchronizes changed data between the {@link LocalStorageAdapter} and {@link AppSync}.
  */
 public final class Orchestrator {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
-    private static final long SYNC_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
-    // This timeout has to be somewhat generous to account for situations where a request to
-    // stop is made immediately after starting things up. This should only be the case
-    // when the clear API is invoked right after the plugin starts.
-    private static final long ACQUIRE_PERMIT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
+    private static final long OP_TIMEOUT_SECONDS = 10;
 
     private final SubscriptionProcessor subscriptionProcessor;
     private final SyncProcessor syncProcessor;
-    private final MutationOutbox mutationOutbox;
     private final MutationProcessor mutationProcessor;
     private final StorageObserver storageObserver;
-    private final AtomicReference<OrchestratorStatus> status;
-    private final Semaphore startStopSemaphore;
-    private Completable initializationCompletable;
+    private final Supplier<Mode> targetMode;
+    private final AtomicReference<Mode> currentMode;
+    private final MutationOutbox mutationOutbox;
+    private final CompositeDisposable disposables;
+    private final Scheduler startStopScheduler;
 
     /**
      * Constructs a new Orchestrator.
@@ -68,31 +69,29 @@ public final class Orchestrator {
      * and the {@link LocalStorageAdapter}.
      * @param modelProvider A provider of the models to be synchronized
      * @param modelSchemaRegistry A registry of model schema
-     * @param localStorageAdapter Interface to local storage, used to
-     *                       durably store offline changes until
-     *                       then can be written to the network
+     * @param localStorageAdapter
+     *        used to durably store offline changes until they can be written to the network
      * @param appSync An AppSync Endpoint
-     * @param dataStoreConfigurationProvider An instance that implements {@link DataStoreConfigurationProvider}
-     *                       Note that the provider-style interface is needed because
-     *                       at the time this constructor is called from the
-     *                       {@link com.amplifyframework.datastore.AWSDataStorePlugin}'s constructor,
-     *                       the plugin is not fully configured yet. The reference to the
-     *                       variable returned by the provider only get set after the plugin's
-     *                       #{@link com.amplifyframework.datastore.AWSDataStorePlugin#configure(JSONObject, Context)}
-     *                       is invoked by Amplify.
-     *
+     * @param dataStoreConfigurationProvider
+     *        A {@link DataStoreConfigurationProvider}; Note that the provider-style interface
+     *        is needed because at the time this constructor is called from the
+     *        {@link AWSDataStorePlugin}'s constructor, the plugin is not fully configured yet.
+     *        The reference to the variable returned by the provider only get set after the plugin's
+     *        {@link AWSDataStorePlugin#configure(JSONObject, Context)} is invoked by Amplify.
+     * @param targetMode The desired mode of operation - online, or offline
      */
     public Orchestrator(
             @NonNull final ModelProvider modelProvider,
             @NonNull final ModelSchemaRegistry modelSchemaRegistry,
             @NonNull final LocalStorageAdapter localStorageAdapter,
             @NonNull final AppSync appSync,
-            @NonNull final DataStoreConfigurationProvider dataStoreConfigurationProvider) {
+            @NonNull final DataStoreConfigurationProvider dataStoreConfigurationProvider,
+            @NonNull final Supplier<Mode> targetMode) {
         Objects.requireNonNull(modelSchemaRegistry);
         Objects.requireNonNull(modelProvider);
         Objects.requireNonNull(appSync);
         Objects.requireNonNull(localStorageAdapter);
-        this.status = new AtomicReference<>(OrchestratorStatus.STOPPED);
+
         this.mutationOutbox = new PersistentMutationOutbox(localStorageAdapter);
         VersionRepository versionRepository = new VersionRepository(localStorageAdapter);
         Merger merger = new Merger(mutationOutbox, versionRepository, localStorageAdapter);
@@ -109,168 +108,242 @@ public final class Orchestrator {
             .build();
         this.subscriptionProcessor = new SubscriptionProcessor(appSync, modelProvider, merger);
         this.storageObserver = new StorageObserver(localStorageAdapter, mutationOutbox);
-        this.startStopSemaphore = new Semaphore(1);
+        this.currentMode = new AtomicReference<>(Mode.STOPPED);
+        this.targetMode = targetMode;
+        this.disposables = new CompositeDisposable();
+        this.startStopScheduler = Schedulers.single();
     }
 
     /**
-     * Checks whether the orchestrator is {@link OrchestratorStatus#STARTED}.
-     * @return True if the orchestrator is started, false otherwise.
+     * Checks if the orchestrator is running in the desired target state.
+     * @return true if so, false otherwise.
      */
     public boolean isStarted() {
-        return OrchestratorStatus.STARTED.equals(status.get());
+        return ObjectsCompat.equals(targetMode.get(), currentMode.get());
+    }
+
+    /**
+     * Checks if the orchestrator is stopped.
+     * @return true if so, false otherwise.
+     */
+    @SuppressWarnings("unused")
+    public boolean isStopped() {
+        return Mode.STOPPED.equals(currentMode.get());
     }
 
     /**
      * Start performing sync operations between the local storage adapter
      * and the remote GraphQL endpoint.
-     * @param onLocalStorageReady Callback to signal that it is safe to start interacting with the DataStore.
-     * @return A Completable operation to start the sync engine orchestrator.
      */
-    @NonNull
-    public synchronized Completable start(Action onLocalStorageReady) {
-        if (!transitionToState(OrchestratorStatus.STARTED)) {
-            return Completable.error(new DataStoreException(
-                "Unable to start the orchestrator because an operation is already in progress.",
-                AmplifyException.TODO_RECOVERY_SUGGESTION)
-            );
-        }
-        return mutationOutbox.load().andThen(
-            Completable.fromAction(() -> {
-                LOG.debug("Starting the orchestrator.");
-                if (!storageObserver.isObservingStorageChanges()) {
-                    LOG.debug("Starting local storage observer.");
-                    // At the very least, we need the local storage observer running. Don't need to block
-                    // for the others. The onLocalStorageReady is invoked to indicate that.
-                    storageObserver.startObservingStorageChanges(onLocalStorageReady);
-                }
-                if (!subscriptionProcessor.isObservingSubscriptionEvents()) {
-                    LOG.debug("Starting subscription processor.");
-                    subscriptionProcessor.startSubscriptions();
-                }
-                if (!syncProcessor.hydrate().blockingAwait(SYNC_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                    throw new DataStoreException(
-                        "Initial sync during DataStore initialization exceeded timeout of " + SYNC_TIMEOUT_MS,
-                        AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
-                    );
-                }
-                if (!mutationProcessor.isDrainingMutationOutbox()) {
-                    LOG.debug("Starting mutation processor.");
-                    mutationProcessor.startDrainingMutationOutbox();
-                }
-                if (!subscriptionProcessor.isDrainingMutationBuffer()) {
-                    LOG.debug("Starting draining mutation buffer.");
-                    subscriptionProcessor.startDrainingMutationBuffer();
-                }
-                status.compareAndSet(OrchestratorStatus.STARTING, OrchestratorStatus.STARTED);
-                LOG.debug("Orchestrator started.");
-                announceRemoteSyncStarted();
-            })
-        ).doFinally(startStopSemaphore::release);
+    public void start() {
+        disposables.add(transitionCompletable()
+            .subscribeOn(startStopScheduler)
+            .doOnDispose(() -> LOG.debug("Orchestrator disposed a transition."))
+            .subscribe(
+                () -> LOG.debug("Orchestrator completed a transition"),
+                failure -> LOG.warn("Orchestrator failed to transition.")
+            ));
     }
 
-    /**
-     * Stop all model synchronization.
-     * @return A completable with the activities
-     */
-    public synchronized Completable stop() {
-        if (!transitionToState(OrchestratorStatus.STOPPED)) {
-            return Completable.error(new DataStoreException(
-                "Unable to stop the orchestrator because an operation is already in progress.",
-                AmplifyException.TODO_RECOVERY_SUGGESTION)
-            );
+    private Completable transitionCompletable() {
+        Mode current = currentMode.get();
+        Mode target = targetMode.get();
+        if (ObjectsCompat.equals(current, target)) {
+            return Completable.complete();
         }
-        return Completable.fromAction(() -> {
-            LOG.info("Intentionally stopping cloud synchronization, now.");
-            subscriptionProcessor.stopAllSubscriptionActivity();
-            storageObserver.stopObservingStorageChanges();
-            mutationProcessor.stopDrainingMutationOutbox();
-            status.compareAndSet(OrchestratorStatus.STOPPING, OrchestratorStatus.STOPPED);
-            LOG.debug("Stopped remote synchronization.");
-            announceRemoteSyncStopped();
-        })
-        .doFinally(startStopSemaphore::release);
-    }
+        LOG.info(String.format(Locale.US,
+            "DataStore orchestrator transitioning states. " +
+                "Current mode = %s, target mode = %s.", current, target
+        ));
 
-    private synchronized boolean transitionToState(OrchestratorStatus targetStatus) {
-        OrchestratorStatus expectedCurrentStatus;
-        switch (targetStatus) {
-            case STARTED:
-                expectedCurrentStatus = OrchestratorStatus.STOPPED;
-                break;
+        switch (target) {
             case STOPPED:
-                expectedCurrentStatus = OrchestratorStatus.STARTED;
-                break;
+                return transitionToStopped(current);
+            case LOCAL_ONLY:
+                return transitionToLocalOnly(current);
+            case SYNC_VIA_API:
+                return transitionToApiSync(current);
             default:
-                LOG.warn("Invalid attempt to transition orchestrator to " + targetStatus.name());
-                return false;
+                return unknownMode(target);
         }
-        try {
-            LOG.debug("Requesting permit to set the orchestrator status to:" + targetStatus.name());
-            boolean permitAcquired = startStopSemaphore.tryAcquire(ACQUIRE_PERMIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-            if (!permitAcquired) {
-                LOG.warn("Unable to acquire permit to set the orchestrator status to:" + targetStatus.name());
-                return false;
-            }
-            boolean statusSet = status.compareAndSet(expectedCurrentStatus, targetStatus);
-            // only stop if it's started AND if we can get a permit.
-            if (!statusSet) {
-                LOG.warn(String.format("Failed to set orchestrator status to: %s. Current status: %s",
-                    targetStatus.name(),
-                    status.get())
-                );
-                // Since we acquired the permit but failed to set the status, let's release the permit.
-                startStopSemaphore.release();
-                return false;
-            }
-        } catch (InterruptedException exception) {
-            LOG.warn("Orchestrator was interrupted while setting status to " + targetStatus.name());
-            return false;
-        }
-        return true;
-    }
-
-    private void announceRemoteSyncStarted() {
-        Amplify.Hub.publish(
-            HubChannel.DATASTORE,
-            HubEvent.create(DataStoreChannelEventName.REMOTE_SYNC_STARTED)
-        );
-    }
-
-    private void announceRemoteSyncStopped() {
-        Amplify.Hub.publish(
-            HubChannel.DATASTORE,
-            HubEvent.create(DataStoreChannelEventName.REMOTE_SYNC_STOPPED)
-        );
     }
 
     /**
-     * Represents possible status of the orchestrator.
+     * Stop the orchestrator.
+     * @return A completable which emits success when orchestrator stops
      */
-    enum OrchestratorStatus {
+    public Completable stop() {
+        LOG.info("DataStore orchestrator stopping. Current mode = " + currentMode.get().name());
+        disposables.clear();
+        return transitionToStopped(currentMode.get())
+            .subscribeOn(startStopScheduler);
+    }
+
+    private static Completable unknownMode(Mode mode) {
+        return Completable.error(new DataStoreException(
+            "Orchestrator state machine made reference to unknown mode = " + mode.name(),
+            AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+        ));
+    }
+
+    private Completable transitionToStopped(Mode current) {
+        switch (current) {
+            case SYNC_VIA_API:
+                return stopApiSync().doFinally(this::stopObservingStorageChanges);
+            case LOCAL_ONLY:
+                stopObservingStorageChanges();
+                return Completable.complete();
+            case STOPPED:
+                return Completable.complete();
+            default:
+                return unknownMode(current);
+        }
+    }
+
+    private Completable transitionToLocalOnly(Mode current) {
+        switch (current) {
+            case STOPPED:
+                startObservingStorageChanges();
+                return Completable.complete();
+            case LOCAL_ONLY:
+                return Completable.complete();
+            case SYNC_VIA_API:
+                return stopApiSync();
+            default:
+                return unknownMode(current);
+        }
+    }
+
+    private Completable transitionToApiSync(Mode current) {
+        switch (current) {
+            case SYNC_VIA_API:
+                return Completable.complete();
+            case LOCAL_ONLY:
+                return startApiSync();
+            case STOPPED:
+                startObservingStorageChanges();
+                return startApiSync();
+            default:
+                return unknownMode(current);
+        }
+    }
+
+    /**
+     * Start observing the local storage adapter for changes;
+     * enqueue them into the mutation outbox.
+     */
+    private void startObservingStorageChanges() {
+        LOG.info("Starting to observe local storage changes.");
+        Throwable throwable = mutationOutbox.load()
+            .andThen(Completable.create(emitter -> {
+                storageObserver.startObservingStorageChanges(emitter::onComplete);
+                currentMode.set(Mode.LOCAL_ONLY);
+            })).blockingGet(OP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (throwable != null) {
+            LOG.warn("Failed to start observing storage changes.", throwable);
+        }
+    }
+
+    /**
+     * Stop observing the local storage. Do not enqueue changes to the outbox.
+     */
+    private void stopObservingStorageChanges() {
+        LOG.info("Stopping observation of local storage changes.");
+        storageObserver.stopObservingStorageChanges();
+        currentMode.set(Mode.STOPPED);
+    }
+
+    /**
+     * Start syncing models to and from a remote API.
+     * @return A Completable that succeeds when API sync is enabled.
+     */
+    private Completable startApiSync() {
+        return Completable.create(emitter -> {
+            LOG.info("Starting API synchronization mode.");
+
+            subscriptionProcessor.startSubscriptions();
+
+            LOG.debug("About to hydrate...");
+            Throwable failure = syncProcessor.hydrate()
+                .blockingGet(OP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (failure != null) {
+                if (!emitter.isDisposed()) {
+                    emitter.onError(new DataStoreException(
+                        "Initial sync during DataStore initialization failed.", failure,
+                        AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+                    ));
+                } else {
+                    LOG.warn("Initial sync during DataStore initialization failed.", failure);
+                    emitter.onComplete();
+                }
+                return;
+            }
+
+            LOG.debug("Draining outbox...");
+            mutationProcessor.startDrainingMutationOutbox();
+
+            LOG.debug("Draining subscription buffer...");
+            subscriptionProcessor.startDrainingMutationBuffer(this::stopApiSyncBlocking);
+
+            LOG.debug("Publishing to hub...");
+            Amplify.Hub.publish(
+                HubChannel.DATASTORE,
+                HubEvent.create(DataStoreChannelEventName.REMOTE_SYNC_STARTED)
+            );
+            currentMode.set(Mode.SYNC_VIA_API);
+            emitter.onComplete();
+        })
+        .doOnError(error -> {
+            LOG.error("Failure encountered while attempting to start API sync.", error);
+            stopApiSyncBlocking();
+        })
+        .onErrorComplete();
+    }
+
+    private void stopApiSyncBlocking() {
+        Throwable failure = stopApiSync()
+            .subscribeOn(startStopScheduler)
+            .blockingGet(OP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (failure != null) {
+            LOG.warn("Failed to stop API sync.", failure);
+        }
+    }
+
+    /**
+     * Stop all model synchronization with the remote API.
+     * A Completable that ends when API sync is stopped.
+     */
+    private Completable stopApiSync() {
+        return Completable.fromAction(() -> {
+            LOG.info("Stopping synchronization with remote API.");
+            subscriptionProcessor.stopAllSubscriptionActivity();
+            mutationProcessor.stopDrainingMutationOutbox();
+            Amplify.Hub.publish(
+                HubChannel.DATASTORE,
+                HubEvent.create(DataStoreChannelEventName.REMOTE_SYNC_STOPPED)
+            );
+        })
+        .onErrorComplete()
+        .doOnComplete(() -> currentMode.set(Mode.LOCAL_ONLY));
+    }
+
+    /**
+     * The mode of operation for the Orchestrator's synchronization logic.
+     */
+    public enum Mode {
         /**
-         * The orchestrator is in the process of shutting down all the necessary components. Any requests to
-         * start it will be ignored.
-         *
-         * Upon completion, the state should be changed to {@link #STOPPED}.
-         */
-        STOPPING,
-        /**
-         * The orchestrator is stopped and it is currently not performing any background processing. At this point
-         * it is safe to start it. Only possible transition from this state should be to {@link #STARTING}
-         * which happens by invoking {@link #start()}
+         * The sync orchestrator is fully stopped.
          */
         STOPPED,
+
         /**
-         * The orchestrator is bootstrapping all the components needed to perform the different background
-         * processes it orchestrates.
-         *
-         * Upon completion, the state should be changed to {@link #STARTED}
+         * The orchestrator will enqueue mutations into a holding pen, to sync with server, later.
          */
-        STARTING,
+        LOCAL_ONLY,
+
         /**
-         * The orchestrator is started. Only possible transition from this state should be to {@link #STOPPING}
-         * which happens by invoking {@link #stop()}
+         * The orchestrator maintains components to actively sync data up and down.
          */
-        STARTED
+        SYNC_VIA_API
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
@@ -78,15 +78,6 @@ final class StorageObserver {
         );
     }
 
-    /**
-     * Checks if the storage observer is listening
-     * for events emitted by the local DataStore.
-     * @return true if there are listeners. False otherwise.
-     */
-    boolean isObservingStorageChanges() {
-        return ongoingOperationsDisposable.size() > 0;
-    }
-
     private <T extends Model> PendingMutation<T> toPendingMutation(StorageItemChange<T> change) {
         switch (change.type()) {
             case CREATE:

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -82,7 +82,7 @@ final class SubscriptionProcessor {
     /**
      * Start subscribing to model mutations.
      */
-    synchronized void startSubscriptions() throws DataStoreException {
+    synchronized void startSubscriptions() {
         int subscriptionCount = modelProvider.models().size() * SubscriptionType.values().length;
         // Create a latch with the number of subscriptions are requesting. Each of these will be
         // counted down when each subscription's onStarted event is called.
@@ -99,6 +99,7 @@ final class SubscriptionProcessor {
         }
         ongoingOperationsDisposable.add(Observable.merge(subscriptions)
             .subscribeOn(Schedulers.io())
+            .observeOn(Schedulers.io())
             .subscribe(
                 buffer::onNext,
                 exception -> {
@@ -109,7 +110,7 @@ final class SubscriptionProcessor {
                 },
                 buffer::onComplete
             ));
-        boolean subscriptionsStarted = false;
+        boolean subscriptionsStarted;
         try {
             LOG.debug("Waiting for subscriptions to start.");
             subscriptionsStarted = latch.await(SUBSCRIPTION_START_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -167,7 +168,6 @@ final class SubscriptionProcessor {
             // this means means closing the underlying network connection.
             emitter.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
         })
-        .retry(RetryStrategy.RX_INTERRUPTIBLE_WITH_BACKOFF::retryHandler)
         .doOnError(subscriptionError ->
             LOG.warn(String.format(Locale.US,
                 "An error occurred on the remote %s subscription for model %s.",
@@ -189,36 +189,18 @@ final class SubscriptionProcessor {
      * Start draining mutations out of the mutation buffer.
      * This should be called after {@link #startSubscriptions()}.
      */
-    void startDrainingMutationBuffer() {
+    void startDrainingMutationBuffer(Action onPipelineBroken) {
         ongoingOperationsDisposable.add(
             buffer
                 .doOnSubscribe(disposable ->
                     LOG.info("Starting processing subscription data buffer.")
                 )
                 .flatMapCompletable(mutation -> merger.merge(mutation.modelWithMetadata()))
-                .subscribe(
-                    () -> LOG.warn("Reading from subscriptions buffer is completed."),
-                    failure -> LOG.warn("Reading subscriptions buffer has failed.", failure)
-                )
+                .doOnError(failure -> LOG.warn("Reading subscriptions buffer has failed.", failure))
+                .doOnComplete(() -> LOG.warn("Reading from subscriptions buffer is completed."))
+                .onErrorComplete()
+                .subscribe(onPipelineBroken::call)
         );
-    }
-
-    /**
-     * Checks if the subscription processor is listening
-     * for events coming from the remote DataStore.
-     * @return true if there are listeners. False otherwise.
-     */
-    boolean isObservingSubscriptionEvents() {
-        return ongoingOperationsDisposable.size() > 0;
-    }
-
-    /**
-     * Check if the subscription processor is processing
-     * changes coming from the remote DataStore.
-     * @return
-     */
-    boolean isDrainingMutationBuffer() {
-        return buffer.hasObservers();
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
@@ -18,10 +18,12 @@ package com.amplifyframework.datastore.appsync;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.async.NoOpCancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.testutils.random.RandomString;
 import com.amplifyframework.util.Time;
 
 import java.util.Arrays;
@@ -36,7 +38,7 @@ import static org.mockito.Mockito.eq;
 /**
  * A utility to mock behaviors of an {@link AppSync} from test code.
  */
-@SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
+@SuppressWarnings({"UnusedReturnValue", "WeakerAccess", "unused"})
 public final class AppSyncMocking {
     private AppSyncMocking() {}
 
@@ -46,7 +48,7 @@ public final class AppSyncMocking {
      * @return A configurator for the sync() behavior.
      */
     @NonNull
-    public static SyncConfigurator onSync(AppSync mock) {
+    public static SyncConfigurator sync(AppSync mock) {
         return new SyncConfigurator(mock);
     }
 
@@ -56,7 +58,7 @@ public final class AppSyncMocking {
      * @return A configurator for the delete() behavior.
      */
     @NonNull
-    public static DeleteConfigurator onDelete(AppSync mock) {
+    public static DeleteConfigurator delete(AppSync mock) {
         return new DeleteConfigurator(mock);
     }
 
@@ -66,15 +68,45 @@ public final class AppSyncMocking {
      * @return A configurator for the create() behavior.
      */
     @NonNull
-    public static CreateConfigurator onCreate(AppSync mock) {
+    public static CreateConfigurator create(AppSync mock) {
         return new CreateConfigurator(mock);
+    }
+
+    /**
+     * Prepares mocks on AppSync, to occur when an onCreate() subscription
+     * request is made.
+     * @param mock A mock of the AppSync interface
+     * @return A configurator for the onCreate() subscription
+     */
+    public static OnCreateConfigurator onCreate(AppSync mock) {
+        return new OnCreateConfigurator(mock);
+    }
+
+    /**
+     * Prepares mocks on AppSync, to occur when an onUpdate() subscription
+     * request is made.
+     * @param mock A mock of the AppSync interface
+     * @return A configurator for the onUpdate() subscription
+     */
+    public static OnUpdateConfigurator onUpdate(AppSync mock) {
+        return new OnUpdateConfigurator(mock);
+    }
+
+    /**
+     * Prepares mocks on AppSync, to occur when an onDelete() subscription
+     * request is made.
+     * @param mock A mock of the AppSync interface
+     * @return A configurator for the onDelete() subscription
+     */
+    public static OnDeleteConfigurator onDelete(AppSync mock) {
+        return new OnDeleteConfigurator(mock);
     }
 
     /**
      * Configures mock behaviors to occur when create() is invoked.
      */
     public static final class CreateConfigurator {
-        private AppSync appSync;
+        private final AppSync appSync;
 
         /**
          * Constructs a CreateConfigurator, bound to a mock AppSync instance.
@@ -122,7 +154,7 @@ public final class AppSyncMocking {
      * Configures mocked behavior when the AppSync delete() API is exercised.
      */
     public static final class DeleteConfigurator {
-        private AppSync appSync;
+        private final AppSync appSync;
 
         /**
          * Constructs a DeleteConfigurator.
@@ -176,7 +208,7 @@ public final class AppSyncMocking {
      * Configures mocking for a particular {@link AppSync} mock.
      */
     public static final class SyncConfigurator {
-        private AppSync appSync;
+        private final AppSync appSync;
 
         /**
          * Constructs a new SyncConfigurator.
@@ -215,7 +247,7 @@ public final class AppSyncMocking {
         }
 
         /**
-         * Creates an instance of an {@link AppSync}, which will provide a fake response when asked to
+         * Configures an instance of an {@link AppSync} to provide a fake response when asked to
          * to {@link AppSync#sync(Class, Long, Consumer, Consumer)}. The response callback will
          * be invoked, and will contain the provided ModelWithMetadata in its response.
          * @param modelClass Class of models for which the endpoint should respond
@@ -267,6 +299,106 @@ public final class AppSyncMocking {
                 any(), // last sync time
                 any(), // Consumer<Iterable<ModelWithMetadata<T>>>
                 any() // Consumer<DataStoreException>
+            );
+            return this;
+        }
+    }
+
+    /**
+     * Configures mock behaviors on an {@link AppSync} instance, to occur when
+     * {@link AppSync#onCreate(Class, Consumer, Consumer, Consumer, Action)} is invoked.
+     */
+    public static final class OnCreateConfigurator {
+        private final AppSync appSync;
+
+        OnCreateConfigurator(AppSync appSync) {
+            this.appSync = appSync;
+        }
+
+        /**
+         * In response to {@link AppSync#onCreate(Class, Consumer, Consumer, Consumer, Action)} being
+         * called, the onStart consumer will be called back immediately.
+         * @return The current configurator instance, for fluent method chaining
+         */
+        public OnCreateConfigurator callOnStart() {
+            doAnswer(invocation -> {
+                final int indexOfOnStart = 1;
+                Consumer<String> onStart = invocation.getArgument(indexOfOnStart);
+                onStart.accept(RandomString.string());
+                return null;
+            }).when(appSync).onCreate(
+                any(), // Class<T>
+                any(), // Consumer<String>, onStart
+                any(), // Consumer<GraphQLResponse<ModelWithMetadata<T>>>, onNextResponse
+                any(), // Consumer<DataStoreException>, onSubscriptionFailure
+                any() // Action, onSubscriptionCompleted
+            );
+            return this;
+        }
+    }
+
+    /**
+     * Configured mocked behaviors on an {@link AppSync} instance,
+     * to be invoked when {@link AppSync#onUpdate(Class, Consumer, Consumer, Consumer, Action)}
+     * is called.
+     */
+    public static final class OnUpdateConfigurator {
+        private final AppSync appSync;
+
+        OnUpdateConfigurator(AppSync appSync) {
+            this.appSync = appSync;
+        }
+
+        /**
+         * In response to {@link AppSync#onUpdate(Class, Consumer, Consumer, Consumer, Action)} being
+         * called, the onStart consumer will be called back immediately.
+         * @return The current configurator instance, for fluent method chaining
+         */
+        public OnUpdateConfigurator callOnStart() {
+            doAnswer(invocation -> {
+                final int indexOfOnStart = 1;
+                Consumer<String> onStart = invocation.getArgument(indexOfOnStart);
+                onStart.accept(RandomString.string());
+                return null;
+            }).when(appSync).onUpdate(
+                any(), // Class<T>
+                any(), // Consumer<String>, onStart
+                any(), // Consumer<GraphQLResponse<ModelWithMetadata<T>>>, onNextResponse
+                any(), // Consumer<DataStoreException>, onSubscriptionFailure
+                any() // Action, onSubscriptionCompleted
+            );
+            return this;
+        }
+    }
+
+    /**
+     * Configures mock behaviors for when {@link AppSync#onDelete(Class, Consumer, Consumer, Consumer, Action)}
+     * is called.
+     */
+    public static final class OnDeleteConfigurator {
+        private final AppSync appSync;
+
+        OnDeleteConfigurator(AppSync appSync) {
+            this.appSync = appSync;
+        }
+
+        /**
+         * In response to {@link AppSync#onDelete(Class, Consumer, Consumer, Consumer, Action)} being
+         * called, the onStart consumer will be called back immediately.
+         * @return The current configurator instance, for fluent method chaining
+         */
+        public OnDeleteConfigurator callOnStart() {
+            doAnswer(invocation -> {
+                final int indexOfOnStart = 1;
+                Consumer<String> onStart = invocation.getArgument(indexOfOnStart);
+                onStart.accept(RandomString.string());
+                return null;
+            }).when(appSync).onDelete(
+                any(), // Class<T>
+                any(), // Consumer<String>, onStart
+                any(), // Consumer<GraphQLResponse<ModelWithMetadata<T>>>, onNextResponse
+                any(), // Consumer<DataStoreException>, onSubscriptionFailure
+                any() // Action, onSubscriptionCompleted
             );
             return this;
         }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -82,7 +82,7 @@ public final class MutationProcessorTest {
         synchronousStorageAdapter.save(tony);
 
         // Arrange a cooked response from AppSync.
-        AppSyncMocking.onCreate(appSync).mockResponse(tony);
+        AppSyncMocking.create(appSync).mockResponse(tony);
 
         // Start listening for publication events.
         HubAccumulator accumulator =

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
@@ -34,6 +34,7 @@ import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testutils.EmptyAction;
 import com.amplifyframework.testutils.random.RandomString;
 import com.amplifyframework.util.Time;
 
@@ -104,10 +105,9 @@ public final class SubscriptionProcessorTest {
     /**
      * When {@link SubscriptionProcessor#startSubscriptions()} is invoked,
      * the {@link AppSync} client receives subscription requests.
-     * @throws DataStoreException Not expected.
      */
     @Test
-    public void appSyncInvokedWhenSubscriptionsStarted() throws DataStoreException {
+    public void appSyncInvokedWhenSubscriptionsStarted() {
         // For every Class-SubscriptionType pairing, use a CountDownLatch
         // to tell whether or not we've "seen" a subscription event for it.
         Map<Pair<Class<? extends Model>, SubscriptionType>, CountDownLatch> seen = new HashMap<>();
@@ -139,7 +139,7 @@ public final class SubscriptionProcessorTest {
     }
 
     /**
-     * When {@link SubscriptionProcessor#startDrainingMutationBuffer()} is called, then the
+     * When {@link SubscriptionProcessor#startDrainingMutationBuffer(Action)} is called, then the
      * {@link Merger} is invoked to begin merging whatever content has shown up on the subscriptions.
      * @throws DataStoreException On failure to arrange mocking
      * @throws InterruptedException On failure to await latch
@@ -167,7 +167,7 @@ public final class SubscriptionProcessorTest {
 
         // Start draining....
         subscriptionProcessor.startSubscriptions();
-        subscriptionProcessor.startDrainingMutationBuffer();
+        subscriptionProcessor.startDrainingMutationBuffer(EmptyAction.create());
 
         // Was the data merged?
         assertTrue(latch.await(OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -141,6 +142,23 @@ public final class HubAccumulator {
     @NonNull
     public List<HubEvent<?>> await() {
         Latch.await(latch);
+        return Immutable.of(events);
+    }
+
+    /**
+     * Wait for the desired quantity of events to be accumulated.
+     * Waits for a specified amount of time.
+     * If there are fewer than the desired amount of events right now, this method will
+     * block until the rest show up. If there are enough, they will
+     * be returned immediately.
+     * @param amount Amount of time, e.g. 5 seconds
+     * @param unit Unit attached to the amount, e.g. {@link TimeUnit#SECONDS}
+     * @return A list of as many items as requested when the accumulator was created
+     * @throws RuntimeException On failure to attain the requested number of events
+     *                          within a reasonable waiting period
+     */
+    public List<HubEvent<?>> await(int amount, TimeUnit unit) {
+        Latch.await(latch, unit.toMillis(amount));
         return Immutable.of(events);
     }
 }


### PR DESCRIPTION
    fix: daemon style lifecycle for orchestrator
    
    The state machine in the orchestrator is changed. The three possible
    states are now:
    
      a. STOPPED      No sync component is running, and local changes are not
                      being queued into an offline mutations queue.
      b. LOCAL_ONLY   Local changes are being buffered into an offline
                      mutations queue, but are not being transacte with the
                      cloud
      c. SYNC_VIA_API Data is syncrhonizing to and from the cloud.
    
    Logic is added to transition safely between any pair of these states
    (there are six possible transitions.)
    
    If the Orchestrator fails to start up cleanly, then tear down any/all
    copmonents that were started, and enter offline-only mode.
    
    0. Retry logic is _removed_ from the subscription processor. Instead, if
       a subscription fails, the failure is communicated back to the
       Orchestrator. The Orchestrator should then exist API sync mode.
    
    1. The AWSDataStorePlugin had strated to take on sync engine
       orchestration concerns. All orchestration concerns are removed from
       the plugin, and moved into the Orchestrator, again.
    
    2. Surface exceptions from the hydrate() call on the SyncProcessor. This
       way, if the sync fails, the orchestrator will catch the exception,
       and begin a graceful shutdown sequence.
    
    Some changes amde in the test code include:
    
    0. Mock AppSync behaviors in the OrchestratorTest. Previously, the
       subcription code was not being included in the test. Once exercised,
       it became necessarily to fulfill the missing mocks.
    
    1. Start listening for HubEvents in AWSDataStorePluginTest _before_ they
       will be published. This will help to ensure we always can catch them,
       in th tests.
    
    2. Since the SyncEngine errors are no longer gobbled, the behavior of
       userProvidedErrorCallbackInvokedOnFailure has changed. We now
       expect only a single call to the user-provided error callback,
       instead of _many_ consecutives ones, as before.
    
    3. Add a version of Latch#await(int, TimeUnit) which allows a custom
       wait time to be provided. This is useful in the orchestrator code,
       where longer-than-usual timeouts are encountered.
    
    Future work will address transient network failures, further. Instead of
    individual sync engine components owning their own retries, the
    Orchestrator's lifecycle *as a whole* should be retried. When the
    network goes down, or when auth fails -- any transient failure -- the
    Orchestrator should back off and enter LOCAL_ONLY mode. Additional retry
    logic added to the orchestrator will ensure that it intelligently
    attempts to reach the target mode, again.
    
    Resolves: https://github.com/aws-amplify/amplify-android/issues/636