### PR TITLE
chore(ci): improve integration test retry logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,7 @@ jobs:
             .circleci/copy-configs
       - run:
           name: Run integration test
-          command: |
-            .circleci/retry.sh 3 "./gradlew cAT --no-daemon"
+          command: .circleci/run-integration-tests.sh
       - store_artifacts:
           path: logcat.log
 workflows:

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.core.Observable;
 
@@ -303,7 +304,7 @@ public final class AppSyncClientInstrumentationTest {
     private <T> T awaitResponseData(
             Await.ResultErrorEmitter<GraphQLResponse<T>, DataStoreException> resultErrorEmitter)
             throws DataStoreException {
-        final GraphQLResponse<T> response = Await.result(resultErrorEmitter);
+        final GraphQLResponse<T> response = Await.result(TimeUnit.SECONDS.toMillis(20), resultErrorEmitter);
         if (response.hasErrors()) {
             String firstErrorMessage = response.getErrors().get(0).getMessage();
             throw new DataStoreException("Response contained errors: " + firstErrorMessage, "Check request.");


### PR DESCRIPTION
This was originally merged here: https://github.com/aws-amplify/amplify-android/pull/608

And I think it was accidentally reverted probably when resolving merge conflicts to disable coverage reports in this PR: https://github.com/aws-amplify/amplify-android/pull/677

This PR adds it back!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
