### PR TITLE
Create environment info UI for developer menu

### DIFF
--- a/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
@@ -15,10 +15,16 @@
 
 package com.amplifyframework.devmenu;
 
+import android.graphics.Typeface;
 import android.os.Bundle;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
+import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 import androidx.fragment.app.Fragment;
 
 import com.amplifyframework.core.R;
@@ -38,6 +44,27 @@ public final class DevMenuEnvironmentFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.dev_menu_fragment_environment, container, false);
+        View envInfoView = inflater.inflate(R.layout.dev_menu_fragment_environment, container, false);
+        displayEnvironmentInfo((TextView) envInfoView.findViewById(R.id.env_info_text));
+        return envInfoView;
+    }
+
+    /**
+     * Displays the environment information on the given TextView.
+     * @param envInfoTextView the TextView that will contain the environment information text
+     */
+    private void displayEnvironmentInfo(TextView envInfoTextView) {
+        SpannableStringBuilder stringBuilder = new SpannableStringBuilder();
+        SpannableString pluginInfoTitle = new SpannableString("Amplify Plugins Information");
+        pluginInfoTitle.setSpan(new StyleSpan(Typeface.BOLD), 0, pluginInfoTitle.length(),
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        stringBuilder.append(pluginInfoTitle);
+        stringBuilder.append("\nPlugin versions will be added here...\n\n");
+        SpannableString devEnvInfoTitle = new SpannableString("Developer Environment Information");
+        devEnvInfoTitle.setSpan(new StyleSpan(Typeface.BOLD), 0, devEnvInfoTitle.length(),
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        stringBuilder.append(devEnvInfoTitle);
+        stringBuilder.append("\nDeveloper environment information will be added here...");
+        envInfoTextView.setText(stringBuilder);
     }
 }

--- a/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
@@ -45,7 +45,7 @@ public final class DevMenuEnvironmentFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View envInfoView = inflater.inflate(R.layout.dev_menu_fragment_environment, container, false);
-        ((TextView) envInfoView.findViewById(R.id.env_info_text)).setText(displayEnvironmentInfo());
+        ((TextView) envInfoView.findViewById(R.id.env_info_text)).setText(getEnvironmentInfo());
         return envInfoView;
     }
 
@@ -53,7 +53,7 @@ public final class DevMenuEnvironmentFragment extends Fragment {
      * Returns the environment information to be displayed.
      * @return a SpannableStringBuilder containing the formatted environment information
      */
-    private SpannableStringBuilder displayEnvironmentInfo() {
+    private SpannableStringBuilder getEnvironmentInfo() {
         SpannableStringBuilder stringBuilder = new SpannableStringBuilder();
         stringBuilder.append(setBold("Amplify Plugins Information"));
         stringBuilder.append("\nPlugin versions will be added here...\n\n");

--- a/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
@@ -45,26 +45,32 @@ public final class DevMenuEnvironmentFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View envInfoView = inflater.inflate(R.layout.dev_menu_fragment_environment, container, false);
-        displayEnvironmentInfo((TextView) envInfoView.findViewById(R.id.env_info_text));
+        ((TextView) envInfoView.findViewById(R.id.env_info_text)).setText(displayEnvironmentInfo());
         return envInfoView;
     }
 
     /**
-     * Displays the environment information on the given TextView.
-     * @param envInfoTextView the TextView that will contain the environment information text
+     * Returns the environment information to be displayed.
+     * @return a SpannableStringBuilder containing the formatted environment information
      */
-    private void displayEnvironmentInfo(TextView envInfoTextView) {
+    private SpannableStringBuilder displayEnvironmentInfo() {
         SpannableStringBuilder stringBuilder = new SpannableStringBuilder();
-        SpannableString pluginInfoTitle = new SpannableString("Amplify Plugins Information");
-        pluginInfoTitle.setSpan(new StyleSpan(Typeface.BOLD), 0, pluginInfoTitle.length(),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        stringBuilder.append(pluginInfoTitle);
+        stringBuilder.append(setBold("Amplify Plugins Information"));
         stringBuilder.append("\nPlugin versions will be added here...\n\n");
-        SpannableString devEnvInfoTitle = new SpannableString("Developer Environment Information");
-        devEnvInfoTitle.setSpan(new StyleSpan(Typeface.BOLD), 0, devEnvInfoTitle.length(),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        stringBuilder.append(devEnvInfoTitle);
+        stringBuilder.append(setBold("Developer Environment Information"));
         stringBuilder.append("\nDeveloper environment information will be added here...");
-        envInfoTextView.setText(stringBuilder);
+        return stringBuilder;
+    }
+
+    /**
+     * Returns the given text in bold.
+     * @param text the text to make bold
+     * @return a SpannableString representing bold text
+     */
+    private SpannableString setBold(String text) {
+        SpannableString boldText = new SpannableString(text);
+        boldText.setSpan(new StyleSpan(Typeface.BOLD), 0, boldText.length(),
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        return boldText;
     }
 }

--- a/core/src/main/res/layout/dev_menu_fragment_environment.xml
+++ b/core/src/main/res/layout/dev_menu_fragment_environment.xml
@@ -14,10 +14,18 @@
    permissions and limitations under the License.
 -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="30dp"
     tools:context="com.amplifyframework.devmenu.DevMenuEnvironmentFragment">
 
-</FrameLayout>
+    <TextView
+        android:id="@+id/env_info_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/placeholder_env_info"
+        android:textColor="?android:attr/textColorPrimaryInverse"
+        android:textSize="16sp"/>
+</ScrollView>

--- a/core/src/main/res/values/dev_menu_strings.xml
+++ b/core/src/main/res/values/dev_menu_strings.xml
@@ -28,6 +28,7 @@
     <string name="search_logs_button_text">Search</string>
     <string name="placeholder_logs">Search results will appear here…</string>
     <string name="placeholder_device_info">Waiting for device info…</string>
+    <string name="placeholder_env_info">Waiting for environment info…</string>
     <string name="file_issue_hint">Please enter a brief description…</string>
     <string name="env_switch_text">Include Environment Information</string>
     <string name="device_switch_text">Include Device Information</string>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Creates the UI for the environment information screen on the developer menu, shown in the picture below.

<img width="413" alt="Dev Menu Environment Info Screen" src="https://user-images.githubusercontent.com/67125657/89583477-43a0f900-d7ef-11ea-9fd2-ff352476584f.png">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
