### PR TITLE
chore: fail build for out of date dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ private void configureAndroidLibrary(Project project) {
             warningsAsErrors true
             abortOnError true
             enable 'UnusedResources'
+            enable 'NewerVersionAvailable'
         }
 
         compileOptions {


### PR DESCRIPTION
Fails the build, if the project is not using the latest version of any
one of its dependencies. This is an aggressive configuration, designed
to bring visibility to the Amplify developers around the availability of
security updates. We should rather not ship the code, than to miss a
security update.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
