### PR TITLE
fix[aws-datastore] selection set for nested custom types

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
@@ -294,7 +294,7 @@ public final class SelectionSet {
          * @param field field we wish to check
          * @return
          */
-        static boolean isCustomType(@NonNull Field field) {
+        private static boolean isCustomType(@NonNull Field field) {
             Class<?> cls = getClassForField(field);
             if (Model.class.isAssignableFrom(cls) || Enum.class.isAssignableFrom(cls)) {
                 return false;

--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
@@ -27,7 +27,6 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.types.JavaFieldType;
 import com.amplifyframework.util.Empty;
 import com.amplifyframework.util.FieldFinder;
-import com.amplifyframework.util.Immutable;
 import com.amplifyframework.util.Wrap;
 
 import java.lang.reflect.Field;
@@ -35,7 +34,6 @@ import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -227,7 +225,7 @@ public final class SelectionSet {
             }
 
             ModelSchema schema = ModelSchema.fromModelClass(clazz);
-            for (Field field : FieldFinder.findFieldsIn(clazz)) {
+            for (Field field : FieldFinder.findModelFieldsIn(clazz)) {
                 String fieldName = field.getName();
                 if (schema.getAssociations().containsKey(fieldName)) {
                     if (List.class.isAssignableFrom(field.getType())) {
@@ -260,7 +258,7 @@ public final class SelectionSet {
          */
         private Set<SelectionSet> getNestedCustomTypeFields(Class<?> clazz) {
             Set<SelectionSet> result = new HashSet<>();
-            for (Field field : findFieldsIn(clazz)) {
+            for (Field field : FieldFinder.findAllFieldsIn(clazz)) {
                 String fieldName = field.getName();
                 if (isCustomType(field)) {
                     result.add(new SelectionSet(fieldName, getNestedCustomTypeFields(getClassForField(field))));
@@ -269,24 +267,6 @@ public final class SelectionSet {
                 }
             }
             return result;
-        }
-
-        /**
-         * Helper for finding fields in a class.
-         * @param clazz class we wish to introspect
-         * @return
-         */
-        private List<Field> findFieldsIn(@NonNull Class<?> clazz) {
-            final List<Field> fields = new ArrayList<>();
-            Class<?> c = clazz;
-            while (c != null) {
-                for (Field field : c.getDeclaredFields()) {
-                    fields.add(field);
-                }
-                c = c.getSuperclass();
-            }
-            Collections.sort(fields, Comparator.comparing(Field::getName));
-            return Immutable.of(fields);
         }
 
         /**

--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
@@ -66,6 +66,12 @@ public enum JavaFieldType {
     TIME(Temporal.Time.class.getSimpleName()),
 
     /**
+     * Represents the Timestamp data type.
+     * Is not currently used by TypeConverter as AWS_TIMESTAMP is being stored as long.
+     */
+    TIMESTAMP(Temporal.Timestamp.class.getSimpleName()),
+
+    /**
      * Represents the Enum type.
      */
     ENUM(Enum.class.getSimpleName()),

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
@@ -18,6 +18,7 @@ package com.amplifyframework.api.aws;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.QueryType;
 import com.amplifyframework.testmodels.commentsblog.Post;
+import com.amplifyframework.testmodels.parenting.Parent;
 import com.amplifyframework.testutils.Resources;
 
 import org.junit.Test;
@@ -40,5 +41,19 @@ public class SelectionSetTest {
                 .requestOptions(new DefaultGraphQLRequestOptions())
                 .build();
         assertEquals(Resources.readAsString("selection-set-post.txt"), selectionSet.toString() + "\n");
+    }
+
+    /**
+     * Test that custom type selection set serialization works as expected.
+     * @throws AmplifyException if a ModelSchema can't be derived from Post.class
+     */
+    @Test
+    public void nestedCustomTypeSelectionSetSerializesToExpectedValue() throws AmplifyException {
+        SelectionSet selectionSet = SelectionSet.builder()
+                .modelClass(Parent.class)
+                .operation(QueryType.GET)
+                .requestOptions(new DefaultGraphQLRequestOptions())
+                .build();
+        assertEquals(Resources.readAsString("selection-set-parent.txt"), selectionSet.toString() + "\n");
     }
 }

--- a/aws-api-appsync/src/test/resources/selection-set-parent.txt
+++ b/aws-api-appsync/src/test/resources/selection-set-parent.txt
@@ -1,0 +1,29 @@
+ {
+  address {
+    city
+    country
+    phonenumber {
+      carrier
+      code
+      number
+    }
+    street
+    street2
+  }
+  children {
+    address {
+      city
+      country
+      phonenumber {
+        carrier
+        code
+        number
+      }
+      street
+      street2
+    }
+    name
+  }
+  id
+  name
+}

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageCustomTypeTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageCustomTypeTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.StrictMode;
+import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
+import com.amplifyframework.testmodels.parenting.Address;
+import com.amplifyframework.testmodels.parenting.AmplifyModelProvider;
+import com.amplifyframework.testmodels.parenting.Child;
+import com.amplifyframework.testmodels.parenting.City;
+import com.amplifyframework.testmodels.parenting.Parent;
+import com.amplifyframework.testmodels.parenting.Phonenumber;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test that nested custom types can be safely used in Models.
+ */
+public final class SQLiteStorageCustomTypeTest {
+    private SynchronousStorageAdapter adapter;
+
+    /**
+     * Enables Android Strict Mode, to help catch common errors while using
+     * SQLite, such as forgetting to close the database.
+     */
+    @BeforeClass
+    public static void enableStrictMode() {
+        StrictMode.enable();
+    }
+
+    /**
+     * Remove any old database files, and the re-provision a new storage adapter.
+     */
+    @Before
+    public void setup() {
+        TestStorageAdapter.cleanup();
+        this.adapter = TestStorageAdapter.create(AmplifyModelProvider.getInstance());
+    }
+
+    /**
+     * Close the open database, and cleanup any database files that it left.
+     */
+    @After
+    public void teardown() {
+        TestStorageAdapter.cleanup(adapter);
+    }
+
+    /**
+     * Assert that save stores data in the SQLite database correctly.
+     * @throws DataStoreException from possible underlying DataStore exceptions
+     */
+    @Test
+    public void saveModelInsertsData() throws DataStoreException {
+        adapter.save(buildTestParentModel());
+    }
+
+    /**
+     * Test querying the saved item in the SQLite database.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void querySavedData() throws DataStoreException {
+        final Parent parent = buildTestParentModel();
+        adapter.save(parent);
+
+        // Get the Parent from the database
+        final List<Parent> parents = adapter.query(Parent.class);
+        assertEquals(1, parents.size());
+        assertTrue(parents.contains(parent));
+    }
+
+    private Parent buildTestParentModel() {
+        Address address = Address.builder()
+                .street("555 Five Fiver")
+                .street2("township")
+                .city(City.BO)
+                .phonenumber(
+                        Phonenumber.builder()
+                                .code(232)
+                                .carrier(54)
+                                .number(11111111)
+                                .build()
+                )
+                .country("Sierra Leone")
+                .build();
+        Child child1 = Child.builder()
+                .name("SAM")
+                .address(address)
+                .build();
+        Child child2 = Child.builder()
+                .name("MAS")
+                .address(address)
+                .build();
+        return Parent.builder()
+                .name("Jane Doe")
+                .address(address)
+                .children(Arrays.asList(child1, child2))
+                .id("426f8e8d-ea0f-4839-a73f-6a2a38565ba1")
+                .build();
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -91,6 +91,7 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
             case LONG:
             case FLOAT:
             case STRING:
+            case TIMESTAMP:
                 // these types require no special treatment
                 return value;
             case BOOLEAN:
@@ -158,6 +159,7 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
                 case FLOAT:
                     return cursor.getFloat(columnIndex);
                 case LONG:
+                case TIMESTAMP:
                     return cursor.getLong(columnIndex);
                 case DATE:
                     return new Temporal.Date(valueAsString);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
@@ -260,7 +260,6 @@ public final class AppSyncRequestFactoryTest {
                 Resources.readAsString("create-parent-request.txt"),
                 AppSyncRequestFactory.buildCreationRequest(buildTestParentModel()).getContent(),
                 true
-
         );
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
@@ -22,6 +22,7 @@ import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testmodels.commentsblog.Comment;
 import com.amplifyframework.testmodels.commentsblog.Post;
+import com.amplifyframework.testmodels.parenting.Parent;
 import com.amplifyframework.testmodels.personcar.Person;
 import com.amplifyframework.testutils.Resources;
 
@@ -52,6 +53,20 @@ public final class AppSyncRequestFactoryTest {
             Resources.readAsString("base-sync-request-document-for-blog-owner.txt"),
             AppSyncRequestFactory.buildSyncRequest(BlogOwner.class, null, null).getContent(),
             true
+        );
+    }
+
+    /**
+     * Validates the construction of a base-sync query document for models with custom types.
+     * @throws DataStoreException On failure to interrogate fields in Parent.class
+     * @throws JSONException from JSONAssert.assertEquals
+     */
+    @Test
+    public void validateCustomTypeRequestGenerationForBaseSync() throws DataStoreException, JSONException {
+        JSONAssert.assertEquals(
+                Resources.readAsString("base-sync-request-document-for-parent.txt"),
+                AppSyncRequestFactory.buildSyncRequest(Parent.class, null, null).getContent(),
+                true
         );
     }
 

--- a/aws-datastore/src/test/resources/base-sync-request-document-for-parent.txt
+++ b/aws-datastore/src/test/resources/base-sync-request-document-for-parent.txt
@@ -1,0 +1,42 @@
+{
+  "query": "query SyncParents {
+  syncParents {
+    items {
+      _deleted
+      _lastChangedAt
+      _version
+      address {
+        city
+        country
+        phonenumber {
+          carrier
+          code
+          number
+        }
+        street
+        street2
+      }
+      children {
+        address {
+          city
+          country
+          phonenumber {
+            carrier
+            code
+            number
+          }
+          street
+          street2
+        }
+        name
+      }
+      id
+      name
+    }
+    nextToken
+    startedAt
+  }
+}
+",
+  "variables": null
+}

--- a/aws-datastore/src/test/resources/create-parent-request.txt
+++ b/aws-datastore/src/test/resources/create-parent-request.txt
@@ -1,0 +1,84 @@
+{
+  "query": "mutation CreateParent($input: CreateParentInput!) {
+  createParent(input: $input) {
+    _deleted
+    _lastChangedAt
+    _version
+    address {
+      city
+      country
+      phonenumber {
+        carrier
+        code
+        number
+      }
+      street
+      street2
+    }
+    children {
+      address {
+        city
+        country
+        phonenumber {
+          carrier
+          code
+          number
+        }
+        street
+        street2
+      }
+      name
+    }
+    id
+    name
+  }
+}
+",
+  "variables": {
+      "input": {
+        "address": {
+          "street": "555 Five Fiver",
+          "street2": "township",
+          "city": "BO",
+          "phonenumber": {
+            "code": 232,
+            "carrier": 54,
+            "number": 11111111
+          },
+          "country": "Sierra Leone"
+        },
+        "children": [
+          {
+            "name": "SAM",
+            "address": {
+              "street": "555 Five Fiver",
+              "street2": "township",
+              "city": "BO",
+              "phonenumber": {
+                "code": 232,
+                "carrier": 54,
+                "number": 11111111
+              },
+              "country": "Sierra Leone"
+            }
+          },
+          {
+            "name": "MAS",
+            "address": {
+              "street": "555 Five Fiver",
+              "street2": "township",
+              "city": "BO",
+              "phonenumber": {
+                "code": 232,
+                "carrier": 54,
+                "number": 11111111
+              },
+              "country": "Sierra Leone"
+            }
+          }
+        ],
+        "name": "Jane Doe",
+        "id": "426f8e8d-ea0f-4839-a73f-6a2a38565ba1"
+      }
+    }
+}

--- a/aws-datastore/src/test/resources/on-create-request-for-parent.txt
+++ b/aws-datastore/src/test/resources/on-create-request-for-parent.txt
@@ -1,0 +1,38 @@
+{
+  "query": "subscription OnCreateParent {
+  onCreateParent {
+    _deleted
+    _lastChangedAt
+    _version
+    address {
+      city
+      country
+      phonenumber {
+        carrier
+        code
+        number
+      }
+      street
+      street2
+    }
+    children {
+      address {
+        city
+        country
+        phonenumber {
+          carrier
+          code
+          number
+        }
+        street
+        street2
+      }
+      name
+    }
+    id
+    name
+  }
+}
+",
+  "variables": null
+}

--- a/aws-datastore/src/test/resources/update-parent-with-predicate.txt
+++ b/aws-datastore/src/test/resources/update-parent-with-predicate.txt
@@ -1,0 +1,90 @@
+{
+  "query": "mutation UpdateParent($condition: ModelParentConditionInput, $input: UpdateParentInput!) {
+  updateParent(condition: $condition, input: $input) {
+    _deleted
+    _lastChangedAt
+    _version
+    address {
+      city
+      country
+      phonenumber {
+        carrier
+        code
+        number
+      }
+      street
+      street2
+    }
+    children {
+      address {
+        city
+        country
+        phonenumber {
+          carrier
+          code
+          number
+        }
+        street
+        street2
+      }
+      name
+    }
+    id
+    name
+  }
+}
+",
+  "variables": {
+    "condition": {
+      "name":{
+        "contains":"Jane Doe"
+      }
+    },
+    "input": {
+        "address": {
+          "street": "555 Five Fiver",
+          "street2": "township",
+          "city": "BO",
+          "phonenumber": {
+            "code": 232,
+            "carrier": 54,
+            "number": 11111111
+          },
+          "country": "Sierra Leone"
+        },
+        "children": [
+          {
+            "name": "SAM",
+            "address": {
+              "street": "555 Five Fiver",
+              "street2": "township",
+              "city": "BO",
+              "phonenumber": {
+                "code": 232,
+                "carrier": 54,
+                "number": 11111111
+              },
+              "country": "Sierra Leone"
+            }
+          },
+          {
+            "name": "MAS",
+            "address": {
+              "street": "555 Five Fiver",
+              "street2": "township",
+              "city": "BO",
+              "phonenumber": {
+                "code": 232,
+                "carrier": 54,
+                "number": 11111111
+              },
+              "country": "Sierra Leone"
+            }
+          }
+        ],
+        "name": "Jane Doe",
+        "id": "426f8e8d-ea0f-4839-a73f-6a2a38565ba1",
+        "_version" : 42
+      }
+  }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -110,7 +110,7 @@ public final class ModelSchema {
     @NonNull
     public static ModelSchema fromModelClass(@NonNull Class<? extends Model> clazz) throws AmplifyException {
         try {
-            final List<Field> classFields = FieldFinder.findFieldsIn(clazz);
+            final List<Field> classFields = FieldFinder.findModelFieldsIn(clazz);
             final TreeMap<String, ModelField> fields = new TreeMap<>();
             final TreeMap<String, ModelAssociation> associations = new TreeMap<>();
             final TreeMap<String, ModelIndex> indexes = new TreeMap<>();

--- a/core/src/main/java/com/amplifyframework/util/FieldFinder.java
+++ b/core/src/main/java/com/amplifyframework/util/FieldFinder.java
@@ -23,6 +23,7 @@ import com.amplifyframework.core.model.annotations.ModelField;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -45,18 +46,37 @@ public final class FieldFinder {
      * @return set of fields
      */
     @NonNull
-    public static List<Field> findFieldsIn(@NonNull Class<?> clazz) {
+    public static List<Field> findModelFieldsIn(@NonNull Class<?> clazz) {
         final List<Field> fields = new ArrayList<>();
-        Class<?> c = clazz;
-        while (c != null) {
-            for (Field field : c.getDeclaredFields()) {
+        Class<?> fieldContainerClazz = clazz;
+        while (fieldContainerClazz != null) {
+            for (Field field : fieldContainerClazz.getDeclaredFields()) {
                 if (field.isAnnotationPresent(ModelField.class)) {
                     fields.add(field);
                 }
             }
-            c = c.getSuperclass();
+            fieldContainerClazz = fieldContainerClazz.getSuperclass();
         }
         Collections.sort(fields, (o1, o2) -> o1.getName().compareTo(o2.getName()));
+        return Immutable.of(fields);
+    }
+
+    /**
+     * Helper for finding all fields in a class without limiting limiting to {@link ModelField}.
+     * @param clazz clazz the Class object.
+     * @return set of fields
+     */
+    @NonNull
+    public static List<Field> findAllFieldsIn(@NonNull Class<?> clazz) {
+        final List<Field> fields = new ArrayList<>();
+        Class<?> fieldContainerClazz = clazz;
+        while (fieldContainerClazz != null) {
+            for (Field field : fieldContainerClazz.getDeclaredFields()) {
+                fields.add(field);
+            }
+            fieldContainerClazz = fieldContainerClazz.getSuperclass();
+        }
+        Collections.sort(fields, Comparator.comparing(Field::getName));
         return Immutable.of(fields);
     }
 

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/Address.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/Address.java
@@ -1,0 +1,202 @@
+package com.amplifyframework.testmodels.parenting;
+
+
+import androidx.core.util.ObjectsCompat;
+
+import java.util.Objects;
+import java.util.List;
+
+/** This is an auto generated class representing the Address type in your schema. */
+public final class Address {
+  private final String street;
+  private final String street2;
+  private final City city;
+  private final Phonenumber phonenumber;
+  private final String country;
+  public String getStreet() {
+      return street;
+  }
+  
+  public String getStreet2() {
+      return street2;
+  }
+  
+  public City getCity() {
+      return city;
+  }
+  
+  public Phonenumber getPhonenumber() {
+      return phonenumber;
+  }
+  
+  public String getCountry() {
+      return country;
+  }
+  
+  private Address(String street, String street2, City city, Phonenumber phonenumber, String country) {
+    this.street = street;
+    this.street2 = street2;
+    this.city = city;
+    this.phonenumber = phonenumber;
+    this.country = country;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Address address = (Address) obj;
+      return ObjectsCompat.equals(getStreet(), address.getStreet()) &&
+              ObjectsCompat.equals(getStreet2(), address.getStreet2()) &&
+              ObjectsCompat.equals(getCity(), address.getCity()) &&
+              ObjectsCompat.equals(getPhonenumber(), address.getPhonenumber()) &&
+              ObjectsCompat.equals(getCountry(), address.getCountry());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getStreet())
+      .append(getStreet2())
+      .append(getCity())
+      .append(getPhonenumber())
+      .append(getCountry())
+      .toString()
+      .hashCode();
+  }
+  
+  public static StreetStep builder() {
+      return new Builder();
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(street,
+      street2,
+      city,
+      phonenumber,
+      country);
+  }
+  public interface StreetStep {
+    Street2Step street(String street);
+  }
+  
+
+  public interface Street2Step {
+    CityStep street2(String street2);
+  }
+  
+
+  public interface CityStep {
+    PhonenumberStep city(City city);
+  }
+  
+
+  public interface PhonenumberStep {
+    CountryStep phonenumber(Phonenumber phonenumber);
+  }
+  
+
+  public interface CountryStep {
+    BuildStep country(String country);
+  }
+  
+
+  public interface BuildStep {
+    Address build();
+  }
+  
+
+  public static class Builder implements StreetStep, Street2Step, CityStep, PhonenumberStep, CountryStep, BuildStep {
+    private String street;
+    private String street2;
+    private City city;
+    private Phonenumber phonenumber;
+    private String country;
+    @Override
+     public Address build() {
+        
+        return new Address(
+          street,
+          street2,
+          city,
+          phonenumber,
+          country);
+    }
+    
+    @Override
+     public Street2Step street(String street) {
+        Objects.requireNonNull(street);
+        this.street = street;
+        return this;
+    }
+    
+    @Override
+     public CityStep street2(String street2) {
+        Objects.requireNonNull(street2);
+        this.street2 = street2;
+        return this;
+    }
+    
+    @Override
+     public PhonenumberStep city(City city) {
+        Objects.requireNonNull(city);
+        this.city = city;
+        return this;
+    }
+    
+    @Override
+     public CountryStep phonenumber(Phonenumber phonenumber) {
+        Objects.requireNonNull(phonenumber);
+        this.phonenumber = phonenumber;
+        return this;
+    }
+    
+    @Override
+     public BuildStep country(String country) {
+        Objects.requireNonNull(country);
+        this.country = country;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String street, String street2, City city, Phonenumber phonenumber, String country) {
+      super.street(street)
+        .street2(street2)
+        .city(city)
+        .phonenumber(phonenumber)
+        .country(country);
+    }
+    
+    @Override
+     public CopyOfBuilder street(String street) {
+      return (CopyOfBuilder) super.street(street);
+    }
+    
+    @Override
+     public CopyOfBuilder street2(String street2) {
+      return (CopyOfBuilder) super.street2(street2);
+    }
+    
+    @Override
+     public CopyOfBuilder city(City city) {
+      return (CopyOfBuilder) super.city(city);
+    }
+    
+    @Override
+     public CopyOfBuilder phonenumber(Phonenumber phonenumber) {
+      return (CopyOfBuilder) super.phonenumber(phonenumber);
+    }
+    
+    @Override
+     public CopyOfBuilder country(String country) {
+      return (CopyOfBuilder) super.country(country);
+    }
+  }
+  
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/AmplifyModelProvider.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/AmplifyModelProvider.java
@@ -1,0 +1,53 @@
+package com.amplifyframework.testmodels.parenting;
+
+import com.amplifyframework.util.Immutable;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+/** 
+ *  Contains the set of model classes that implement {@link Model}
+ * interface.
+ */
+
+public final class AmplifyModelProvider implements ModelProvider {
+  private static final String AMPLIFY_MODEL_VERSION = "fc03f79742d3d7d0930446b0053e5247";
+  private static AmplifyModelProvider amplifyGeneratedModelInstance;
+  private AmplifyModelProvider() {
+    
+  }
+  
+  public static AmplifyModelProvider getInstance() {
+    if (amplifyGeneratedModelInstance == null) {
+      amplifyGeneratedModelInstance = new AmplifyModelProvider();
+    }
+    return amplifyGeneratedModelInstance;
+  }
+  
+  /** 
+   * Get a set of the model classes.
+   * 
+   * @return a set of the model classes.
+   */
+  @Override
+   public Set<Class<? extends Model>> models() {
+    final Set<Class<? extends Model>> modifiableSet = new HashSet<>(
+          Arrays.<Class<? extends Model>>asList(Parent.class)
+        );
+    
+        return Immutable.of(modifiableSet);
+        
+  }
+  
+  /** 
+   * Get the version of the models.
+   * 
+   * @return the version string of the models.
+   */
+  @Override
+   public String version() {
+    return AMPLIFY_MODEL_VERSION;
+  }
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/Child.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/Child.java
@@ -1,0 +1,115 @@
+package com.amplifyframework.testmodels.parenting;
+
+
+import androidx.core.util.ObjectsCompat;
+
+import java.util.Objects;
+import java.util.List;
+
+/** This is an auto generated class representing the Child type in your schema. */
+public final class Child {
+  private final String name;
+  private final Address address;
+  public String getName() {
+      return name;
+  }
+  
+  public Address getAddress() {
+      return address;
+  }
+  
+  private Child(String name, Address address) {
+    this.name = name;
+    this.address = address;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Child child = (Child) obj;
+      return ObjectsCompat.equals(getName(), child.getName()) &&
+              ObjectsCompat.equals(getAddress(), child.getAddress());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getName())
+      .append(getAddress())
+      .toString()
+      .hashCode();
+  }
+  
+  public static NameStep builder() {
+      return new Builder();
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(name,
+      address);
+  }
+  public interface NameStep {
+    AddressStep name(String name);
+  }
+  
+
+  public interface AddressStep {
+    BuildStep address(Address address);
+  }
+  
+
+  public interface BuildStep {
+    Child build();
+  }
+  
+
+  public static class Builder implements NameStep, AddressStep, BuildStep {
+    private String name;
+    private Address address;
+    @Override
+     public Child build() {
+        
+        return new Child(
+          name,
+          address);
+    }
+    
+    @Override
+     public AddressStep name(String name) {
+        Objects.requireNonNull(name);
+        this.name = name;
+        return this;
+    }
+    
+    @Override
+     public BuildStep address(Address address) {
+        Objects.requireNonNull(address);
+        this.address = address;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String name, Address address) {
+      super.name(name)
+        .address(address);
+    }
+    
+    @Override
+     public CopyOfBuilder name(String name) {
+      return (CopyOfBuilder) super.name(name);
+    }
+    
+    @Override
+     public CopyOfBuilder address(Address address) {
+      return (CopyOfBuilder) super.address(address);
+    }
+  }
+  
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/City.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/City.java
@@ -1,0 +1,9 @@
+package com.amplifyframework.testmodels.parenting;
+/** Auto generated enum from GraphQL schema. */
+@SuppressWarnings("all")
+public enum City {
+  FREETOWN,
+  BO,
+  MAKENI,
+  KENEMA
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/Parent.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/Parent.java
@@ -1,0 +1,227 @@
+package com.amplifyframework.testmodels.parenting;
+
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the Parent type in your schema. */
+@SuppressWarnings("all")
+@ModelConfig(pluralName = "Parents")
+public final class Parent implements Model {
+  public static final QueryField ID = field("id");
+  public static final QueryField NAME = field("name");
+  public static final QueryField ADDRESS = field("address");
+  public static final QueryField CHILDREN = field("children");
+  private final @ModelField(targetType="ID", isRequired = true) String id;
+  private final @ModelField(targetType="String", isRequired = true) String name;
+  private final @ModelField(targetType="Address", isRequired = true) Address address;
+  private final @ModelField(targetType="Child") List<Child> children;
+  public String getId() {
+      return id;
+  }
+  
+  public String getName() {
+      return name;
+  }
+  
+  public Address getAddress() {
+      return address;
+  }
+  
+  public List<Child> getChildren() {
+      return children;
+  }
+  
+  private Parent(String id, String name, Address address, List<Child> children) {
+    this.id = id;
+    this.name = name;
+    this.address = address;
+    this.children = children;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Parent parent = (Parent) obj;
+      return ObjectsCompat.equals(getId(), parent.getId()) &&
+              ObjectsCompat.equals(getName(), parent.getName()) &&
+              ObjectsCompat.equals(getAddress(), parent.getAddress()) &&
+              ObjectsCompat.equals(getChildren(), parent.getChildren());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getName())
+      .append(getAddress())
+      .append(getChildren())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append("Parent {")
+      .append("id=" + String.valueOf(getId()) + ", ")
+      .append("name=" + String.valueOf(getName()) + ", ")
+      .append("address=" + String.valueOf(getAddress()) + ", ")
+      .append("children=" + String.valueOf(getChildren()))
+      .append("}")
+      .toString();
+  }
+  
+  public static NameStep builder() {
+      return new Builder();
+  }
+  
+  /** 
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   * @throws IllegalArgumentException Checks that ID is in the proper format
+   */
+  public static Parent justId(String id) {
+    try {
+      UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+    } catch (Exception exception) {
+      throw new IllegalArgumentException(
+              "Model IDs must be unique in the format of UUID. This method is for creating instances " +
+              "of an existing object with only its ID field for sending as a mutation parameter. When " +
+              "creating a new object, use the standard builder method and leave the ID field blank."
+      );
+    }
+    return new Parent(
+      id,
+      null,
+      null,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      name,
+      address,
+      children);
+  }
+  public interface NameStep {
+    AddressStep name(String name);
+  }
+  
+
+  public interface AddressStep {
+    BuildStep address(Address address);
+  }
+  
+
+  public interface BuildStep {
+    Parent build();
+    BuildStep id(String id) throws IllegalArgumentException;
+    BuildStep children(List<Child> children);
+  }
+  
+
+  public static class Builder implements NameStep, AddressStep, BuildStep {
+    private String id;
+    private String name;
+    private Address address;
+    private List<Child> children;
+    @Override
+     public Parent build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        
+        return new Parent(
+          id,
+          name,
+          address,
+          children);
+    }
+    
+    @Override
+     public AddressStep name(String name) {
+        Objects.requireNonNull(name);
+        this.name = name;
+        return this;
+    }
+    
+    @Override
+     public BuildStep address(Address address) {
+        Objects.requireNonNull(address);
+        this.address = address;
+        return this;
+    }
+    
+    @Override
+     public BuildStep children(List<Child> children) {
+        this.children = children;
+        return this;
+    }
+    
+    /** 
+     * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
+     * This should only be set when referring to an already existing object.
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     * @throws IllegalArgumentException Checks that ID is in the proper format
+     */
+    public BuildStep id(String id) throws IllegalArgumentException {
+        this.id = id;
+        
+        try {
+            UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+        } catch (Exception exception) {
+          throw new IllegalArgumentException("Model IDs must be unique in the format of UUID.",
+                    exception);
+        }
+        
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, String name, Address address, List<Child> children) {
+      super.id(id);
+      super.name(name)
+        .address(address)
+        .children(children);
+    }
+    
+    @Override
+     public CopyOfBuilder name(String name) {
+      return (CopyOfBuilder) super.name(name);
+    }
+    
+    @Override
+     public CopyOfBuilder address(Address address) {
+      return (CopyOfBuilder) super.address(address);
+    }
+    
+    @Override
+     public CopyOfBuilder children(List<Child> children) {
+      return (CopyOfBuilder) super.children(children);
+    }
+  }
+  
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/Phonenumber.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/Phonenumber.java
@@ -1,0 +1,144 @@
+package com.amplifyframework.testmodels.parenting;
+
+
+import androidx.core.util.ObjectsCompat;
+
+import java.util.Objects;
+import java.util.List;
+
+/** This is an auto generated class representing the Phonenumber type in your schema. */
+public final class Phonenumber {
+  private final Integer code;
+  private final Integer carrier;
+  private final Integer number;
+  public Integer getCode() {
+      return code;
+  }
+  
+  public Integer getCarrier() {
+      return carrier;
+  }
+  
+  public Integer getNumber() {
+      return number;
+  }
+  
+  private Phonenumber(Integer code, Integer carrier, Integer number) {
+    this.code = code;
+    this.carrier = carrier;
+    this.number = number;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Phonenumber phonenumber = (Phonenumber) obj;
+      return ObjectsCompat.equals(getCode(), phonenumber.getCode()) &&
+              ObjectsCompat.equals(getCarrier(), phonenumber.getCarrier()) &&
+              ObjectsCompat.equals(getNumber(), phonenumber.getNumber());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getCode())
+      .append(getCarrier())
+      .append(getNumber())
+      .toString()
+      .hashCode();
+  }
+  
+  public static CodeStep builder() {
+      return new Builder();
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(code,
+      carrier,
+      number);
+  }
+  public interface CodeStep {
+    CarrierStep code(Integer code);
+  }
+  
+
+  public interface CarrierStep {
+    NumberStep carrier(Integer carrier);
+  }
+  
+
+  public interface NumberStep {
+    BuildStep number(Integer number);
+  }
+  
+
+  public interface BuildStep {
+    Phonenumber build();
+  }
+  
+
+  public static class Builder implements CodeStep, CarrierStep, NumberStep, BuildStep {
+    private Integer code;
+    private Integer carrier;
+    private Integer number;
+    @Override
+     public Phonenumber build() {
+        
+        return new Phonenumber(
+          code,
+          carrier,
+          number);
+    }
+    
+    @Override
+     public CarrierStep code(Integer code) {
+        Objects.requireNonNull(code);
+        this.code = code;
+        return this;
+    }
+    
+    @Override
+     public NumberStep carrier(Integer carrier) {
+        Objects.requireNonNull(carrier);
+        this.carrier = carrier;
+        return this;
+    }
+    
+    @Override
+     public BuildStep number(Integer number) {
+        Objects.requireNonNull(number);
+        this.number = number;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(Integer code, Integer carrier, Integer number) {
+      super.code(code)
+        .carrier(carrier)
+        .number(number);
+    }
+    
+    @Override
+     public CopyOfBuilder code(Integer code) {
+      return (CopyOfBuilder) super.code(code);
+    }
+    
+    @Override
+     public CopyOfBuilder carrier(Integer carrier) {
+      return (CopyOfBuilder) super.carrier(carrier);
+    }
+    
+    @Override
+     public CopyOfBuilder number(Integer number) {
+      return (CopyOfBuilder) super.number(number);
+    }
+  }
+  
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/schema.graphql
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/schema.graphql
@@ -6,20 +6,20 @@ type Parent @model {
 }
 
 type Child {
-	name: String!
-	address: Address!
+  name: String!
+  address: Address!
 }
 
 type Address {
-	street: String!
-	street2: String!
-	city: City!
-	country: String!
+  street: String!
+  street2: String!
+  city: City!
+  country: String!
 }
 
 enum City {
-	FREETOWN
-	BO
-	MAKENI
-	KENEMA
+  FREETOWN
+  BO
+  MAKENI
+  KENEMA
 }

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/schema.graphql
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/parenting/schema.graphql
@@ -1,0 +1,25 @@
+type Parent @model {
+  id: ID!
+  name: String!
+  address: Address!
+  children: [Child]
+}
+
+type Child {
+	name: String!
+	address: Address!
+}
+
+type Address {
+	street: String!
+	street2: String!
+	city: City!
+	country: String!
+}
+
+enum City {
+	FREETOWN
+	BO
+	MAKENI
+	KENEMA
+}


### PR DESCRIPTION
This PR fixes a bug in the selection set involving fields of custom types.
*Issue #, if available:*

#702 

Custom types were not being transversed to build selection sets.  

*Description of changes:*

This PR recursively introspects a custom type and adds its properties to the selection set.

*TODO* 

- [x] Tests to ensure that mutation selection sets with inputs are being properly built. 
- [x] Tests to ensure serialization and deserialization to/from SQLite works as expected

*Not Handled**
-  there are instances that might lead to infinite recursion, e.g. circular relationships so we may want to set a hard max_depth unrelated to datastore's model association max_depth .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
