### PR TITLE
[core] Add Amplify.unconfigure method that is opposite to configure

### DIFF
--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 import androidx.annotation.VisibleForTesting;
 
+import com.amazonaws.mobileconnectors.pinpoint.analytics.SessionClient;
 import com.amplifyframework.analytics.AnalyticsBooleanProperty;
 import com.amplifyframework.analytics.AnalyticsDoubleProperty;
 import com.amplifyframework.analytics.AnalyticsEventBehavior;
@@ -74,6 +75,7 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
     private AutoEventSubmitter autoEventSubmitter;
     private AnalyticsClient analyticsClient;
     private AutoSessionTracker autoSessionTracker;
+    private SessionClient sessionClient;
     private TargetingClient targetingClient;
     private AWSCredentialsProvider credentialsProviderOverride; // Currently used for integration testing purposes
 
@@ -294,6 +296,20 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
         analyticsClient.submitEvents();
     }
 
+    @Override
+    public void startSession() {
+        if (sessionClient != null) {
+            sessionClient.startSession();
+        }
+    }
+
+    @Override
+    public void stopSession() {
+        if (sessionClient != null) {
+            sessionClient.stopSession();
+        }
+    }
+
     @NonNull
     @Override
     public String getPluginKey() {
@@ -373,6 +389,7 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
         );
         this.analyticsClient = pinpointManager.getAnalyticsClient();
         this.targetingClient = pinpointManager.getTargetingClient();
+        this.sessionClient = pinpointManager.getSessionClient();
 
         // Initiate the logic to automatically submit events periodically
         autoEventSubmitter = new AutoEventSubmitter(analyticsClient,
@@ -380,7 +397,7 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
         autoEventSubmitter.start();
 
         // Instantiate the logic to automatically track app session
-        autoSessionTracker = new AutoSessionTracker(this.analyticsClient, pinpointManager.getSessionClient());
+        autoSessionTracker = new AutoSessionTracker(this.analyticsClient, sessionClient);
         autoSessionTracker.startSessionTracking(application);
     }
 

--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsCategory.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsCategory.java
@@ -102,4 +102,14 @@ public final class AnalyticsCategory extends Category<AnalyticsPlugin<?>>
             getSelectedPlugin().flushEvents();
         }
     }
+
+    @Override
+    public void startSession() {
+        getSelectedPlugin().startSession();
+    }
+
+    @Override
+    public void stopSession() {
+        getSelectedPlugin().stopSession();
+    }
 }

--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsCategoryBehavior.java
@@ -86,4 +86,20 @@ public interface AnalyticsCategoryBehavior {
      * What is the behavior in this case? Naming ??
      */
     void flushEvents();
+
+    /**
+     * Starts analytics session. Should be avoided if sessions tracked per activity and should
+     * favored to default implementation that is using AutoSessionTracker that integrates
+     * with {@link android.app.Application.ActivityLifecycleCallbacks}. This implementation is done
+     * for apps that want to track analytics outside Activity lifecycle like {@link android.app.Service}.
+     */
+    void startSession();
+
+    /**
+     * Stops analytics session. Should be avoided if sessions tracked per activity and should
+     * favored to default implementation that is using AutoSessionTracker that integrates
+     * with {@link android.app.Application.ActivityLifecycleCallbacks}. This implementation is done
+     * for apps that want to track analytics outside Activity lifecycle like {@link android.app.Service}.
+     */
+    void stopSession();
 }

--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -157,6 +157,23 @@ public final class Amplify {
         }
     }
 
+    /**
+     * An opposite to {@link Amplify#configure(Context)} ()}. Removes all registered {@link Plugin}s
+     * and sets states t
+     */
+    public static void unconfigure() {
+        synchronized (CONFIGURATION_LOCK) {
+            if (CONFIGURATION_LOCK.get()) {
+                for (Category<? extends Plugin<?>> category : CATEGORIES.values()) {
+                    category.removeAllPlugins();
+                }
+
+                UserAgent.unconfigure();
+                CONFIGURATION_LOCK.set(false);
+            }
+        }
+    }
+
     private static void beginInitialization(@NonNull Category<? extends Plugin<?>> category, @NonNull Context context) {
         INITIALIZATION_POOL.execute(() -> category.initialize(context));
     }

--- a/core/src/main/java/com/amplifyframework/core/category/Category.java
+++ b/core/src/main/java/com/amplifyframework/core/category/Category.java
@@ -169,6 +169,14 @@ public abstract class Category<P extends Plugin<?>> implements CategoryTypeable 
     }
 
     /**
+     * Removes all plugins and resets state to {@link State#NOT_CONFIGURED}.
+     */
+    public final void removeAllPlugins() {
+        plugins.clear();
+        state.set(State.NOT_CONFIGURED);
+    }
+
+    /**
      * Retrieve a plugin by its key.
      * @param pluginKey A key that identifies a plugin implementation
      * @return The plugin object associated to pluginKey, if registered

--- a/core/src/main/java/com/amplifyframework/util/UserAgent.java
+++ b/core/src/main/java/com/amplifyframework/util/UserAgent.java
@@ -79,6 +79,13 @@ public final class UserAgent {
     }
 
     /**
+     * Resets the UserAgent
+     */
+    public static void unconfigure() {
+        reset();
+    }
+
+    /**
      * Reset User-Agent configuration for testing purposes.
      * No-op if User-Agent was not configured yet.
      */

--- a/core/src/test/java/com/amplifyframework/core/category/CategoryTest.java
+++ b/core/src/test/java/com/amplifyframework/core/category/CategoryTest.java
@@ -34,6 +34,8 @@ import java.util.Set;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -55,6 +57,30 @@ public final class CategoryTest {
         CategoryInitializationResult result = category.initialize(getApplicationContext());
         assertEquals(1, result.getSuccessfulPlugins().size());
         assertEquals(0, result.getFailedPlugins().size());
+    }
+
+    /**
+     * Validate the behavior of successful category plugin clean up.
+     */
+    @Test
+    public void successfulPluginClearing() throws AmplifyException {
+        Category<Plugin<Void>> category = SimpleCategory.type(CategoryType.ANALYTICS);
+        category.addPlugin(SimplePlugin.type(CategoryType.ANALYTICS));
+
+        category.configure(SimpleCategoryConfiguration.type(CategoryType.ANALYTICS), getApplicationContext());
+
+        CategoryInitializationResult result = category.initialize(getApplicationContext());
+        assertEquals(1, result.getSuccessfulPlugins().size());
+        assertEquals(0, result.getFailedPlugins().size());
+
+        assertTrue(category.isInitialized());
+
+        category.removeAllPlugins();
+        assertFalse(category.isInitialized());
+
+        CategoryInitializationResult resultPostCleanUp = category.initialize(getApplicationContext());
+        assertEquals(0, resultPostCleanUp.getSuccessfulPlugins().size());
+        assertEquals(0, resultPostCleanUp.getFailedPlugins().size());
     }
 
     /**


### PR DESCRIPTION
Amplify.configure configures: plugins, AWSMobileClient, UserAgent, etc. There is no way to reset configuration. Our application is an Android Service that consumes awspinpointconfiguration.json in runtime. A client passes configuration when binded and analytics events as user interacts with the client. Client might change configuration (AWS account) or another client might bind with a different configuration. To handle this case and taking into account heavily used singleton pattern within amplify-android and underlying libraries we need a way to de-configure the singleton and set new parameters.

[aws-analytics-pinpoint] expose startSession and stopSession

Currently sessions are tracked automatically and the logic is bound to Android Activity lifecycle. However, if the code is running in Android Service this path is not invoked. The exposure of methods allows to manually track sessions for library consumers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
