### PR TITLE
feat(api): allow pinning of api name in datastore

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -94,7 +94,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             modelProvider,
             modelSchemaRegistry,
             sqliteStorageAdapter,
-            AppSyncClient.via(api),
+            AppSyncClient.via(api, () -> pluginConfiguration.getApiName()),
             () -> pluginConfiguration,
             () -> api.getPlugins().isEmpty() ? Orchestrator.Mode.LOCAL_ONLY : Orchestrator.Mode.SYNC_VIA_API
         );

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
@@ -304,7 +304,7 @@ public final class DataStoreConfiguration {
 
         /**
          * Sets the name of the API which will be used for model synchronization.
-         * This name corresponds to a configured API in the `amplifyconfiguraiton.json`'s API
+         * This name corresponds to a configured API in the `amplifyconfiguration.json`'s API
          * category config. This is an optional configuration value. If it is not provided,
          * and the value is null, then the DataStore will attempt to use the first (and only)
          * configured API in the config file. This option is useful when you have *multiple*


### PR DESCRIPTION
If you have multiple APIs configured in your
`amplifyconfiguration.json`, you won't be able to use the DataStore.
There's no deep reason for this, it is just a simple shortcoming of the
configuration.

Before this change, the DataStore would call API methods which
auto-select a first-and-only configured API.

After this change, the user can optionally "pin" the DataStore to a
*specific* API (other than the automatically detected one), by adding
the following `"datastore"` block to `amplifyconfiguration.json`:

```json
{
    ...
    "api": {
        "plugins": {
            "awsApiPlugin": {
                "[API NAME 1]": {
                    ...
                },
                "[API NAME 2]": {
                    ...
                }
            }
        }
    },
    ...
    "datastore": {
        "plugins": {
            "awsDataStorePlugin": {
                "apiName": "[API NAME 1]"
            }
        }
    }
    ...
}
```

If this value is *not* specified, there is no change in behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.