### PR TITLE
feature: adds progress callbacks to storage

### DIFF
--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadTest.java
@@ -36,7 +36,6 @@ import com.amplifyframework.testutils.sync.SynchronousMobileClient;
 import com.amplifyframework.testutils.sync.SynchronousStorage;
 
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferState;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageDownloadTest.java
@@ -36,6 +36,7 @@ import com.amplifyframework.testutils.sync.SynchronousMobileClient;
 import com.amplifyframework.testutils.sync.SynchronousStorage;
 
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferState;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -176,18 +177,6 @@ public final class AWSS3StorageDownloadTest {
         final AtomicReference<Cancelable> opContainer = new AtomicReference<>();
         final AtomicReference<Throwable> errorContainer = new AtomicReference<>();
 
-        // Listen to Hub events to cancel when progress has been made
-        SubscriptionToken progressToken = Amplify.Hub.subscribe(HubChannel.STORAGE, hubEvent -> {
-            if (StorageChannelEventName.DOWNLOAD_PROGRESS.toString().equals(hubEvent.getName())) {
-                HubEvent<Float> progressEvent = (HubEvent<Float>) hubEvent;
-                Float progress = progressEvent.getData();
-                if (progress != null && progress > 0) {
-                    opContainer.get().cancel();
-                }
-            }
-        });
-        subscriptions.add(progressToken);
-
         // Listen to Hub events for cancel
         SubscriptionToken cancelToken = Amplify.Hub.subscribe(HubChannel.STORAGE, hubEvent -> {
             if (StorageChannelEventName.DOWNLOAD_STATE.toString().equals(hubEvent.getName())) {
@@ -205,7 +194,12 @@ public final class AWSS3StorageDownloadTest {
             LARGE_FILE_NAME,
             downloadFile,
             options,
-            onResult -> errorContainer.set(new RuntimeException("Download completed without canceling.")),
+            progress -> {
+                if (progress.getCurrentBytes() > 0 && canceled.getCount() > 0) {
+                    opContainer.get().cancel();
+                }
+            },
+            result -> errorContainer.set(new RuntimeException("Download completed without canceling.")),
             errorContainer::set
         );
         opContainer.set(op);
@@ -230,26 +224,12 @@ public final class AWSS3StorageDownloadTest {
         final AtomicReference<Resumable> opContainer = new AtomicReference<>();
         final AtomicReference<Throwable> errorContainer = new AtomicReference<>();
 
-        // Listen to Hub events to pause when progress has been made
-        SubscriptionToken pauseToken = Amplify.Hub.subscribe(HubChannel.STORAGE, hubEvent -> {
-            if (StorageChannelEventName.DOWNLOAD_PROGRESS.toString().equals(hubEvent.getName())) {
-                HubEvent<Float> progressEvent = (HubEvent<Float>) hubEvent;
-                Float progress = progressEvent.getData();
-                if (progress != null && progress > 0) {
-                    opContainer.get().pause();
-                }
-            }
-        });
-        subscriptions.add(pauseToken);
-
         // Listen to Hub events to resume when operation has been paused
         SubscriptionToken resumeToken = Amplify.Hub.subscribe(HubChannel.STORAGE, hubEvent -> {
             if (StorageChannelEventName.DOWNLOAD_STATE.toString().equals(hubEvent.getName())) {
                 HubEvent<String> stateEvent = (HubEvent<String>) hubEvent;
                 TransferState state = TransferState.getState(stateEvent.getData());
                 if (TransferState.PAUSED.equals(state)) {
-                    // So it doesn't pause on each progress report
-                    Amplify.Hub.unsubscribe(pauseToken);
                     opContainer.get().resume();
                     resumed.countDown();
                 }
@@ -262,7 +242,12 @@ public final class AWSS3StorageDownloadTest {
             LARGE_FILE_NAME,
             downloadFile,
             options,
-            onResult -> completed.countDown(),
+            progress -> {
+                if (progress.getCurrentBytes() > 0 && resumed.getCount() > 0) {
+                    opContainer.get().pause();
+                }
+            },
+            result -> completed.countDown(),
             errorContainer::set
         );
         opContainer.set(op);

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.storage.StorageAccessLevel;
 import com.amplifyframework.storage.StorageException;
 import com.amplifyframework.storage.StoragePlugin;
@@ -37,6 +38,7 @@ import com.amplifyframework.storage.result.StorageDownloadFileResult;
 import com.amplifyframework.storage.result.StorageGetUrlResult;
 import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.result.StorageRemoveResult;
+import com.amplifyframework.storage.result.StorageTransferProgress;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 import com.amplifyframework.storage.s3.operation.AWSS3StorageDownloadFileOperation;
 import com.amplifyframework.storage.s3.operation.AWSS3StorageGetPresignedUrlOperation;
@@ -66,7 +68,6 @@ import java.util.concurrent.TimeUnit;
  * repository.
  */
 public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
-
     private static final String AWS_S3_STORAGE_PLUGIN_KEY = "awsS3StoragePlugin";
 
     private final StorageService.Factory storageServiceFactory;
@@ -79,6 +80,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     /**
      * Constructs the AWS S3 Storage Plugin initializing the executor service.
      */
+    @SuppressWarnings("unused") // This is a public API.
     public AWSS3StoragePlugin() {
         this(new AWSMobileClientAuthProvider());
     }
@@ -221,7 +223,8 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
             @NonNull Consumer<StorageDownloadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
-        return downloadFile(key, local, StorageDownloadFileOptions.defaultInstance(), onSuccess, onError);
+        StorageDownloadFileOptions options = StorageDownloadFileOptions.defaultInstance();
+        return downloadFile(key, local, options, NoOpConsumer.create(), onSuccess, onError);
     }
 
     @NonNull
@@ -230,6 +233,19 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
             @NonNull String key,
             @NonNull File local,
             @NonNull StorageDownloadFileOptions options,
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError
+    ) {
+        return downloadFile(key, local, options, NoOpConsumer.create(), onSuccess, onError);
+    }
+
+    @NonNull
+    @Override
+    public StorageDownloadFileOperation<?> downloadFile(
+            @NonNull String key,
+            @NonNull File local,
+            @NonNull StorageDownloadFileOptions options,
+            @NonNull Consumer<StorageTransferProgress> onProgress,
             @NonNull Consumer<StorageDownloadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
@@ -242,8 +258,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                 options.getTargetIdentityId()
         );
 
-        AWSS3StorageDownloadFileOperation operation =
-                new AWSS3StorageDownloadFileOperation(storageService, cognitoAuthProvider, request, onSuccess, onError);
+        AWSS3StorageDownloadFileOperation operation = new AWSS3StorageDownloadFileOperation(
+            storageService, cognitoAuthProvider, request, onProgress, onSuccess, onError
+        );
         operation.start();
 
         return operation;
@@ -257,7 +274,8 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
-        return uploadFile(key, local, StorageUploadFileOptions.defaultInstance(), onSuccess, onError);
+        StorageUploadFileOptions options = StorageUploadFileOptions.defaultInstance();
+        return uploadFile(key, local, options, NoOpConsumer.create(), onSuccess, onError);
     }
 
     @NonNull
@@ -266,6 +284,19 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
             @NonNull String key,
             @NonNull File local,
             @NonNull StorageUploadFileOptions options,
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError
+    ) {
+        return uploadFile(key, local, options, NoOpConsumer.create(), onSuccess, onError);
+    }
+
+    @NonNull
+    @Override
+    public StorageUploadFileOperation<?> uploadFile(
+            @NonNull String key,
+            @NonNull File local,
+            @NonNull StorageUploadFileOptions options,
+            @NonNull Consumer<StorageTransferProgress> onProgress,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
@@ -280,9 +311,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                 options.getMetadata()
         );
 
-        AWSS3StorageUploadFileOperation operation =
-                new AWSS3StorageUploadFileOperation(storageService, cognitoAuthProvider, request, onSuccess, onError);
-
+        AWSS3StorageUploadFileOperation operation = new AWSS3StorageUploadFileOperation(
+            storageService, cognitoAuthProvider, request, onProgress, onSuccess, onError
+        );
         operation.start();
 
         return operation;
@@ -405,4 +436,3 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         }
     }
 }
-

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
@@ -25,6 +25,7 @@ import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.storage.StorageChannelEventName;
 import com.amplifyframework.storage.StorageException;
 import com.amplifyframework.storage.operation.StorageUploadFileOperation;
+import com.amplifyframework.storage.result.StorageTransferProgress;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 import com.amplifyframework.storage.s3.CognitoAuthProvider;
 import com.amplifyframework.storage.s3.request.AWSS3StorageUploadFileRequest;
@@ -45,6 +46,7 @@ import java.util.Objects;
 public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOperation<AWSS3StorageUploadFileRequest> {
     private final StorageService storageService;
     private final CognitoAuthProvider cognitoAuthProvider;
+    private final Consumer<StorageTransferProgress> onProgress;
     private final Consumer<StorageUploadFileResult> onSuccess;
     private final Consumer<StorageException> onError;
     private TransferObserver transferObserver;
@@ -54,6 +56,7 @@ public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOper
      * @param storageService S3 client wrapper
      * @param cognitoAuthProvider Interface to retrieve AWS specific auth information
      * @param request upload request parameters
+     * @param onProgress Notified upon advancements in upload progress
      * @param onSuccess Will be notified when results of upload are available
      * @param onError Notified when upload fails with an error
      */
@@ -61,12 +64,14 @@ public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOper
             @NonNull StorageService storageService,
             @NonNull CognitoAuthProvider cognitoAuthProvider,
             @NonNull AWSS3StorageUploadFileRequest request,
+            @NonNull Consumer<StorageTransferProgress> onProgress,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
         super(Objects.requireNonNull(request));
         this.storageService = Objects.requireNonNull(storageService);
         this.cognitoAuthProvider = cognitoAuthProvider;
+        this.onProgress = Objects.requireNonNull(onProgress);
         this.onSuccess = Objects.requireNonNull(onSuccess);
         this.onError = Objects.requireNonNull(onError);
         this.transferObserver = null;
@@ -186,14 +191,7 @@ public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOper
 
         @Override
         public void onProgressChanged(int transferId, long bytesCurrent, long bytesTotal) {
-            final float progress;
-            if (bytesTotal != 0) {
-                progress = (float) bytesCurrent / bytesTotal;
-            } else {
-                progress = 1f;
-            }
-            Amplify.Hub.publish(HubChannel.STORAGE,
-                    HubEvent.create(StorageChannelEventName.UPLOAD_PROGRESS, progress));
+            onProgress.accept(new StorageTransferProgress(bytesCurrent, bytesTotal));
         }
 
         @Override

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategory.java
@@ -34,6 +34,7 @@ import com.amplifyframework.storage.result.StorageDownloadFileResult;
 import com.amplifyframework.storage.result.StorageGetUrlResult;
 import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.result.StorageRemoveResult;
+import com.amplifyframework.storage.result.StorageTransferProgress;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 
 import java.io.File;
@@ -95,6 +96,19 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
 
     @NonNull
     @Override
+    public StorageDownloadFileOperation<?> downloadFile(
+            @NonNull String key,
+            @NonNull File local,
+            @NonNull StorageDownloadFileOptions options,
+            @NonNull Consumer<StorageTransferProgress> onProgress,
+            @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError
+    ) {
+        return getSelectedPlugin().downloadFile(key, local, options, onProgress, onSuccess, onError);
+    }
+
+    @NonNull
+    @Override
     public StorageUploadFileOperation<?> uploadFile(
             @NonNull String key,
             @NonNull File local,
@@ -114,6 +128,19 @@ public final class StorageCategory extends Category<StoragePlugin<?>> implements
             @NonNull Consumer<StorageException> onError
     ) {
         return getSelectedPlugin().uploadFile(key, local, options, onSuccess, onError);
+    }
+
+    @NonNull
+    @Override
+    public StorageUploadFileOperation<?> uploadFile(
+            @NonNull String key,
+            @NonNull File local,
+            @NonNull StorageUploadFileOptions options,
+            @NonNull Consumer<StorageTransferProgress> onProgress,
+            @NonNull Consumer<StorageUploadFileResult> onSuccess,
+            @NonNull Consumer<StorageException> onError
+    ) {
+        return getSelectedPlugin().uploadFile(key, local, options, onProgress, onSuccess, onError);
     }
 
     @NonNull

--- a/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageCategoryBehavior.java
@@ -32,6 +32,7 @@ import com.amplifyframework.storage.result.StorageDownloadFileResult;
 import com.amplifyframework.storage.result.StorageGetUrlResult;
 import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.result.StorageRemoveResult;
+import com.amplifyframework.storage.result.StorageTransferProgress;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 
 import java.io.File;
@@ -77,7 +78,7 @@ public interface StorageCategoryBehavior {
             @NonNull Consumer<StorageException> onError);
 
     /**
-     * Download object to file from storage.
+     * Download a remote resource and store it as a local file.
      * Provide callbacks to obtain the download results.
      * @param key the unique identifier for the object in storage
      * @param local the path to a local file
@@ -94,7 +95,7 @@ public interface StorageCategoryBehavior {
             @NonNull Consumer<StorageException> onError);
 
     /**
-     * Download object to memory from storage.
+     * Download a remote resource and store it as a local file.
      * Set advanced options such as the access level of the object
      * you want to retrieve (you can have different objects with
      * the same name under different access levels).
@@ -116,7 +117,32 @@ public interface StorageCategoryBehavior {
             @NonNull Consumer<StorageException> onError);
 
     /**
-     * Upload local file on given path to storage.
+     * Download a remote resource and store it as a local file.
+     * Set advanced options such as the access level of the object
+     * you want to retrieve (you can have different objects with
+     * the same name under different access levels).
+     * Provide callbacks to obtain the results of the download, as
+     * well as intermediary progress updates.
+     * @param key the unique identifier for the object in storage
+     * @param local the path to a local file
+     * @param options parameters specific to plugin behavior
+     * @param onProgress Called periodically to provides updates on download progress
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
+     * @return an operation object that provides notifications and
+     *         actions related to the execution of the work
+     */
+    @NonNull
+    StorageDownloadFileOperation<?> downloadFile(
+        @NonNull String key,
+        @NonNull File local,
+        @NonNull StorageDownloadFileOptions options,
+        @NonNull Consumer<StorageTransferProgress> onProgress,
+        @NonNull Consumer<StorageDownloadFileResult> onSuccess,
+        @NonNull Consumer<StorageException> onError);
+
+    /**
+     * Upload a local File, storing it as a remote resource.
      * Register consumers to obtain the results of the upload.
      * @param key the unique identifier of the object in storage
      * @param local the local file
@@ -133,12 +159,13 @@ public interface StorageCategoryBehavior {
             @NonNull Consumer<StorageException> onError);
 
     /**
-     * Upload local file on given path to storage.
+     * Upload a local File, storing it as a remote resource.
      * Specify options such as the access level the file should have.
      * Register consumers to observe results of upload request.
      * @param key the unique identifier of the object in storage
      * @param local the local file
      * @param options parameters specific to plugin behavior
+     * @param onProgress Called periodically to provides updates on upload progress
      * @param onSuccess Called if operation completed successfully and furnishes a result
      * @param onError Called if an error occurs during operation
      * @return an operation object that provides notifications and
@@ -149,8 +176,30 @@ public interface StorageCategoryBehavior {
             @NonNull String key,
             @NonNull File local,
             @NonNull StorageUploadFileOptions options,
+            @NonNull Consumer<StorageTransferProgress> onProgress,
             @NonNull Consumer<StorageUploadFileResult> onSuccess,
             @NonNull Consumer<StorageException> onError);
+
+    /**
+     * Upload a local File, storing it as a remote resource.
+     * Specify options such as the access level the file should have.
+     * Register consumers to observe results of upload request,
+     * as well as intermediary progress updates.
+     * @param key the unique identifier of the object in storage
+     * @param local the local file
+     * @param options parameters specific to plugin behavior
+     * @param onSuccess Called if operation completed successfully and furnishes a result
+     * @param onError Called if an error occurs during operation
+     * @return an operation object that provides notifications and
+     *         actions related to the execution of the work
+     */
+    @NonNull
+    StorageUploadFileOperation<?> uploadFile(
+        @NonNull String key,
+        @NonNull File local,
+        @NonNull StorageUploadFileOptions options,
+        @NonNull Consumer<StorageUploadFileResult> onSuccess,
+        @NonNull Consumer<StorageException> onError);
 
     /**
      * Delete object from storage.

--- a/core/src/main/java/com/amplifyframework/storage/StorageChannelEventName.java
+++ b/core/src/main/java/com/amplifyframework/storage/StorageChannelEventName.java
@@ -30,7 +30,6 @@ import java.util.Objects;
  * {@link HubChannel#DATASTORE} channel.
  */
 public enum StorageChannelEventName {
-
     /**
      * An error occurred while uploading a file.
      */
@@ -42,11 +41,6 @@ public enum StorageChannelEventName {
     UPLOAD_STATE("upload_state"),
 
     /**
-     * Progress has been made on an upload.
-     */
-    UPLOAD_PROGRESS("upload_progress"),
-
-    /**
      * A download has erred out.
      */
     DOWNLOAD_ERROR("download_error"),
@@ -54,12 +48,7 @@ public enum StorageChannelEventName {
     /**
      * A download has undergone a state change.
      */
-    DOWNLOAD_STATE("download_state"),
-
-    /**
-     * A download has made some progress.
-     */
-    DOWNLOAD_PROGRESS("download_progress");
+    DOWNLOAD_STATE("download_state");
 
     private final String hubEventName;
 

--- a/core/src/main/java/com/amplifyframework/storage/result/StorageTransferProgress.java
+++ b/core/src/main/java/com/amplifyframework/storage/result/StorageTransferProgress.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.result;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Represents the current amount of progress that has made during a storage transfer operation.
+ */
+public final class StorageTransferProgress {
+    private final long currentBytes;
+    private final long totalBytes;
+
+    /**
+     * Creates a new StorageTransferProgress instance.
+     * @param currentBytes The number of bytes that have been transferred so far
+     * @param totalBytes The total number of bytes that are expected to transfer
+     */
+    public StorageTransferProgress(long currentBytes, long totalBytes) {
+        this.currentBytes = currentBytes;
+        this.totalBytes = totalBytes;
+    }
+
+    /**
+     * Gets the current number of bytes that have been transferred.
+     * This is number greater than 0, and less than or equal to the value of
+     * {@link #getTotalBytes()}. For example, if 5 bytes have been transferred,
+     * and 10 bytes are expected to transfer, this value is 5.
+     * @return The current number of bytes that have been transferred
+     */
+    public long getCurrentBytes() {
+        return currentBytes;
+    }
+
+    /**
+     * Gets the total number of bytes that are expected to transfer. When this number
+     * of bytes has transferred, the transfer is complete. This value is greater than or
+     * equal to the value of {@link #getCurrentBytes()}.
+     * @return The total number of bytes that are expected to transfer.
+     */
+    public long getTotalBytes() {
+        return totalBytes;
+    }
+
+    /**
+     * Gets the fraction of the transfer that has been completed, so far. This is a value
+     * greater than or equal to 0, and less than or equal to 1. When the value is 0, the transfer
+     * has not started. When the value is 1, the transfer is complete. If 5 bytes have been transferred,
+     * and 10 bytes are expected, this value is (5.0f/10.0f) = 0.5f.
+     * @return Fraction of transfer that has been completed, a value between 0 and 1, inclusive.
+     */
+    public double getFractionCompleted() {
+        return ((double) currentBytes) / totalBytes;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object thatObject) {
+        if (this == thatObject) {
+            return true;
+        }
+        if (thatObject == null || getClass() != thatObject.getClass()) {
+            return false;
+        }
+        StorageTransferProgress that = (StorageTransferProgress) thatObject;
+        if (getCurrentBytes() != that.getCurrentBytes()) {
+            return false;
+        }
+        return getTotalBytes() == that.getTotalBytes();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (getCurrentBytes() ^ (getCurrentBytes() >>> 32));
+        result = 31 * result + (int) (getTotalBytes() ^ (getTotalBytes() >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "StorageTransferProgress{" +
+            "currentBytes=" + getCurrentBytes() +
+            ", totalBytes=" + getTotalBytes() +
+            ", fractionCompleted=" + getFractionCompleted() +
+            '}';
+    }
+}


### PR DESCRIPTION
The Storage category in Amplify iOS includes progress listeners, which
can be used to monitor the status of an active download or upload. The
original APIs launched for Amplify Android did not include this
capability.

This commit adds overloads for `uploadFile(...)` and `downloadFile(...)`, in a
non-breaking way. The old signatures are still available. However, a caller may
optionally tap into progress updates by using these newly available forms:

```kotlin
Amplify.Storage.downloadFile(fromRemoteKey, toLocalFile,
    StorageDownloadFileOptions.defaultInstance(),
    { Log.i("download", "Progress = ${it.fractionCompleted}") },
    { Log.i("download", "Result = ${it.file.canonicalPath}") },
    { Log.e("download", "Error = ${it.localizedMessage}") }
)
```

Or:
```kotlin
Amplify.Storage.uploadFile(toRemoteKey, fromLocalFile,
    StorageUploadFileOptions.defaultInstance(),
    { Log.i("upload", "Progress = ${it.fractionCompleted}") },
    { Log.i("upload", "Result = ${it.key}") },
    { Log.e("upload", "Error = ${it.localizedMessage}") }
)
```

While not part of the public API, the `UPLOAD_PROGRESS` and
`DOWNLOAD_PROGRESS` Hub events are being removed. Previously they were
published without any token to signify which download or which upload
to which they meant to refer. In a system with multiple uploads and
downloads, this would become a source of defects.

Resolves: https://github.com/aws-amplify/amplify-android/issues/679

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
