### PR TITLE
feat(rxbindings) Create operation for subscription

### DIFF
--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxApiBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxApiBinding.java
@@ -36,7 +36,7 @@ import io.reactivex.rxjava3.core.Single;
  * An implementation of the RxApiCategoryBehavior which satisfies the API contract by wrapping
  * {@link ApiCategoryBehavior} in Rx primitives.
  */
-public final class RxApiBinding implements RxApiCategoryBehavior {
+final class RxApiBinding implements RxApiCategoryBehavior {
     private final ApiCategoryBehavior api;
 
     RxApiBinding() {

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxApiBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxApiBinding.java
@@ -16,7 +16,6 @@
 package com.amplifyframework.rx;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.api.ApiCategory;
@@ -27,21 +26,17 @@ import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.rest.RestOptions;
 import com.amplifyframework.api.rest.RestResponse;
 import com.amplifyframework.core.Amplify;
-import com.amplifyframework.core.Consumer;
-import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.rx.RxAdapters.CancelableBehaviors;
-
-import java.util.Objects;
+import com.amplifyframework.rx.RxOperations.RxSubscriptionOperation;
 
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.subjects.BehaviorSubject;
 
 /**
  * An implementation of the RxApiCategoryBehavior which satisfies the API contract by wrapping
  * {@link ApiCategoryBehavior} in Rx primitives.
  */
-final class RxApiBinding implements RxApiCategoryBehavior {
+public final class RxApiBinding implements RxApiCategoryBehavior {
     private final ApiCategoryBehavior api;
 
     RxApiBinding() {
@@ -177,132 +172,4 @@ final class RxApiBinding implements RxApiCategoryBehavior {
         return CancelableBehaviors.toObservable(method);
     }
 
-    /**
-     * A class that represents a subscription operation and exposes
-     * observables for consumers to listen to subscription data and
-     * status events.
-     * @param <T> The type representing the subscription data.
-     */
-    public static final class RxSubscriptionOperation<T> implements Cancelable {
-        private BehaviorSubject<ConnectionStateEvent> connectionStateSubject;
-        private Observable<T> subscriptionData;
-        private Cancelable amplifyOperation;
-        private OnConnectedConsumer onConnected;
-
-        RxSubscriptionOperation(CancelableBehaviors.StreamEmitter<String, T, ApiException> callbacks) {
-            onConnected = new OnConnectedConsumer();
-            connectionStateSubject = BehaviorSubject.create();
-            subscriptionData = Observable.create(emitter -> {
-                amplifyOperation = callbacks.streamTo(onConnected::accept,
-                                                      emitter::onNext,
-                                                      emitter::onError,
-                                                      emitter::onComplete);
-            });
-        }
-
-        /**
-         * Returns an {@link Observable} which consumers can use to
-         * retrieve data received by the subscription operation.
-         * @return Reference to the {@link Observable} with subscription data.
-         */
-        public Observable<T> observeSubscriptionData() {
-            return subscriptionData;
-        }
-
-        /**
-         * Returns an {@link Observable} which consumers can use to
-         * receive notfication about the status of the subscription connection. Currently,
-         * only {@link ConnectionState#CONNECTED} is emitted.
-         * @return Reference to the {@link Observable} that receives connection events.
-         */
-        public Observable<ConnectionStateEvent> observeConnectionState() {
-            return connectionStateSubject;
-        }
-
-        @Override
-        public void cancel() {
-            connectionStateSubject.onComplete();
-            if (amplifyOperation != null) {
-                amplifyOperation.cancel();
-            }
-        }
-
-        /**
-         * Enum representing connection states of a
-         * subscription operation.
-         */
-        public enum ConnectionState {
-            /**
-             * The subscription successfully established a connection and is
-             * ready to receive data.
-             */
-            CONNECTED
-        }
-
-        /**
-         * Describes events emitted by the {@link RxSubscriptionOperation} class.
-         */
-        static class ConnectionStateEvent {
-            private ConnectionState connectionState;
-            private String subscriptionId;
-
-            ConnectionStateEvent(@NonNull ConnectionState connectionState,
-                                 @Nullable String subscriptionId) {
-                this.connectionState = connectionState;
-                this.subscriptionId = subscriptionId;
-            }
-
-            /**
-             * The connection state reported in the event.
-             * @return The {@link ConnectionState} representing the state of the connection.
-             */
-            @NonNull
-            public ConnectionState getConnectionState() {
-                return connectionState;
-            }
-
-            /**
-             * The subscriptionId associated with the event.
-             * @return The value of the subscriptionId.
-             */
-            @Nullable
-            public String getSubscriptionId() {
-                return subscriptionId;
-            }
-
-            @Override
-            public int hashCode() {
-                int result = connectionState.hashCode();
-                result = 31 * result + (subscriptionId != null ? subscriptionId.hashCode() : 0);
-                return result;
-            }
-
-            @Override
-            public boolean equals(@Nullable Object obj) {
-                if (this == obj) {
-                    return true;
-                } else if (obj == null || getClass() != obj.getClass()) {
-                    return false;
-                } else {
-                    ConnectionStateEvent privateNote = (ConnectionStateEvent) obj;
-                    return Objects.equals(getConnectionState(), privateNote.getConnectionState()) &&
-                        Objects.equals(getSubscriptionId(), privateNote.getSubscriptionId());
-                }
-            }
-
-            @NonNull
-            @Override
-            public String toString() {
-                return "ConnectionStateEvent{connectionState=" + connectionState + "," +
-                    "subscriptionId=" + subscriptionId + "}";
-            }
-        }
-
-        private final class OnConnectedConsumer implements Consumer<String> {
-            @Override
-            public void accept(@NonNull String subscriptionId) {
-                connectionStateSubject.onNext(new ConnectionStateEvent(ConnectionState.CONNECTED, subscriptionId));
-            }
-        }
-    }
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxGraphQlBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxGraphQlBehavior.java
@@ -22,6 +22,7 @@ import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.GraphQLBehavior;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.rx.RxOperations.RxSubscriptionOperation;
 
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
@@ -154,7 +155,7 @@ public interface RxGraphQlBehavior {
      *         the GraphQL network subscription will be closed.
      */
     @NonNull
-    <T> RxApiBinding.RxSubscriptionOperation<GraphQLResponse<T>> subscribe(
+    <T> RxSubscriptionOperation<GraphQLResponse<T>> subscribe(
             @NonNull GraphQLRequest<T> graphQlRequest
     );
 
@@ -180,7 +181,7 @@ public interface RxGraphQlBehavior {
      *         the GraphQL network subscription will be closed.
      */
     @NonNull
-    <R> RxApiBinding.RxSubscriptionOperation<GraphQLResponse<R>> subscribe(
+    <R> RxSubscriptionOperation<GraphQLResponse<R>> subscribe(
             @NonNull String apiName,
             @NonNull GraphQLRequest<R> graphQlRequest
     );

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxGraphQlBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxGraphQlBehavior.java
@@ -154,7 +154,7 @@ public interface RxGraphQlBehavior {
      *         the GraphQL network subscription will be closed.
      */
     @NonNull
-    <T> Observable<GraphQLResponse<T>> subscribe(
+    <T> RxApiBinding.RxSubscriptionOperation<GraphQLResponse<T>> subscribe(
             @NonNull GraphQLRequest<T> graphQlRequest
     );
 
@@ -180,7 +180,7 @@ public interface RxGraphQlBehavior {
      *         the GraphQL network subscription will be closed.
      */
     @NonNull
-    <R> Observable<GraphQLResponse<R>> subscribe(
+    <R> RxApiBinding.RxSubscriptionOperation<GraphQLResponse<R>> subscribe(
             @NonNull String apiName,
             @NonNull GraphQLRequest<R> graphQlRequest
     );

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.rx;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.async.Cancelable;
+import com.amplifyframework.rx.RxAdapters.CancelableBehaviors.StreamEmitter;
+
+import java.util.Objects;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+
+/**
+ * Top level container class created to hold Rx-specific operation types.
+ */
+public final class RxOperations {
+    /**
+     * A class that represents a subscription operation and exposes
+     * observables for consumers to listen to subscription data and
+     * status events.
+     * @param <T> The type representing the subscription data.
+     */
+    public static final class RxSubscriptionOperation<T> implements Cancelable {
+        private BehaviorSubject<ConnectionStateEvent> connectionStateSubject;
+        private Observable<T> subscriptionData;
+        private Cancelable amplifyOperation;
+        private OnConnectedConsumer onConnected;
+
+        /**
+         * Constructor for RxSubscriptionOperation.
+         * @param callbacks Implementation of {@link StreamEmitter} used to map callbacks
+         *                  for the callback-style invocations.
+         */
+        public RxSubscriptionOperation(StreamEmitter<String, T, ApiException> callbacks) {
+            onConnected = new OnConnectedConsumer();
+            connectionStateSubject = BehaviorSubject.create();
+            subscriptionData = Observable.create(emitter -> {
+                amplifyOperation = callbacks.streamTo(onConnected::accept,
+                                                      emitter::onNext,
+                                                      emitter::onError,
+                                                      emitter::onComplete);
+            });
+        }
+
+        /**
+         * Returns an {@link Observable} which consumers can use to
+         * retrieve data received by the subscription operation.
+         * @return Reference to the {@link Observable} with subscription data.
+         */
+        public Observable<T> observeSubscriptionData() {
+            return subscriptionData;
+        }
+
+        /**
+         * Returns an {@link Observable} which consumers can use to
+         * receive notfication about the status of the subscription connection. Currently,
+         * only {@link ConnectionState#CONNECTED} is emitted.
+         * @return Reference to the {@link Observable} that receives connection events.
+         */
+        public Observable<ConnectionStateEvent> observeConnectionState() {
+            return connectionStateSubject;
+        }
+
+        @Override
+        public void cancel() {
+            connectionStateSubject.onComplete();
+            if (amplifyOperation != null) {
+                amplifyOperation.cancel();
+            }
+        }
+
+        /**
+         * Enum representing connection states of a
+         * subscription operation.
+         */
+        public enum ConnectionState {
+            /**
+             * The subscription successfully established a connection and is
+             * ready to receive data.
+             */
+            CONNECTED
+        }
+
+        /**
+         * Describes events emitted by the {@link RxSubscriptionOperation} class.
+         */
+        static class ConnectionStateEvent {
+            private ConnectionState connectionState;
+            private String subscriptionId;
+
+            ConnectionStateEvent(@NonNull ConnectionState connectionState,
+                                 @Nullable String subscriptionId) {
+                this.connectionState = connectionState;
+                this.subscriptionId = subscriptionId;
+            }
+
+            /**
+             * The connection state reported in the event.
+             * @return The {@link ConnectionState} representing the state of the connection.
+             */
+            @NonNull
+            public ConnectionState getConnectionState() {
+                return connectionState;
+            }
+
+            /**
+             * The subscriptionId associated with the event.
+             * @return The value of the subscriptionId.
+             */
+            @Nullable
+            public String getSubscriptionId() {
+                return subscriptionId;
+            }
+
+            @Override
+            public int hashCode() {
+                int result = connectionState.hashCode();
+                result = 31 * result + (subscriptionId != null ? subscriptionId.hashCode() : 0);
+                return result;
+            }
+
+            @Override
+            public boolean equals(@Nullable Object obj) {
+                if (this == obj) {
+                    return true;
+                } else if (obj == null || getClass() != obj.getClass()) {
+                    return false;
+                } else {
+                    ConnectionStateEvent privateNote = (ConnectionStateEvent) obj;
+                    return Objects.equals(getConnectionState(), privateNote.getConnectionState()) &&
+                        Objects.equals(getSubscriptionId(), privateNote.getSubscriptionId());
+                }
+            }
+
+            @NonNull
+            @Override
+            public String toString() {
+                return "ConnectionStateEvent{connectionState=" + connectionState + "," +
+                    "subscriptionId=" + subscriptionId + "}";
+            }
+        }
+
+        private final class OnConnectedConsumer implements Consumer<String> {
+            @Override
+            public void accept(@NonNull String subscriptionId) {
+                connectionStateSubject.onNext(new ConnectionStateEvent(ConnectionState.CONNECTED, subscriptionId));
+            }
+        }
+    }
+}

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxApiBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxApiBindingTest.java
@@ -31,8 +31,8 @@ import com.amplifyframework.api.rest.RestResponse;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
-import com.amplifyframework.rx.RxApiBinding.RxSubscriptionOperation.ConnectionState;
-import com.amplifyframework.rx.RxApiBinding.RxSubscriptionOperation.ConnectionStateEvent;
+import com.amplifyframework.rx.RxOperations.RxSubscriptionOperation.ConnectionState;
+import com.amplifyframework.rx.RxOperations.RxSubscriptionOperation.ConnectionStateEvent;
 import com.amplifyframework.testutils.random.RandomModel;
 import com.amplifyframework.testutils.random.RandomString;
 
@@ -230,7 +230,7 @@ public final class RxApiBindingTest {
         );
 
         // Act: subscribe via binding
-        RxApiBinding.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
+        RxOperations.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
         // Act: subscribe via binding
         TestObserver<GraphQLResponse<Model>> dataObserver = rxOperation.observeSubscriptionData().test();
         TestObserver<ConnectionStateEvent> startObserver = rxOperation.observeConnectionState().test();
@@ -272,7 +272,7 @@ public final class RxApiBindingTest {
             anyConsumer(),
             anyAction()
         );
-        RxApiBinding.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
+        RxOperations.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
         // Act: subscribe via binding
         TestObserver<GraphQLResponse<Model>> dataObserver = rxOperation.observeSubscriptionData().test();
         TestObserver<ConnectionStateEvent> startObserver = rxOperation.observeConnectionState().test();
@@ -321,7 +321,7 @@ public final class RxApiBindingTest {
         );
 
         // Act: subscribe via binding
-        RxApiBinding.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
+        RxOperations.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
         // Act: subscribe via binding
         TestObserver<GraphQLResponse<Model>> dataObserver = rxOperation.observeSubscriptionData().test();
         TestObserver<ConnectionStateEvent> startObserver = rxOperation.observeConnectionState().test();

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxApiBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxApiBindingTest.java
@@ -31,6 +31,7 @@ import com.amplifyframework.api.rest.RestResponse;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.rx.RxOperations.RxSubscriptionOperation;
 import com.amplifyframework.rx.RxOperations.RxSubscriptionOperation.ConnectionState;
 import com.amplifyframework.rx.RxOperations.RxSubscriptionOperation.ConnectionStateEvent;
 import com.amplifyframework.testutils.random.RandomModel;
@@ -230,7 +231,7 @@ public final class RxApiBindingTest {
         );
 
         // Act: subscribe via binding
-        RxOperations.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
+        RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
         // Act: subscribe via binding
         TestObserver<GraphQLResponse<Model>> dataObserver = rxOperation.observeSubscriptionData().test();
         TestObserver<ConnectionStateEvent> startObserver = rxOperation.observeConnectionState().test();
@@ -272,7 +273,7 @@ public final class RxApiBindingTest {
             anyConsumer(),
             anyAction()
         );
-        RxOperations.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
+        RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
         // Act: subscribe via binding
         TestObserver<GraphQLResponse<Model>> dataObserver = rxOperation.observeSubscriptionData().test();
         TestObserver<ConnectionStateEvent> startObserver = rxOperation.observeConnectionState().test();
@@ -321,7 +322,7 @@ public final class RxApiBindingTest {
         );
 
         // Act: subscribe via binding
-        RxOperations.RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
+        RxSubscriptionOperation<GraphQLResponse<Model>> rxOperation = rxApi.subscribe(request);
         // Act: subscribe via binding
         TestObserver<GraphQLResponse<Model>> dataObserver = rxOperation.observeSubscriptionData().test();
         TestObserver<ConnectionStateEvent> startObserver = rxOperation.observeConnectionState().test();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Created an operation class to address the subscription use case. The callback-style API invokes an onStart consumer with the subscriptionId. To align with iOS that aspect of the functionality will look a bit different the rxbindings for the API category.

The `RxSubscriptionOperation` will have two methods that return observables. 
- observeSubscriptionData: emits one event for each item received via the subscription.
- observeConnectionState: when the onStart callback is triggered by the API category, we will publish a message to the observable and will save the subscriptionId as a property of the `RxSubscriptionOperation`. This will enable customer to listen for a start event if they wish, and also aligns our async functionality with the  iOS implementation. 

To still provide access to the subscriptionId, the `RxSubscriptionOperation` also has a `getSubscriptionId()`, which consumers can use if they need that data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
