### PR TITLE
fix(Auth): Fixes guest / anonymous user access

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/MobileClientSessionAdapter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/MobileClientSessionAdapter.java
@@ -291,9 +291,9 @@ final class MobileClientSessionAdapter {
         return new AWSCognitoAuthSession(
                 false,
                 AuthSessionResult.failure(new AuthException.SignedOutException(
-                        AuthException.GuestAccess.GUEST_ACCESS_ENABLED)),
+                        AuthException.GuestAccess.GUEST_ACCESS_POSSIBLE)),
                 AuthSessionResult.failure(new AuthException.SignedOutException(
-                        AuthException.GuestAccess.GUEST_ACCESS_ENABLED)),
+                        AuthException.GuestAccess.GUEST_ACCESS_POSSIBLE)),
                 AuthSessionResult.failure(new AuthException.SignedOutException()),
                 AuthSessionResult.failure(new AuthException.SignedOutException())
         );

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -44,6 +44,7 @@ import com.amplifyframework.testutils.random.RandomString;
 import com.amplifyframework.testutils.sync.SynchronousAuth;
 import com.amplifyframework.util.UserAgent;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.mobile.client.AWSMobileClient;
@@ -88,7 +89,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -679,7 +679,14 @@ public final class AuthComponentTest {
      */
     @Test
     public void signedOutSessionWithIdentityPoolAndNoGuest() throws AuthException {
-        doAnswer(invocation -> null).when(mobileClient).getIdentityId();
+        AmazonClientException credentialsResult =
+                new AmazonClientException("Failed to get credentials from Cognito Identity", null);
+
+        doAnswer(invocation -> {
+            Callback<AWSCredentials> callback = invocation.getArgument(0);
+            callback.onError(credentialsResult);
+            return null;
+        }).when(mobileClient).getAWSCredentials(any());
 
         UserStateDetails stateResult = new UserStateDetails(UserState.SIGNED_OUT, null);
         doAnswer(invocation -> {
@@ -690,12 +697,14 @@ public final class AuthComponentTest {
 
         AWSCognitoAuthSession authSession = (AWSCognitoAuthSession) synchronousAuth.fetchAuthSession();
         verify(mobileClient).currentUserState(any());
-        verify(mobileClient).getIdentityId();
+        verify(mobileClient).getAWSCredentials(any());
 
         AWSCognitoAuthSession expectedResult = new AWSCognitoAuthSession(
                 false,
-                AuthSessionResult.failure(new AuthException.SignedOutException()),
-                AuthSessionResult.failure(new AuthException.SignedOutException()),
+                AuthSessionResult.failure(new AuthException.SignedOutException(
+                        AuthException.GuestAccess.GUEST_ACCESS_ENABLED)),
+                AuthSessionResult.failure(new AuthException.SignedOutException(
+                        AuthException.GuestAccess.GUEST_ACCESS_ENABLED)),
                 AuthSessionResult.failure(new AuthException.SignedOutException()),
                 AuthSessionResult.failure(new AuthException.SignedOutException())
         );
@@ -749,12 +758,12 @@ public final class AuthComponentTest {
      */
     @Test
     public void signedOutSessionWithNoIdentityPool() throws AuthException {
-        doThrow(new RuntimeException()).when(mobileClient).getIdentityId();
+        AmazonClientException credentialsResult =
+                new AmazonClientException("Cognito Identity not configured", null);
 
-        AWSCredentials awsCredentialsResult = new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY);
         doAnswer(invocation -> {
             Callback<AWSCredentials> callback = invocation.getArgument(0);
-            callback.onResult(awsCredentialsResult);
+            callback.onError(credentialsResult);
             return null;
         }).when(mobileClient).getAWSCredentials(any());
 
@@ -767,7 +776,7 @@ public final class AuthComponentTest {
 
         AWSCognitoAuthSession authSession = (AWSCognitoAuthSession) synchronousAuth.fetchAuthSession();
         verify(mobileClient).currentUserState(any());
-        verify(mobileClient).getIdentityId();
+        verify(mobileClient).getAWSCredentials(any());
 
         AWSCognitoAuthSession expectedResult = new AWSCognitoAuthSession(
                 false,

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -702,9 +702,9 @@ public final class AuthComponentTest {
         AWSCognitoAuthSession expectedResult = new AWSCognitoAuthSession(
                 false,
                 AuthSessionResult.failure(new AuthException.SignedOutException(
-                        AuthException.GuestAccess.GUEST_ACCESS_ENABLED)),
+                        AuthException.GuestAccess.GUEST_ACCESS_POSSIBLE)),
                 AuthSessionResult.failure(new AuthException.SignedOutException(
-                        AuthException.GuestAccess.GUEST_ACCESS_ENABLED)),
+                        AuthException.GuestAccess.GUEST_ACCESS_POSSIBLE)),
                 AuthSessionResult.failure(new AuthException.SignedOutException()),
                 AuthSessionResult.failure(new AuthException.SignedOutException())
         );

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -58,13 +58,28 @@ public class AuthException extends AmplifyException {
     public static class SignedOutException extends AuthException {
         private static final long serialVersionUID = 1L;
         private static final String MESSAGE = "You are currently signed out.";
-        private static final String RECOVERY_SUGGESTION = "Please sign in and reattempt the operation.";
+        private static final String DEFAULT_RECOVERY_SUGGESTION = "Please sign in and reattempt the operation.";
+        private static final String IDENTITY_POOL_RECOVERY_SUGGESTION = "If you have guest access enabled, please " +
+                "check that your device is online and try again. Otherwise if guest access is not enabled, you'll " +
+                "need to sign in and try again.";
 
         /**
          * Default message/recovery suggestion without a cause.
          */
         public SignedOutException() {
-            super(MESSAGE, RECOVERY_SUGGESTION);
+            super(MESSAGE, DEFAULT_RECOVERY_SUGGESTION);
+        }
+
+        /**
+         * Returns the default error message with a recovery message based on whether guest access is enabled or not
+         * since the user would not necessarily have to sign in to recover from the error if guest access is enabled.
+         * @param guestAccess specifies whether guest access is enabled or not so that the proper recovery message can
+         *                    be returned.
+         */
+        public SignedOutException(GuestAccess guestAccess) {
+            super(MESSAGE, guestAccess == GuestAccess.GUEST_ACCESS_ENABLED ?
+                            IDENTITY_POOL_RECOVERY_SUGGESTION :
+                            DEFAULT_RECOVERY_SUGGESTION);
         }
 
         /**
@@ -72,7 +87,7 @@ public class AuthException extends AmplifyException {
          * @param cause The original error.
          */
         public SignedOutException(Throwable cause) {
-            super(MESSAGE, cause, RECOVERY_SUGGESTION);
+            super(MESSAGE, cause, DEFAULT_RECOVERY_SUGGESTION);
         }
     }
 
@@ -417,5 +432,21 @@ public class AuthException extends AmplifyException {
         public FailedAttemptsLimitExceededException(Throwable cause) {
             super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+    }
+
+    /**
+     * Allows the user to specify whether guest access is enabled or not since this can affect which
+     * recovery message should be included.
+     */
+    public enum GuestAccess {
+        /**
+         * Auth has been configured to support guest access (where a user can get credentials once online without being
+         * signed in).
+         */
+        GUEST_ACCESS_ENABLED,
+        /**
+         * AAuth has not been configured to support guest access.
+         */
+        GUEST_ACCESS_DISABLED
     }
 }

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -19,6 +19,9 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Exception thrown by Storage category plugins.
  */
@@ -57,17 +60,29 @@ public class AuthException extends AmplifyException {
      */
     public static class SignedOutException extends AuthException {
         private static final long serialVersionUID = 1L;
+        private static final Map<GuestAccess, String> RECOVERY_SUGGESTIONS;
+
+        static {
+            RECOVERY_SUGGESTIONS = new HashMap<>();
+            RECOVERY_SUGGESTIONS.put(GuestAccess.GUEST_ACCESS_DISABLED,
+                    "Please sign in and reattempt the operation.");
+            RECOVERY_SUGGESTIONS.put(GuestAccess.GUEST_ACCESS_POSSIBLE,
+                    "If you have guest access enabled, please check that your device is online and try again. " +
+                        "Otherwise if guest access is not enabled, you'll need to sign in and try again.");
+            RECOVERY_SUGGESTIONS.put(GuestAccess.GUEST_ACCESS_ENABLED,
+                    "For guest access, please check that your device is online and try again. For normal user " +
+                    "access, please sign in.");
+        }
+
         private static final String MESSAGE = "You are currently signed out.";
-        private static final String DEFAULT_RECOVERY_SUGGESTION = "Please sign in and reattempt the operation.";
-        private static final String IDENTITY_POOL_RECOVERY_SUGGESTION = "If you have guest access enabled, please " +
-                "check that your device is online and try again. Otherwise if guest access is not enabled, you'll " +
-                "need to sign in and try again.";
 
         /**
          * Default message/recovery suggestion without a cause.
          */
         public SignedOutException() {
-            super(MESSAGE, DEFAULT_RECOVERY_SUGGESTION);
+            // Return the guest access disabled message by default since it's the most straightforward way to address
+            // a signed out error.
+            super(MESSAGE, RECOVERY_SUGGESTIONS.get(GuestAccess.GUEST_ACCESS_DISABLED));
         }
 
         /**
@@ -77,9 +92,7 @@ public class AuthException extends AmplifyException {
          *                    be returned.
          */
         public SignedOutException(GuestAccess guestAccess) {
-            super(MESSAGE, guestAccess == GuestAccess.GUEST_ACCESS_ENABLED ?
-                            IDENTITY_POOL_RECOVERY_SUGGESTION :
-                            DEFAULT_RECOVERY_SUGGESTION);
+            super(MESSAGE, RECOVERY_SUGGESTIONS.get(guestAccess));
         }
 
         /**
@@ -87,7 +100,9 @@ public class AuthException extends AmplifyException {
          * @param cause The original error.
          */
         public SignedOutException(Throwable cause) {
-            super(MESSAGE, cause, DEFAULT_RECOVERY_SUGGESTION);
+            // Return the guest access disabled message by default since it's the most straightforward way to address
+            // a signed out error.
+            super(MESSAGE, cause, RECOVERY_SUGGESTIONS.get(GuestAccess.GUEST_ACCESS_DISABLED));
         }
     }
 
@@ -444,6 +459,10 @@ public class AuthException extends AmplifyException {
          * signed in).
          */
         GUEST_ACCESS_ENABLED,
+        /**
+         * Auth could support guest access but it is unknown if that mode is currently enabled.
+         */
+        GUEST_ACCESS_POSSIBLE,
         /**
          * AAuth has not been configured to support guest access.
          */

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -68,7 +68,7 @@ public class AuthException extends AmplifyException {
                     "Please sign in and reattempt the operation.");
             RECOVERY_SUGGESTIONS.put(GuestAccess.GUEST_ACCESS_POSSIBLE,
                     "If you have guest access enabled, please check that your device is online and try again. " +
-                        "Otherwise if guest access is not enabled, you'll need to sign in and try again.");
+                    "Otherwise if guest access is not enabled, you'll need to sign in and try again.");
             RECOVERY_SUGGESTIONS.put(GuestAccess.GUEST_ACCESS_ENABLED,
                     "For guest access, please check that your device is online and try again. For normal user " +
                     "access, please sign in.");
@@ -464,7 +464,7 @@ public class AuthException extends AmplifyException {
          */
         GUEST_ACCESS_POSSIBLE,
         /**
-         * AAuth has not been configured to support guest access.
+         * Auth has not been configured to support guest access.
          */
         GUEST_ACCESS_DISABLED
     }


### PR DESCRIPTION
Changes the order of operations to the same one that iOS uses to avoid the bug in AWSMobileClient where it doesn't return identity id until getAWSCredentials is called.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
