### PR TITLE
fix(amplify-tools) added a null check for RunManagerNode by parsing o…

### DIFF
--- a/amplify-tools/amplify-tools-gradle-plugin/src/main/groovy/com/amplifyframework/tools/gradle/plugin/AmplifyTools.groovy
+++ b/amplify-tools/amplify-tools-gradle-plugin/src/main/groovy/com/amplifyframework/tools/gradle/plugin/AmplifyTools.groovy
@@ -165,9 +165,12 @@ class AmplifyTools implements Plugin<Project> {
                 //Open XML file
                 def xml = new XmlParser().parse('./.idea/workspace.xml')
                 def RunManagerNode = xml.component.find { it.'@name' == 'RunManager' } as Node
-                def configModelgenCheck = RunManagerNode.children().find {
-                    it.'@name' == 'modelgen'
-                } as Node
+                def configModelgenCheck = null
+                if (RunManagerNode) {
+                    configModelgenCheck = RunManagerNode.children().find {
+                        it.'@name' == 'modelgen'
+                    } as Node
+                }
 
                 if (!configModelgenCheck) {
                     // Nested nodes for modelgen run configuration
@@ -202,9 +205,12 @@ class AmplifyTools implements Plugin<Project> {
                 //Open file
                 def xml = new XmlParser().parse('./.idea/workspace.xml')
                 def RunManagerNode = xml.component.find { it.'@name' == 'RunManager' } as Node
-                def configAmplifyPushCheck = RunManagerNode.children().find {
-                    it.'@name' == 'amplifyPush'
-                } as Node
+                def configAmplifyPushCheck = null
+                if (RunManagerNode) {
+                    configAmplifyPushCheck = RunManagerNode.children().find {
+                        it.'@name' == 'amplifyPush'
+                    } as Node
+                }
 
                 if (!configAmplifyPushCheck) {
                     // Nested nodes for amplifyPush run configuration


### PR DESCRIPTION
…f workspace.xml

Amplify Gradle plugin tries to parse the workspace file of Android Studio.
If in the Android Studio no run configurations are defined, there is
no RunManagerNode in the workspace.xml which causes a crash of the plugin.

Fixes #672

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
