### PR TITLE
chore: latest dependency versions

### DIFF
--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -17,6 +17,7 @@ package com.amplifyframework.auth.cognito;
 
 import android.app.Activity;
 import android.content.Context;
+import androidx.annotation.Nullable;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.auth.AuthCategory;
@@ -63,6 +64,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.Collections;
@@ -218,7 +220,8 @@ public final class AuthComponentTest {
             Callback<SignUpResult> callback = invocation.getArgument(4);
             callback.onResult(amcResult);
             return null;
-        }).when(mobileClient).signUp(any(), any(), any(), any(), any());
+        }).when(mobileClient)
+            .signUp(any(), any(), any(), any(), Mockito.<Callback<SignUpResult>>any());
 
         AWSCognitoAuthSignUpOptions options = AWSCognitoAuthSignUpOptions.builder()
                 .userAttribute(AuthUserAttributeKey.email(), ATTRIBUTE_VAL)
@@ -233,7 +236,13 @@ public final class AuthComponentTest {
 
         validateSignUpResult(result, AuthSignUpStep.CONFIRM_SIGN_UP_STEP);
         Map<String, String> expectedAttributeMap = Collections.singletonMap(ATTRIBUTE_KEY, ATTRIBUTE_VAL);
-        verify(mobileClient).signUp(eq(USERNAME), eq(PASSWORD), eq(expectedAttributeMap), eq(METADATA), any());
+        verify(mobileClient).signUp(
+            eq(USERNAME),
+            eq(PASSWORD),
+            eq(expectedAttributeMap),
+            eq(METADATA),
+            Mockito.<Callback<SignUpResult>>any()
+        );
     }
 
     /**
@@ -258,11 +267,12 @@ public final class AuthComponentTest {
             Callback<SignUpResult> callback = invocation.getArgument(2);
             callback.onResult(amcResult);
             return null;
-        }).when(mobileClient).confirmSignUp(any(), any(), any());
+        }).when(mobileClient).confirmSignUp(any(), any(), Mockito.<Callback<SignUpResult>>any());
 
         AuthSignUpResult result = synchronousAuth.confirmSignUp(USERNAME, CONFIRMATION_CODE);
         validateSignUpResult(result, AuthSignUpStep.DONE);
-        verify(mobileClient).confirmSignUp(eq(USERNAME), eq(CONFIRMATION_CODE), any());
+        verify(mobileClient)
+            .confirmSignUp(eq(USERNAME), eq(CONFIRMATION_CODE), Mockito.<Callback<SignUpResult>>any());
     }
 
     /**
@@ -493,7 +503,7 @@ public final class AuthComponentTest {
             callback.onResult(amcResult);
             return null;
         }).when(mobileClient)
-            .forgotPassword(any(), any());
+            .forgotPassword(any(), Mockito.<Callback<ForgotPasswordResult>>any());
 
         AuthResetPasswordResult result = synchronousAuth.resetPassword(USERNAME);
         assertFalse(result.isPasswordReset());
@@ -502,7 +512,7 @@ public final class AuthComponentTest {
                 result.getNextStep().getResetPasswordStep()
         );
         validateCodeDeliveryDetails(result.getNextStep().getCodeDeliveryDetails());
-        verify(mobileClient).forgotPassword(eq(USERNAME), any());
+        verify(mobileClient).forgotPassword(eq(USERNAME), Mockito.<Callback<ForgotPasswordResult>>any());
     }
 
     /**
@@ -521,7 +531,7 @@ public final class AuthComponentTest {
             callback.onResult(amcResult);
             return null;
         }).when(mobileClient)
-            .confirmForgotPassword(any(), any(), any());
+            .confirmForgotPassword(any(), any(), Mockito.<Callback<ForgotPasswordResult>>any());
 
         synchronousAuth.confirmResetPassword(NEW_PASSWORD, CONFIRMATION_CODE);
         verify(mobileClient).confirmForgotPassword(eq(NEW_PASSWORD), eq(CONFIRMATION_CODE), any());
@@ -881,7 +891,8 @@ public final class AuthComponentTest {
         assertEquals(targetStep, nextStep.getSignInStep());
     }
 
-    private void validateCodeDeliveryDetails(AuthCodeDeliveryDetails codeDetails) {
+    private void validateCodeDeliveryDetails(@Nullable AuthCodeDeliveryDetails codeDetails) {
+        assertNotNull(codeDetails);
         assertEquals(DESTINATION, codeDetails.getDestination());
         assertEquals(AuthCodeDeliveryDetails.DeliveryMedium.fromString(DELIVERY_MEDIUM),
                 codeDetails.getDeliveryMedium());

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 
@@ -42,15 +42,15 @@ task clean(type: Delete) {
 }
 
 ext {
-    buildToolsVersion = "29.0.2"
-    compileSdkVersion = 29
+    buildToolsVersion = "29.0.3"
+    compileSdkVersion = 30
     minSdkVersion = 16
-    targetSdkVersion = 29
+    targetSdkVersion = 30
 
-    awsSdkVersion = '2.16.12'
+    awsSdkVersion = '2.16.13'
     dependency = [
         android: [
-            desugartools: 'com.android.tools:desugar_jdk_libs:1.0.5',
+            desugartools: 'com.android.tools:desugar_jdk_libs:1.0.9',
         ],
         androidx: [
             v4support: 'androidx.legacy:legacy-support-v4:1.0.0',
@@ -78,7 +78,7 @@ ext {
             translate: "com.amazonaws:aws-android-sdk-translate:$awsSdkVersion"
         ],
 
-        okhttp: 'com.squareup.okhttp3:okhttp:4.7.2',
+        okhttp: 'com.squareup.okhttp3:okhttp:4.8.0',
         gson: 'com.google.code.gson:gson:2.8.6',
         rxandroid: 'io.reactivex.rxjava2:rxandroid:2.1.1',
         rxjava: 'io.reactivex.rxjava2:rxjava:2.2.13',
@@ -87,7 +87,7 @@ ext {
 
         junit: 'junit:junit:4.13',
         mockito: 'org.mockito:mockito-core:3.1.0',
-        mockwebserver: 'com.squareup.okhttp3:mockwebserver:4.7.2',
+        mockwebserver: 'com.squareup.okhttp3:mockwebserver:4.8.0',
         robolectric: 'org.robolectric:robolectric:4.3.1',
         jsonassert: 'org.skyscreamer:jsonassert:1.5.0'
     ]


### PR DESCRIPTION
OkHttp & MockWebServer 4.8.0
Desugar Tools 1.0.9
AWS SDK 2.16.13
AGP 4.0.1
Compile & Target SDK 30
Build Tools 29.0.3

----------------------------

AWS SDK 2.16.13 adds some method overloads to `AWSMobileClient` that necessitate some changes in the `AuthComponentTest`, in Amplify. Changes are made to disambiguate between method signatures with the same runtime erasures.

----------------------------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
