### PR TITLE
Fix gradle configuration of mavenLocal in 'Consuming Development Versions'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ the root of the `amplify-android` project:
 
 After this, you can use the published development artifacts from an app.
 To do so, specify `mavenLocal()` inside the app's top-level
-`build.gradle` file:
+`build.gradle(Project)` file:
 
 ```gradle
 buildscript {
@@ -89,8 +89,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
-        
-	 implementation 'com.amplifyframework:core:main' // Specify `main` instead of a version number to point to mavenLocal
     }
 }
 
@@ -100,6 +98,11 @@ allprojects {
     }
 }
 ```
+Then, specify `main` instead of a version number to point to mavenLocal inside `build.gradle(Module)` file:
+```
+dependencies {
+    implementation 'com.amplifyframework:core:main'
+}
 
 ## Tools
 [Gradle](https://gradle.org) is used for all [build and dependency management](https://developer.android.com/studio/build).


### PR DESCRIPTION
The gradle configuration of mavenLocal should be done in `build.gradle(Module)` rather than `build.gradle(Project)`. The previous description was somehow misleading.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
