### PR TITLE
feat(rxbindings) Make uploads progress-aware

### DIFF
--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageBinding.java
@@ -71,15 +71,18 @@ final class RxStorageBinding implements RxStorageCategoryBehavior {
 
     @NonNull
     @Override
-    public Single<StorageUploadFileResult> uploadFile(@NonNull String key, @NonNull File local) {
-        return toSingle((onResult, onError) -> storage.uploadFile(key, local, onResult, onError));
+    public RxProgressAwareSingleOperation<StorageUploadFileResult> uploadFile(@NonNull String key,
+                                                                              @NonNull File local) {
+        return uploadFile(key, local, StorageUploadFileOptions.defaultInstance());
     }
 
     @NonNull
     @Override
-    public Single<StorageUploadFileResult> uploadFile(
+    public RxProgressAwareSingleOperation<StorageUploadFileResult> uploadFile(
             @NonNull String key, @NonNull File local, @NonNull StorageUploadFileOptions options) {
-        return toSingle((onResult, onError) -> storage.uploadFile(key, local, options, onResult, onError));
+        return new RxProgressAwareSingleOperation<>((onProgress, onResult, onError) -> {
+            return storage.uploadFile(key, local, options, onProgress, onResult, onError);
+        });
     }
 
     @NonNull

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageCategoryBehavior.java
@@ -81,7 +81,7 @@ public interface RxStorageCategoryBehavior {
      *         by disposing the single subscription.
      */
     @NonNull
-    Single<StorageUploadFileResult> uploadFile(
+    RxStorageBinding.RxProgressAwareSingleOperation<StorageUploadFileResult> uploadFile(
             @NonNull String key,
             @NonNull File local
     );
@@ -96,7 +96,7 @@ public interface RxStorageCategoryBehavior {
      *         by disposing the single subscription.
      */
     @NonNull
-    Single<StorageUploadFileResult> uploadFile(
+    RxStorageBinding.RxProgressAwareSingleOperation<StorageUploadFileResult> uploadFile(
             @NonNull String key,
             @NonNull File local,
             @NonNull StorageUploadFileOptions options


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make upload calls progress-aware and return a cancellable operation. Notice the diff is against a feature branch (feature/rxbindings).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
