### PR TITLE
fix(aws-datastore): emit outbox status event on mutation process

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -25,6 +25,7 @@ import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.AppSync;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
+import com.amplifyframework.datastore.events.OutboxStatusEvent;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.logging.Logger;
@@ -134,6 +135,7 @@ final class MutationProcessor {
                         "and removed from the mutation outbox: " + mutationOutboxItem
                 );
                 announceSuccessfulPublication(mutationOutboxItem);
+                publishCurrentOutboxStatus();
             })
             .doOnError(error -> LOG.warn("Failed to publish a local change = " + mutationOutboxItem, error));
     }
@@ -161,6 +163,16 @@ final class MutationProcessor {
         Amplify.Hub.publish(
             HubChannel.DATASTORE,
             HubEvent.create(DataStoreChannelEventName.OUTBOX_MUTATION_PROCESSED, mutationEvent)
+        );
+    }
+
+    /**
+     * Publish current outbox status to hub.
+     */
+    private void publishCurrentOutboxStatus() {
+        Amplify.Hub.publish(
+                HubChannel.DATASTORE,
+                new OutboxStatusEvent(mutationOutbox.peek() == null).toHubEvent()
         );
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -33,6 +33,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.util.List;
 
+import static com.amplifyframework.datastore.syncengine.TestHubEventFilters.outboxIsEmpty;
 import static com.amplifyframework.datastore.syncengine.TestHubEventFilters.publicationOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -64,6 +65,33 @@ public final class MutationProcessorTest {
         Merger merger = new Merger(mutationOutbox, versionRepository, localStorageAdapter);
         this.appSync = mock(AppSync.class);
         this.mutationProcessor = new MutationProcessor(merger, versionRepository, mutationOutbox, appSync);
+    }
+
+    /**
+     * Processing a mutation should publish current outbox status.
+     */
+    @Test
+    public void outboxStatusIsPublishedToHubOnProcess() {
+        BlogOwner raphael = BlogOwner.builder()
+                .name("Raphael Kim")
+                .build();
+        PendingMutation<BlogOwner> createRaphael = PendingMutation.creation(raphael, BlogOwner.class);
+
+        // Mock up a response from AppSync and enqueue a mutation.
+        AppSyncMocking.create(appSync).mockResponse(raphael);
+        mutationOutbox.enqueue(createRaphael).blockingAwait();
+
+        // Start listening for publication events.
+        HubAccumulator statusAccumulator = HubAccumulator.create(
+                HubChannel.DATASTORE,
+                outboxIsEmpty(true), // outbox should be empty after processing its only mutation
+                1
+        ).start();
+
+        // Start draining the outbox which has one mutation enqueued,
+        // and make sure that outbox status is published to hub.
+        mutationProcessor.startDrainingMutationOutbox();
+        statusAccumulator.await();
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -76,11 +76,13 @@ public final class PersistentMutationOutboxTest {
      * Enqueueing a mutation should publish current outbox status.
      */
     @Test
-    public void outboxStatusIsPublishedToHub() {
+    public void outboxStatusIsPublishedToHubOnEnqueue() {
         BlogOwner raphael = BlogOwner.builder()
                 .name("Raphael Kim")
                 .build();
         PendingMutation<BlogOwner> createRaphael = PendingMutation.creation(raphael, BlogOwner.class);
+
+        // Start listening for publication events.
         HubAccumulator statusAccumulator = HubAccumulator.create(
                 HubChannel.DATASTORE,
                 TestHubEventFilters.outboxIsEmpty(false), // outbox should not be empty


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make `MutationProcessor` also emit `OutboxStatusEvent` hub event after each successful mutation processing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
