### PR TITLE
fix(core): remove dev menu app icon

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -19,12 +19,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <application>
         <activity android:name="com.amplifyframework.devmenu.DeveloperMenuActivity"
-            android:theme="@style/OverlayActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:theme="@style/OverlayActivity" />
     </application>
 </manifest>
 


### PR DESCRIPTION
*Issue #, if available:* [794](https://github.com/aws-amplify/amplify-android/issues/794)

*Description of changes:* Removes the intent filter from the developer menu activity in the AndroidManifest to avoid creating a second app icon for the developer menu when running the app.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
