### PR TITLE
chore(rxbindings): cleanup adapters and align datastore apis

### DIFF
--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAdapters.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAdapters.java
@@ -66,7 +66,7 @@ final class RxAdapters {
         }
 
         /**
-         * Describes a behavior emits a notification of start to an {@link Consumer},
+         * Describes a behavior which emits a notification of start to an {@link Consumer},
          * then emits 0..n values to a value {@link Consumer}, and finally terminated
          * either by calling a successful {@link Action}, or emitting an error to an
          * error {@link Consumer}. May be canceled via a returned {@link Cancelable}.

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAdapters.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAdapters.java
@@ -25,80 +25,142 @@ import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 
 /**
- * Utility method to convert between behaviors that use the Amplify framework's native
- * {@link Consumer} and {@link Action}, into {@link Single} and {@link Observable}.
+ * Utilities for modeling Amplify category behaviors, and converting
+ * those category behaviors into Rx objects (Observable, Single, Completable).
  */
 final class RxAdapters {
     private RxAdapters() {}
 
-    static <T, E extends Throwable> Completable toCompletable(VoidResultEmitter<T, E> voidResultEmitter) {
-        return Completable.defer(() -> Completable.create(emitter ->
-            voidResultEmitter.emitTo(result -> emitter.onComplete(), emitter::onError)
-        ));
-    }
+    /**
+     * Cancelable behaviors are those Amplify category behaviors which return a cancelable
+     * operation. For example, most behaviors in Storage and Predictions will return
+     * a cancelable operation, whereas DataStore and Auth do not.
+     */
+    static final class CancelableBehaviors {
+        private CancelableBehaviors() {}
 
-    static <T, E extends Throwable> Single<T> toSingle(CancelableResultEmitter<T, E> cancelableResultEmitter) {
-        return Single.defer(() -> Single.create(emitter -> {
-            final Cancelable cancelable =
-                cancelableResultEmitter.emitTo(emitter::onSuccess, emitter::onError);
-            emitter.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
-        }));
-    }
+        static <E extends Throwable> Completable toCompletable(ActionEmitter<E> behavior) {
+            return Completable.create(subscriber -> {
+                Cancelable cancelable = behavior.emitTo(subscriber::onComplete, subscriber::onError);
+                subscriber.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
+            });
+        }
 
-    static <S, T, E extends Throwable> Observable<T> toObservable(
-            CancelableStreamEmitter<S, T, E> cancelableStreamEmitter) {
-        return Observable.defer(() -> Observable.create(emitter -> {
-            Cancelable cancelable = cancelableStreamEmitter.streamTo(
-                NoOpConsumer.create(),
-                emitter::onNext,
-                emitter::onError,
-                emitter::onComplete
-            );
-            emitter.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
-        }));
+        static <T, E extends Throwable> Single<T> toSingle(ResultEmitter<T, E> behavior) {
+            return Single.create(subscriber -> {
+                Cancelable cancelable = behavior.emitTo(subscriber::onSuccess, subscriber::onError);
+                subscriber.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
+            });
+        }
+
+        static <S, T, E extends Throwable> Observable<T> toObservable(StreamEmitter<S, T, E> behavior) {
+            return Observable.create(subscriber -> {
+                Cancelable cancelable = behavior.streamTo(
+                    NoOpConsumer.create(),
+                    subscriber::onNext,
+                    subscriber::onError,
+                    subscriber::onComplete
+                );
+                subscriber.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
+            });
+        }
+
+        /**
+         * Describes a behavior emits a notification of start to an {@link Consumer},
+         * then emits 0..n values to a value {@link Consumer}, and finally terminated
+         * either by calling a successful {@link Action}, or emitting an error to an
+         * error {@link Consumer}. May be canceled via a returned {@link Cancelable}.
+         * Such a method may be wrapped into an {@link Observable}
+         * by using the {@link CancelableBehaviors#toObservable(StreamEmitter)} utility.
+         * @param <S> Type emitted to the start consumer
+         * @param <T> Type of object being emitted to the value consumer
+         * @param <E> Type emitted to error consumer
+         */
+        interface StreamEmitter<S, T, E> {
+            Cancelable streamTo(Consumer<S> onStart, Consumer<T> onItem, Consumer<E> onError, Action onComplete);
+        }
+
+        /**
+         * Describes a behavior which emits results to a result or error {@link Consumer},
+         * and can be canceled via an {@link Cancelable}. Such a method
+         * may be wrapped into an {@link Single} in a uniform way by using the
+         * {@link CancelableBehaviors#toSingle(ResultEmitter)} utility.
+         * @param <T> Type of result accepted by result consumer
+         * @param <E> Type of error accepted by error consumer
+         */
+        interface ResultEmitter<T, E extends Throwable> {
+            Cancelable emitTo(Consumer<T> onResult, Consumer<E> onError);
+        }
+
+        /**
+         * A behavior which terminates in a completion action or an error.
+         * Returns a cancelable when the behavior starts. Such a method
+         * may be wrapped into an {@link Completable} in a uniform way
+         * by using the {@link CancelableBehaviors#toCompletable(ActionEmitter)}
+         * utility.
+         * @param <E> Type of error emitted
+         */
+        interface ActionEmitter<E> {
+            Cancelable emitTo(Action onComplete, Consumer<E> onError);
+        }
     }
 
     /**
-     * A behavior which emits to a result listener, but returns no value, itself.
+     * Void behaviors are those Amplify category behaviors which have a void return type.
+     * For example, most behaviors in Auth and DataStore have a void return. Unlike
+     * {@link CancelableBehaviors}, such behaviors may not be canceled once begun.
      */
-    interface VoidResultEmitter<T, E extends Throwable> {
-        void emitTo(Consumer<T> onResult, Consumer<E> onError);
-    }
+    static final class VoidBehaviors {
+        private VoidBehaviors() {}
 
-    /**
-     * Describes a behavior which emits results to a result or error {@link Consumer},
-     * and can be canceled via an {@link Cancelable}. Such a method
-     * may be wrapped into an {@link Single} in a uniform way such as by the
-     * {@link RxAdapters#toSingle(CancelableResultEmitter)} method.
-     * @param <T> Type of result accepted by result consumer
-     * @param <E> Type of error accepted by error consumer
-     */
-    interface CancelableResultEmitter<T, E extends Throwable> {
-        Cancelable emitTo(Consumer<T> onResult, Consumer<E> onError);
-    }
+        static <E extends Throwable> Completable toCompletable(ActionEmitter<E> behavior) {
+            return Completable.create(subscriber -> behavior.emitTo(subscriber::onComplete, subscriber::onError));
+        }
 
-    /**
-     * Describes a behavior emits a notification of start to an {@link Consumer},
-     * then emits 0..n values to a value {@link Consumer}, and finally terminated
-     * either by calling a successful {@link Action}, or emitting an error to an
-     * error {@link Consumer}. May be canceled via a returned {@link Cancelable}.
-     * Such a method may be wrapped into an {@link Observable} in a uniform way such as
-     * by the {@link RxAdapters#toObservable(CancelableStreamEmitter)} method.
-     * @param <S> Type emitted to the start consumer
-     * @param <T> Type of object being emitted to the value consumer
-     * @param <E> Type emitted to error consumer
-     */
-    interface CancelableStreamEmitter<S, T, E> {
-        Cancelable streamTo(Consumer<S> onStart, Consumer<T> onItem, Consumer<E> onError, Action onComplete);
-    }
+        static <T, E extends Throwable> Single<T> toSingle(ResultEmitter<T, E> behavior) {
+            return Single.create(subscriber -> behavior.emitTo(subscriber::onSuccess, subscriber::onError));
+        }
 
-    /**
-     * Describes behavior which emits a completion notification via an {@link Action},
-     * or alternately, emits an error to a {@link Consumer}.
-     * @param <E> Type of error emitted
-     */
-    interface VoidCompletionEmitter<E> {
-        void emitTo(Action onComplete, Consumer<E> onError);
+        static <S, T, E extends Throwable> Observable<T> toObservable(StreamEmitter<S, T, E> behavior) {
+            return Observable.create(subscriber -> {
+                behavior.streamTo(
+                    NoOpConsumer.create(),
+                    subscriber::onNext,
+                    subscriber::onError,
+                    subscriber::onComplete
+                );
+            });
+        }
+
+        /**
+         * A behavior which streams items to a consumer, and then ends with an error or completion signal.
+         * The behavior does not itself return anything synchronously.
+         * The behavior begins by emitting to a start consumer.
+         * @param <S> Type of token emitted on successful start
+         * @param <T> Type of item output to stream consumer
+         * @param <E> Type of error emitted
+         */
+        interface StreamEmitter<S, T, E extends Throwable> {
+            void streamTo(Consumer<S> onStart, Consumer<T> onItem, Consumer<E> onError, Action onComplete);
+        }
+
+        /**
+         * A behavior which emits to a result listener, but returns no value, itself.
+         * @param <T> Type of result emitted
+         * @param <E> Type of error emitted
+         */
+        interface ResultEmitter<T, E extends Throwable> {
+            void emitTo(Consumer<T> onResult, Consumer<E> onError);
+        }
+
+        /**
+         * Describes behavior which emits a completion notification via an {@link Action},
+         * or alternately, emits an error to a {@link Consumer}.
+         * @param <E> Type of error emitted
+         */
+        interface ActionEmitter<E> {
+            void emitTo(Action onComplete, Consumer<E> onError);
+        }
     }
 
     /**

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxApiBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxApiBinding.java
@@ -26,6 +26,7 @@ import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.rest.RestOptions;
 import com.amplifyframework.api.rest.RestResponse;
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.rx.RxAdapters.CancelableBehaviors;
 
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
@@ -47,20 +48,20 @@ final class RxApiBinding implements RxApiCategoryBehavior {
     }
 
     @NonNull
-    public <R> Single<GraphQLResponse<R>> query(@NonNull GraphQLRequest<R> graphQlRequest) {
+    public <T> Single<GraphQLResponse<T>> query(@NonNull GraphQLRequest<T> graphQlRequest) {
         return toSingle((onResult, onError) -> api.query(graphQlRequest, onResult, onError));
     }
 
     @NonNull
     @Override
-    public <R> Single<GraphQLResponse<R>> query(
-            @NonNull String apiName, @NonNull GraphQLRequest<R> graphQlRequest) {
+    public <T> Single<GraphQLResponse<T>> query(
+            @NonNull String apiName, @NonNull GraphQLRequest<T> graphQlRequest) {
         return toSingle((onResult, onError) -> api.query(apiName, graphQlRequest, onResult, onError));
     }
 
     @NonNull
     @Override
-    public <R> Single<GraphQLResponse<R>> mutate(@NonNull GraphQLRequest<R> graphQlRequest) {
+    public <T> Single<GraphQLResponse<T>> mutate(@NonNull GraphQLRequest<T> graphQlRequest) {
         return toSingle((onResult, onError) -> api.mutate(graphQlRequest, onResult, onError));
     }
 
@@ -75,7 +76,8 @@ final class RxApiBinding implements RxApiCategoryBehavior {
     @Override
     public <T> Observable<GraphQLResponse<T>> subscribe(@NonNull GraphQLRequest<T> graphQlRequest) {
         return toObservable((onStart, onResult, onError, onComplete) ->
-                api.subscribe(graphQlRequest, onStart, onResult, onError, onComplete));
+            api.subscribe(graphQlRequest, onStart, onResult, onError, onComplete)
+        );
     }
 
     @NonNull
@@ -83,7 +85,7 @@ final class RxApiBinding implements RxApiCategoryBehavior {
     public <T> Observable<GraphQLResponse<T>> subscribe(
             @NonNull String apiName, @NonNull GraphQLRequest<T> graphQlRequest) {
         return toObservable((onStart, onResult, onError, onComplete) ->
-                api.subscribe(apiName, graphQlRequest, onStart, onResult, onError, onComplete));
+            api.subscribe(apiName, graphQlRequest, onStart, onResult, onError, onComplete));
     }
 
     @NonNull
@@ -158,11 +160,12 @@ final class RxApiBinding implements RxApiCategoryBehavior {
         return toSingle((onResult, onError) -> api.patch(apiName, request, onResult, onError));
     }
 
-    private <T> Single<T> toSingle(RxAdapters.CancelableResultEmitter<T, ApiException> method) {
-        return RxAdapters.toSingle(method);
+    private <T> Single<T> toSingle(CancelableBehaviors.ResultEmitter<T, ApiException> method) {
+        return CancelableBehaviors.toSingle(method);
     }
 
-    private <T> Observable<T> toObservable(RxAdapters.CancelableStreamEmitter<String, T, ApiException> method) {
-        return RxAdapters.toObservable(method);
+    private <T> Observable<T> toObservable(
+            CancelableBehaviors.StreamEmitter<String, T, ApiException> method) {
+        return CancelableBehaviors.toObservable(method);
     }
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -35,6 +35,7 @@ import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
 import com.amplifyframework.auth.result.AuthSignUpResult;
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.rx.RxAdapters.VoidBehaviors;
 
 import java.util.List;
 import java.util.Objects;
@@ -69,8 +70,7 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
 
     @Override
     public Single<AuthSignUpResult> resendSignUpCode(@NonNull String username) {
-        return toSingle((onResult, onError) ->
-            delegate.resendSignUpCode(username, onResult, onError));
+        return toSingle((onResult, onError) -> delegate.resendSignUpCode(username, onResult, onError));
     }
 
     @Override
@@ -140,7 +140,8 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
 
     @Override
     public Completable forgetDevice(@NonNull AuthDevice device) {
-        return toCompletable((onComplete, onError) -> delegate.forgetDevice(device, onComplete, onError));
+        return toCompletable((onComplete, onError) ->
+            delegate.forgetDevice(device, onComplete, onError));
     }
 
     @Override
@@ -177,18 +178,15 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
 
     @Override
     public Completable signOut(@NonNull AuthSignOutOptions options) {
-        return toCompletable((onComplete, onError) -> delegate.signOut(options, onComplete, onError));
+        return toCompletable((onComplete, onError) ->
+            delegate.signOut(options, onComplete, onError));
     }
 
-    private <T> Single<T> toSingle(RxAdapters.VoidResultEmitter<T, AuthException> resultEmitter) {
-        return Single.defer(() ->
-            Single.create(emitter -> resultEmitter.emitTo(emitter::onSuccess, emitter::onError))
-        );
+    private <T> Single<T> toSingle(VoidBehaviors.ResultEmitter<T, AuthException> behavior) {
+        return VoidBehaviors.toSingle(behavior);
     }
 
-    private Completable toCompletable(RxAdapters.VoidCompletionEmitter<AuthException> resultEmitter) {
-        return Completable.defer(() -> Completable.create(emitter ->
-            resultEmitter.emitTo(emitter::onComplete, emitter::onError)
-        ));
+    private Completable toCompletable(VoidBehaviors.ActionEmitter<AuthException> behavior) {
+        return VoidBehaviors.toCompletable(behavior);
     }
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
@@ -18,17 +18,16 @@ package com.amplifyframework.rx;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
-import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Amplify;
-import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.async.Cancelable;
-import com.amplifyframework.core.async.NoOpCancelable;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreCategory;
 import com.amplifyframework.datastore.DataStoreCategoryBehavior;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.DataStoreItemChange;
+import com.amplifyframework.rx.RxAdapters.VoidBehaviors;
 
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicReference;
@@ -56,8 +55,21 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
 
     @NonNull
     @Override
+    public <T extends Model> Completable save(@NonNull T item, @NonNull QueryPredicate predicate) {
+        return toCompletable((onResult, onError) -> dataStore.save(item, predicate, onResult, onError));
+    }
+
+    @NonNull
+    @Override
     public <T extends Model> Completable delete(@NonNull T item) {
         return toCompletable((onResult, onError) -> dataStore.delete(item, onResult, onError));
+    }
+
+    @NonNull
+    @Override
+    public <T extends Model> Completable delete(@NonNull T item, @NonNull QueryPredicate predicate) {
+        return toCompletable((onResult, onError) ->
+            dataStore.delete(item, predicate, onResult, onError));
     }
 
     @NonNull
@@ -70,7 +82,16 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
     @Override
     public <T extends Model> Observable<T> query(
             @NonNull Class<T> itemClass, @NonNull QueryPredicate predicate) {
-        return toObservable((onResult, onError) -> dataStore.query(itemClass, predicate, onResult, onError));
+        return toObservable((onResult, onError) ->
+            dataStore.query(itemClass, predicate, onResult, onError));
+    }
+
+    @NonNull
+    @Override
+    public <T extends Model> Observable<T> query(
+            @NonNull Class<T> itemClass, @NonNull QueryOptions options) {
+        return toObservable((onResult, onError) ->
+            dataStore.query(itemClass, options, onResult, onError));
     }
 
     @NonNull
@@ -81,10 +102,10 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
 
     @NonNull
     @Override
-    public <T extends Model> Observable<DataStoreItemChange<T>> observe(
-            @NonNull Class<T> itemClass) {
+    public <T extends Model> Observable<DataStoreItemChange<T>> observe(@NonNull Class<T> itemClass) {
         return toObservable((onStart, onItem, onError, onComplete) ->
-            dataStore.observe(itemClass, onStart, onItem, onError, onComplete));
+            dataStore.observe(itemClass, onStart, onItem, onError, onComplete)
+        );
     }
 
     @NonNull
@@ -92,7 +113,8 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
     public <T extends Model> Observable<DataStoreItemChange<T>> observe(
             @NonNull Class<T> itemClass, @NonNull String uniqueId) {
         return toObservable((onStart, onItem, onError, onComplete) ->
-            dataStore.observe(itemClass, uniqueId, onStart, onItem, onError, onComplete));
+            dataStore.observe(itemClass, uniqueId, onStart, onItem, onError, onComplete)
+        );
     }
 
     @NonNull
@@ -100,45 +122,47 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
     public <T extends Model> Observable<DataStoreItemChange<T>> observe(
             @NonNull Class<T> itemClass, @NonNull QueryPredicate selectionCriteria) {
         return toObservable((onStart, onItem, onError, onComplete) ->
-            dataStore.observe(itemClass, selectionCriteria, onStart, onItem, onError, onComplete));
+            dataStore.observe(itemClass, selectionCriteria, onStart, onItem, onError, onComplete)
+        );
+    }
+
+    @Override
+    public Completable clear() {
+        return VoidBehaviors.toCompletable(dataStore::clear);
     }
 
     private static <T extends Model> Observable<T> toObservable(
-            RxAdapters.VoidResultEmitter<Iterator<T>, DataStoreException> method) {
-        return RxAdapters.<Iterator<T>, DataStoreException>toSingle((onResult, onError) -> {
-            method.emitTo(onResult, onError);
-            return new NoOpCancelable();
-        }).flatMapObservable(iterator -> Observable.create(emitter -> {
-            while (iterator.hasNext()) {
-                emitter.onNext(iterator.next());
-            }
-            emitter.onComplete();
-        }));
+            VoidBehaviors.ResultEmitter<Iterator<T>, DataStoreException> method) {
+        return VoidBehaviors.toSingle(method)
+            .flatMapObservable(iterator -> Observable.create(emitter -> {
+                while (iterator.hasNext()) {
+                    emitter.onNext(iterator.next());
+                }
+                emitter.onComplete();
+            }));
     }
 
-    private static <T> Observable<T> toObservable(DataStoreObserveMethod<T> method) {
-        return RxAdapters.<Cancelable, T, DataStoreException>toObservable(((onStart, onItem, onError, onComplete) -> {
-            AtomicReference<Cancelable> cancelableContainer = new AtomicReference<>();
-            method.streamTo(cancelableContainer::set, onItem, onError, onComplete);
-            return () -> {
-                final Cancelable containedCancelable = cancelableContainer.get();
-                if (containedCancelable != null) {
-                    containedCancelable.cancel();
-                }
-            };
-        }));
+    private static <T> Observable<T> toObservable(
+            VoidBehaviors.StreamEmitter<Cancelable, T, DataStoreException> method) {
+        // The provided behavior receives a cancelable in callback.
+        // It is, in effect, like a cancelable behavior, we just have to remap the cancelable.
+        return RxAdapters.CancelableBehaviors.<Cancelable, T, DataStoreException>toObservable(
+            (onStart, onItem, onError, onComplete) -> {
+                AtomicReference<Cancelable> cancelableContainer = new AtomicReference<>();
+                method.streamTo(cancelableContainer::set, onItem, onError, onComplete);
+                return () -> {
+                    final Cancelable containedCancelable = cancelableContainer.get();
+                    if (containedCancelable != null) {
+                        containedCancelable.cancel();
+                    }
+                };
+            }
+        );
     }
 
     private static <T extends Model> Completable toCompletable(
-            RxAdapters.VoidResultEmitter<DataStoreItemChange<T>, DataStoreException> method) {
-        return RxAdapters.toCompletable(method);
-    }
-
-    interface DataStoreObserveMethod<T> {
-        void streamTo(
-            Consumer<Cancelable> onStart,
-            Consumer<T> onItem,
-            Consumer<DataStoreException> onError,
-            Action onComplete);
+            VoidBehaviors.ResultEmitter<DataStoreItemChange<T>, DataStoreException> method) {
+        return VoidBehaviors.<DataStoreException>toCompletable((onComplete, onError) ->
+                method.emitTo(result -> onComplete.call(), onError));
     }
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreCategoryBehavior.java
@@ -18,6 +18,7 @@ package com.amplifyframework.rx;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreCategoryBehavior;
 import com.amplifyframework.datastore.DataStoreItemChange;
@@ -28,13 +29,12 @@ import io.reactivex.rxjava3.core.Observable;
 /**
  * An Rx-idiomatic expression of the behaviors in {@link DataStoreCategoryBehavior}.
  */
-@SuppressWarnings("unused") // These are all public APIs
 public interface RxDataStoreCategoryBehavior {
 
     /**
      * Saves an item into the DataStore.
-     * @param item An item to save
      * @param <T> The time of item being saved
+     * @param item An item to save
      * @return A {@link Completable} which completes on success, emits error on error
      */
     @NonNull
@@ -43,14 +43,40 @@ public interface RxDataStoreCategoryBehavior {
     );
 
     /**
+     * Saves an item into the DataStore, considering a predicate.
+     * @param <T> The time of item being saved
+     * @param item An item to save
+     * @param predicate Predicate condition to apply for conditional write
+     * @return A {@link Completable} which completes on success, emits error on error
+     */
+    @NonNull
+    <T extends Model> Completable save(
+            @NonNull T item,
+            @NonNull QueryPredicate predicate
+    );
+
+    /**
      * Deletes an item from the DataStore.
-     * @param item An item to delete from the DataStore
      * @param <T> The type of item being deleted
+     * @param item An item to delete from the DataStore
      * @return A {@link Completable} which completes on success, emits error on error
      */
     @NonNull
     <T extends Model> Completable delete(
             @NonNull T item
+    );
+
+    /**
+     * Deletes an item from the DataStore, considering a predicate.
+     * @param <T> The type of item being deleted
+     * @param item An item to delete from the DataStore
+     * @param predicate Predicate condition to apply for conditional write
+     * @return A {@link Completable} which completes on success, emits error on error
+     */
+    @NonNull
+    <T extends Model> Completable delete(
+            @NonNull T item,
+            @NonNull QueryPredicate predicate
     );
 
     /**
@@ -78,6 +104,21 @@ public interface RxDataStoreCategoryBehavior {
     <T extends Model> Observable<T> query(
             @NonNull Class<T> itemClass,
             @NonNull QueryPredicate predicate
+    );
+
+    /**
+     * Query the DataStore to find items of the requests Java class, using the provided
+     * {@link QueryOptions}. The query options include support for filtering and paging.
+     * @param itemClass Class of items that will be queried
+     * @param options Filtering and paging options
+     * @param <T> The type of items being queried
+     * @return An observable stream of 0..n query results, if available.
+     *         The Observable will then terminate either either a completion or error.
+     */
+    @NonNull
+    <T extends Model> Observable<T> query(
+            @NonNull Class<T> itemClass,
+            @NonNull QueryOptions options
     );
 
     /**
@@ -134,4 +175,13 @@ public interface RxDataStoreCategoryBehavior {
             @NonNull Class<T> itemClass,
             @NonNull QueryPredicate selectionCriteria
     );
+
+    /**
+     * Resets the underlying DataStore to its pre-initialized state such that no data remains on the local
+     * device. Every implementation of this behavior may have its own interpretation of what clear means.
+     * This is meant to be a destructive operation that allows for safe disposal of data stored locally.
+     * @return A {@link Completable} which emits success upon successful clear of DataStore,
+     *         emits an error, otherwise
+     */
+    Completable clear();
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxHubBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxHubBinding.java
@@ -30,7 +30,6 @@ import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
 
 final class RxHubBinding implements RxHubCategoryBehavior {
-
     private final HubCategoryBehavior hub;
 
     RxHubBinding() {
@@ -46,15 +45,15 @@ final class RxHubBinding implements RxHubCategoryBehavior {
     @NonNull
     @Override
     public <T> Completable publish(@NonNull HubChannel hubChannel, @NonNull HubEvent<T> hubEvent) {
-        return Completable.defer(() -> Completable.fromAction(() -> hub.publish(hubChannel, hubEvent)));
+        return Completable.fromAction(() -> hub.publish(hubChannel, hubEvent));
     }
 
     @NonNull
     @Override
     public Observable<HubEvent<?>> on(@NonNull HubChannel hubChannel) {
-        return Observable.defer(() -> Observable.create(emitter -> {
+        return Observable.create(emitter -> {
             SubscriptionToken token = hub.subscribe(hubChannel, emitter::onNext);
             emitter.setDisposable(Disposable.fromAction(() -> hub.unsubscribe(token)));
-        }));
+        });
     }
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxPredictionsBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxPredictionsBinding.java
@@ -21,6 +21,7 @@ import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.predictions.PredictionsCategoryBehavior;
+import com.amplifyframework.predictions.PredictionsException;
 import com.amplifyframework.predictions.models.IdentifyAction;
 import com.amplifyframework.predictions.models.LanguageType;
 import com.amplifyframework.predictions.options.IdentifyOptions;
@@ -31,6 +32,7 @@ import com.amplifyframework.predictions.result.IdentifyResult;
 import com.amplifyframework.predictions.result.InterpretResult;
 import com.amplifyframework.predictions.result.TextToSpeechResult;
 import com.amplifyframework.predictions.result.TranslateTextResult;
+import com.amplifyframework.rx.RxAdapters.VoidBehaviors;
 
 import java.util.Objects;
 
@@ -50,30 +52,28 @@ final class RxPredictionsBinding implements RxPredictionsCategoryBehavior {
 
     @Override
     public Single<TextToSpeechResult> convertTextToSpeech(@NonNull String text) {
-        return Single.create(emitter ->
-            delegate.convertTextToSpeech(text, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) ->
+            delegate.convertTextToSpeech(text, onResult, onError));
     }
 
     @Override
     public Single<TextToSpeechResult> convertTextToSpeech(
             @NonNull String text,
             @NonNull TextToSpeechOptions options) {
-        return Single.create(emitter ->
-            delegate.convertTextToSpeech(text, options, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) ->
+            delegate.convertTextToSpeech(text, options, onResult, onError));
     }
 
     @Override
     public Single<TranslateTextResult> translateText(@NonNull String text) {
-        return Single.create(emitter ->
-            delegate.translateText(text, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) -> delegate.translateText(text, onResult, onError));
     }
 
     @Override
     public Single<TranslateTextResult> translateText(
             @NonNull String text,
             @NonNull TranslateTextOptions options) {
-        return Single.create(emitter ->
-            delegate.translateText(text, options, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) -> delegate.translateText(text, options, onResult, onError));
     }
 
     @Override
@@ -81,8 +81,8 @@ final class RxPredictionsBinding implements RxPredictionsCategoryBehavior {
             @NonNull String text,
             @NonNull LanguageType fromLanguage,
             @NonNull LanguageType toLanguage) {
-        return Single.create(emitter ->
-            delegate.translateText(text, fromLanguage, toLanguage, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) ->
+            delegate.translateText(text, fromLanguage, toLanguage, onResult, onError));
     }
 
     @Override
@@ -91,14 +91,13 @@ final class RxPredictionsBinding implements RxPredictionsCategoryBehavior {
             @NonNull LanguageType fromLanguage,
             @NonNull LanguageType toLanguage,
             @NonNull TranslateTextOptions options) {
-        return Single.create(emitter ->
-            delegate.translateText(text, fromLanguage, toLanguage, options, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) ->
+            delegate.translateText(text, fromLanguage, toLanguage, options, onResult, onError));
     }
 
     @Override
     public Single<IdentifyResult> identify(@NonNull IdentifyAction actionType, @NonNull Bitmap image) {
-        return Single.create(emitter ->
-            delegate.identify(actionType, image, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) -> delegate.identify(actionType, image, onResult, onError));
     }
 
     @Override
@@ -106,17 +105,21 @@ final class RxPredictionsBinding implements RxPredictionsCategoryBehavior {
             @NonNull IdentifyAction actionType,
             @NonNull Bitmap image,
             @NonNull IdentifyOptions options) {
-        return Single.create(emitter ->
-            delegate.identify(actionType, image, options, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) ->
+            delegate.identify(actionType, image, options, onResult, onError));
     }
 
     @Override
     public Single<InterpretResult> interpret(@NonNull String text) {
-        return Single.create(emitter -> delegate.interpret(text, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) -> delegate.interpret(text, onResult, onError));
     }
 
     @Override
     public Single<InterpretResult> interpret(@NonNull String text, @NonNull InterpretOptions options) {
-        return Single.create(emitter -> delegate.interpret(text, options, emitter::onSuccess, emitter::onError));
+        return toSingle((onResult, onError) -> delegate.interpret(text, options, onResult, onError));
+    }
+
+    private static <T> Single<T> toSingle(VoidBehaviors.ResultEmitter<T, PredictionsException> behavior) {
+        return VoidBehaviors.toSingle(behavior);
     }
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageBinding.java
@@ -21,6 +21,7 @@ import androidx.annotation.VisibleForTesting;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.async.NoOpCancelable;
+import com.amplifyframework.rx.RxAdapters.CancelableBehaviors;
 import com.amplifyframework.storage.StorageCategory;
 import com.amplifyframework.storage.StorageCategoryBehavior;
 import com.amplifyframework.storage.StorageException;
@@ -118,8 +119,8 @@ final class RxStorageBinding implements RxStorageCategoryBehavior {
         });
     }
 
-    private <T> Single<T> toSingle(RxAdapters.CancelableResultEmitter<T, StorageException> method) {
-        return RxAdapters.toSingle(method);
+    private <T> Single<T> toSingle(CancelableBehaviors.ResultEmitter<T, StorageException> method) {
+        return CancelableBehaviors.toSingle(method);
     }
 
     /**

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxDataStoreBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxDataStoreBindingTest.java
@@ -372,4 +372,53 @@ public final class RxDataStoreBindingTest {
         verify(delegate)
             .observe(eq(Model.class), anyConsumer(), anyConsumer(), anyConsumer(), anyAction());
     }
+
+    /**
+     * The Rx binding for the DataStore's clear() method will propagate failures
+     * faithfully from the underlying delegate.
+     * @throws InterruptedException If interrupted while test observer is awaiting terminal event
+     */
+    @Test
+    public void clearFailsWhenCategoryBehaviorDoes() throws InterruptedException {
+        // Arrange a failure in the category behavior
+        DataStoreException expectedFailure = new DataStoreException("Expected", "Failure");
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            final int positionOfOnFailure = 1;
+            Consumer<DataStoreException> onFailure = invocation.getArgument(positionOfOnFailure);
+            onFailure.accept(expectedFailure);
+            return null; // "void"
+        }).when(delegate).clear(anyAction(), anyConsumer());
+
+        // Act: clear the store.
+        TestObserver<Void> observer = rxDataStore.clear().test();
+
+        // Assert: failure propagates through binding.
+        observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertError(expectedFailure);
+    }
+
+    /**
+     * The Rx binding for the DataStore's clear() method will propagate success
+     * faithfully from the underlying delegate.
+     * @throws InterruptedException If interrupted while test observer is awaiting terminal event
+     */
+    @Test
+    public void clearSucceedsWhenCategoryBehaviorDoes() throws InterruptedException {
+        // Arrange success in the category behavior
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            final int positionOfOnSuccess = 0;
+            Action onSuccess = invocation.getArgument(positionOfOnSuccess);
+            onSuccess.call();
+            return null; // "void"
+        }).when(delegate).clear(anyAction(), anyConsumer());
+
+        // Act: clear the store.
+        TestObserver<Void> observer = rxDataStore.clear().test();
+
+        // Assert: success propagates through binding.
+        observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertComplete();
+    }
 }


### PR DESCRIPTION
1. Refactor RxAdapters, to clearly distinguish beteween cancelable and
   void behaviors.
2. Update all bindings to make more deliberate use of the updated
   RxAdapters
3. Update the RxDataStoreCategoryBehavior and RxDataStoreBinding with
   new APIs that had been added to the vanilla category spec, but did
   not make their way into the Rx spec.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
