### PR TITLE
feat(api) Implement Comparable for Temporal types so they can be used in predicates

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -50,7 +51,7 @@ public final class Temporal {
      * <p>
      * https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html#appsync-defined-scalars
      */
-    public static final class Date {
+    public static final class Date implements Comparable<Date> {
         private final LocalDate localDate;
         private final ZoneOffset zoneOffset;
 
@@ -176,6 +177,12 @@ public final class Temporal {
                     ", zoneOffset=\'" + zoneOffset + "\'" +
                     '}';
         }
+
+        @Override
+        public int compareTo(Date date) {
+            Objects.requireNonNull(date);
+            return toDate().compareTo(date.toDate());
+        }
     }
 
     /**
@@ -185,7 +192,7 @@ public final class Temporal {
      * <p>
      * https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html#appsync-defined-scalars
      */
-    public static final class DateTime {
+    public static final class DateTime implements Comparable<DateTime> {
         private final OffsetDateTime offsetDateTime;
 
         /**
@@ -261,6 +268,12 @@ public final class Temporal {
                     "offsetDateTime=\'" + offsetDateTime + "\'" +
                     '}';
         }
+
+        @Override
+        public int compareTo(DateTime dateTime) {
+            Objects.requireNonNull(dateTime);
+            return toDate().compareTo(dateTime.toDate());
+        }
     }
 
     /**
@@ -272,7 +285,7 @@ public final class Temporal {
      * <p>
      * https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html#appsync-defined-scalars
      */
-    public static final class Time {
+    public static final class Time implements Comparable<Time> {
         private final LocalTime localTime;
         private final ZoneOffset zoneOffset;
 
@@ -391,6 +404,12 @@ public final class Temporal {
                     ", zoneOffset=\'" + zoneOffset + "\'" +
                     '}';
         }
+
+        @Override
+        public int compareTo(Time time) {
+            Objects.requireNonNull(time);
+            return toDate().compareTo(time.toDate());
+        }
     }
 
     /**
@@ -399,7 +418,7 @@ public final class Temporal {
      * Negative values are also accepted and these represent the number of seconds
      * til 1970-01-01T00:00Z.
      */
-    public static final class Timestamp {
+    public static final class Timestamp implements Comparable<Timestamp> {
         private final long secondsSinceEpoch;
 
         /**
@@ -467,6 +486,12 @@ public final class Temporal {
             return "Temporal.Timestamp{" +
                     "timestamp=" + secondsSinceEpoch +
                     '}';
+        }
+
+        @Override
+        public int compareTo(Timestamp timestamp) {
+            Objects.requireNonNull(timestamp);
+            return Long.compare(getSecondsSinceEpoch(), timestamp.getSecondsSinceEpoch());
         }
     }
 }

--- a/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalDateTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalDateTest.java
@@ -92,4 +92,23 @@ public final class TemporalDateTest {
         assertEquals(date, temporalDate.toDate());
         assertEquals(offsetInSeconds, temporalDate.getOffsetTotalSeconds());
     }
+
+    /**
+     * A {@link Temporal.Date} implements {@link java.lang.Comparable} correctly.
+     */
+    @Test
+    public void temporalDateIsComparable() {
+        Temporal.Date marchThirdPST = new Temporal.Date("2001-03-03-08:00:00");
+        Temporal.Date marchFourthPST = new Temporal.Date("2001-03-04-08:00:00");
+        Temporal.Date marchFifthPST = new Temporal.Date("2001-03-05-08:00:00");
+        Temporal.Date marchFourthCST = new Temporal.Date("2001-03-04-06:00:00");
+
+        // Verify comparison of DateTimes with same TimeZone
+        assertEquals(1, marchFourthPST.compareTo(marchThirdPST)); // march 4th is after march 3rd
+        assertEquals(0, marchFourthPST.compareTo(marchFourthPST)); // march 4th is equal to march 4th
+        assertEquals(-1, marchFourthPST.compareTo(marchFifthPST)); // march 4th is before march 5th
+
+        // Verify comparison of DateTimes with different TimeZones
+        assertEquals(1, marchFourthPST.compareTo(marchFourthCST)); // march 4th PST is after march 4th CST
+    }
 }

--- a/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalDateTimeTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalDateTimeTest.java
@@ -68,4 +68,23 @@ public final class TemporalDateTimeTest {
         assertEquals(date, temporalDateTime.toDate());
         assertEquals(offsetInSeconds, temporalDateTime.getOffsetTotalSeconds());
     }
+
+    /**
+     * A {@link Temporal.DateTime} implements {@link java.lang.Comparable} correctly.
+     */
+    @Test
+    public void temporalDateTimeIsComparable() {
+        Temporal.DateTime sixAmPST = new Temporal.DateTime("2001-03-03T06:00:00.000-08:00:00");
+        Temporal.DateTime sevenAmPST = new Temporal.DateTime("2001-03-03T07:00:00.000-08:00:00");
+        Temporal.DateTime eightAmPST = new Temporal.DateTime("2001-03-03T08:00:00.000-08:00:00");
+        Temporal.DateTime eightAmCST = new Temporal.DateTime("2001-03-03T08:00:00.000-06:00:00");
+
+        // Verify comparison of DateTimes with same TimeZone
+        assertEquals(1, sevenAmPST.compareTo(sixAmPST));
+        assertEquals(0, sevenAmPST.compareTo(sevenAmPST));
+        assertEquals(-1, sevenAmPST.compareTo(eightAmPST));
+
+        // Verify comparison of DateTimes with different TimeZones
+        assertEquals(1, sevenAmPST.compareTo(eightAmCST));
+    }
 }

--- a/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalTimeTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalTimeTest.java
@@ -101,4 +101,24 @@ public final class TemporalTimeTest {
         assertEquals(date, temporalTime.toDate());
         assertEquals(offsetInSeconds, temporalTime.getOffsetTotalSeconds());
     }
+
+    /**
+     * A {@link Temporal.Time} implements {@link java.lang.Comparable} correctly.
+     */
+
+    @Test
+    public void temporalTimeIsComparable() {
+        Temporal.Time sixAmPST = new Temporal.Time("06:00:00.000-08:00:00");
+        Temporal.Time sevenAmPST = new Temporal.Time("07:00:00.000-08:00:00");
+        Temporal.Time eightAmPST = new Temporal.Time("08:00:00.000-08:00:00");
+        Temporal.Time eightAmCST = new Temporal.Time("08:00:00.000-06:00:00");
+
+        // Verify comparison of DateTimes with same TimeZone
+        assertEquals(1, sevenAmPST.compareTo(sixAmPST));
+        assertEquals(0, sevenAmPST.compareTo(sevenAmPST));
+        assertEquals(-1, sevenAmPST.compareTo(eightAmPST));
+
+        // Verify comparison of DateTimes with different TimeZones
+        assertEquals(1, sevenAmPST.compareTo(eightAmCST));
+    }
 }

--- a/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalTimestampTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalTimestampTest.java
@@ -83,4 +83,18 @@ public final class TemporalTimestampTest {
         assertEquals(1, times.size());
         assertEquals(first, second);
     }
+
+    /**
+     * A {@link Temporal.Timestamp} implements {@link java.lang.Comparable} correctly.
+     */
+    @Test
+    public void testCompare() {
+        Temporal.Timestamp first = new Temporal.Timestamp(5_000, TimeUnit.SECONDS);
+        Temporal.Timestamp second = new Temporal.Timestamp(6_000, TimeUnit.SECONDS);
+        Temporal.Timestamp third = new Temporal.Timestamp(7_000, TimeUnit.SECONDS);
+
+        assertEquals(1, second.compareTo(first));
+        assertEquals(0, second.compareTo(second));
+        assertEquals(-1, second.compareTo(third));
+    }
 }


### PR DESCRIPTION
This adds support for using `Temporal` date types for comparison in a `QueryPredicate`.

For example, given this schema:
```
type Todo @model {
  id: ID!
  name: String!
  description: String
  updatedAt: AWSDateTime
}
```

and the following implementation:
```
Amplify.API.query(
                ModelQuery.list(Todo.class, Todo.UPDATED_AT.gt(new Temporal.DateTime(new Date(), 0))),
                response -> LOG.info("query completed"),
                error -> LOG.error("query failed")) 
```

it fails to compile with this error:
```
error: method gt in class QueryField cannot be applied to given types;
        Amplify.API.query(ModelQuery.list(Todo.class, Todo.DATE.gt(dateTime)),
                                                               ^
  required: T
  found: DateTime
  reason: inferred type does not conform to upper bound(s)
    inferred: DateTime
    upper bound(s): Comparable<DateTime>
  where T is a type-variable:
    T extends Comparable<T> declared in method <T>gt(T)
```

This PR resolves this error by implementing `Comparable` on the 4 `Temporal` types (`Date`, `DateTime`, `Time`, `Timestamp`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
