### PR TITLE
Fix (datastore) quote sql commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ amplifyconfiguration.json
 test-results/
 build-artifacts/
 build-artifacts.tar.gz
+
+# add ignore for jenv
+.java-version

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageReservedWordTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageReservedWordTest.java
@@ -1,0 +1,559 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.annotations.HasMany;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.StrictMode;
+import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
+import com.amplifyframework.util.Immutable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test that reserved SQLite words can be safely used in Model names and fields.
+ */
+public final class SQLiteStorageReservedWordTest {
+    private SynchronousStorageAdapter adapter;
+
+    /**
+     * Enables Android Strict Mode, to help catch common errors while using.
+     * SQLite, such as forgetting to close the database.
+     */
+    @BeforeClass
+    public static void enableStrictMode() {
+        StrictMode.enable();
+    }
+
+    /**
+     * Remove any old database files, and the re-provision a new storage adapter.
+     */
+    @Before
+    public void setup() {
+        TestStorageAdapter.cleanup();
+        this.adapter = TestStorageAdapter.create(AmplifyModelProvider.getInstance());
+    }
+
+    /**
+     * Close the open database, and cleanup any database files that it left.
+     */
+    @After
+    public void teardown() {
+        TestStorageAdapter.cleanup(adapter);
+    }
+
+    /**
+     * Assert that save stores data in the SQLite database correctly.
+     * @throws DataStoreException from possible underlying DataStore exceptions
+     */
+    @Test
+    public void saveModelInsertsData() throws DataStoreException {
+        final Group group = Group.builder()
+                .abort("aborting")
+                .build();
+        adapter.save(group);
+    }
+
+    /**
+     * Test querying the saved item in the SQLite database.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void querySavedData() throws DataStoreException {
+        final Group group = Group.builder()
+                .abort("aborting")
+                .build();
+        adapter.save(group);
+
+        // Get the Group from the database
+        final List<Group> groups = adapter.query(Group.class);
+        assertEquals(1, groups.size());
+        assertTrue(groups.contains(group));
+    }
+
+    /**
+     * Test querying the saved item in the SQLite database with predicate that includes our sqlite keyword.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void querySavedDataByColumn() throws DataStoreException {
+        final Group group = Group.builder()
+                .abort("aborting")
+                .build();
+        adapter.save(group);
+
+        // Get the Group from the database
+        final List<Group> groups = adapter.query(
+                Group.class,
+                Where.matches(field("abort").eq("aborting"))
+        );
+        assertEquals(1, groups.size());
+        assertTrue(groups.contains(group));
+    }
+
+    /**
+     * Test querying with predicate condition on connected model with id.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void querySavedDataWithPredicatesOnForeignKeyID() throws DataStoreException {
+        final Group group = Group.builder()
+                .abort("aborting")
+                .build();
+        adapter.save(group);
+
+        final Alter alter = Alter.builder()
+                .index("index")
+                .group(group)
+                .build();
+        adapter.save(alter);
+
+        final List<Alter> altersByGroup = adapter.query(
+                Alter.class,
+                Where.matches(field("group").eq(group.id))
+        );
+        assertTrue(altersByGroup.contains(altersByGroup));
+    }
+
+    /**
+     * Test querying with predicate condition on connected model.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void querySavedDataWithPredicatesOnForeignKeyColumn() throws DataStoreException {
+        final Group group = Group.builder()
+                .abort("aborting")
+                .build();
+        adapter.save(group);
+
+        final Alter alter = Alter.builder()
+                .index("index")
+                .group(group)
+                .build();
+        adapter.save(alter);
+
+        final List<Alter> altersByGroup = adapter.query(
+                Alter.class,
+                Where.matches(field("Group.abort").eq("aborting"))
+        );
+        assertTrue(altersByGroup.contains(altersByGroup));
+    }
+
+    @SuppressWarnings("all")
+    @ModelConfig(pluralName = "Groups")
+    public static final class Group implements Model {
+        public static final QueryField ID = field("id");
+        public static final QueryField ABORT = field("abort");
+        private final @ModelField(targetType="ID", isRequired = true) String id;
+        private final @ModelField(targetType="String", isRequired = true) String abort;
+        private final @ModelField(targetType="Alter") @HasMany(associatedWith = "group", type = Alter.class) List<Alter> alters = null;
+        public String getId() {
+            return id;
+        }
+
+        public String getAbort() {
+            return abort;
+        }
+
+        public List<Alter> getAlters() {
+            return alters;
+        }
+
+        private Group(String id, String abort) {
+            this.id = id;
+            this.abort = abort;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if(obj == null || getClass() != obj.getClass()) {
+                return false;
+            } else {
+                Group group = (Group) obj;
+                return ObjectsCompat.equals(getId(), group.getId()) &&
+                        ObjectsCompat.equals(getAbort(), group.getAbort());
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return new StringBuilder()
+                    .append(getId())
+                    .append(getAbort())
+                    .toString()
+                    .hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder()
+                    .append("Group {")
+                    .append("id=" + String.valueOf(getId()) + ", ")
+                    .append("abort=" + String.valueOf(getAbort()))
+                    .append("}")
+                    .toString();
+        }
+
+        public static AbortStep builder() {
+            return new Builder();
+        }
+
+        /**
+         * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+         * This is a convenience method to return an instance of the object with only its ID populated
+         * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+         * in a relationship.
+         * @param id the id of the existing item this instance will represent
+         * @return an instance of this model with only ID populated
+         * @throws IllegalArgumentException Checks that ID is in the proper format
+         */
+        public static Group justId(String id) {
+            try {
+                UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+            } catch (Exception exception) {
+                throw new IllegalArgumentException(
+                        "Model IDs must be unique in the format of UUID. This method is for creating instances " +
+                                "of an existing object with only its ID field for sending as a mutation parameter. When " +
+                                "creating a new object, use the standard builder method and leave the ID field blank."
+                );
+            }
+            return new Group(
+                    id,
+                    null
+            );
+        }
+
+        public CopyOfBuilder copyOfBuilder() {
+            return new CopyOfBuilder(id,
+                    abort);
+        }
+        public interface AbortStep {
+            BuildStep abort(String abort);
+        }
+
+
+        public interface BuildStep {
+            Group build();
+            BuildStep id(String id) throws IllegalArgumentException;
+        }
+
+
+        public static class Builder implements AbortStep, BuildStep {
+            private String id;
+            private String abort;
+            @Override
+            public Group build() {
+                String id = this.id != null ? this.id : UUID.randomUUID().toString();
+
+                return new Group(
+                        id,
+                        abort);
+            }
+
+            @Override
+            public BuildStep abort(String abort) {
+                Objects.requireNonNull(abort);
+                this.abort = abort;
+                return this;
+            }
+
+            /**
+             * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
+             * This should only be set when referring to an already existing object.
+             * @param id id
+             * @return Current Builder instance, for fluent method chaining
+             * @throws IllegalArgumentException Checks that ID is in the proper format
+             */
+            public BuildStep id(String id) throws IllegalArgumentException {
+                this.id = id;
+
+                try {
+                    UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+                } catch (Exception exception) {
+                    throw new IllegalArgumentException("Model IDs must be unique in the format of UUID.",
+                            exception);
+                }
+
+                return this;
+            }
+        }
+
+
+        public final class CopyOfBuilder extends Builder {
+            private CopyOfBuilder(String id, String abort) {
+                super.id(id);
+                super.abort(abort);
+            }
+
+            @Override
+            public CopyOfBuilder abort(String abort) {
+                return (CopyOfBuilder) super.abort(abort);
+            }
+        }
+
+    }
+
+    @SuppressWarnings("all")
+    @ModelConfig(pluralName = "Alters")
+    @Index(name = "byGroup", fields = {"groupID"})
+    public static final class Alter implements Model {
+        public static final QueryField ID = field("id");
+        public static final QueryField INDEX = field("index");
+        public static final QueryField GROUP = field("groupID");
+        private final @ModelField(targetType="ID", isRequired = true) String id;
+        private final @ModelField(targetType="String", isRequired = true) String index;
+        private final @ModelField(targetType="Group") @BelongsTo(targetName = "groupID", type = Group.class) Group group;
+        public String getId() {
+            return id;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+
+        public Group getGroup() {
+            return group;
+        }
+
+        private Alter(String id, String index, Group group) {
+            this.id = id;
+            this.index = index;
+            this.group = group;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if(obj == null || getClass() != obj.getClass()) {
+                return false;
+            } else {
+                Alter alter = (Alter) obj;
+                return ObjectsCompat.equals(getId(), alter.getId()) &&
+                        ObjectsCompat.equals(getIndex(), alter.getIndex()) &&
+                        ObjectsCompat.equals(getGroup(), alter.getGroup());
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return new StringBuilder()
+                    .append(getId())
+                    .append(getIndex())
+                    .append(getGroup())
+                    .toString()
+                    .hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder()
+                    .append("Alter {")
+                    .append("id=" + String.valueOf(getId()) + ", ")
+                    .append("index=" + String.valueOf(getIndex()) + ", ")
+                    .append("group=" + String.valueOf(getGroup()))
+                    .append("}")
+                    .toString();
+        }
+
+        public static IndexStep builder() {
+            return new Builder();
+        }
+
+        /**
+         * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+         * This is a convenience method to return an instance of the object with only its ID populated
+         * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+         * in a relationship.
+         * @param id the id of the existing item this instance will represent
+         * @return an instance of this model with only ID populated
+         * @throws IllegalArgumentException Checks that ID is in the proper format
+         */
+        public static Alter justId(String id) {
+            try {
+                UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+            } catch (Exception exception) {
+                throw new IllegalArgumentException(
+                        "Model IDs must be unique in the format of UUID. This method is for creating instances " +
+                                "of an existing object with only its ID field for sending as a mutation parameter. When " +
+                                "creating a new object, use the standard builder method and leave the ID field blank."
+                );
+            }
+            return new Alter(
+                    id,
+                    null,
+                    null
+            );
+        }
+
+        public CopyOfBuilder copyOfBuilder() {
+            return new CopyOfBuilder(id,
+                    index,
+                    group);
+        }
+        public interface IndexStep {
+            BuildStep index(String index);
+        }
+
+
+        public interface BuildStep {
+            Alter build();
+            BuildStep id(String id) throws IllegalArgumentException;
+            BuildStep group(Group group);
+        }
+
+
+        public static class Builder implements IndexStep, BuildStep {
+            private String id;
+            private String index;
+            private Group group;
+            @Override
+            public Alter build() {
+                String id = this.id != null ? this.id : UUID.randomUUID().toString();
+
+                return new Alter(
+                        id,
+                        index,
+                        group);
+            }
+
+            @Override
+            public BuildStep index(String index) {
+                Objects.requireNonNull(index);
+                this.index = index;
+                return this;
+            }
+
+            @Override
+            public BuildStep group(Group group) {
+                this.group = group;
+                return this;
+            }
+
+            /**
+             * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
+             * This should only be set when referring to an already existing object.
+             * @param id id
+             * @return Current Builder instance, for fluent method chaining
+             * @throws IllegalArgumentException Checks that ID is in the proper format
+             */
+            public BuildStep id(String id) throws IllegalArgumentException {
+                this.id = id;
+
+                try {
+                    UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+                } catch (Exception exception) {
+                    throw new IllegalArgumentException("Model IDs must be unique in the format of UUID.",
+                            exception);
+                }
+
+                return this;
+            }
+        }
+
+
+        public final class CopyOfBuilder extends Builder {
+            private CopyOfBuilder(String id, String index, Group group) {
+                super.id(id);
+                super.index(index)
+                        .group(group);
+            }
+
+            @Override
+            public CopyOfBuilder index(String index) {
+                return (CopyOfBuilder) super.index(index);
+            }
+
+            @Override
+            public CopyOfBuilder group(Group group) {
+                return (CopyOfBuilder) super.group(group);
+            }
+        }
+
+    }
+
+    public static final class AmplifyModelProvider implements ModelProvider {
+        private static final String AMPLIFY_MODEL_VERSION = "305719dace2b972243b439fbd551fe1a";
+        private static AmplifyModelProvider amplifyGeneratedModelInstance;
+
+        private AmplifyModelProvider() {
+
+        }
+
+        /**
+         * Instance of AmplifyModelProvider.
+         *
+         * @return Instance of AmplifyModelProvider
+         */
+        public static AmplifyModelProvider getInstance() {
+            if (amplifyGeneratedModelInstance == null) {
+                amplifyGeneratedModelInstance = new AmplifyModelProvider();
+            }
+            return amplifyGeneratedModelInstance;
+        }
+
+        /**
+         * Get a set of the model classes.
+         *
+         * @return a set of the model classes
+         */
+        @Override
+        public Set<Class<? extends Model>> models() {
+            final Set<Class<? extends Model>> modifiableSet = new HashSet<>(
+                    Arrays.<Class<? extends Model>>asList(Group.class, Alter.class)
+            );
+
+            return Immutable.of(modifiableSet);
+        }
+
+        /**
+         * Get the version of the models.
+         *
+         * @return the version string of the models.
+         */
+        @Override
+        public String version() {
+            return AMPLIFY_MODEL_VERSION;
+        }
+    }
+
+}

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageReservedWordTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageReservedWordTest.java
@@ -54,7 +54,7 @@ public final class SQLiteStorageReservedWordTest {
     private SynchronousStorageAdapter adapter;
 
     /**
-     * Enables Android Strict Mode, to help catch common errors while using.
+     * Enables Android Strict Mode, to help catch common errors while using
      * SQLite, such as forgetting to close the database.
      */
     @BeforeClass

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -181,7 +181,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                     .append(SqlKeyword.DELIMITER)
                     .append(SqlKeyword.ON)
                     .append(SqlKeyword.DELIMITER)
-                    .append(foreignKey.getColumnName())
+                    .append(foreignKey.getQuotedColumnName())
                     .append(SqlKeyword.EQUAL)
                     .append(ownedTable.getPrimaryKeyColumnName());
 
@@ -194,13 +194,13 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         Iterator<SQLiteColumn> columnsIterator = columns.iterator();
         while (columnsIterator.hasNext()) {
             final SQLiteColumn column = columnsIterator.next();
-            selectColumns.append(column.getColumnName());
+            selectColumns.append(column.getQuotedColumnName());
 
             // Alias primary keys to avoid duplicate column names
             selectColumns.append(SqlKeyword.DELIMITER)
                     .append(SqlKeyword.AS)
                     .append(SqlKeyword.DELIMITER)
-                    .append(column.getAliasedName());
+                    .append(Wrap.inBackticks(column.getAliasedName()));
 
             if (columnsIterator.hasNext()) {
                 selectColumns.append(",").append(SqlKeyword.DELIMITER);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -84,7 +84,9 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("CREATE TABLE IF NOT EXISTS")
                 .append(SqlKeyword.DELIMITER)
+                .append(SqlKeyword.QUOTE)
                 .append(table.getName())
+                .append(SqlKeyword.QUOTE)
                 .append(SqlKeyword.DELIMITER);
         if (Empty.check(table.getColumns())) {
             return new SqlCommand(table.getName(), stringBuilder.toString());
@@ -115,18 +117,24 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
             final StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("CREATE INDEX IF NOT EXISTS")
                     .append(SqlKeyword.DELIMITER)
+                    .append(SqlKeyword.QUOTE)
                     .append(modelIndex.getIndexName())
+                    .append(SqlKeyword.QUOTE)
                     .append(SqlKeyword.DELIMITER)
                     .append(SqlKeyword.ON)
                     .append(SqlKeyword.DELIMITER)
+                    .append(SqlKeyword.QUOTE)
                     .append(table.getName())
+                    .append(SqlKeyword.QUOTE)
                     .append(SqlKeyword.DELIMITER);
 
             stringBuilder.append("(");
             Iterator<String> iterator = modelIndex.getIndexFieldNames().iterator();
             while (iterator.hasNext()) {
                 final String indexColumnName = iterator.next();
-                stringBuilder.append(indexColumnName);
+                stringBuilder.append(SqlKeyword.QUOTE)
+                        .append(indexColumnName)
+                        .append(SqlKeyword.QUOTE);
                 if (iterator.hasNext()) {
                     stringBuilder.append(",").append(SqlKeyword.DELIMITER);
                 }
@@ -176,7 +184,9 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
 
             joinStatement.append(joinType)
                     .append(SqlKeyword.DELIMITER)
+                    .append(SqlKeyword.QUOTE)
                     .append(ownedTableName)
+                    .append(SqlKeyword.QUOTE)
                     .append(SqlKeyword.DELIMITER)
                     .append(SqlKeyword.ON)
                     .append(SqlKeyword.DELIMITER)
@@ -214,7 +224,9 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                 .append(SqlKeyword.DELIMITER)
                 .append(SqlKeyword.FROM)
                 .append(SqlKeyword.DELIMITER)
-                .append(tableName);
+                .append(SqlKeyword.QUOTE)
+                .append(tableName)
+                .append(SqlKeyword.QUOTE);
 
         // Append join statements.
         // INNER JOIN tableOne ON tableName.id=tableOne.foreignKey
@@ -270,14 +282,19 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("INSERT INTO")
                 .append(SqlKeyword.DELIMITER)
+                .append(SqlKeyword.QUOTE)
                 .append(table.getName())
+                .append(SqlKeyword.QUOTE)
                 .append(SqlKeyword.DELIMITER)
                 .append("(");
         final List<SQLiteColumn> columns = table.getSortedColumns();
         final Iterator<SQLiteColumn> columnsIterator = columns.iterator();
         while (columnsIterator.hasNext()) {
             final String columnName = columnsIterator.next().getName();
-            stringBuilder.append(columnName);
+            stringBuilder
+                    .append(SqlKeyword.QUOTE)
+                    .append(columnName)
+                    .append(SqlKeyword.QUOTE);
             if (columnsIterator.hasNext()) {
                 stringBuilder.append(",").append(SqlKeyword.DELIMITER);
             }
@@ -318,7 +335,9 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("UPDATE")
                 .append(SqlKeyword.DELIMITER)
+                .append(SqlKeyword.QUOTE)
                 .append(table.getName())
+                .append(SqlKeyword.QUOTE)
                 .append(SqlKeyword.DELIMITER)
                 .append("SET")
                 .append(SqlKeyword.DELIMITER);
@@ -330,7 +349,9 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final Iterator<SQLiteColumn> columnsIterator = columns.iterator();
         while (columnsIterator.hasNext()) {
             final String columnName = columnsIterator.next().getName();
-            stringBuilder.append(columnName)
+            stringBuilder.append(SqlKeyword.QUOTE)
+                    .append(columnName)
+                    .append(SqlKeyword.QUOTE)
                     .append(SqlKeyword.DELIMITER)
                     .append(SqlKeyword.EQUAL)
                     .append(SqlKeyword.DELIMITER)
@@ -372,7 +393,9 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final SQLPredicate sqlPredicate = new SQLPredicate(predicate);
         stringBuilder.append("DELETE FROM")
                 .append(SqlKeyword.DELIMITER)
+                .append(SqlKeyword.QUOTE)
                 .append(table.getName())
+                .append(SqlKeyword.QUOTE)
                 .append(SqlKeyword.DELIMITER)
                 .append(SqlKeyword.WHERE)
                 .append(SqlKeyword.DELIMITER)
@@ -398,7 +421,9 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
             final SQLiteColumn column = columnsIterator.next();
             final String columnName = column.getName();
 
-            builder.append(columnName)
+            builder.append(SqlKeyword.QUOTE)
+                    .append(columnName)
+                    .append(SqlKeyword.QUOTE)
                     .append(SqlKeyword.DELIMITER)
                     .append(column.getColumnType());
 
@@ -430,12 +455,14 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
 
             builder.append("FOREIGN KEY")
                     .append(SqlKeyword.DELIMITER)
-                    .append("(" + connectedName + ")")
+                    .append("(" + SqlKeyword.QUOTE + connectedName + SqlKeyword.QUOTE + ")")
                     .append(SqlKeyword.DELIMITER)
                     .append("REFERENCES")
                     .append(SqlKeyword.DELIMITER)
+                    .append(SqlKeyword.QUOTE)
                     .append(connectedType)
-                    .append("(" + connectedId + ")")
+                    .append(SqlKeyword.QUOTE)
+                    .append("(" + SqlKeyword.QUOTE + connectedId + SqlKeyword.QUOTE + ")")
                     .append(SqlKeyword.DELIMITER)
                     .append("ON DELETE CASCADE");
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -36,6 +36,7 @@ import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteColumn;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteTable;
 import com.amplifyframework.util.Empty;
 import com.amplifyframework.util.Immutable;
+import com.amplifyframework.util.Wrap;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -84,9 +85,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("CREATE TABLE IF NOT EXISTS")
                 .append(SqlKeyword.DELIMITER)
-                .append(SqlKeyword.QUOTE)
-                .append(table.getName())
-                .append(SqlKeyword.QUOTE)
+                .append(Wrap.inBackticks(table.getName()))
                 .append(SqlKeyword.DELIMITER);
         if (Empty.check(table.getColumns())) {
             return new SqlCommand(table.getName(), stringBuilder.toString());
@@ -117,24 +116,18 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
             final StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("CREATE INDEX IF NOT EXISTS")
                     .append(SqlKeyword.DELIMITER)
-                    .append(SqlKeyword.QUOTE)
-                    .append(modelIndex.getIndexName())
-                    .append(SqlKeyword.QUOTE)
+                    .append(Wrap.inBackticks(modelIndex.getIndexName()))
                     .append(SqlKeyword.DELIMITER)
                     .append(SqlKeyword.ON)
                     .append(SqlKeyword.DELIMITER)
-                    .append(SqlKeyword.QUOTE)
-                    .append(table.getName())
-                    .append(SqlKeyword.QUOTE)
+                    .append(Wrap.inBackticks(table.getName()))
                     .append(SqlKeyword.DELIMITER);
 
             stringBuilder.append("(");
             Iterator<String> iterator = modelIndex.getIndexFieldNames().iterator();
             while (iterator.hasNext()) {
                 final String indexColumnName = iterator.next();
-                stringBuilder.append(SqlKeyword.QUOTE)
-                        .append(indexColumnName)
-                        .append(SqlKeyword.QUOTE);
+                stringBuilder.append(Wrap.inBackticks(indexColumnName));
                 if (iterator.hasNext()) {
                     stringBuilder.append(",").append(SqlKeyword.DELIMITER);
                 }
@@ -184,9 +177,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
 
             joinStatement.append(joinType)
                     .append(SqlKeyword.DELIMITER)
-                    .append(SqlKeyword.QUOTE)
-                    .append(ownedTableName)
-                    .append(SqlKeyword.QUOTE)
+                    .append(Wrap.inBackticks(ownedTableName))
                     .append(SqlKeyword.DELIMITER)
                     .append(SqlKeyword.ON)
                     .append(SqlKeyword.DELIMITER)
@@ -224,9 +215,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                 .append(SqlKeyword.DELIMITER)
                 .append(SqlKeyword.FROM)
                 .append(SqlKeyword.DELIMITER)
-                .append(SqlKeyword.QUOTE)
-                .append(tableName)
-                .append(SqlKeyword.QUOTE);
+                .append(Wrap.inBackticks(tableName));
 
         // Append join statements.
         // INNER JOIN tableOne ON tableName.id=tableOne.foreignKey
@@ -282,19 +271,14 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("INSERT INTO")
                 .append(SqlKeyword.DELIMITER)
-                .append(SqlKeyword.QUOTE)
-                .append(table.getName())
-                .append(SqlKeyword.QUOTE)
+                .append(Wrap.inBackticks(table.getName()))
                 .append(SqlKeyword.DELIMITER)
                 .append("(");
         final List<SQLiteColumn> columns = table.getSortedColumns();
         final Iterator<SQLiteColumn> columnsIterator = columns.iterator();
         while (columnsIterator.hasNext()) {
             final String columnName = columnsIterator.next().getName();
-            stringBuilder
-                    .append(SqlKeyword.QUOTE)
-                    .append(columnName)
-                    .append(SqlKeyword.QUOTE);
+            stringBuilder.append(Wrap.inBackticks(columnName));
             if (columnsIterator.hasNext()) {
                 stringBuilder.append(",").append(SqlKeyword.DELIMITER);
             }
@@ -335,9 +319,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("UPDATE")
                 .append(SqlKeyword.DELIMITER)
-                .append(SqlKeyword.QUOTE)
-                .append(table.getName())
-                .append(SqlKeyword.QUOTE)
+                .append(Wrap.inBackticks(table.getName()))
                 .append(SqlKeyword.DELIMITER)
                 .append("SET")
                 .append(SqlKeyword.DELIMITER);
@@ -349,9 +331,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final Iterator<SQLiteColumn> columnsIterator = columns.iterator();
         while (columnsIterator.hasNext()) {
             final String columnName = columnsIterator.next().getName();
-            stringBuilder.append(SqlKeyword.QUOTE)
-                    .append(columnName)
-                    .append(SqlKeyword.QUOTE)
+            stringBuilder.append(Wrap.inBackticks(columnName))
                     .append(SqlKeyword.DELIMITER)
                     .append(SqlKeyword.EQUAL)
                     .append(SqlKeyword.DELIMITER)
@@ -393,9 +373,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final SQLPredicate sqlPredicate = new SQLPredicate(predicate);
         stringBuilder.append("DELETE FROM")
                 .append(SqlKeyword.DELIMITER)
-                .append(SqlKeyword.QUOTE)
-                .append(table.getName())
-                .append(SqlKeyword.QUOTE)
+                .append(Wrap.inBackticks(table.getName()))
                 .append(SqlKeyword.DELIMITER)
                 .append(SqlKeyword.WHERE)
                 .append(SqlKeyword.DELIMITER)
@@ -421,9 +399,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
             final SQLiteColumn column = columnsIterator.next();
             final String columnName = column.getName();
 
-            builder.append(SqlKeyword.QUOTE)
-                    .append(columnName)
-                    .append(SqlKeyword.QUOTE)
+            builder.append(Wrap.inBackticks(columnName))
                     .append(SqlKeyword.DELIMITER)
                     .append(column.getColumnType());
 
@@ -455,14 +431,12 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
 
             builder.append("FOREIGN KEY")
                     .append(SqlKeyword.DELIMITER)
-                    .append("(" + SqlKeyword.QUOTE + connectedName + SqlKeyword.QUOTE + ")")
+                    .append("(" + Wrap.inBackticks(connectedName) + ")")
                     .append(SqlKeyword.DELIMITER)
                     .append("REFERENCES")
                     .append(SqlKeyword.DELIMITER)
-                    .append(SqlKeyword.QUOTE)
-                    .append(connectedType)
-                    .append(SqlKeyword.QUOTE)
-                    .append("(" + SqlKeyword.QUOTE + connectedId + SqlKeyword.QUOTE + ")")
+                    .append(Wrap.inBackticks(connectedType))
+                    .append("(" + Wrap.inBackticks(connectedId) + ")")
                     .append(SqlKeyword.DELIMITER)
                     .append("ON DELETE CASCADE");
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
@@ -30,6 +30,11 @@ import java.util.Objects;
  */
 public enum SqlKeyword {
     /**
+     * SQL keyword quote.
+     */
+    QUOTE("`"),
+
+    /**
      * Acts as a delimiter between commands in SQL.
      */
     DELIMITER(" "),

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
@@ -30,11 +30,6 @@ import java.util.Objects;
  */
 public enum SqlKeyword {
     /**
-     * SQL keyword quote.
-     */
-    QUOTE("`"),
-
-    /**
      * Acts as a delimiter between commands in SQL.
      */
     DELIMITER(" "),

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteColumn.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteColumn.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.storage.sqlite.adapter;
 
 import com.amplifyframework.core.model.PrimaryKey;
 import com.amplifyframework.datastore.storage.sqlite.SQLiteDataType;
+import com.amplifyframework.util.Wrap;
 
 /**
  * Adapts a {@link com.amplifyframework.core.model.ModelField}
@@ -85,10 +86,18 @@ public final class SQLiteColumn {
 
     /**
      * Returns the aliased name of column.
-     * @return the aliased name of column
+     * @return the aliased name of column.
      */
     public String getAliasedName() {
         return tableName + CUSTOM_ALIAS_DELIMITER + name;
+    }
+
+    /**
+     * Returns the unambiguous name of column with table and column name quoted.
+     * @return the unambiguous name of column with table and column name quoted
+     */
+    public String getQuotedColumnName() {
+        return Wrap.inBackticks(tableName) + SQLITE_NAME_DELIMITER + Wrap.inBackticks(name);
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -54,8 +54,8 @@ import static org.junit.Assert.assertTrue;
 public class SqlCommandTest {
 
     private static final String PERSON_BASE_QUERY =
-            "SELECT Person.id AS Person_id, Person.age AS Person_age, Person.firstName AS Person_firstName, " +
-                    "Person.lastName AS Person_lastName FROM `Person`";
+            "SELECT `Person`.`id` AS `Person_id`, `Person`.`age` AS `Person_age`, `Person`.`firstName` AS " +
+                    "`Person_firstName`, `Person`.`lastName` AS `Person_lastName` FROM `Person`";
 
     private SQLCommandFactory sqlCommandFactory;
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -55,7 +55,7 @@ public class SqlCommandTest {
 
     private static final String PERSON_BASE_QUERY =
             "SELECT Person.id AS Person_id, Person.age AS Person_age, Person.firstName AS Person_firstName, " +
-                    "Person.lastName AS Person_lastName FROM Person";
+                    "Person.lastName AS Person_lastName FROM `Person`";
 
     private SQLCommandFactory sqlCommandFactory;
 
@@ -78,11 +78,11 @@ public class SqlCommandTest {
 
         final SqlCommand sqlCommand = sqlCommandFactory.createTableFor(personSchema);
         assertEquals("Person", sqlCommand.tableName());
-        assertEquals("CREATE TABLE IF NOT EXISTS Person (" +
-                "id TEXT PRIMARY KEY NOT NULL, " +
-                "age INTEGER, " +
-                "firstName TEXT NOT NULL, " +
-                "lastName TEXT NOT NULL);", sqlCommand.sqlStatement());
+        assertEquals("CREATE TABLE IF NOT EXISTS `Person` (" +
+                "`id` TEXT PRIMARY KEY NOT NULL, " +
+                "`age` INTEGER, " +
+                "`firstName` TEXT NOT NULL, " +
+                "`lastName` TEXT NOT NULL);", sqlCommand.sqlStatement());
     }
 
     /**
@@ -98,7 +98,7 @@ public class SqlCommandTest {
 
         final SqlCommand sqlCommand = sqlCommandFactory.createTableFor(modelSchema);
         assertEquals("Guitar", sqlCommand.tableName());
-        assertEquals("CREATE TABLE IF NOT EXISTS Guitar ", sqlCommand.sqlStatement());
+        assertEquals("CREATE TABLE IF NOT EXISTS `Guitar` ", sqlCommand.sqlStatement());
     }
 
     /**
@@ -124,7 +124,7 @@ public class SqlCommandTest {
 
         final SqlCommand createIndexSqlCommand = sqlCommandIterator.next();
         assertEquals("Person", createIndexSqlCommand.tableName());
-        assertEquals("CREATE INDEX IF NOT EXISTS idBasedIndex ON Person (id);",
+        assertEquals("CREATE INDEX IF NOT EXISTS `idBasedIndex` ON `Person` (`id`);",
                 createIndexSqlCommand.sqlStatement());
     }
 
@@ -143,8 +143,8 @@ public class SqlCommandTest {
             // expected
             new SqlCommand(
                 "PersistentRecord",
-                "CREATE INDEX IF NOT EXISTS containedModelClassNameBasedIndex " +
-                    "ON PersistentRecord (containedModelClassName);"
+                "CREATE INDEX IF NOT EXISTS `containedModelClassNameBasedIndex` " +
+                    "ON `PersistentRecord` (`containedModelClassName`);"
             ),
             // actual
             sqlCommandIterator.next()

--- a/core/src/main/java/com/amplifyframework/util/Wrap.java
+++ b/core/src/main/java/com/amplifyframework/util/Wrap.java
@@ -25,6 +25,20 @@ public final class Wrap {
     private Wrap() {}
 
     /**
+     * Returns original string wrapped with in backticks.
+     * @param original Original string to modify.
+     * @return Original string wrapped with backtick.
+     *         If original string is null or empty, it just returns the original.
+     */
+    @Nullable
+    public static String inBackticks(@Nullable String original) {
+        if (original == null) {
+            return null;
+        }
+        return "`" + original + "`";
+    }
+
+    /**
      * Returns original string wrapped with single quotes.
      * @param original Original string to modify
      * @return Original string wrapped with single quotes.

--- a/core/src/main/java/com/amplifyframework/util/Wrap.java
+++ b/core/src/main/java/com/amplifyframework/util/Wrap.java
@@ -32,8 +32,8 @@ public final class Wrap {
      */
     @Nullable
     public static String inBackticks(@Nullable String original) {
-        if (original == null) {
-            return null;
+        if (Empty.check(original)) {
+            return original;
         }
         return "`" + original + "`";
     }


### PR DESCRIPTION
*Issue #, if available:*
Datastore SQL commands fail if your model has SQLite reserved words in them. see #707

*Description of changes:*

This quotes table and column names to avoid that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
