### PR TITLE
Fix/duplicating subscriptions

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -86,6 +86,15 @@ final class SubscriptionProcessor {
      * Start subscribing to model mutations.
      */
     synchronized void startSubscriptions() {
+        // let's ensure that we are not duplicating subscriptions here
+        if (ongoingOperationsDisposable.size() > 0) {
+            if  (!ongoingOperationsDisposable.isDisposed()){
+                LOG.info("Subscription already started");
+                return;
+            } else {
+                ongoingOperationsDisposable.clear();
+            }
+        }
         int subscriptionCount = modelProvider.models().size() * SubscriptionType.values().length;
         // Create a latch with the number of subscriptions are requesting. Each of these will be
         // counted down when each subscription's onStarted event is called.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -88,7 +88,7 @@ final class SubscriptionProcessor {
     synchronized void startSubscriptions() {
         // let's ensure that we are not duplicating subscriptions here
         if (ongoingOperationsDisposable.size() > 0) {
-            if  (!ongoingOperationsDisposable.isDisposed()){
+            if (!ongoingOperationsDisposable.isDisposed()) {
                 LOG.info("Subscription already started");
                 return;
             } else {


### PR DESCRIPTION
*Issue #, if available:*

SubscriptionProcessor.startSubscriptions can be called multiple times as datastore transitions through
STOPPED, LOCAL_ONLY, SYNC_VIA_API states. Guard ensures that we are not duplicating subscriptions.

At worse this can lead to appsync's maximum allowed subscription threshold of 100 being exceeded which throws an error

*Description of changes:*
Check if subscriptions already started before running SubscriptionProcessor.startSubscriptions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
