### PR TITLE
feat(auth): Adds user info to sign up result

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -802,7 +802,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     }
 
     private AuthSignUpResult convertSignUpResult(@NonNull SignUpResult result, @NonNull String username) {
-        UserCodeDeliveryDetails details = result.getUserCodeDeliveryDetails();
+        UserCodeDeliveryDetails details = Objects.requireNonNull(result).getUserCodeDeliveryDetails();
         AuthCodeDeliveryDetails newDetails = details != null
                 ? new AuthCodeDeliveryDetails(
                     details.getDestination(),

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -267,7 +267,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             new Callback<SignUpResult>() {
                 @Override
                 public void onResult(SignUpResult result) {
-                    onSuccess.accept(convertSignUpResult(result));
+                    onSuccess.accept(convertSignUpResult(result, username));
                 }
 
                 @Override
@@ -290,7 +290,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
         awsMobileClient.confirmSignUp(username, confirmationCode, new Callback<SignUpResult>() {
             @Override
             public void onResult(SignUpResult result) {
-                onSuccess.accept(convertSignUpResult(result));
+                onSuccess.accept(convertSignUpResult(result, username));
             }
 
             @Override
@@ -311,7 +311,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
         awsMobileClient.resendSignUp(username, new Callback<SignUpResult>() {
             @Override
             public void onResult(SignUpResult result) {
-                onSuccess.accept(convertSignUpResult(result));
+                onSuccess.accept(convertSignUpResult(result, username));
             }
 
             @Override
@@ -801,7 +801,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
         }
     }
 
-    private AuthSignUpResult convertSignUpResult(SignUpResult result) {
+    private AuthSignUpResult convertSignUpResult(@NonNull SignUpResult result, @NonNull String username) {
         UserCodeDeliveryDetails details = result.getUserCodeDeliveryDetails();
         AuthCodeDeliveryDetails newDetails = details != null
                 ? new AuthCodeDeliveryDetails(
@@ -819,7 +819,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                                 : AuthSignUpStep.CONFIRM_SIGN_UP_STEP,
                         Collections.emptyMap(),
                         newDetails
-                )
+                ),
+                result.getUserSub() != null ? new AuthUser(result.getUserSub(), username) : null
         );
     }
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -217,7 +217,7 @@ public final class AuthComponentTest {
                     DELIVERY_MEDIUM,
                     ATTRIBUTE_NAME
             ),
-            null
+            USER_SUB
         );
 
         doAnswer(invocation -> {
@@ -264,7 +264,7 @@ public final class AuthComponentTest {
                         DELIVERY_MEDIUM,
                         ATTRIBUTE_NAME
                 ),
-                null
+                USER_SUB
         );
 
         doAnswer(invocation -> {
@@ -295,7 +295,7 @@ public final class AuthComponentTest {
                         DELIVERY_MEDIUM,
                         ATTRIBUTE_NAME
                 ),
-                null
+                USER_SUB
         );
 
         doAnswer(invocation -> {
@@ -889,6 +889,8 @@ public final class AuthComponentTest {
         validateCodeDeliveryDetails(nextStep.getCodeDeliveryDetails());
         assertTrue(result.isSignUpComplete());
         assertEquals(targetStep, nextStep.getSignUpStep());
+        assertEquals(USER_SUB, result.getUser().getUserId());
+        assertEquals(USERNAME, result.getUser().getUsername());
     }
 
     private void validateSignInResult(AuthSignInResult result, boolean targetIsSignedIn, AuthSignInStep targetStep) {

--- a/core/src/main/java/com/amplifyframework/auth/result/AuthSignUpResult.java
+++ b/core/src/main/java/com/amplifyframework/auth/result/AuthSignUpResult.java
@@ -16,8 +16,10 @@
 package com.amplifyframework.auth.result;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
+import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.result.step.AuthNextSignUpStep;
 
 import java.util.Objects;
@@ -28,6 +30,7 @@ import java.util.Objects;
 public final class AuthSignUpResult {
     private final boolean isSignUpComplete;
     private final AuthNextSignUpStep nextStep;
+    private final AuthUser user;
 
     /**
      * Wraps the result of a sign up operation.
@@ -35,10 +38,12 @@ public final class AuthSignUpResult {
      *                         is successfully registered, there still may be additional steps that can be performed
      *                         such as user confirmation. Check {@link #getNextStep()} for this information.
      * @param nextStep Details about the next step in the sign up process (or whether the flow is now done).
+     * @param user If {@link #isSignUpComplete} is true, this holds the newly registered user. Otherwise, null.
      */
-    public AuthSignUpResult(boolean isSignUpComplete, @NonNull AuthNextSignUpStep nextStep) {
+    public AuthSignUpResult(boolean isSignUpComplete, @NonNull AuthNextSignUpStep nextStep, @Nullable AuthUser user) {
         this.isSignUpComplete = isSignUpComplete;
         this.nextStep = Objects.requireNonNull(nextStep);
+        this.user = user;
     }
 
     /**
@@ -61,19 +66,29 @@ public final class AuthSignUpResult {
     }
 
     /**
-     * When overriding, be sure to include isSignUpComplete and nextStep in the hash.
+     * If {@link #isSignUpComplete} is true, this returns the newly registered user. Otherwise, null.
+     * @return the newly registered user if {@link #isSignUpComplete} is true. Otherwise, null.
+     */
+    @Nullable
+    public AuthUser getUser() {
+        return user;
+    }
+
+    /**
+     * When overriding, be sure to include isSignUpComplete, nextStep, and user in the hash.
      * @return Hash code of this object
      */
     @Override
     public int hashCode() {
         return ObjectsCompat.hash(
                 isSignUpComplete(),
-                getNextStep()
+                getNextStep(),
+                getUser()
         );
     }
 
     /**
-     * When overriding, be sure to include isSignUpComplete and nextStep in the comparison.
+     * When overriding, be sure to include isSignUpComplete, nextStep, and user in the comparison.
      * @return True if the two objects are equal, false otherwise
      */
     @Override
@@ -85,19 +100,21 @@ public final class AuthSignUpResult {
         } else {
             AuthSignUpResult authSignUpResult = (AuthSignUpResult) obj;
             return ObjectsCompat.equals(isSignUpComplete(), authSignUpResult.isSignUpComplete()) &&
-                    ObjectsCompat.equals(getNextStep(), authSignUpResult.getNextStep());
+                    ObjectsCompat.equals(getNextStep(), authSignUpResult.getNextStep()) &&
+                    ObjectsCompat.equals(getUser(), authSignUpResult.getUser());
         }
     }
 
     /**
-     * When overriding, be sure to include isSignUpComplete and nextStep in the output string.
+     * When overriding, be sure to include isSignUpComplete, nextStep, and user in the output string.
      * @return A string representation of the object
      */
     @Override
     public String toString() {
         return "AuthSignUpResult{" +
-                "userConfirmed=" + isSignUpComplete() +
+                "isSignUpComplete=" + isSignUpComplete() +
                 ", nextStep=" + getNextStep() +
+                ", user=" + getUser() +
                 '}';
     }
 }

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -87,7 +87,7 @@ public final class RxAuthBindingTest {
         AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.SMS);
         AuthSignUpStep step = AuthSignUpStep.CONFIRM_SIGN_UP_STEP;
         AuthNextSignUpStep nextStep = new AuthNextSignUpStep(step, Collections.emptyMap(), details);
-        AuthSignUpResult result = new AuthSignUpResult(false, nextStep, new AuthUser(userId, username));
+        AuthSignUpResult result = new AuthSignUpResult(false, nextStep, null);
         doAnswer(invocation -> {
             // 0 = username, 1 = pass, 2 = options, 3 = onSuccess, 4 = onFailure
             int positionOfSuccessConsumer = 3;
@@ -148,7 +148,7 @@ public final class RxAuthBindingTest {
         AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.EMAIL);
         AuthSignUpStep step = AuthSignUpStep.CONFIRM_SIGN_UP_STEP;
         AuthNextSignUpStep nextStep = new AuthNextSignUpStep(step, Collections.emptyMap(), details);
-        AuthSignUpResult result = new AuthSignUpResult(false, nextStep, new AuthUser(userId, username));
+        AuthSignUpResult result = new AuthSignUpResult(false, nextStep, null);
         doAnswer(invocation -> {
             // 0 = username, 1 = onResult, 2 = onFailure
             int positionOfResultConsumer = 1;

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -78,6 +78,7 @@ public final class RxAuthBindingTest {
     @Test
     public void testSignUpSucceeds() {
         // Arrange a response from delegate
+        String userId = RandomString.string();
         String username = RandomString.string();
         String password = RandomString.string();
         AuthSignUpOptions options = AuthSignUpOptions.builder().build();
@@ -86,7 +87,7 @@ public final class RxAuthBindingTest {
         AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.SMS);
         AuthSignUpStep step = AuthSignUpStep.CONFIRM_SIGN_UP_STEP;
         AuthNextSignUpStep nextStep = new AuthNextSignUpStep(step, Collections.emptyMap(), details);
-        AuthSignUpResult result = new AuthSignUpResult(false, nextStep);
+        AuthSignUpResult result = new AuthSignUpResult(false, nextStep, new AuthUser(userId, username));
         doAnswer(invocation -> {
             // 0 = username, 1 = pass, 2 = options, 3 = onSuccess, 4 = onFailure
             int positionOfSuccessConsumer = 3;
@@ -140,13 +141,14 @@ public final class RxAuthBindingTest {
      */
     @Test
     public void testResendSignUpCodeSucceeds() {
+        String userId = RandomString.string();
         String username = RandomString.string();
 
         // Arrange a result on the result consumer
         AuthCodeDeliveryDetails details = new AuthCodeDeliveryDetails(RandomString.string(), DeliveryMedium.EMAIL);
         AuthSignUpStep step = AuthSignUpStep.CONFIRM_SIGN_UP_STEP;
         AuthNextSignUpStep nextStep = new AuthNextSignUpStep(step, Collections.emptyMap(), details);
-        AuthSignUpResult result = new AuthSignUpResult(false, nextStep);
+        AuthSignUpResult result = new AuthSignUpResult(false, nextStep, new AuthUser(userId, username));
         doAnswer(invocation -> {
             // 0 = username, 1 = onResult, 2 = onFailure
             int positionOfResultConsumer = 1;


### PR DESCRIPTION
After a successful sign up, the sign up result will now contain the user info.

Note that the user will be null for `resendSignUpCode()` and `confirmSignUp()` operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
