### PR TITLE
fix(aws-datastore): make subscription timeout model count dependent

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -322,11 +322,11 @@ public final class Orchestrator {
 
     private void stopApiSyncBlocking() {
         try {
-            boolean subscribed = stopApiSync()
+            boolean stopped = stopApiSync()
                 .subscribeOn(startStopScheduler)
-                .blockingAwait(adjustedTimeoutSeconds, TimeUnit.SECONDS);
-            if (!subscribed) {
-                throw new TimeoutException("Subscription timed out.");
+                .blockingAwait(LOCAL_OP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!stopped) {
+                throw new TimeoutException("Operation timed out.");
             }
         } catch (Throwable failure) {
             LOG.warn("Failed to stop API sync.", failure);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -286,7 +286,7 @@ public final class Orchestrator {
             LOG.debug("About to hydrate...");
             try {
                 boolean subscribed = syncProcessor.hydrate()
-                    .blockingAwait(adjustedTimeoutSeconds, TimeUnit.MILLISECONDS);
+                    .blockingAwait(adjustedTimeoutSeconds, TimeUnit.SECONDS);
                 if (!subscribed) {
                     throw new TimeoutException("Subscription timed out.");
                 }
@@ -323,7 +323,7 @@ public final class Orchestrator {
         try {
             boolean subscribed = stopApiSync()
                 .subscribeOn(startStopScheduler)
-                .blockingAwait(adjustedTimeoutSeconds, TimeUnit.MILLISECONDS);
+                .blockingAwait(adjustedTimeoutSeconds, TimeUnit.SECONDS);
             if (!subscribed) {
                 throw new TimeoutException("Subscription timed out.");
             }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -53,7 +53,8 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 public final class Orchestrator {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
     private static final long TIMEOUT_SECONDS_PER_MODEL = 2;
-    private static final long MINIMUM_OP_TIMEOUT_SECONDS = 10;
+    private static final long NETWORK_OP_TIMEOUT_SECONDS = 10;
+    private static final long LOCAL_OP_TIMEOUT_SECONDS = 2;
 
     private final SubscriptionProcessor subscriptionProcessor;
     private final SyncProcessor syncProcessor;
@@ -119,7 +120,7 @@ public final class Orchestrator {
         // Operation times out after 10 seconds. If there are more than 5 models,
         // then 2 seconds are added to the timer per additional model count.
         this.adjustedTimeoutSeconds = Math.max(
-            MINIMUM_OP_TIMEOUT_SECONDS,
+            NETWORK_OP_TIMEOUT_SECONDS,
             TIMEOUT_SECONDS_PER_MODEL * modelProvider.models().size()
         );
     }
@@ -255,7 +256,7 @@ public final class Orchestrator {
                 .andThen(Completable.create(emitter -> {
                     storageObserver.startObservingStorageChanges(emitter::onComplete);
                     currentMode.set(Mode.LOCAL_ONLY);
-                })).blockingAwait(adjustedTimeoutSeconds, TimeUnit.SECONDS);
+                })).blockingAwait(LOCAL_OP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!subscribed) {
                 throw new TimeoutException("Subscription timed out.");
             }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -258,7 +258,7 @@ public final class Orchestrator {
                     currentMode.set(Mode.LOCAL_ONLY);
                 })).blockingAwait(LOCAL_OP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!subscribed) {
-                throw new TimeoutException("Subscription timed out.");
+                throw new TimeoutException("Timed out while preparing local-only mode.");
             }
         } catch (Throwable throwable) {
             LOG.warn("Failed to start observing storage changes.", throwable);
@@ -289,7 +289,7 @@ public final class Orchestrator {
                 boolean subscribed = syncProcessor.hydrate()
                     .blockingAwait(adjustedTimeoutSeconds, TimeUnit.SECONDS);
                 if (!subscribed) {
-                    throw new TimeoutException("Subscription timed out.");
+                    throw new TimeoutException("Timed out while performing initial model sync.");
                 }
             } catch (Throwable failure) {
                 if (!emitter.isDisposed()) {
@@ -324,9 +324,9 @@ public final class Orchestrator {
         try {
             boolean stopped = stopApiSync()
                 .subscribeOn(startStopScheduler)
-                .blockingAwait(LOCAL_OP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                .blockingAwait(NETWORK_OP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!stopped) {
-                throw new TimeoutException("Operation timed out.");
+                throw new TimeoutException("Timed out while waiting for API synchronization to end.");
             }
         } catch (Throwable failure) {
             LOG.warn("Failed to stop API sync.", failure);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -59,7 +59,7 @@ import io.reactivex.rxjava3.subjects.ReplaySubject;
 final class SubscriptionProcessor {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
     private static final long TIMEOUT_SECONDS_PER_MODEL = 2;
-    private static final long MINIMUM_OP_TIMEOUT_SECONDS = 10;
+    private static final long NETWORK_OP_TIMEOUT_SECONDS = 10;
 
     private final AppSync appSync;
     private final ModelProvider modelProvider;
@@ -82,9 +82,12 @@ final class SubscriptionProcessor {
         this.modelProvider = Objects.requireNonNull(modelProvider);
         this.merger = Objects.requireNonNull(merger);
         this.ongoingOperationsDisposable = new CompositeDisposable();
+
+        // Operation times out after 10 seconds. If there are more than 5 models,
+        // then 2 seconds are added to the timer per additional model count.
         this.adjustedTimeoutSeconds = Math.max(
-                MINIMUM_OP_TIMEOUT_SECONDS,
-                TIMEOUT_SECONDS_PER_MODEL * modelProvider.models().size()
+            NETWORK_OP_TIMEOUT_SECONDS,
+            TIMEOUT_SECONDS_PER_MODEL * modelProvider.models().size()
         );
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#854 

*Description of changes:*
* Orchestrator operations now have timeout that depends on the number of models.
* Orchestrator now throws `TimeoutException` if `blockingAwait()` times out.
* Subscription processor operations also have timeout that depends on the number of models.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
