### PR TITLE
fix(aws-datastore): remove insert statement cache

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -605,21 +605,6 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         return new CreateSqlCommands(createTableCommands, createIndexCommands);
     }
 
-    private Map<String, SqlCommand> getInsertSqlPreparedStatements() {
-        final Map<String, SqlCommand> modifiableMap = new HashMap<>();
-        final Set<Map.Entry<String, ModelSchema>> modelSchemaEntrySet =
-                modelSchemaRegistry.getModelSchemaMap().entrySet();
-        for (final Map.Entry<String, ModelSchema> entry : modelSchemaEntrySet) {
-            final String tableName = entry.getKey();
-            final ModelSchema modelSchema = entry.getValue();
-            modifiableMap.put(
-                    tableName,
-                    sqlCommandFactory.insertFor(modelSchema)
-            );
-        }
-        return Immutable.of(modifiableMap);
-    }
-
     // Binds each value inside list onto compiled statement in order
     private void bindStatementToValues(
             @NonNull SqlCommand sqlCommand,

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/personcar/RandomVersionModelProvider.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/personcar/RandomVersionModelProvider.java
@@ -17,6 +17,7 @@ package com.amplifyframework.testmodels.personcar;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.testmodels.meeting.Meeting;
 import com.amplifyframework.util.Immutable;
 
 import java.util.HashSet;
@@ -58,6 +59,7 @@ public final class RandomVersionModelProvider implements ModelProvider {
         final Set<Class<? extends Model>> modifiableSet = new HashSet<>();
         modifiableSet.add(Person.class);
         modifiableSet.add(Car.class);
+        modifiableSet.add(Meeting.class);
         return Immutable.of(modifiableSet);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#595 

*Description of changes:*
Removed caching logic for insert statements:

When the `SQLiteStorageAdapter` was first written, small optimization logic was added to cache insert statements during initialization. These statements were to be re-used whenever new entries were being entered in a table. Currently, no other types of sqlite statements are cached like this, and are generated on the spot whenever they are called. 

When the database was updated with new tables, it caused a chicken-and-egg problem between generating insert statements and updating the database. To prevent this problem, the original optimization logic is removed in this PR so that insert statements are prepared on the spot like the other types of sqlite operations. 

No explicit tests were written, but I was able to confirm the fix with @rjuliano 's suggestion for [reproducing the bug](https://github.com/aws-amplify/amplify-android/issues/595#issuecomment-662651419).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
