### PR TITLE
fix(datastore) Add missing converters for AWSTimestamp used by SQLiteStorageAdapter

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
@@ -66,6 +66,11 @@ public enum JavaFieldType {
     TIME(Temporal.Time.class.getSimpleName()),
 
     /**
+     * Represents the Timestamp data type.
+     */
+    TIMESTAMP(Temporal.Timestamp.class.getSimpleName()),
+    
+    /**
      * Represents the Enum type.
      */
     ENUM(Enum.class.getSimpleName()),

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * <code>ModelField</code> value converter for SQLite. It converts from SQLite's <code>Cursor</code>
@@ -109,6 +110,8 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
                 return ((Temporal.DateTime) value).format();
             case TIME:
                 return ((Temporal.Time) value).format();
+            case TIMESTAMP:
+                return ((Temporal.Timestamp) value).getSecondsSinceEpoch();
             default:
                 LOGGER.warn(String.format("Field of type %s is not supported. Fallback to null.", fieldType));
                 return null;
@@ -165,6 +168,8 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
                     return new Temporal.DateTime(valueAsString);
                 case TIME:
                     return new Temporal.Time(valueAsString);
+                case TIMESTAMP:
+                    return new Temporal.Timestamp(cursor.getLong(columnIndex), TimeUnit.SECONDS);
                 default:
                     LOGGER.warn(String.format("Field of type %s is not supported. Fallback to null.", javaFieldType));
                     return null;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
@@ -64,6 +64,7 @@ public final class TypeConverter {
         JAVA_TO_SQL.put(JavaFieldType.DATE, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.DATE_TIME, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.TIME, SQLiteDataType.TEXT);
+        JAVA_TO_SQL.put(JavaFieldType.TIMESTAMP, SQLiteDataType.INTEGER);
         JAVA_TO_SQL.put(JavaFieldType.MODEL, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.CUSTOM_TYPE, SQLiteDataType.TEXT);
     }


### PR DESCRIPTION
After this gets merged, we should be able to re-merge @saltonmassally 's PR (https://github.com/aws-amplify/amplify-android/pull/730) which adds support for non-model types, as well as https://github.com/aws-amplify/amplify-android/pull/670, which updates the representation of `lastChangedAt` from `long` to `AWSTimestamp`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
