### PR TITLE
chore: fix broken integration test assert statement

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
@@ -201,7 +201,7 @@ public final class CodeGenerationInstrumentationTest {
                 .build(),
             Person.LAST_NAME.eq("Dandelion")
         );
-        assertTrue(errors.get(0).getMessage().contains("ConditionalCheckFailedException"));
+        assertTrue(errors.get(0).toString().contains("ConditionalCheckFailedException"));
 
         api.delete(PERSON_API_NAME, Person.justId(person.getId()));
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`GraphQLResponse.Error` object used to only have `message` property. After more properties such as locations and extensions were introduced, the message portion alone did not contain the desired substring. The error type is contained inside `extensions` property now.

This PR fixes the test to use `toString()` to check against the entire error content rather than just the message.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
