### PR TITLE
chore: increase jvm max heap size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ allprojects {
         tasks.withType(JavaCompile) {
             options.compilerArgs << "-Xlint:all" << "-Werror"
         }
+        tasks.withType(Test) {
+            minHeapSize = '128m'
+            maxHeapSize = '4g'
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx3g
+org.gradle.jvmargs=-Xmx4g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Increase jvm max heap size to 4Gb to prevent exit value 137 in circleCI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
