### PR TITLE
Adding SyncType to LastSyncMetadata

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/model/SystemModelsProviderFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/model/SystemModelsProviderFactory.java
@@ -28,7 +28,7 @@ import com.amplifyframework.datastore.syncengine.PendingMutation;
  */
 public final class SystemModelsProviderFactory {
     // CHANGE this models version whenever any system models are added/removed/updated.
-    private static final String SYSTEM_MODELS_VERSION = "6232f439-0e0a-4aaa-a1b0-7a3abf7fcebc";
+    private static final String SYSTEM_MODELS_VERSION = "2f378292-cb5f-480e-b71d-cf441fd2e8be";
 
     private SystemModelsProviderFactory() {}
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/LastSyncMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/LastSyncMetadata.java
@@ -150,6 +150,9 @@ public final class LastSyncMetadata implements Model {
         if (!ObjectsCompat.equals(modelClassName, that.modelClassName)) {
             return false;
         }
+        if (!ObjectsCompat.equals(lastSyncType, that.lastSyncType)) {
+            return false;
+        }
         return ObjectsCompat.equals(lastSyncTime, that.lastSyncTime);
     }
 
@@ -158,6 +161,7 @@ public final class LastSyncMetadata implements Model {
         int result = id.hashCode();
         result = 31 * result + modelClassName.hashCode();
         result = 31 * result + lastSyncTime.hashCode();
+        result = 31 * result + lastSyncType.hashCode();
         return result;
     }
 
@@ -167,6 +171,7 @@ public final class LastSyncMetadata implements Model {
             "id='" + id + '\'' +
             ", modelClassName='" + modelClassName + '\'' +
             ", lastSyncTime=" + lastSyncTime +
+            ", lastSyncType=" + lastSyncType +
             '}';
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/LastSyncMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/LastSyncMetadata.java
@@ -50,16 +50,28 @@ public final class LastSyncMetadata implements Model {
 
     /**
      * Creates an instance of an {@link LastSyncMetadata}, indicating that the provided
-     * model has been sync'd, and that the last sync occurred at the given time.
+     * model has been base sync'd, and that the last sync occurred at the given time.
      * @param modelClass Class of model
      * @param lastSyncTime Last time it was synced
      * @return {@link LastSyncMetadata} for the model class
      */
-    static <T extends Model> LastSyncMetadata lastSyncedAt(@NonNull Class<T> modelClass,
-                                                           @Nullable long lastSyncTime,
-                                                           @NonNull SyncType syncType) {
+    static <T extends Model> LastSyncMetadata baseSyncedAt(@NonNull Class<T> modelClass,
+                                                           @Nullable long lastSyncTime) {
         Objects.requireNonNull(modelClass);
-        return create(modelClass, lastSyncTime, syncType);
+        return create(modelClass, lastSyncTime, SyncType.BASE);
+    }
+
+    /**
+     * Creates an instance of an {@link LastSyncMetadata}, indicating that the provided
+     * model has been base delta sync'd, and that the last sync occurred at the given time.
+     * @param modelClass Class of model
+     * @param lastSyncTime Last time it was synced
+     * @return {@link LastSyncMetadata} for the model class
+     */
+    static <T extends Model> LastSyncMetadata deltaSyncedAt(@NonNull Class<T> modelClass,
+                                                           @Nullable long lastSyncTime) {
+        Objects.requireNonNull(modelClass);
+        return create(modelClass, lastSyncTime, SyncType.DELTA);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -37,7 +37,6 @@ import com.amplifyframework.util.Time;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.Completable;
 import io.reactivex.Observable;
@@ -103,28 +102,25 @@ final class SyncProcessor {
 
     private Completable createHydrationTask(
             ModelWithMetadataComparator modelWithMetadataComparator, Class<? extends Model> modelClass) {
-        // Default this to BASE since if there is no LastSyncMetadata record for this
-        // model, a BASE sync will be performed.
-        AtomicReference<SyncType> syncType = new AtomicReference<>(SyncType.BASE);
-
         return syncTimeRegistry.lookupLastSyncTime(modelClass)
             .map(this::filterOutOldSyncTimes)
-            .map(lastSyncTime -> {
-                long syncIntervalMs = dataStoreConfigurationProvider.getConfiguration().getSyncIntervalMs();
-                syncType.set(SyncType.fromSyncTimeAndThreshold(lastSyncTime, syncIntervalMs));
-                return lastSyncTime;
-            })
             // And for each, perform a sync. The network response will contain an Iterable<ModelWithMetadata<T>>
-            .flatMapCompletable(lastSyncTime -> syncModel(modelClass, lastSyncTime)
-                // Okay, but we want to flatten the Iterable elements back into an Observable stream.
-                .flatMapObservable(Observable::fromIterable)
-                // And sort them all, according to their model's topological order,
-                // So that when we save them, the references will exist.
-                .sorted(modelWithMetadataComparator::compare)
-                // For each ModelWithMetadata, merge it into the local store.
-                .flatMapCompletable(merger::merge)
-            )
-            .andThen(syncTimeRegistry.saveLastSyncTime(modelClass, SyncTime.now(), syncType.get()))
+            .flatMap(lastSyncTime -> {
+                return syncModel(modelClass, lastSyncTime)
+                    // Okay, but we want to flatten the Iterable elements back into an Observable stream.
+                    .flatMapObservable(Observable::fromIterable)
+                    // And sort them all, according to their model's topological order,
+                    // So that when we save them, the references will exist.
+                    .sorted(modelWithMetadataComparator::compare)
+                    // For each ModelWithMetadata, merge it into the local store.
+                    .flatMapCompletable(merger::merge)
+                    .toSingle(() -> lastSyncTime.exists() ? SyncType.DELTA : SyncType.BASE);
+            })
+            .flatMapCompletable(syncType -> {
+                return SyncType.DELTA.equals(syncType) ?
+                    syncTimeRegistry.saveLastDeltaSyncTime(modelClass, SyncTime.now()) :
+                    syncTimeRegistry.saveLastBaseSyncTime(modelClass, SyncTime.now());
+            })
             .doOnError(failureToSync -> {
                 LOG.warn("Initial cloud sync failed.", failureToSync);
                 DataStoreErrorHandler dataStoreErrorHandler =

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncTimeRegistry.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncTimeRegistry.java
@@ -57,7 +57,7 @@ final class SyncTimeRegistry {
     }
 
     <T extends Model> Completable saveLastDeltaSyncTime(@NonNull Class<T> modelClazz,
-                                                   @Nullable SyncTime syncTime) {
+                                                        @Nullable SyncTime syncTime) {
         LastSyncMetadata metadata = syncTime.exists() ?
             LastSyncMetadata.deltaSyncedAt(modelClazz, syncTime.toLong()) :
             LastSyncMetadata.neverSynced(modelClazz);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncTimeRegistry.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncTimeRegistry.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.datastore.syncengine;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.Where;
@@ -55,9 +56,11 @@ final class SyncTimeRegistry {
         });
     }
 
-    <T extends Model> Completable saveLastSyncTime(@NonNull Class<T> modelClazz, SyncTime syncTime) {
+    <T extends Model> Completable saveLastSyncTime(@NonNull Class<T> modelClazz,
+                                                   @Nullable SyncTime syncTime,
+                                                   @NonNull SyncType syncType) {
         LastSyncMetadata metadata = syncTime.exists() ?
-            LastSyncMetadata.lastSyncedAt(modelClazz, syncTime.toLong()) :
+            LastSyncMetadata.lastSyncedAt(modelClazz, syncTime.toLong(), syncType) :
             LastSyncMetadata.neverSynced(modelClazz);
 
         return Completable.create(emitter ->

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncType.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import com.amplifyframework.util.Time;
+
+/**
+ * Enum representing the type of initial sync.
+ */
+public enum SyncType {
+    /**
+     * Hydrate local store by retrieving the entire remote dataset.
+     */
+    BASE,
+
+    /**
+     * Hydrate local store by retrieving only a subset of the remote dataset.
+     */
+    DELTA;
+
+    /**
+     * Returns the type of sync based on when the last sync was executed and
+     * the configured sync interval.
+     * @param lastSyncTime Timestamp of when the last sync was executed.
+     * @param syncIntervalMs The maximum elapsed time before forcing a full sync.
+     * @return {@link #BASE} if (now - lastSyncTime) > syncIntervalMs, {@link #DELTA} otherwise.
+     */
+    public static SyncType fromSyncTimeAndThreshold(SyncTime lastSyncTime, long syncIntervalMs) {
+        if (SyncTime.never().equals(lastSyncTime)) {
+            return BASE;
+        }
+        long timeSinceLastSync = Time.now() - lastSyncTime.toLong();
+        return timeSinceLastSync > syncIntervalMs ? BASE : DELTA;
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -316,7 +316,7 @@ public final class SyncProcessorTest {
         // were sync'd too long ago. That is, longer ago than the base sync interval.
         long longAgoTimeMs = Time.now() - (TimeUnit.MINUTES.toMillis(BASE_SYNC_INTERVAL_MINUTES) * 2);
         Observable.fromIterable(modelProvider.models())
-            .map(modelClass -> LastSyncMetadata.lastSyncedAt(modelClass, longAgoTimeMs))
+            .map(modelClass -> LastSyncMetadata.lastSyncedAt(modelClass, longAgoTimeMs, SyncType.BASE))
             .blockingForEach(storageAdapter::save);
 
         // Arrange: return some content from the fake AppSync endpoint
@@ -354,7 +354,7 @@ public final class SyncProcessorTest {
         // were sync'd very recently (within the interval.)
         long recentTimeMs = Time.now();
         Observable.fromIterable(modelProvider.models())
-            .map(modelClass -> LastSyncMetadata.lastSyncedAt(modelClass, recentTimeMs))
+            .map(modelClass -> LastSyncMetadata.lastSyncedAt(modelClass, recentTimeMs, SyncType.BASE))
             .blockingForEach(storageAdapter::save);
 
         // Arrange: return some content from the fake AppSync endpoint

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -316,7 +316,7 @@ public final class SyncProcessorTest {
         // were sync'd too long ago. That is, longer ago than the base sync interval.
         long longAgoTimeMs = Time.now() - (TimeUnit.MINUTES.toMillis(BASE_SYNC_INTERVAL_MINUTES) * 2);
         Observable.fromIterable(modelProvider.models())
-            .map(modelClass -> LastSyncMetadata.lastSyncedAt(modelClass, longAgoTimeMs, SyncType.BASE))
+            .map(modelClass -> LastSyncMetadata.baseSyncedAt(modelClass, longAgoTimeMs))
             .blockingForEach(storageAdapter::save);
 
         // Arrange: return some content from the fake AppSync endpoint
@@ -354,7 +354,7 @@ public final class SyncProcessorTest {
         // were sync'd very recently (within the interval.)
         long recentTimeMs = Time.now();
         Observable.fromIterable(modelProvider.models())
-            .map(modelClass -> LastSyncMetadata.lastSyncedAt(modelClass, recentTimeMs, SyncType.BASE))
+            .map(modelClass -> LastSyncMetadata.deltaSyncedAt(modelClass, recentTimeMs))
             .blockingForEach(storageAdapter::save);
 
         // Arrange: return some content from the fake AppSync endpoint


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As part of implementing the hub events for DataStore sync (#710), we need to save sync type (BASE or DELTA) as part of the `LastSyncMetadata` system model. This will allow us to decouple the process of tracking the sync metrics from the actual sync process. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
