### PR TITLE
chore(aws-api-appsync) Use class as value instead of simpleName for JavaFieldTy…

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
@@ -280,7 +280,7 @@ public final class SelectionSet {
                 return false;
             }
             try {
-                JavaFieldType.from(cls.getSimpleName());
+                JavaFieldType.from(cls);
                 return false;
             } catch (IllegalArgumentException exception) {
                 // if we get here then field is  a custom type

--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
@@ -20,6 +20,8 @@ import androidx.annotation.NonNull;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.temporal.Temporal;
 
+import java.util.Date;
+
 /**
  * Enumerate the types used in the fields
  * of {@link com.amplifyframework.core.model.Model} classes.
@@ -28,75 +30,72 @@ public enum JavaFieldType {
     /**
      * Represents the boolean data type.
      */
-    BOOLEAN(Boolean.class.getSimpleName()),
+    BOOLEAN(Boolean.class),
 
     /**
      * Represents the int data type.
      */
-    INTEGER(Integer.class.getSimpleName()),
+    INTEGER(Integer.class),
 
     /**
      * Represents the long data type.
      */
-    LONG(Long.class.getSimpleName()),
+    LONG(Long.class),
 
     /**
      * Represents the float data type.
      */
-    FLOAT(Float.class.getSimpleName()),
+    FLOAT(Float.class),
 
     /**
      * Represents the String data type.
      */
-    STRING(String.class.getSimpleName()),
+    STRING(String.class),
+
+    /**
+     * Represents the java.lang.Date data type.
+     */
+    JAVA_DATE(Date.class),
 
     /**
      * Represents the Date data type.
      */
-    DATE(Temporal.Date.class.getSimpleName()),
+    DATE(Temporal.Date.class),
 
     /**
      * Represents the DateTime data type.
      */
-    DATE_TIME(Temporal.DateTime.class.getSimpleName()),
+    DATE_TIME(Temporal.DateTime.class),
 
     /**
      * Represents the Time data type.
      */
-    TIME(Temporal.Time.class.getSimpleName()),
+    TIME(Temporal.Time.class),
 
     /**
      * Represents the Timestamp data type.
      */
-    TIMESTAMP(Temporal.Timestamp.class.getSimpleName()),
+    TIMESTAMP(Temporal.Timestamp.class),
     
     /**
      * Represents the Enum type.
      */
-    ENUM(Enum.class.getSimpleName()),
+    ENUM(Enum.class),
 
     /**
      * Represents the Model type.
      */
-    MODEL(Model.class.getSimpleName()),
+    MODEL(Model.class),
 
     /**
      * Represents any custom type (objects that are not models).
      */
-    CUSTOM_TYPE(Object.class.getSimpleName());
+    CUSTOM_TYPE(Object.class);
 
-    private final String javaFieldType;
+    private final Class<?> javaFieldType;
 
-    JavaFieldType(@NonNull String javaFieldType) {
+    JavaFieldType(@NonNull Class<?> javaFieldType) {
         this.javaFieldType = javaFieldType;
-    }
-
-    /**
-     * Return the string that represents the value of the enumeration constant.
-     * @return the string that represents the value of the enumeration constant.
-     */
-    public String stringValue() {
-        return this.javaFieldType;
     }
 
     /**
@@ -105,9 +104,9 @@ public enum JavaFieldType {
      * @param javaFieldType the string representation of the field type.
      * @return the enumeration constant.
      */
-    public static JavaFieldType from(@NonNull String javaFieldType) {
+    public static JavaFieldType from(@NonNull Class<?> javaFieldType) {
         for (final JavaFieldType type : JavaFieldType.values()) {
-            if (javaFieldType.equals(type.stringValue())) {
+            if (javaFieldType.equals(type.javaFieldType)) {
                 return type;
             }
         }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
@@ -62,6 +62,7 @@ public final class TypeConverter {
         JAVA_TO_SQL.put(JavaFieldType.STRING, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.ENUM, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.DATE, SQLiteDataType.TEXT);
+        JAVA_TO_SQL.put(JavaFieldType.JAVA_DATE, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.DATE_TIME, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.TIME, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.TIMESTAMP, SQLiteDataType.INTEGER);
@@ -77,7 +78,7 @@ public final class TypeConverter {
             return JavaFieldType.ENUM;
         }
         try {
-            return JavaFieldType.from(field.getType().getSimpleName());
+            return JavaFieldType.from(field.getType());
         } catch (IllegalArgumentException exception) {
             // fallback to custom type, which will result in the field being converted to a JSON string
             return JavaFieldType.CUSTOM_TYPE;
@@ -97,7 +98,7 @@ public final class TypeConverter {
             return JavaFieldType.ENUM;
         }
         try {
-            return JavaFieldType.from(value.getClass().getSimpleName());
+            return JavaFieldType.from(value.getClass());
         } catch (IllegalArgumentException exception) {
             // fallback to custom type, which will result in the field being converted to a JSON string
             return JavaFieldType.CUSTOM_TYPE;


### PR DESCRIPTION
 Use class as value instead of simpleName for JavaFieldType in case of duplicated Class simple name.

We were using class's simple name as identifier , this will cause issues when classes have same name (different package) , In fact, there are already two duplicated classes:

java.lang.Date vs Temporal.Date , former is used in our model class.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
