### PR TITLE
fix(rxbindings) Make ConnectionStateEvent public

### DIFF
--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
@@ -102,7 +102,7 @@ public final class RxOperations {
         /**
          * Describes events emitted by the {@link RxSubscriptionOperation} class.
          */
-        public static class ConnectionStateEvent {
+        public static final class ConnectionStateEvent {
             private ConnectionState connectionState;
             private String subscriptionId;
 

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
@@ -102,7 +102,7 @@ public final class RxOperations {
         /**
          * Describes events emitted by the {@link RxSubscriptionOperation} class.
          */
-        static class ConnectionStateEvent {
+        public static class ConnectionStateEvent {
             private ConnectionState connectionState;
             private String subscriptionId;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ConnectionStateEvent needs to be public instead of package private.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
