### PR TITLE
Categorize auth errors

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -280,13 +280,9 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
                 @Override
                 public void onError(Exception error) {
-                    if (CognitoAuthExceptionConverter.lookup(error) != null) {
-                        onException.accept(CognitoAuthExceptionConverter.lookup(error));
-                    } else {
-                        onException.accept(
-                                new AuthException("Sign up failed", error, "See attached exception for more details")
-                        );
-                    }
+                    onException.accept(
+                           CognitoAuthExceptionConverter.lookup("Sign up failed", error)
+                    );
                 }
             }
         );
@@ -307,14 +303,9 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                if (CognitoAuthExceptionConverter.lookup(error) != null) {
-                    onException.accept(CognitoAuthExceptionConverter.lookup(error));
-                } else {
-                    onException.accept(
-                            new AuthException("Confirm sign up failed", error,
-                                            "See attached exception for more details")
-                    );
-                }
+                onException.accept(
+                        CognitoAuthExceptionConverter.lookup("Confirm sign up failed", error)
+                );
             }
         });
     }
@@ -333,17 +324,10 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                if (CognitoAuthExceptionConverter.lookup(error) != null) {
-                    onException.accept(CognitoAuthExceptionConverter.lookup(error));
-                } else {
-                    onException.accept(
-                            new AuthException(
-                                    "Resend confirmation code failed",
-                                    error,
-                                    "See attached exception for more details"
-                            )
-                    );
-                }
+                onException.accept(
+                        CognitoAuthExceptionConverter.lookup(
+                                "Resend confirmation code failed", error)
+                );
             }
         });
     }
@@ -375,13 +359,9 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                if (CognitoAuthExceptionConverter.lookup(error) != null) {
-                    onException.accept(CognitoAuthExceptionConverter.lookup(error));
-                } else {
-                    onException.accept(
-                            new AuthException("Sign in failed", error, "See attached exception for more details")
-                    );
-                }
+                onException.accept(
+                        CognitoAuthExceptionConverter.lookup("Sign in failed", error)
+                );
             }
         });
     }
@@ -415,15 +395,10 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                if (CognitoAuthExceptionConverter.lookup(error) != null) {
-                    onException.accept(CognitoAuthExceptionConverter.lookup(error));
-                } else {
-                    onException.accept(
-                            new AuthException("Confirm sign in failed",
-                                    error,
-                                    "See attached exception for more details")
-                    );
-                }
+                onException.accept(
+                        CognitoAuthExceptionConverter.lookup(
+                                "Confirm sign in failed", error)
+                );
             }
         });
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -35,6 +35,7 @@ import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignUpOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthWebUISignInOptions;
 import com.amplifyframework.auth.cognito.util.AuthProviderConverter;
+import com.amplifyframework.auth.cognito.util.CognitoAuthExceptionConverter;
 import com.amplifyframework.auth.cognito.util.SignInStateConverter;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
@@ -57,7 +58,6 @@ import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.util.UserAgent;
 
-import com.amazonaws.AmazonClientException;
 import com.amazonaws.logging.LogFactory;
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobile.client.Callback;
@@ -76,15 +76,7 @@ import com.amazonaws.mobile.client.results.UserCodeDeliveryDetails;
 import com.amazonaws.mobile.config.AWSConfiguration;
 import com.amazonaws.mobileconnectors.cognitoauth.AuthClient;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoJWTParser;
-import com.amazonaws.services.cognitoidentityprovider.model.AliasExistsException;
-import com.amazonaws.services.cognitoidentityprovider.model.CodeDeliveryFailureException;
-import com.amazonaws.services.cognitoidentityprovider.model.CodeMismatchException;
-import com.amazonaws.services.cognitoidentityprovider.model.ExpiredCodeException;
-import com.amazonaws.services.cognitoidentityprovider.model.InvalidPasswordException;
 import com.amazonaws.services.cognitoidentityprovider.model.NotAuthorizedException;
-import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
-import com.amazonaws.services.cognitoidentityprovider.model.UserNotFoundException;
-import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -113,6 +105,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     private String userId;
     private AWSMobileClient awsMobileClient;
     private AuthChannelEventName lastEvent;
+//    private CognitoAuthExceptionMapping cognitoAuthExceptionMapping = new CognitoAuthExceptionMapping();
 
     /**
      * A Cognito implementation of the Auth Plugin.
@@ -288,24 +281,13 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
                 @Override
                 public void onError(Exception error) {
-                    if (error instanceof UsernameExistsException) {
-                        onException.accept(
-                                new AuthException.AWSCognitoAuthException.UsernameExistsException(error.getCause())
-                        );
-                    } else if (error instanceof AliasExistsException) {
-                        onException.accept(
-                                new AuthException.AWSCognitoAuthException.AliasExistsException(error.getCause())
-                        );
-                    } else if (error instanceof AmazonClientException) {
-                        onException.accept(
-                                new AuthException.AWSCognitoAuthException.NetworkException(error.getCause())
-                        );
+                    if (CognitoAuthExceptionConverter.lookup(error) != null) {
+                        onException.accept(CognitoAuthExceptionConverter.lookup(error));
                     } else {
                         onException.accept(
                                 new AuthException("Sign up failed", error, "See attached exception for more details")
                         );
                     }
-
                 }
             }
         );
@@ -326,30 +308,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                if (error instanceof UserNotFoundException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.UserNotFoundException(error.getCause())
-                    );
-                } else if (error instanceof CodeMismatchException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.CodeMismatchException(error.getCause())
-                    );
-                } else if (error instanceof ExpiredCodeException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.CodeExpiredException(error.getCause())
-                    );
-                } else if (error instanceof CodeDeliveryFailureException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.CodeDeliveryFailureException(error.getCause())
-                    );
-                } else if (error instanceof UserNotConfirmedException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.UserNotConfirmedException(error.getCause())
-                    );
-                } else if (error instanceof AmazonClientException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.NetworkException(error.getCause())
-                    );
+                if (CognitoAuthExceptionConverter.lookup(error) != null) {
+                    onException.accept(CognitoAuthExceptionConverter.lookup(error));
                 } else {
                     onException.accept(
                             new AuthException("Confirm sign up failed", error,
@@ -374,13 +334,17 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                onException.accept(
-                    new AuthException(
-                        "Resend confirmation code failed",
-                        error,
-                        "See attached exception for more details"
-                    )
-                );
+                if (CognitoAuthExceptionConverter.lookup(error) != null) {
+                    onException.accept(CognitoAuthExceptionConverter.lookup(error));
+                } else {
+                    onException.accept(
+                            new AuthException(
+                                    "Resend confirmation code failed",
+                                    error,
+                                    "See attached exception for more details"
+                            )
+                    );
+                }
             }
         });
     }
@@ -412,18 +376,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                if (error instanceof InvalidPasswordException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.InvalidPasswordException(error.getCause())
-                    );
-                } else if (error instanceof UserNotFoundException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.UserNotFoundException(error.getCause())
-                    );
-                } else if (error instanceof AmazonClientException) {
-                    onException.accept(
-                            new AuthException.AWSCognitoAuthException.NetworkException(error.getCause())
-                    );
+                if (CognitoAuthExceptionConverter.lookup(error) != null) {
+                    onException.accept(CognitoAuthExceptionConverter.lookup(error));
                 } else {
                     onException.accept(
                             new AuthException("Sign in failed", error, "See attached exception for more details")
@@ -462,9 +416,15 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                onException.accept(
-                        new AuthException("Confirm sign in failed", error, "See attached exception for more details")
-                );
+                if (CognitoAuthExceptionConverter.lookup(error) != null) {
+                    onException.accept(CognitoAuthExceptionConverter.lookup(error));
+                } else {
+                    onException.accept(
+                            new AuthException("Confirm sign in failed",
+                                    error,
+                                    "See attached exception for more details")
+                    );
+                }
             }
         });
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -76,7 +76,7 @@ import com.amazonaws.mobile.client.results.UserCodeDeliveryDetails;
 import com.amazonaws.mobile.config.AWSConfiguration;
 import com.amazonaws.mobileconnectors.cognitoauth.AuthClient;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoJWTParser;
-import com.amazonaws.services.cognitoidentityprovider.model.NotAuthorizedException;
+import com.amazonaws.services.cognitoidentity.model.NotAuthorizedException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -105,7 +105,6 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     private String userId;
     private AWSMobileClient awsMobileClient;
     private AuthChannelEventName lastEvent;
-//    private CognitoAuthExceptionMapping cognitoAuthExceptionMapping = new CognitoAuthExceptionMapping();
 
     /**
      * A Cognito implementation of the Auth Plugin.

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -281,7 +281,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                 @Override
                 public void onError(Exception error) {
                     onException.accept(
-                           CognitoAuthExceptionConverter.lookup("Sign up failed", error)
+                           CognitoAuthExceptionConverter.lookup(error, "Sign up failed")
                     );
                 }
             }
@@ -304,7 +304,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             @Override
             public void onError(Exception error) {
                 onException.accept(
-                        CognitoAuthExceptionConverter.lookup("Confirm sign up failed", error)
+                        CognitoAuthExceptionConverter.lookup(error, "Confirm sign up failed")
                 );
             }
         });
@@ -326,7 +326,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             public void onError(Exception error) {
                 onException.accept(
                         CognitoAuthExceptionConverter.lookup(
-                                "Resend confirmation code failed", error)
+                                error, "Resend confirmation code failed")
                 );
             }
         });
@@ -360,7 +360,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             @Override
             public void onError(Exception error) {
                 onException.accept(
-                        CognitoAuthExceptionConverter.lookup("Sign in failed", error)
+                        CognitoAuthExceptionConverter.lookup(error, "Sign in failed")
                 );
             }
         });
@@ -397,7 +397,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             public void onError(Exception error) {
                 onException.accept(
                         CognitoAuthExceptionConverter.lookup(
-                                "Confirm sign in failed", error)
+                                error, "Confirm sign in failed")
                 );
             }
         });

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.util;
+
+import com.amplifyframework.auth.AuthException;
+
+import com.amazonaws.services.cognitoidentityprovider.model.AliasExistsException;
+import com.amazonaws.services.cognitoidentityprovider.model.CodeDeliveryFailureException;
+import com.amazonaws.services.cognitoidentityprovider.model.CodeMismatchException;
+import com.amazonaws.services.cognitoidentityprovider.model.ExpiredCodeException;
+import com.amazonaws.services.cognitoidentityprovider.model.InvalidParameterException;
+import com.amazonaws.services.cognitoidentityprovider.model.InvalidPasswordException;
+import com.amazonaws.services.cognitoidentityprovider.model.LimitExceededException;
+import com.amazonaws.services.cognitoidentityprovider.model.PasswordResetRequiredException;
+import com.amazonaws.services.cognitoidentityprovider.model.ResourceNotFoundException;
+import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttemptsException;
+import com.amazonaws.services.cognitoidentityprovider.model.UnexpectedLambdaException;
+import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
+import com.amazonaws.services.cognitoidentityprovider.model.UserNotFoundException;
+import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
+
+/**
+ * Convert AWS Cognito Exceptions to AuthExceptions.
+ */
+public final class CognitoAuthExceptionConverter {
+
+    /**
+     * Dis-allows instantiation of this class.
+     */
+    private CognitoAuthExceptionConverter() {}
+
+    /**
+     * Lookup method to convert AWS Cognito Exception to AuthException.
+     * @param error Exception thrown by AWSMobileClient
+     * @return AuthException
+     */
+    public static AuthException lookup(Exception error) {
+        if (error instanceof UserNotFoundException) {
+            return new AuthException.UserNotFoundException(error);
+        }
+
+        if (error instanceof UserNotConfirmedException) {
+            return new AuthException.UserNotConfirmedException(error);
+        }
+
+        if (error instanceof UsernameExistsException) {
+            return new AuthException.UsernameExistsException(error);
+        }
+
+        if (error instanceof AliasExistsException) {
+            return new AuthException.AliasExistsException(error);
+        }
+
+        if (error instanceof InvalidPasswordException) {
+            return new AuthException.InvalidPasswordException(error);
+        }
+
+        if (error instanceof InvalidParameterException) {
+            return new AuthException.InvalidParameterException(error);
+        }
+
+        if (error instanceof ExpiredCodeException) {
+            return new AuthException.CodeExpiredException(error);
+        }
+
+        if (error instanceof CodeMismatchException) {
+            return new AuthException.CodeMismatchException(error);
+        }
+
+        if (error instanceof CodeDeliveryFailureException) {
+            return new AuthException.CodeDeliveryFailureException(error);
+        }
+
+        if (error instanceof LimitExceededException) {
+            return new AuthException.LimitExceededException(error);
+        }
+
+        if (error instanceof ResourceNotFoundException) {
+            return new AuthException.ResourceNotFoundException(error);
+        }
+
+        if (error instanceof TooManyFailedAttemptsException) {
+            return new AuthException.FailedAttemptsLimitExceededException(error);
+        }
+
+        if (error instanceof UnexpectedLambdaException) {
+            return new AuthException.LambdaException(error);
+        }
+
+        if (error instanceof PasswordResetRequiredException) {
+            return new AuthException.PasswordResetRequiredException(error);
+        }
+
+        return null;
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.auth.cognito.util;
 
+import androidx.annotation.NonNull;
+
 import com.amplifyframework.auth.AuthException;
 
 import com.amazonaws.services.cognitoidentityprovider.model.AliasExistsException;
@@ -45,9 +47,10 @@ public final class CognitoAuthExceptionConverter {
      * Lookup method to convert AWS Cognito Exception to AuthException.
      * @param error Exception thrown by AWSMobileClient
      * @param fallbackMessage Fallback message to inform failure
-     * @return AuthException
+     * @return AuthException Specific exception for Amplify Auth
      */
-    public static AuthException lookup(Exception error, String fallbackMessage) {
+    @NonNull
+    public static AuthException lookup(@NonNull Exception error, @NonNull String fallbackMessage) {
         if (error instanceof UserNotFoundException) {
             return new AuthException.UserNotFoundException(error);
         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -27,7 +27,6 @@ import com.amazonaws.services.cognitoidentityprovider.model.LimitExceededExcepti
 import com.amazonaws.services.cognitoidentityprovider.model.PasswordResetRequiredException;
 import com.amazonaws.services.cognitoidentityprovider.model.ResourceNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttemptsException;
-import com.amazonaws.services.cognitoidentityprovider.model.UnexpectedLambdaException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
@@ -44,10 +43,11 @@ public final class CognitoAuthExceptionConverter {
 
     /**
      * Lookup method to convert AWS Cognito Exception to AuthException.
+     * @param fallbackMessage Fallback message to inform failure
      * @param error Exception thrown by AWSMobileClient
      * @return AuthException
      */
-    public static AuthException lookup(Exception error) {
+    public static AuthException lookup(String fallbackMessage, Exception error) {
         if (error instanceof UserNotFoundException) {
             return new AuthException.UserNotFoundException(error);
         }
@@ -96,14 +96,11 @@ public final class CognitoAuthExceptionConverter {
             return new AuthException.FailedAttemptsLimitExceededException(error);
         }
 
-        if (error instanceof UnexpectedLambdaException) {
-            return new AuthException.LambdaException(error);
-        }
-
         if (error instanceof PasswordResetRequiredException) {
             return new AuthException.PasswordResetRequiredException(error);
         }
 
-        return null;
+        return new AuthException(fallbackMessage, error, "See attached exception for more details.");
+
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -43,11 +43,11 @@ public final class CognitoAuthExceptionConverter {
 
     /**
      * Lookup method to convert AWS Cognito Exception to AuthException.
-     * @param fallbackMessage Fallback message to inform failure
      * @param error Exception thrown by AWSMobileClient
+     * @param fallbackMessage Fallback message to inform failure
      * @return AuthException
      */
-    public static AuthException lookup(String fallbackMessage, Exception error) {
+    public static AuthException lookup(Exception error, String fallbackMessage) {
         if (error instanceof UserNotFoundException) {
             return new AuthException.UserNotFoundException(error);
         }

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -193,7 +193,7 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     * Could not perform the action because user not found in the system.
+     * Could not perform the action because user was not found in the system.
      */
     public static class UserNotFoundException extends AuthException {
         private static final long serialVersionUID = 1L;
@@ -211,7 +211,7 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     * Could not perform the action because user not confirmed in the system.
+     * Could not perform the action because user is not confirmed in the system.
      */
     public static class UserNotConfirmedException extends AuthException {
         private static final long serialVersionUID = 1L;
@@ -263,7 +263,7 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     * Could not perform the action because error occurs when delivering the confirmation code.
+     * Could not perform the action because error occured when delivering the confirmation code.
      */
     public static class CodeDeliveryFailureException extends AuthException {
         private static final long serialVersionUID = 1L;
@@ -280,7 +280,7 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     * Could not perform the action because user enters incorrect confirmation code.
+     * Could not perform the action because user entered incorrect confirmation code.
      */
     public static class CodeMismatchException extends AuthException {
         private static final long serialVersionUID = 1L;
@@ -315,7 +315,7 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     * Could not perform the action because there exists incorrect parameters.
+     * Could not perform the action because there are incorrect parameters.
      */
     public static class InvalidParameterException extends AuthException {
         private static final long serialVersionUID = 1L;

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -384,7 +384,7 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     * Could not perform the action because Amazon Cognito service cannot find the requested resource.
+     * Could not perform the action because Amplify cannot find the requested resource.
      */
     public static class ResourceNotFoundException extends AuthException {
         private static final long serialVersionUID = 1L;
@@ -417,60 +417,4 @@ public class AuthException extends AmplifyException {
             super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
     }
-
-    /**
-     * Could not perform the action because Amazon Cognito service encounters an invalid AWS Lambda response
-     * or encounters an unexpected exception with the AWS Lambda service.
-     */
-    public static class LambdaException extends AuthException {
-        private static final long serialVersionUID = 1L;
-        private static final String MESSAGE =
-                "Amazon Cognito service encountered an invalid AWS Lambda response " +
-                        "or an unexpected exception with the AWS Lambda service.";
-        private static final String RECOVERY_SUGGESTION = "Please retry the operation.";
-
-        /**
-         * Default message/recovery suggestion with a cause.
-         * @param cause The original error.
-         */
-        public LambdaException(Throwable cause) {
-            super(MESSAGE, cause, RECOVERY_SUGGESTION);
-        }
-    }
-
-    /**
-     * Could not perform the action because device is not tracked.
-     */
-    public static class DeviceNotTrackedException extends AuthException {
-        private static final long serialVersionUID = 1L;
-        private static final String MESSAGE = "Device is not tracked.";
-        private static final String RECOVERY_SUGGESTION = "Please check out the device configuration.";
-
-        /**
-         * Default message/recovery suggestion with a cause.
-         * @param cause The original error.
-         */
-        public DeviceNotTrackedException(Throwable cause) {
-            super(MESSAGE, cause, RECOVERY_SUGGESTION);
-        }
-    }
-
-    /**
-     * Could not perform the action because user cancelled the step.
-     */
-    public static class UserCancelledException extends AuthException {
-        private static final long serialVersionUID = 1L;
-        private static final String MESSAGE = "User cancelled the flow.";
-        private static final String RECOVERY_SUGGESTION = "Please retry the operation if needed.";
-
-        /**
-         * Default message/recovery suggestion with a cause.
-         * @param cause The original error.
-         */
-        public UserCancelledException(Throwable cause) {
-            super(MESSAGE, cause, RECOVERY_SUGGESTION);
-        }
-    }
 }
-
-

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -389,7 +389,8 @@ public class AuthException extends AmplifyException {
     public static class ResourceNotFoundException extends AuthException {
         private static final long serialVersionUID = 1L;
         private static final String MESSAGE = "Could not find the requested online resource.";
-        private static final String RECOVERY_SUGGESTION = "Retry with exponential back-off";
+        private static final String RECOVERY_SUGGESTION =
+                "Retry with exponential back-off or check your config file to be sure the endpoint is valid.";
 
         /**
          * Default message/recovery suggestion with a cause.

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -191,4 +191,386 @@ public class AuthException extends AmplifyException {
             );
         }
     }
+
+    /**
+     * Exception thrown by AWS Cognito Auth.
+     */
+    public static class AWSCognitoAuthException extends AuthException {
+
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Creates a new AWS cognito auth related exception with a message, root cause, and recovery suggestion.
+         *
+         * @param message            An error message describing why this exception was thrown
+         * @param cause              The underlying cause of this exception
+         * @param recoverySuggestion Text suggesting a way to recover from the error being described
+         */
+        public AWSCognitoAuthException(
+                @NonNull final String message,
+                @NonNull final Throwable cause,
+                @NonNull final String recoverySuggestion
+        ) {
+            super(message, cause, recoverySuggestion);
+        }
+
+        /**
+         * Constructs a new AWS cognito auth related exception using a provided message and an associated error.
+         *
+         * @param message            Explains the reason for the exception
+         * @param recoverySuggestion Text suggesting a way to recover from the error being described
+         */
+        public AWSCognitoAuthException(
+                @NonNull final String message,
+                @NonNull final String recoverySuggestion
+        ) {
+            super(message, recoverySuggestion);
+        }
+
+        /**
+         * Could not perform the action because user not found in the system.
+         */
+        public static class UserNotFoundException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "User not found in the system.";
+            private static final String RECOVERY_SUGGESTION = "Please enter correct username.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             *
+             * @param cause The original error.
+             */
+            public UserNotFoundException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because user not confirmed in the system.
+         */
+        public static class UserNotConfirmedException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "User not confirmed in the system.";
+            private static final String RECOVERY_SUGGESTION = "Retry operation and make a confirmation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public UserNotConfirmedException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because username already exists in the system.
+         */
+        public static class UsernameExistsException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Username already exists in the system.";
+            private static final String RECOVERY_SUGGESTION = "Retry operation and enter another username.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public UsernameExistsException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because alias already exists in the system.
+         */
+        public static class AliasExistsException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Alias already exists in the system.";
+            private static final String RECOVERY_SUGGESTION = "Retry operation and enter another alias.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public AliasExistsException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because error occurs when delivering the confirmation code.
+         */
+        public static class CodeDeliveryFailureException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Error in delivering the confirmation code.";
+            private static final String RECOVERY_SUGGESTION = "Retry operation and send another confirmation code.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public CodeDeliveryFailureException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because user enters incorrect confirmation code.
+         */
+        public static class CodeMismatchException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Confirmation code entered is not correct.";
+            private static final String RECOVERY_SUGGESTION = "Enter correct confirmation code.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public CodeMismatchException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because confirmation code has expired.
+         */
+        public static class CodeExpiredException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Confirmation code has expired.";
+            private static final String RECOVERY_SUGGESTION = "Retry operation and send another confirmation code.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public CodeExpiredException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because there exists incorrect parameters.
+         */
+        public class InvalidParameterException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "One or more parameters are incorrect.";
+            private static final String RECOVERY_SUGGESTION = "Enter correct parameters.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public InvalidParameterException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because the password given is invalid.
+         */
+        public static class InvalidPasswordException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "The password given is invalid.";
+            private static final String RECOVERY_SUGGESTION = "Enter correct password.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public InvalidPasswordException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because number of allowed operation has exceeded.
+         */
+        public class LimitExceededException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Number of allowed operation has exceeded.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public LimitExceededException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because password needs to be reset.
+         */
+        public static class PasswordResetRequiredException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Required to reset the password of the user.";
+            private static final String RECOVERY_SUGGESTION = "Reset the password of the user.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public PasswordResetRequiredException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because Amazon Cognito service cannot find the requested resource.
+         */
+        public static class ResourceNotFoundException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Amazon Cognito service cannot find the requested resource.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public ResourceNotFoundException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because user made too many failed attempts for a given action.
+         */
+        public static class FailedAttemptsLimitExceededException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "User has made too many failed attempts for a given action.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public FailedAttemptsLimitExceededException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because user made too many requests for a given operation.
+         */
+        public static class RequestLimitExceededException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "The user has made too many requests for a given operation.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public RequestLimitExceededException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because Amazon Cognito service encounters an invalid AWS Lambda response
+         * or encounters an unexpected exception with the AWS Lambda service.
+         */
+        public static class LambdaException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE =
+                    "Amazon Cognito service encounters an invalid AWS Lambda response " +
+                            "or encounters an unexpected exception with the AWS Lambda service.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public LambdaException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because device is not tracked.
+         */
+        public static class DeviceNotTrackedException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Device is not tracked.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public DeviceNotTrackedException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because there exists error in loading web UI.
+         */
+        public static class ErrorLoadingUIException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Error in loading the web UI.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public ErrorLoadingUIException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because user cancelled the step.
+         */
+        public static class UserCancelledException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "User cancelled the step.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public UserCancelledException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action because requested resource is not available with the current account setup.
+         */
+        public static class InvalidAccountTypeException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Requested resource is not available with the current account setup.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public InvalidAccountTypeException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+
+        /**
+         * Could not perform the action since request was not completed because of any network related issue.
+         */
+        public static class NetworkException extends AWSCognitoAuthException {
+            private static final long serialVersionUID = 1L;
+            private static final String MESSAGE = "Request was not completed because of any network related issue.";
+            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
+
+            /**
+             * Default message/recovery suggestion with a cause.
+             * @param cause The original error.
+             */
+            public NetworkException(Throwable cause) {
+                super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            }
+        }
+    }
 }
+
+

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -193,382 +193,282 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     * Exception thrown by AWS Cognito Auth.
+     * Could not perform the action because user not found in the system.
      */
-    public static class AWSCognitoAuthException extends AuthException {
-
+    public static class UserNotFoundException extends AuthException {
         private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "User not found in the system.";
+        private static final String RECOVERY_SUGGESTION = "Please enter correct username.";
 
         /**
-         * Creates a new AWS cognito auth related exception with a message, root cause, and recovery suggestion.
+         * Default message/recovery suggestion with a cause.
          *
-         * @param message            An error message describing why this exception was thrown
-         * @param cause              The underlying cause of this exception
-         * @param recoverySuggestion Text suggesting a way to recover from the error being described
+         * @param cause The original error.
          */
-        public AWSCognitoAuthException(
-                @NonNull final String message,
-                @NonNull final Throwable cause,
-                @NonNull final String recoverySuggestion
-        ) {
-            super(message, cause, recoverySuggestion);
+        public UserNotFoundException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because user not confirmed in the system.
+     */
+    public static class UserNotConfirmedException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "User not confirmed in the system.";
+        private static final String RECOVERY_SUGGESTION = "Please confirm user first and then retry operation";
 
         /**
-         * Constructs a new AWS cognito auth related exception using a provided message and an associated error.
-         *
-         * @param message            Explains the reason for the exception
-         * @param recoverySuggestion Text suggesting a way to recover from the error being described
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public AWSCognitoAuthException(
-                @NonNull final String message,
-                @NonNull final String recoverySuggestion
-        ) {
-            super(message, recoverySuggestion);
+        public UserNotConfirmedException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because username already exists in the system.
+     */
+    public static class UsernameExistsException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Username already exists in the system.";
+        private static final String RECOVERY_SUGGESTION = "Retry operation and enter another username.";
 
         /**
-         * Could not perform the action because user not found in the system.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class UserNotFoundException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "User not found in the system.";
-            private static final String RECOVERY_SUGGESTION = "Please enter correct username.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             *
-             * @param cause The original error.
-             */
-            public UserNotFoundException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public UsernameExistsException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because alias (an account with certain email or phone) already exists in the system.
+     */
+    public static class AliasExistsException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE =
+                "Alias (an account with this email or phone) already exists in the system.";
+        private static final String RECOVERY_SUGGESTION = "Retry operation and use another alias.";
 
         /**
-         * Could not perform the action because user not confirmed in the system.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class UserNotConfirmedException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "User not confirmed in the system.";
-            private static final String RECOVERY_SUGGESTION = "Retry operation and make a confirmation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public UserNotConfirmedException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public AliasExistsException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because error occurs when delivering the confirmation code.
+     */
+    public static class CodeDeliveryFailureException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Error in delivering the confirmation code.";
+        private static final String RECOVERY_SUGGESTION = "Retry operation and send another confirmation code.";
 
         /**
-         * Could not perform the action because username already exists in the system.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class UsernameExistsException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Username already exists in the system.";
-            private static final String RECOVERY_SUGGESTION = "Retry operation and enter another username.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public UsernameExistsException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public CodeDeliveryFailureException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because user enters incorrect confirmation code.
+     */
+    public static class CodeMismatchException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Confirmation code entered is not correct.";
+        private static final String RECOVERY_SUGGESTION = "Enter correct confirmation code.";
 
         /**
-         * Could not perform the action because alias already exists in the system.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class AliasExistsException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Alias already exists in the system.";
-            private static final String RECOVERY_SUGGESTION = "Retry operation and enter another alias.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public AliasExistsException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public CodeMismatchException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because confirmation code has expired.
+     */
+    public static class CodeExpiredException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Confirmation code has expired.";
+        private static final String RECOVERY_SUGGESTION =
+                "Resend a new confirmation code and then retry operation with it.";
 
         /**
-         * Could not perform the action because error occurs when delivering the confirmation code.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class CodeDeliveryFailureException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Error in delivering the confirmation code.";
-            private static final String RECOVERY_SUGGESTION = "Retry operation and send another confirmation code.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public CodeDeliveryFailureException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public CodeExpiredException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because there exists incorrect parameters.
+     */
+    public static class InvalidParameterException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "One or more parameters are incorrect.";
+        private static final String RECOVERY_SUGGESTION = "Enter correct parameters.";
 
         /**
-         * Could not perform the action because user enters incorrect confirmation code.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class CodeMismatchException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Confirmation code entered is not correct.";
-            private static final String RECOVERY_SUGGESTION = "Enter correct confirmation code.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public CodeMismatchException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public InvalidParameterException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because the password given is invalid.
+     */
+    public static class InvalidPasswordException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "The password given is invalid.";
+        private static final String RECOVERY_SUGGESTION = "Enter correct password.";
 
         /**
-         * Could not perform the action because confirmation code has expired.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class CodeExpiredException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Confirmation code has expired.";
-            private static final String RECOVERY_SUGGESTION = "Retry operation and send another confirmation code.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public CodeExpiredException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public InvalidPasswordException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because number of allowed operation has exceeded.
+     */
+    public static class LimitExceededException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Number of allowed operation has exceeded.";
+        private static final String RECOVERY_SUGGESTION =
+                "Please wait a while before re-attempting or increase the service limit.";
 
         /**
-         * Could not perform the action because there exists incorrect parameters.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public class InvalidParameterException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "One or more parameters are incorrect.";
-            private static final String RECOVERY_SUGGESTION = "Enter correct parameters.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public InvalidParameterException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public LimitExceededException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because password needs to be reset.
+     */
+    public static class PasswordResetRequiredException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Required to reset the password of the user.";
+        private static final String RECOVERY_SUGGESTION = "Reset the password of the user.";
 
         /**
-         * Could not perform the action because the password given is invalid.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class InvalidPasswordException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "The password given is invalid.";
-            private static final String RECOVERY_SUGGESTION = "Enter correct password.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public InvalidPasswordException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public PasswordResetRequiredException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because Amazon Cognito service cannot find the requested resource.
+     */
+    public static class ResourceNotFoundException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Could not find the requested online resource.";
+        private static final String RECOVERY_SUGGESTION = "Retry with exponential back-off";
 
         /**
-         * Could not perform the action because number of allowed operation has exceeded.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public class LimitExceededException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Number of allowed operation has exceeded.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public LimitExceededException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public ResourceNotFoundException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because user made too many failed attempts for a given action.
+     */
+    public static class FailedAttemptsLimitExceededException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "User has made too many failed attempts for a given action.";
+        private static final String RECOVERY_SUGGESTION =
+                "Please check out the service configuration to see the condition of locking.";
 
         /**
-         * Could not perform the action because password needs to be reset.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class PasswordResetRequiredException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Required to reset the password of the user.";
-            private static final String RECOVERY_SUGGESTION = "Reset the password of the user.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public PasswordResetRequiredException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public FailedAttemptsLimitExceededException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because Amazon Cognito service encounters an invalid AWS Lambda response
+     * or encounters an unexpected exception with the AWS Lambda service.
+     */
+    public static class LambdaException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE =
+                "Amazon Cognito service encountered an invalid AWS Lambda response " +
+                        "or an unexpected exception with the AWS Lambda service.";
+        private static final String RECOVERY_SUGGESTION = "Please retry the operation.";
 
         /**
-         * Could not perform the action because Amazon Cognito service cannot find the requested resource.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class ResourceNotFoundException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Amazon Cognito service cannot find the requested resource.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public ResourceNotFoundException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public LambdaException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because device is not tracked.
+     */
+    public static class DeviceNotTrackedException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Device is not tracked.";
+        private static final String RECOVERY_SUGGESTION = "Please check out the device configuration.";
 
         /**
-         * Could not perform the action because user made too many failed attempts for a given action.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class FailedAttemptsLimitExceededException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "User has made too many failed attempts for a given action.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public FailedAttemptsLimitExceededException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public DeviceNotTrackedException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Could not perform the action because user cancelled the step.
+     */
+    public static class UserCancelledException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "User cancelled the flow.";
+        private static final String RECOVERY_SUGGESTION = "Please retry the operation if needed.";
 
         /**
-         * Could not perform the action because user made too many requests for a given operation.
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
          */
-        public static class RequestLimitExceededException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "The user has made too many requests for a given operation.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public RequestLimitExceededException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
-        }
-
-        /**
-         * Could not perform the action because Amazon Cognito service encounters an invalid AWS Lambda response
-         * or encounters an unexpected exception with the AWS Lambda service.
-         */
-        public static class LambdaException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE =
-                    "Amazon Cognito service encounters an invalid AWS Lambda response " +
-                            "or encounters an unexpected exception with the AWS Lambda service.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public LambdaException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
-        }
-
-        /**
-         * Could not perform the action because device is not tracked.
-         */
-        public static class DeviceNotTrackedException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Device is not tracked.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public DeviceNotTrackedException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
-        }
-
-        /**
-         * Could not perform the action because there exists error in loading web UI.
-         */
-        public static class ErrorLoadingUIException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Error in loading the web UI.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public ErrorLoadingUIException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
-        }
-
-        /**
-         * Could not perform the action because user cancelled the step.
-         */
-        public static class UserCancelledException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "User cancelled the step.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public UserCancelledException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
-        }
-
-        /**
-         * Could not perform the action because requested resource is not available with the current account setup.
-         */
-        public static class InvalidAccountTypeException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Requested resource is not available with the current account setup.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public InvalidAccountTypeException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
-        }
-
-        /**
-         * Could not perform the action since request was not completed because of any network related issue.
-         */
-        public static class NetworkException extends AWSCognitoAuthException {
-            private static final long serialVersionUID = 1L;
-            private static final String MESSAGE = "Request was not completed because of any network related issue.";
-            private static final String RECOVERY_SUGGESTION = "Turn off and re-attempt this operation.";
-
-            /**
-             * Default message/recovery suggestion with a cause.
-             * @param cause The original error.
-             */
-            public NetworkException(Throwable cause) {
-                super(MESSAGE, cause, RECOVERY_SUGGESTION);
-            }
+        public UserCancelledException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
     }
 }


### PR DESCRIPTION
Add `CognitoAuthExceptionConverter` as a utility to centralize error mapping.
Resolve incorrect error messages and recovery suggestions.
Get rid of improper subclass `AWSCognitoAuthException` of `AuthException`. Now all the exception class are children of `AuthException`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
