### PR TITLE
Create file issue UI for developer menu

### DIFF
--- a/core/src/main/res/color/switch_state_colors.xml
+++ b/core/src/main/res/color/switch_state_colors.xml
@@ -14,16 +14,11 @@
    permissions and limitations under the License.
 -->
 
-<resources >
-    <style name="OverlayActivity" parent="@android:style/Theme.Translucent">
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowActionBar">false</item>
-    </style>
-    <style name="SwitchStyle" parent="Widget.AppCompat.CompoundButton.Switch">
-        <item name="android:track">@drawable/switch_track</item>
-        <item name="android:textSize">15sp</item>
-        <item name="android:checked">false</item>
-        <item name="android:layout_centerVertical">true</item>
-        <item name="android:switchMinWidth">50dp</item>
-    </style>
-</resources>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:state_checked="false"
+        android:color="@android:color/darker_gray" />
+    <item
+        android:state_checked="true"
+        android:color="@android:color/holo_green_light" />
+</selector>

--- a/core/src/main/res/drawable/switch_track.xml
+++ b/core/src/main/res/drawable/switch_track.xml
@@ -14,16 +14,11 @@
    permissions and limitations under the License.
 -->
 
-<resources >
-    <style name="OverlayActivity" parent="@android:style/Theme.Translucent">
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowActionBar">false</item>
-    </style>
-    <style name="SwitchStyle" parent="Widget.AppCompat.CompoundButton.Switch">
-        <item name="android:track">@drawable/switch_track</item>
-        <item name="android:textSize">15sp</item>
-        <item name="android:checked">false</item>
-        <item name="android:layout_centerVertical">true</item>
-        <item name="android:switchMinWidth">50dp</item>
-    </style>
-</resources>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+        android:shape="rectangle">
+    <corners android:radius="10dp" />
+    <size
+        android:height="10dp"
+        android:width="30dp" />
+    <solid android:color="@color/switch_state_colors" />
+</shape>

--- a/core/src/main/res/layout/fragment_file_issue.xml
+++ b/core/src/main/res/layout/fragment_file_issue.xml
@@ -14,10 +14,66 @@
    permissions and limitations under the License.
 -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.amplifyframework.devmenu.DevMenuFileIssueFragment">
 
-</FrameLayout>
+    <EditText
+        android:id="@+id/issue_description"
+        android:layout_width="match_parent"
+        android:layout_height="fill_parent"
+        android:autofillHints="no"
+        android:hint="@string/file_issue_hint"
+        android:inputType="text"
+        android:layout_above="@+id/env_info_switch"
+        android:layout_marginBottom="10dp"
+        android:textSize="16sp" />
+
+    <Switch
+        android:id="@+id/env_info_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checked="false"
+        android:text="@string/env_switch_text"
+        android:layout_above="@+id/device_info_switch"
+        android:textColor="?android:attr/textColorPrimaryInverse"
+        android:textSize="15sp"
+        android:theme="@style/Widget.AppCompat.CompoundButton.Switch"
+        android:switchMinWidth="50dp" />
+
+    <Switch
+        android:id="@+id/device_info_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/logs_switch"
+        android:checked="false"
+        android:switchMinWidth="50dp"
+        android:text="@string/device_switch_text"
+        android:textColor="?android:attr/textColorPrimaryInverse"
+        android:textSize="15sp"
+        android:theme="@style/Widget.AppCompat.CompoundButton.Switch" />
+
+    <Switch
+        android:id="@+id/logs_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/file_issue"
+        android:checked="false"
+        android:switchMinWidth="50dp"
+        android:text="@string/logs_switch_text"
+        android:textColor="?android:attr/textColorPrimaryInverse"
+        android:textSize="15sp"
+        android:theme="@style/Widget.AppCompat.CompoundButton.Switch" />
+
+    <Button
+        android:id="@+id/file_issue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/create_issue_button_title"
+        android:textAllCaps="false"
+        android:textSize="14sp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true" />
+</RelativeLayout>

--- a/core/src/main/res/layout/fragment_file_issue.xml
+++ b/core/src/main/res/layout/fragment_file_issue.xml
@@ -41,8 +41,8 @@
         android:text="@string/env_switch_text"
         android:layout_above="@+id/device_info_switch"
         android:textColor="?android:attr/textColorPrimaryInverse"
-        android:textOff=""
-        android:textOn=""
+        android:textOff="@string/empty"
+        android:textOn="@string/empty"
         android:theme="@style/SwitchStyle" />
 
     <Switch
@@ -52,8 +52,8 @@
         android:layout_above="@+id/logs_switch"
         android:text="@string/device_switch_text"
         android:textColor="?android:attr/textColorPrimaryInverse"
-        android:textOff=""
-        android:textOn=""
+        android:textOff="@string/empty"
+        android:textOn="@string/empty"
         android:theme="@style/SwitchStyle" />
 
     <Switch
@@ -63,8 +63,8 @@
         android:layout_above="@+id/file_issue"
         android:text="@string/logs_switch_text"
         android:textColor="?android:attr/textColorPrimaryInverse"
-        android:textOff=""
-        android:textOn=""
+        android:textOff="@string/empty"
+        android:textOn="@string/empty"
         android:theme="@style/SwitchStyle" />
 
     <Button

--- a/core/src/main/res/layout/fragment_file_issue.xml
+++ b/core/src/main/res/layout/fragment_file_issue.xml
@@ -18,6 +18,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_marginLeft="20dp"
+    android:layout_marginRight="20dp"
+    android:layout_marginTop="10dp"
+    android:layout_marginBottom="10dp"
     tools:context="com.amplifyframework.devmenu.DevMenuFileIssueFragment">
 
     <EditText
@@ -26,52 +30,48 @@
         android:layout_height="fill_parent"
         android:autofillHints="no"
         android:hint="@string/file_issue_hint"
-        android:inputType="text"
+        android:inputType="textMultiLine"
         android:layout_above="@+id/env_info_switch"
-        android:layout_marginBottom="10dp"
         android:textSize="16sp" />
 
     <Switch
         android:id="@+id/env_info_switch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:checked="false"
         android:text="@string/env_switch_text"
         android:layout_above="@+id/device_info_switch"
         android:textColor="?android:attr/textColorPrimaryInverse"
-        android:textSize="15sp"
-        android:theme="@style/Widget.AppCompat.CompoundButton.Switch"
-        android:switchMinWidth="50dp" />
+        android:textOff=""
+        android:textOn=""
+        android:theme="@style/SwitchStyle" />
 
     <Switch
         android:id="@+id/device_info_switch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@+id/logs_switch"
-        android:checked="false"
-        android:switchMinWidth="50dp"
         android:text="@string/device_switch_text"
         android:textColor="?android:attr/textColorPrimaryInverse"
-        android:textSize="15sp"
-        android:theme="@style/Widget.AppCompat.CompoundButton.Switch" />
+        android:textOff=""
+        android:textOn=""
+        android:theme="@style/SwitchStyle" />
 
     <Switch
         android:id="@+id/logs_switch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@+id/file_issue"
-        android:checked="false"
-        android:switchMinWidth="50dp"
         android:text="@string/logs_switch_text"
         android:textColor="?android:attr/textColorPrimaryInverse"
-        android:textSize="15sp"
-        android:theme="@style/Widget.AppCompat.CompoundButton.Switch" />
+        android:textOff=""
+        android:textOn=""
+        android:theme="@style/SwitchStyle" />
 
     <Button
         android:id="@+id/file_issue"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/create_issue_button_title"
+        android:text="@string/file_issue_button_title"
         android:textAllCaps="false"
         android:textSize="14sp"
         android:layout_alignParentBottom="true"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -32,5 +32,4 @@
     <string name="env_switch_text">Include Environment Information</string>
     <string name="device_switch_text">Include Device Information</string>
     <string name="logs_switch_text">Include Logs</string>
-    <string name="create_issue_button_title">File an Issue</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
     <string name="env_switch_text">Include Environment Information</string>
     <string name="device_switch_text">Include Device Information</string>
     <string name="logs_switch_text">Include Logs</string>
+    <string name="empty" />
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -28,4 +28,9 @@
     <string name="search_logs_button_text">Search</string>
     <string name="placeholder_logs">Search results will appear here…</string>
     <string name="placeholder_device_info">Waiting for device info…</string>
+    <string name="file_issue_hint">Please enter a brief description…</string>
+    <string name="env_switch_text">Include Environment Information</string>
+    <string name="device_switch_text">Include Device Information</string>
+    <string name="logs_switch_text">Include Logs</string>
+    <string name="create_issue_button_title">File an Issue</string>
 </resources>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Creates the UI for the file issue screen on the developer menu.

File issue screen when first opened:
<img width="413" alt="Dev Menu File Issue UI" src="https://user-images.githubusercontent.com/67125657/89232924-5f14c580-d59d-11ea-8cf2-fb5da0827fed.png">


File issue screen after toggling all three switches to be on:
<img width="423" alt="Dev Menu File Issue UI Switches On" src="https://user-images.githubusercontent.com/67125657/89232934-6340e300-d59d-11ea-891a-f5ba01939ea8.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
