### PR TITLE
fix(api) owner with readonly access should be able to sub to on_delete, on_create, on_update

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -32,7 +32,6 @@ import com.amplifyframework.api.events.ApiEndpointStatusChangeEvent.ApiEndpointS
 import com.amplifyframework.api.graphql.GraphQLOperation;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.api.graphql.Operation;
 import com.amplifyframework.api.rest.HttpMethod;
 import com.amplifyframework.api.rest.RestOperation;
 import com.amplifyframework.api.rest.RestOperationRequest;
@@ -286,7 +285,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             try {
                 AppSyncGraphQLRequest<R> appSyncRequest = (AppSyncGraphQLRequest<R>) request;
                 for (AuthRule authRule : appSyncRequest.getModelSchema().getAuthRules()) {
-                    if (isOwnerArgumentRequired(authRule, appSyncRequest.getOperation())) {
+                    if (isOwnerArgumentRequired(authRule)) {
                         request = appSyncRequest.newBuilder()
                                 .variable(authRule.getOwnerFieldOrDefault(), "String!", getUsername())
                                 .build();
@@ -313,7 +312,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         return operation;
     }
 
-    private boolean isOwnerArgumentRequired(AuthRule authRule, Operation operation) {
+    private boolean isOwnerArgumentRequired(AuthRule authRule) {
         return AuthStrategy.OWNER.equals(authRule.getAuthStrategy())
             && authRule.getOperationsOrDefault().contains(ModelOperation.READ);
     }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
@@ -25,10 +25,8 @@ import com.amplifyframework.api.events.ApiEndpointStatusChangeEvent;
 import com.amplifyframework.api.graphql.GraphQLOperation;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.api.graphql.Operation;
 import com.amplifyframework.api.graphql.PaginatedResult;
-import com.amplifyframework.api.graphql.QueryType;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.api.graphql.model.ModelMutation;
 import com.amplifyframework.api.graphql.model.ModelPagination;
@@ -294,33 +292,19 @@ public final class AWSApiPluginTest {
     }
 
     /**
-     * Verify that owner argument is required for ON_CREATE subscription if ModelOperation.CREATE is specified.
+     * Verify that owner argument is required for all subscriptions if ModelOperation.READ is specified.
      * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
      */
     @Test
-    public void ownerArgumentAddedForOnCreate() throws AmplifyException {
-        assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_CREATE));
-        assertTrue(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_CREATE));
-    }
-
-    /**
-     * Verify that owner argument is required for ON_UPDATE subscription if ModelOperation.UPDATE is specified.
-     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
-     */
-    @Test
-    public void ownerArgumentAddedForOnUpdate() throws AmplifyException {
+    public void ownerArgumentAddedForRestrictedRead() throws AmplifyException {
         assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_UPDATE));
-        assertTrue(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_UPDATE));
-    }
+        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_UPDATE));
 
-    /**
-     * Verify that owner argument is required for ON_DELETE subscription if ModelOperation.DELETE is specified.
-     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
-     */
-    @Test
-    public void ownerArgumentAddedForOnDelete() throws AmplifyException {
         assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_DELETE));
-        assertTrue(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_DELETE));
+        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_DELETE));
+
+        assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_CREATE));
+        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_CREATE));
     }
 
     /**
@@ -330,14 +314,14 @@ public final class AWSApiPluginTest {
     @Test
     public void ownerArgumentNotAddedIfOperationNotRestricted() throws AmplifyException {
         assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_UPDATE));
-        assertFalse(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_UPDATE));
+        assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_UPDATE));
         assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_UPDATE));
 
         assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_DELETE));
-        assertFalse(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_DELETE));
         assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_DELETE));
+        assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_DELETE));
 
-        assertFalse(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_CREATE));
+        assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_CREATE));
         assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_CREATE));
         assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_CREATE));
     }
@@ -349,16 +333,6 @@ public final class AWSApiPluginTest {
     @Test
     public void ownerArgumentNotAddedIfNotOwnerStrategy() throws AmplifyException {
         assertFalse(isOwnerArgumentAdded(Group.class, SubscriptionType.ON_CREATE));
-    }
-
-    /**
-     * Verify owner argument NOT added for Query or Mutation operations.
-     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
-     */
-    @Test
-    public void verifyOwnerArgumentNotAddedIfNotSubscriptionOperation() throws AmplifyException {
-        assertFalse(isOwnerArgumentAdded(Owner.class, QueryType.GET));
-        assertFalse(isOwnerArgumentAdded(Owner.class, MutationType.CREATE));
     }
 
     private boolean isOwnerArgumentAdded(Class<? extends Model> clazz, Operation operation)


### PR DESCRIPTION
Same as https://github.com/aws-amplify/amplify-android/pull/779, but with updated unit tests. 

Fixes https://github.com/aws-amplify/amplify-android/issues/778 and https://github.com/aws-amplify/amplify-android/issues/699.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
