### PR TITLE
fix(datastore): order hydration tasks topologically

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -97,7 +97,7 @@ final class SyncProcessor {
         ModelClassComparator modelClassComparator =
                 new ModelClassComparator(modelProvider, modelSchemaRegistry);
 
-        final Set<Completable> hydrationTasks = new HashSet<>();
+        final List<Completable> hydrationTasks = new ArrayList<>();
         List<Class<? extends Model>> modelClsList =
             new ArrayList<Class<? extends Model>>(modelProvider.models());
 


### PR DESCRIPTION
*Issue #, if available:*

topological ordering was being applied to the individual hydration stream, i.e. given classes of model A and Model B, it appears that the original implementation was being applied on the model A hydration observable and Model B hydration observable. As such model A will always be compared to model A and B to B. Which I don't believe we want. What we want is to have models that depend on another hydrate first and so sort the hydration task by that.

*Description of changes:*

Proposing a different implementation that first sorts the hydration tasks by the model's typological sort and then continue with Compete.concat which then handles the completion of each stream sequentially.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
