### PR TITLE
Display environment info on developer menu

### DIFF
--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
@@ -389,6 +389,12 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
         return analyticsClient;
     }
 
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
     /**
      * Pinpoint Analytics configuration in amplifyconfiguration.json contains following values.
      */

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -150,6 +150,12 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         return Collections.unmodifiableMap(apiClientsByName);
     }
 
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
     @Nullable
     @Override
     public <R> GraphQLOperation<R> query(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -666,6 +666,12 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
         return awsMobileClient;
     }
 
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
     private void signOutLocally(@NonNull Action onSuccess, @NonNull Consumer<AuthException> onError) {
         awsMobileClient.signOut(
                 SignOutOptions.builder().signOutGlobally(false).invalidateTokens(true).build(),

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -234,6 +234,12 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         return null;
     }
 
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/TensorFlowPredictionsPlugin.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/TensorFlowPredictionsPlugin.java
@@ -98,6 +98,12 @@ public final class TensorFlowPredictionsPlugin extends PredictionsPlugin<TensorF
 
     @NonNull
     @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
+    @NonNull
+    @Override
     public TextToSpeechOperation<?> convertTextToSpeech(
             @NonNull String text,
             @NonNull Consumer<TextToSpeechResult> onSuccess,

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPlugin.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPlugin.java
@@ -127,6 +127,12 @@ public final class AWSPredictionsPlugin extends PredictionsPlugin<AWSPredictions
 
     @NonNull
     @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
+    @NonNull
+    @Override
     public TextToSpeechOperation<?> convertTextToSpeech(
             @NonNull String text,
             @NonNull Consumer<TextToSpeechResult> onSuccess,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -175,6 +175,12 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
 
     @NonNull
     @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
+    @NonNull
+    @Override
     public StorageGetUrlOperation<?> getUrl(
             @NonNull String key,
             @NonNull Consumer<StorageGetUrlResult> onSuccess,

--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -71,10 +71,7 @@ public final class Amplify {
     @SuppressWarnings("checkstyle:all") public static final DataStoreCategory DataStore = new DataStoreCategory();
     @SuppressWarnings("checkstyle:all") public static final PredictionsCategory Predictions = new PredictionsCategory();
 
-    /**
-     * A map from each type of category to an entry point for that category.
-     */
-    public static final Map<CategoryType, Category<? extends Plugin<?>>> CATEGORIES = buildCategoriesMap();
+    private static final LinkedHashMap<CategoryType, Category<? extends Plugin<?>>> CATEGORIES = buildCategoriesMap();
 
     // Used as a synchronization locking object. Set to true once configure() is complete.
     private static final AtomicBoolean CONFIGURATION_LOCK = new AtomicBoolean(false);
@@ -89,9 +86,9 @@ public final class Amplify {
         throw new UnsupportedOperationException("No instances allowed.");
     }
 
-    // The fact that this is a LinkedHashMap is important.
+    // The fact that this is a LinkedHashMap, and not a Map, is important.
     // We are relying on the ordering of this data-structure, for configuration.
-    private static Map<CategoryType, Category<? extends Plugin<?>>> buildCategoriesMap() {
+    private static LinkedHashMap<CategoryType, Category<? extends Plugin<?>>> buildCategoriesMap() {
         final LinkedHashMap<CategoryType, Category<? extends Plugin<?>>> categories = new LinkedHashMap<>();
         categories.put(CategoryType.ANALYTICS, Analytics);
         categories.put(CategoryType.API, API);
@@ -101,7 +98,15 @@ public final class Amplify {
         categories.put(CategoryType.HUB, Hub);
         categories.put(CategoryType.DATASTORE, DataStore);
         categories.put(CategoryType.PREDICTIONS, Predictions);
-        return Immutable.of(categories);
+        return categories;
+    }
+
+    /**
+     * Returns an unordered map from each type of category to an entry point for that category.
+     * @return a Map from CategoryType to Category.
+     */
+    public static Map<CategoryType, Category<? extends Plugin<?>>> getCategoriesMap() {
+        return Immutable.of(CATEGORIES);
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -33,8 +33,10 @@ import com.amplifyframework.logging.LoggingCategory;
 import com.amplifyframework.predictions.PredictionsCategory;
 import com.amplifyframework.storage.StorageCategory;
 import com.amplifyframework.util.Empty;
+import com.amplifyframework.util.Immutable;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -69,7 +71,10 @@ public final class Amplify {
     @SuppressWarnings("checkstyle:all") public static final DataStoreCategory DataStore = new DataStoreCategory();
     @SuppressWarnings("checkstyle:all") public static final PredictionsCategory Predictions = new PredictionsCategory();
 
-    private static final LinkedHashMap<CategoryType, Category<? extends Plugin<?>>> CATEGORIES = buildCategoriesMap();
+    /**
+     * A map from each type of category to an entry point for that category.
+     */
+    public static final Map<CategoryType, Category<? extends Plugin<?>>> CATEGORIES = buildCategoriesMap();
 
     // Used as a synchronization locking object. Set to true once configure() is complete.
     private static final AtomicBoolean CONFIGURATION_LOCK = new AtomicBoolean(false);
@@ -84,9 +89,9 @@ public final class Amplify {
         throw new UnsupportedOperationException("No instances allowed.");
     }
 
-    // The fact that this is a LinkedHashMap, and not a Map, is important.
+    // The fact that this is a LinkedHashMap is important.
     // We are relying on the ordering of this data-structure, for configuration.
-    private static LinkedHashMap<CategoryType, Category<? extends Plugin<?>>> buildCategoriesMap() {
+    private static Map<CategoryType, Category<? extends Plugin<?>>> buildCategoriesMap() {
         final LinkedHashMap<CategoryType, Category<? extends Plugin<?>>> categories = new LinkedHashMap<>();
         categories.put(CategoryType.ANALYTICS, Analytics);
         categories.put(CategoryType.API, API);
@@ -96,7 +101,7 @@ public final class Amplify {
         categories.put(CategoryType.HUB, Hub);
         categories.put(CategoryType.DATASTORE, DataStore);
         categories.put(CategoryType.PREDICTIONS, Predictions);
-        return categories;
+        return Immutable.of(categories);
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
+++ b/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
@@ -16,7 +16,6 @@
 package com.amplifyframework.core;
 
 import android.content.Context;
-import android.content.res.Resources;
 import androidx.annotation.NonNull;
 import androidx.annotation.RawRes;
 
@@ -37,12 +36,10 @@ import com.amplifyframework.util.Immutable;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 
 /**
  * AmplifyConfiguration serves as the top-level configuration object for the
@@ -112,7 +109,7 @@ public final class AmplifyConfiguration {
     @SuppressWarnings("WeakerAccess")
     @NonNull
     public static AmplifyConfiguration fromConfigFile(@NonNull Context context) throws AmplifyException {
-        return fromConfigFile(context, getConfigResourceId(context));
+        return fromConfigFile(context, Resources.getRawResourceId(context, DEFAULT_IDENTIFIER));
     }
 
     /**
@@ -127,48 +124,7 @@ public final class AmplifyConfiguration {
     @NonNull
     public static AmplifyConfiguration fromConfigFile(
             @NonNull Context context, @RawRes int configFileResourceId) throws AmplifyException {
-        return fromJson(readInputJson(context, configFileResourceId));
-    }
-
-    private static int getConfigResourceId(Context context) throws AmplifyException {
-        try {
-            return context.getResources()
-                .getIdentifier(DEFAULT_IDENTIFIER, "raw", context.getPackageName());
-        } catch (Exception exception) {
-            throw new AmplifyException(
-                "Failed to read " + DEFAULT_IDENTIFIER + ".",
-                exception, "Please check that it is correctly formed."
-            );
-        }
-    }
-
-    private static JSONObject readInputJson(Context context, int resourceId) throws AmplifyException {
-        InputStream inputStream;
-
-        try {
-            inputStream = context.getResources().openRawResource(resourceId);
-        } catch (Resources.NotFoundException exception) {
-            throw new AmplifyException(
-                    "Failed to find " + DEFAULT_IDENTIFIER + ".",
-                    exception, "Please check that it has been created."
-            );
-        }
-
-        final Scanner in = new Scanner(inputStream);
-        final StringBuilder sb = new StringBuilder();
-        while (in.hasNextLine()) {
-            sb.append(in.nextLine());
-        }
-        in.close();
-
-        try {
-            return new JSONObject(sb.toString());
-        } catch (JSONException jsonError) {
-            throw new AmplifyException(
-                "Failed to read " + DEFAULT_IDENTIFIER + ".",
-                jsonError, "Please check that it is correctly formed."
-            );
-        }
+        return fromJson(Resources.readJsonResourceFromId(context, configFileResourceId));
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/Resources.java
+++ b/core/src/main/java/com/amplifyframework/core/Resources.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.core;
 
 import android.content.Context;
+import android.content.res.Resources.NotFoundException;
 import androidx.annotation.RawRes;
 
 import com.amplifyframework.AmplifyException;
@@ -75,7 +76,7 @@ public final class Resources {
 
         try {
             inputStream = context.getResources().openRawResource(resourceId);
-        } catch (android.content.res.Resources.NotFoundException exception) {
+        } catch (NotFoundException exception) {
             throw new AmplifyException(
                     "Failed to find the resource with ID " + resourceId + ".",
                     exception, "Please check that it has been created."

--- a/core/src/main/java/com/amplifyframework/core/Resources.java
+++ b/core/src/main/java/com/amplifyframework/core/Resources.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core;
+
+import android.content.Context;
+import androidx.annotation.RawRes;
+
+import com.amplifyframework.AmplifyException;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.InputStream;
+import java.util.Scanner;
+
+/**
+ * A utility to read resource files.
+ */
+public final class Resources {
+
+    private Resources() { }
+
+    /**
+     * Obtains the raw resource ID for the given resource identifier.
+     * @param context An Android Context
+     * @param identifier Name of a raw resource
+     * @return ID of the raw resource
+     * @throws AmplifyException if the specified raw resource does not exist
+     */
+    @RawRes
+    public static int getRawResourceId(Context context, String identifier) throws AmplifyException {
+        try {
+            return context.getResources().getIdentifier(identifier, "raw", context.getPackageName());
+        } catch (Exception exception) {
+            throw new AmplifyException(
+                    "Failed to find " + identifier + ".",
+                    exception, "Please check that it exists."
+            );
+        }
+    }
+
+    /**
+     * Reads the content of the resource with the given identifier, as a {@link JSONObject}.
+     * @param context An Android Context
+     * @param identifier Name of a raw resource
+     * @return JSON Object equivalent of the raw resource
+     * @throws AmplifyException If resource with given ID does not exist or cannot be read
+     */
+    public static JSONObject readJsonResource(Context context, String identifier) throws AmplifyException {
+        return readJsonResourceFromId(context, getRawResourceId(context, identifier));
+    }
+
+    /**
+     * Reads the content of the resource with the given ID, as a {@link JSONObject}.
+     * @param context An Android Context
+     * @param resourceId ID of a raw resource
+     * @return JSON Object equivalent of the raw resource
+     * @throws AmplifyException If resource with given ID does not exist or cannot be read
+     */
+    public static JSONObject readJsonResourceFromId(Context context, int resourceId) throws AmplifyException {
+        InputStream inputStream;
+
+        try {
+            inputStream = context.getResources().openRawResource(resourceId);
+        } catch (android.content.res.Resources.NotFoundException exception) {
+            throw new AmplifyException(
+                    "Failed to find the resource with ID " + resourceId + ".",
+                    exception, "Please check that it has been created."
+            );
+        }
+
+        final Scanner in = new Scanner(inputStream);
+        final StringBuilder sb = new StringBuilder();
+        while (in.hasNextLine()) {
+            sb.append(in.nextLine());
+        }
+        in.close();
+
+        try {
+            return new JSONObject(sb.toString());
+        } catch (JSONException jsonError) {
+            throw new AmplifyException(
+                    "Failed to read the resource with ID " + resourceId + ".",
+                    jsonError, "Please check that it is correctly formed."
+            );
+        }
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/Resources.java
+++ b/core/src/main/java/com/amplifyframework/core/Resources.java
@@ -70,7 +70,7 @@ public final class Resources {
      * @return JSON Object equivalent of the raw resource
      * @throws AmplifyException If resource with given ID does not exist or cannot be read
      */
-    public static JSONObject readJsonResourceFromId(Context context, int resourceId) throws AmplifyException {
+    public static JSONObject readJsonResourceFromId(Context context, @RawRes int resourceId) throws AmplifyException {
         InputStream inputStream;
 
         try {

--- a/core/src/main/java/com/amplifyframework/core/plugin/Plugin.java
+++ b/core/src/main/java/com/amplifyframework/core/plugin/Plugin.java
@@ -82,4 +82,11 @@ public interface Plugin<E> extends CategoryTypeable {
     @Nullable
     E getEscapeHatch();
 
+    /**
+     * Returns the plugin version.
+     * @return the plugin version
+     */
+    @NonNull
+    String getVersion();
+
 }

--- a/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
@@ -28,13 +28,16 @@ import android.widget.TextView;
 import androidx.fragment.app.Fragment;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.R;
+import com.amplifyframework.logging.Logger;
 
 /**
  * A {@link Fragment} subclass representing the view
  * to display the environment information on the developer menu.
  */
 public final class DevMenuEnvironmentFragment extends Fragment {
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:devmenu");
 
     /**
      * Required empty public constructor.
@@ -68,7 +71,7 @@ public final class DevMenuEnvironmentFragment extends Fragment {
         try {
             devEnvInfo = envInfo.getDeveloperEnvironmentInfo(requireContext());
         } catch (AmplifyException error) {
-            DeveloperMenu.LOG.warn("Error reading developer environment information.");
+            LOG.warn("Error reading developer environment information.");
         }
         if (devEnvInfo.isEmpty()) {
             stringBuilder.append("\nUnable to retrieve developer environment information.");

--- a/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
@@ -27,10 +27,8 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.fragment.app.Fragment;
 
-import com.amplifyframework.core.Amplify;
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.R;
-
-import org.json.JSONException;
 
 /**
  * A {@link Fragment} subclass representing the view
@@ -69,9 +67,8 @@ public final class DevMenuEnvironmentFragment extends Fragment {
         String devEnvInfo = "";
         try {
             devEnvInfo = envInfo.getDeveloperEnvironmentInfo(requireContext());
-        } catch (JSONException jsonError) {
-            Amplify.Logging.forNamespace("amplify").error("Error reading developer environment information.",
-                    jsonError);
+        } catch (AmplifyException error) {
+            DeveloperMenu.LOG.warn("Error reading developer environment information.");
         }
         if (devEnvInfo.isEmpty()) {
             stringBuilder.append("\nUnable to retrieve developer environment information.");

--- a/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DevMenuEnvironmentFragment.java
@@ -27,7 +27,10 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.fragment.app.Fragment;
 
+import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.R;
+
+import org.json.JSONException;
 
 /**
  * A {@link Fragment} subclass representing the view
@@ -55,10 +58,27 @@ public final class DevMenuEnvironmentFragment extends Fragment {
      */
     private SpannableStringBuilder getEnvironmentInfo() {
         SpannableStringBuilder stringBuilder = new SpannableStringBuilder();
+        EnvironmentInfo envInfo = new EnvironmentInfo();
+        // Append the amplify plugin versions to stringBuilder
         stringBuilder.append(setBold("Amplify Plugins Information"));
-        stringBuilder.append("\nPlugin versions will be added here...\n\n");
+        String pluginVersions = "\n" + envInfo.getPluginVersions() + "\n";
+        stringBuilder.append(pluginVersions);
+
+        // Append the developer environment information to stringBuilder
         stringBuilder.append(setBold("Developer Environment Information"));
-        stringBuilder.append("\nDeveloper environment information will be added here...");
+        String devEnvInfo = "";
+        try {
+            devEnvInfo = envInfo.getDeveloperEnvironmentInfo(requireContext());
+        } catch (JSONException jsonError) {
+            Amplify.Logging.forNamespace("amplify").error("Error reading developer environment information.",
+                    jsonError);
+        }
+        if (devEnvInfo.isEmpty()) {
+            stringBuilder.append("\nUnable to retrieve developer environment information.");
+        } else {
+            devEnvInfo = "\n" + devEnvInfo;
+            stringBuilder.append(devEnvInfo);
+        }
         return stringBuilder;
     }
 

--- a/core/src/main/java/com/amplifyframework/devmenu/DevMenuFileIssueFragment.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DevMenuFileIssueFragment.java
@@ -72,13 +72,13 @@ public final class DevMenuFileIssueFragment extends Fragment {
      * @return the issue body
      */
     private String getIssueBody() {
-        EditText issueDescription = (EditText) fileIssueView.findViewById(R.id.issue_description);
+        EditText issueDescription = fileIssueView.findViewById(R.id.issue_description);
         String description = issueDescription.getText().toString();
         if (description.length() < MIN_DESCRIPTION_LENGTH) {
             issueDescription.setError(DESCRIPTION_LENGTH_ERROR);
             return "";
         } else {
-            Switch logsSwitch = (Switch) fileIssueView.findViewById(R.id.logs_switch);
+            Switch logsSwitch = fileIssueView.findViewById(R.id.logs_switch);
             return developerMenu.createIssueBody(description, logsSwitch.isChecked());
         }
     }

--- a/core/src/main/java/com/amplifyframework/devmenu/DevMenuFileIssueFragment.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DevMenuFileIssueFragment.java
@@ -33,7 +33,7 @@ import com.amplifyframework.core.R;
  */
 public final class DevMenuFileIssueFragment extends Fragment {
     // Minimum number of characters required for the issue description.
-    private static final int MIN_DESCRIPTION_LENGTH = 140;
+    private static final int MIN_DESCRIPTION_LENGTH = 20;
     // Error message to display when the description does not satisfy the
     // minimum character count requirement.
     private static final String DESCRIPTION_LENGTH_ERROR = "Issue description must be at least "

--- a/core/src/main/java/com/amplifyframework/devmenu/DeveloperMenu.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DeveloperMenu.java
@@ -25,6 +25,8 @@ import android.text.TextUtils;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
 
+import org.json.JSONException;
+
 import java.util.List;
 import java.util.Locale;
 
@@ -137,8 +139,18 @@ public final class DeveloperMenu implements ShakeDetector.Listener {
      * @return the issue body
      */
     public String createIssueBody(String description, boolean includeLogs) {
-        // TODO: add environment information to issue body
-        String envInfo = "";
+        EnvironmentInfo environmentInfo = new EnvironmentInfo();
+        String envInfo = "Amplify Plugins Information:\n" + environmentInfo.getPluginVersions();
+        String devEnvInfo = "";
+        try {
+            devEnvInfo = environmentInfo.getDeveloperEnvironmentInfo(context);
+        } catch (JSONException jsonError) {
+            Amplify.Logging.forNamespace("amplify").error("Error reading developer environment information.",
+                    jsonError);
+        }
+        if (!devEnvInfo.isEmpty()) {
+            envInfo += "\n\nDeveloper Environment Information:\n" + devEnvInfo;
+        }
         String deviceInfo = new DeviceInfo().toString();
         String logsText = "";
         if (includeLogs && !loggingPlugin.getLogs().isEmpty()) {

--- a/core/src/main/java/com/amplifyframework/devmenu/DeveloperMenu.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DeveloperMenu.java
@@ -34,10 +34,7 @@ import java.util.Locale;
  * developer menu.
  */
 public final class DeveloperMenu implements ShakeDetector.Listener {
-    /**
-     * Logger for the developer menu.
-     */
-    protected static final Logger LOG = Amplify.Logging.forNamespace("amplify:devmenu");
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:devmenu");
     // An instance of DeveloperMenu.
     private static DeveloperMenu sInstance;
     // Indicates whether the developer menu is visible.

--- a/core/src/main/java/com/amplifyframework/devmenu/DeveloperMenu.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DeveloperMenu.java
@@ -140,7 +140,7 @@ public final class DeveloperMenu implements ShakeDetector.Listener {
      */
     public String createIssueBody(String description, boolean includeLogs) {
         EnvironmentInfo environmentInfo = new EnvironmentInfo();
-        String envInfo = "Amplify Plugins Information:\n" + environmentInfo.getPluginVersions();
+        String envInfo = "*Amplify Plugins Information:*\n" + environmentInfo.getPluginVersions();
         String devEnvInfo = "";
         try {
             devEnvInfo = environmentInfo.getDeveloperEnvironmentInfo(context);
@@ -149,7 +149,7 @@ public final class DeveloperMenu implements ShakeDetector.Listener {
                     jsonError);
         }
         if (!devEnvInfo.isEmpty()) {
-            envInfo += "\n\nDeveloper Environment Information:\n" + devEnvInfo;
+            envInfo += "\n\n*Developer Environment Information:*\n" + devEnvInfo;
         }
         String deviceInfo = new DeviceInfo().toString();
         String logsText = "";

--- a/core/src/main/java/com/amplifyframework/devmenu/DeveloperMenu.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/DeveloperMenu.java
@@ -24,8 +24,7 @@ import android.text.TextUtils;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
-
-import org.json.JSONException;
+import com.amplifyframework.logging.Logger;
 
 import java.util.List;
 import java.util.Locale;
@@ -35,6 +34,10 @@ import java.util.Locale;
  * developer menu.
  */
 public final class DeveloperMenu implements ShakeDetector.Listener {
+    /**
+     * Logger for the developer menu.
+     */
+    protected static final Logger LOG = Amplify.Logging.forNamespace("amplify:devmenu");
     // An instance of DeveloperMenu.
     private static DeveloperMenu sInstance;
     // Indicates whether the developer menu is visible.
@@ -144,9 +147,8 @@ public final class DeveloperMenu implements ShakeDetector.Listener {
         String devEnvInfo = "";
         try {
             devEnvInfo = environmentInfo.getDeveloperEnvironmentInfo(context);
-        } catch (JSONException jsonError) {
-            Amplify.Logging.forNamespace("amplify").error("Error reading developer environment information.",
-                    jsonError);
+        } catch (AmplifyException error) {
+            LOG.warn("Error reading developer environment information.");
         }
         if (!devEnvInfo.isEmpty()) {
             envInfo += "\n\n*Developer Environment Information:*\n" + devEnvInfo;

--- a/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
@@ -27,9 +27,7 @@ import com.amplifyframework.core.plugin.Plugin;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -62,11 +60,8 @@ public final class EnvironmentInfo {
      * @return version information for each plugin added
      */
     public String getPluginVersions() {
-        // TODO: can we centralize these somewhere? We want ~1 file in the code base that lists all the categories.
-        List<Category<?>> categories = Arrays.asList(Amplify.Analytics, Amplify.API, Amplify.Auth, Amplify.Logging,
-                Amplify.Storage, Amplify.Hub, Amplify.DataStore, Amplify.Predictions);
         StringBuilder pluginStringBuilder = new StringBuilder();
-        for (Category<?> category : categories) {
+        for (Category<?> category : Amplify.CATEGORIES.values()) {
             pluginStringBuilder.append(getCategoryPluginVersions(category));
         }
         String pluginVersions = pluginStringBuilder.toString();

--- a/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
@@ -16,22 +16,20 @@
 package com.amplifyframework.devmenu;
 
 import android.content.Context;
-import android.content.res.Resources;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.Resources;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.plugin.Plugin;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Scanner;
 
 /**
  * Contains information about the plugin versions added to the application
@@ -82,26 +80,7 @@ public final class EnvironmentInfo {
      */
     public String getDeveloperEnvironmentInfo(@NonNull Context context) throws AmplifyException {
         Context appContext = Objects.requireNonNull(context).getApplicationContext();
-        Resources resources = appContext.getApplicationContext().getResources();
-        int resourceId = resources.getIdentifier(DEV_ENV_INFO_FILE_NAME, "raw", appContext.getPackageName());
-        if (resourceId == 0) {
-            throw new AmplifyException("Error reading the developer environment information.",
-                    "Check that the resource " + DEV_ENV_INFO_FILE_NAME + ".json exists.");
-        }
-        InputStream inputStream = resources.openRawResource(resourceId);
-        Scanner in = new Scanner(inputStream);
-        StringBuilder stringBuilder = new StringBuilder();
-        while (in.hasNextLine()) {
-            stringBuilder.append(in.nextLine());
-        }
-        in.close();
-        JSONObject envInfo;
-        try {
-            envInfo = new JSONObject(stringBuilder.toString());
-        } catch (JSONException jsonError) {
-            throw new AmplifyException("Error reading the developer environment information.", jsonError,
-                    "Check that " + DEV_ENV_INFO_FILE_NAME + ".json is properly formatted");
-        }
+        JSONObject envInfo = Resources.readJsonResource(appContext, DEV_ENV_INFO_FILE_NAME);
         StringBuilder formattedEnvInfo = new StringBuilder();
         for (String envItem : devEnvironmentItems.keySet()) {
             if (envInfo.has(envItem)) {
@@ -109,8 +88,10 @@ public final class EnvironmentInfo {
                 try {
                     envValue = envInfo.getString(envItem);
                 } catch (JSONException jsonError) {
-                    throw new AmplifyException("Error reading the developer environment information.", jsonError,
-                            "Check that " + DEV_ENV_INFO_FILE_NAME + ".json is properly formatted");
+                    throw new AmplifyException(
+                            "Error reading the developer environment information.", jsonError,
+                            "Check that " + DEV_ENV_INFO_FILE_NAME + ".json is properly formatted"
+                    );
                 }
                 String devEnvInfoItem = devEnvironmentItems.get(envItem) + ": " + envValue + "\n";
                 formattedEnvInfo.append(devEnvInfoItem);

--- a/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
@@ -72,8 +72,7 @@ public final class EnvironmentInfo {
     }
 
     /**
-     * Returns a String representation of information about the developer's environment, or
-     * an empty string if the developer environment information could not be found.
+     * Returns a String representation of information about the developer's environment.
      * @param context an Android Context
      * @return developer environment information
      * @throws AmplifyException if the developer environment information could not be read

--- a/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
@@ -27,7 +27,9 @@ import com.amplifyframework.core.plugin.Plugin;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -60,14 +62,14 @@ public final class EnvironmentInfo {
      * @return version information for each plugin added
      */
     public String getPluginVersions() {
-        String pluginVersions = getCategoryPluginVersions(Amplify.Analytics) +
-                getCategoryPluginVersions(Amplify.API) +
-                getCategoryPluginVersions(Amplify.Auth) +
-                getCategoryPluginVersions(Amplify.Logging) +
-                getCategoryPluginVersions(Amplify.Storage) +
-                getCategoryPluginVersions(Amplify.Hub) +
-                getCategoryPluginVersions(Amplify.DataStore) +
-                getCategoryPluginVersions(Amplify.Predictions);
+        // TODO: can we centralize these somewhere? We want ~1 file in the code base that lists all the categories.
+        List<Category<?>> categories = Arrays.asList(Amplify.Analytics, Amplify.API, Amplify.Auth, Amplify.Logging,
+                Amplify.Storage, Amplify.Hub, Amplify.DataStore, Amplify.Predictions);
+        StringBuilder pluginStringBuilder = new StringBuilder();
+        for (Category<?> category : categories) {
+            pluginStringBuilder.append(getCategoryPluginVersions(category));
+        }
+        String pluginVersions = pluginStringBuilder.toString();
         return pluginVersions.isEmpty() ? "No plugins added." : pluginVersions;
     }
 

--- a/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.devmenu;
+
+import android.content.Context;
+import android.content.res.Resources;
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.category.Category;
+import com.amplifyframework.core.plugin.Plugin;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Scanner;
+
+/**
+ * Contains information about the plugin versions added to the application
+ * and the developer's environment.
+ */
+public final class EnvironmentInfo {
+    // Name of the file that contains the developer environment information.
+    private static final String DEV_ENV_INFO_FILE_NAME = "localenvinfo";
+    // A map from developer environment information items to the formatted name of that item.
+    private final Map<String, String> devEnvironmentItems;
+
+    /**
+     * Constructs a new EnvironmentInfo instance.
+     */
+    public EnvironmentInfo() {
+        devEnvironmentItems = new HashMap<>();
+        devEnvironmentItems.put("nodejsVersion", "Node.js Version");
+        devEnvironmentItems.put("npmVersion", "NPM Version");
+        devEnvironmentItems.put("amplifyCliVersion", "Amplify CLI Version");
+        devEnvironmentItems.put("androidStudioVersion", "Android Studio Version");
+        devEnvironmentItems.put("osName", "OS");
+        devEnvironmentItems.put("osVersion", "OS Version");
+    }
+
+    /**
+     * Returns a String representation of the version of each plugin added, or
+     * "No plugins added." if no plugins were added.
+     * @return version information for each plugin added
+     */
+    public String getPluginVersions() {
+        String pluginVersions = getCategoryPluginVersions(Amplify.Analytics) +
+                getCategoryPluginVersions(Amplify.API) +
+                getCategoryPluginVersions(Amplify.Auth) +
+                getCategoryPluginVersions(Amplify.Logging) +
+                getCategoryPluginVersions(Amplify.Storage) +
+                getCategoryPluginVersions(Amplify.Hub) +
+                getCategoryPluginVersions(Amplify.DataStore) +
+                getCategoryPluginVersions(Amplify.Predictions);
+        return pluginVersions.isEmpty() ? "No plugins added." : pluginVersions;
+    }
+
+    /**
+     * Returns a String representation of information about the developer's environment, or
+     * an empty string if the developer environment information could not be found.
+     * @param context an Android Context
+     * @return developer environment information
+     * @throws JSONException if the developer environment information could not be read
+     */
+    public String getDeveloperEnvironmentInfo(@NonNull Context context) throws JSONException {
+        Context appContext = Objects.requireNonNull(context).getApplicationContext();
+        Resources resources = appContext.getApplicationContext().getResources();
+        int resourceId = resources.getIdentifier(DEV_ENV_INFO_FILE_NAME, "raw", appContext.getPackageName());
+        if (resourceId == 0) {
+            return "";
+        }
+        InputStream inputStream = resources.openRawResource(resourceId);
+        Scanner in = new Scanner(inputStream);
+        StringBuilder stringBuilder = new StringBuilder();
+        while (in.hasNextLine()) {
+            stringBuilder.append(in.nextLine());
+        }
+        in.close();
+        JSONObject envInfo = new JSONObject(stringBuilder.toString());
+        StringBuilder formattedEnvInfo = new StringBuilder();
+        for (String envItem : devEnvironmentItems.keySet()) {
+            if (envInfo.has(envItem)) {
+                String devEnvInfoItem = devEnvironmentItems.get(envItem) + ": " + envInfo.get(envItem) + "\n";
+                formattedEnvInfo.append(devEnvInfoItem);
+            }
+        }
+        return formattedEnvInfo.toString();
+    }
+
+    /**
+     * Returns a String representation of the version for each added plugin
+     * that belongs to the given category.
+     * @param category Category to retrieve plugin versions from
+     * @return the version for each added plugin in the given category
+     */
+    private String getCategoryPluginVersions(Category<?> category) {
+        StringBuilder pluginVersions = new StringBuilder();
+        for (Plugin<?> plugin : category.getPlugins()) {
+            String versionInfo = plugin.getPluginKey() + ": " + plugin.getVersion() + "\n";
+            pluginVersions.append(versionInfo);
+        }
+        return pluginVersions.toString();
+    }
+}

--- a/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
@@ -61,7 +61,7 @@ public final class EnvironmentInfo {
      */
     public String getPluginVersions() {
         StringBuilder pluginStringBuilder = new StringBuilder();
-        for (Category<?> category : Amplify.CATEGORIES.values()) {
+        for (Category<?> category : Amplify.getCategoriesMap().values()) {
             pluginStringBuilder.append(getCategoryPluginVersions(category));
         }
         String pluginVersions = pluginStringBuilder.toString();

--- a/core/src/main/java/com/amplifyframework/devmenu/PersistentLogStoragePlugin.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/PersistentLogStoragePlugin.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.core.BuildConfig;
 import com.amplifyframework.logging.Logger;
 import com.amplifyframework.logging.LoggingCategoryBehavior;
 import com.amplifyframework.logging.LoggingPlugin;
@@ -75,6 +76,12 @@ public final class PersistentLogStoragePlugin extends LoggingPlugin<Void> {
     @Override
     public Void getEscapeHatch() {
         return null;
+    }
+
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/hub/AWSHubPlugin.java
+++ b/core/src/main/java/com/amplifyframework/hub/AWSHubPlugin.java
@@ -20,6 +20,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
+import com.amplifyframework.core.BuildConfig;
+
 import org.json.JSONObject;
 
 import java.util.HashSet;
@@ -112,6 +114,12 @@ public final class AWSHubPlugin extends HubPlugin<Void> {
     @Override
     public Void getEscapeHatch() {
         return null;
+    }
+
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/logging/AndroidLoggingPlugin.java
+++ b/core/src/main/java/com/amplifyframework/logging/AndroidLoggingPlugin.java
@@ -20,6 +20,8 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.core.BuildConfig;
+
 import org.json.JSONObject;
 
 /**
@@ -73,5 +75,11 @@ public final class AndroidLoggingPlugin extends LoggingPlugin<Void> {
     @Override
     public Void getEscapeHatch() {
         return null;
+    }
+
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
     }
 }

--- a/core/src/main/java/com/amplifyframework/util/Immutable.java
+++ b/core/src/main/java/com/amplifyframework/util/Immutable.java
@@ -19,8 +19,8 @@ import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,7 +46,7 @@ public final class Immutable {
             return null;
         }
 
-        final Map<K, V> copy = new HashMap<>(mutableMap);
+        final Map<K, V> copy = new LinkedHashMap<>(mutableMap);
         return Collections.unmodifiableMap(copy);
     }
 

--- a/core/src/main/java/com/amplifyframework/util/Immutable.java
+++ b/core/src/main/java/com/amplifyframework/util/Immutable.java
@@ -19,8 +19,8 @@ import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,7 +46,7 @@ public final class Immutable {
             return null;
         }
 
-        final Map<K, V> copy = new LinkedHashMap<>(mutableMap);
+        final Map<K, V> copy = new HashMap<>(mutableMap);
         return Collections.unmodifiableMap(copy);
     }
 

--- a/core/src/main/res/layout/activity_dev_menu.xml
+++ b/core/src/main/res/layout/activity_dev_menu.xml
@@ -42,7 +42,7 @@
             android:id="@+id/nav_host_fragment"
             android:name="androidx.navigation.fragment.NavHostFragment"
             android:layout_width="match_parent"
-            android:layout_height="220dp"
+            android:layout_height="250dp"
             app:defaultNavHost="true"
             app:navGraph="@navigation/dev_menu_nav_graph"
             tools:ignore="FragmentTagUsage" />

--- a/core/src/main/res/layout/dev_menu_fragment_file_issue.xml
+++ b/core/src/main/res/layout/dev_menu_fragment_file_issue.xml
@@ -54,7 +54,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/file_issue_warning_text"
-        android:textSize="14sp"
+        android:textSize="15sp"
         android:textColor="?android:attr/textColorPrimaryInverse"
         android:textStyle="bold"
         android:gravity="center"

--- a/core/src/main/res/values/dev_menu_strings.xml
+++ b/core/src/main/res/values/dev_menu_strings.xml
@@ -34,7 +34,7 @@
     <string name="empty" />
     <string name="copy_issue_text">Copy to Clipboard</string>
     <string name="file_issue_warning_text">
-        Device and environment information will be included in the issue description.
-        You can preview this information before it is submitted by pressing \"File Issue\".
+        After pressing \"File Issue\", you will have the opportunity to review the logs and other
+        information included. Please ensure any sensitive data is removed before submitting.
     </string>
 </resources>

--- a/core/src/test/java/com/amplifyframework/core/BadInitLoggingPlugin.java
+++ b/core/src/test/java/com/amplifyframework/core/BadInitLoggingPlugin.java
@@ -67,6 +67,12 @@ public final class BadInitLoggingPlugin extends LoggingPlugin<Void> {
 
     @NonNull
     @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
+    @NonNull
+    @Override
     public Logger forNamespace(@Nullable String namespace) {
         return null;
     }

--- a/core/src/test/java/com/amplifyframework/core/SimpleLoggingPlugin.java
+++ b/core/src/test/java/com/amplifyframework/core/SimpleLoggingPlugin.java
@@ -69,6 +69,12 @@ public final class SimpleLoggingPlugin extends LoggingPlugin<Void> {
 
     @NonNull
     @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
+    }
+
+    @NonNull
+    @Override
     public Logger forNamespace(@Nullable String namespace) {
         return null;
     }

--- a/core/src/test/java/com/amplifyframework/core/category/FakePlugin.java
+++ b/core/src/test/java/com/amplifyframework/core/category/FakePlugin.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.BuildConfig;
 import com.amplifyframework.core.plugin.Plugin;
 
 import org.json.JSONObject;
@@ -62,6 +63,12 @@ final class FakePlugin<T> implements Plugin<T> {
     @Override
     public T getEscapeHatch() {
         return escapeHatch;
+    }
+
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
     }
 
     @NonNull

--- a/core/src/test/java/com/amplifyframework/core/category/SimplePlugin.java
+++ b/core/src/test/java/com/amplifyframework/core/category/SimplePlugin.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.core.BuildConfig;
 import com.amplifyframework.core.plugin.Plugin;
 
 import org.json.JSONObject;
@@ -71,6 +72,12 @@ final class SimplePlugin<T> implements Plugin<T> {
     @Override
     public T getEscapeHatch() {
         return escapeHatch;
+    }
+
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
     }
 
     @NonNull

--- a/core/src/test/java/com/amplifyframework/logging/FakeLoggingPlugin.java
+++ b/core/src/test/java/com/amplifyframework/logging/FakeLoggingPlugin.java
@@ -19,6 +19,8 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.core.BuildConfig;
+
 import org.json.JSONObject;
 
 /**
@@ -56,6 +58,12 @@ final class FakeLoggingPlugin<E> extends LoggingPlugin<E> {
     @Override
     public E getEscapeHatch() {
         return escapeHatch;
+    }
+
+    @NonNull
+    @Override
+    public String getVersion() {
+        return BuildConfig.VERSION_NAME;
     }
 
     @NonNull


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Displays environment information (Amplify plugin information and developer environment information) on the developer menu. Note that the developer environment information currently contains only simulated values. Also makes the following changes:

- Increases the height of the developer menu.
- Changes the message displayed on the file issue screen and increases the font size of this message.
- Reduces the minimum character count requirement for the issue description on the file issue screen.
- Adds environment information to the issue body generated when the "Copy to Clipboard" or "File Issue" button is pressed on the file issue screen.

Environment information screen (note that the PersistentLogStoragePlugin is part of core and inside my sample app's build.gradle, the version for the dependency on the core package is set to main):
<img width="420" alt="Dev Menu Env Info Screen" src="https://user-images.githubusercontent.com/67125657/89954233-91e63b80-dbe5-11ea-8083-90ee21a093c1.png">

File issue screen after pressing the "File Issue" button on the main screen of the developer menu:
<img width="414" alt="Dev Menu File Issue Modified" src="https://user-images.githubusercontent.com/67125657/89954311-b215fa80-dbe5-11ea-8399-6de5a12b2193.png">

When the user clicks the "File Issue" button on the file issue screen, they are taken to the new issue page on GitHub (after logging in, if necessary). The issue body on GitHub looks as follows when clicking the "Preview" button on the GitHub new issue page:
<img width="424" alt="Dev Menu GitHub File New Issue" src="https://user-images.githubusercontent.com/67125657/89955090-1d140100-dbe7-11ea-8c30-add01ddbb88b.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
