### PR TITLE
chore: use latest dependency versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     parameters:
       gradle_version:
         description: "The version of Gradle to install"
-        default: "6.5.1"
+        default: "6.6.1"
         type: string
 
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext {
         androidx: [
             v4support: 'androidx.legacy:legacy-support-v4:1.0.0',
             annotation: 'androidx.annotation:annotation:1.1.0',
-            appcompat: 'androidx.appcompat:appcompat:1.1.0',
+            appcompat: 'androidx.appcompat:appcompat:1.2.0',
             core: 'androidx.core:core:1.3.1',
             nav: [
                 fragment: "androidx.navigation:navigation-fragment:$navigationVersion",
@@ -72,10 +72,10 @@ ext {
             ],
             multidex: 'androidx.multidex:multidex:2.0.1',
             test: [
-                core: 'androidx.test:core:1.2.0',
-                runner: 'androidx.test:runner:1.2.0',
-                junit: 'androidx.test.ext:junit:1.1.1',
-                espresso: 'androidx.test.espresso:espresso-core:3.2.0',
+                core: 'androidx.test:core:1.3.0',
+                runner: 'androidx.test:runner:1.3.0',
+                junit: 'androidx.test.ext:junit:1.1.2',
+                espresso: 'androidx.test.espresso:espresso-core:3.3.0',
                 navigation: "androidx.navigation:navigation-testing:$navigationVersion",
                 fragment: "androidx.fragment:fragment-testing:$fragmentVersion"
             ]
@@ -94,7 +94,7 @@ ext {
             translate: "com.amazonaws:aws-android-sdk-translate:$awsSdkVersion"
         ],
 
-        okhttp: 'com.squareup.okhttp3:okhttp:4.8.0',
+        okhttp: 'com.squareup.okhttp3:okhttp:4.8.1',
         gson: 'com.google.code.gson:gson:2.8.6',
         rxandroid: 'io.reactivex.rxjava3:rxandroid:3.0.0',
         rxjava: 'io.reactivex.rxjava3:rxjava:3.0.6',
@@ -103,8 +103,8 @@ ext {
 
         junit: 'junit:junit:4.13',
         mockito: 'org.mockito:mockito-core:3.1.0',
-        mockwebserver: 'com.squareup.okhttp3:mockwebserver:4.8.0',
-        robolectric: 'org.robolectric:robolectric:4.3.1',
+        mockwebserver: 'com.squareup.okhttp3:mockwebserver:4.8.1',
+        robolectric: 'org.robolectric:robolectric:4.4',
         jsonassert: 'org.skyscreamer:jsonassert:1.5.0'
     ]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 10 23:25:41 MDT 2020
+#Tue Sep 08 22:39:49 MDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip


### PR DESCRIPTION
Gradle -> 6.6.1
OkHttp & MockWebServer -> 4.8.1
Android X AppCompat -> 1.2.0
Android X Test Core & Runner -> 1.3.0
Android X jUnit Extension -> 1.1.2
Espresso Core -> 3.3.0
Robolectric -> 4.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
