### PR TITLE
chore(api) remove JAVA_DATE since codegen does not generate java.lang.Date

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
@@ -20,8 +20,6 @@ import androidx.annotation.NonNull;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.temporal.Temporal;
 
-import java.util.Date;
-
 /**
  * Enumerate the types used in the fields
  * of {@link com.amplifyframework.core.model.Model} classes.
@@ -51,11 +49,6 @@ public enum JavaFieldType {
      * Represents the String data type.
      */
     STRING(String.class),
-
-    /**
-     * Represents the java.lang.Date data type.
-     */
-    JAVA_DATE(Date.class),
 
     /**
      * Represents the Date data type.

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/CodeGenerationInstrumentationTest.java
@@ -21,6 +21,7 @@ import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.aws.test.R;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.testmodels.noteswithauth.PrivateNote;
 import com.amplifyframework.testmodels.personcar.MaritalStatus;
 import com.amplifyframework.testmodels.personcar.Person;
@@ -82,7 +83,7 @@ public final class CodeGenerationInstrumentationTest {
             .firstName("David")
             .lastName("Daudelin")
             .age(29)
-            .dob(new SimpleDateFormat("MM/dd/yyyy").parse("07/25/1990"))
+            .dob(new Temporal.Date(new SimpleDateFormat("MM/dd/yyyy").parse("07/25/1990")))
             .relationship(MaritalStatus.married)
             .build();
         Person createdPerson = api.create(PERSON_API_NAME, david);

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
@@ -101,7 +101,7 @@ public final class AppSyncGraphQLRequestFactoryTest {
             .firstName("Tony")
             .lastName("Swanson")
             .age(19)
-            .dob(new Date(2000, 1, 15))
+            .dob(new Temporal.Date(new Date(2000, 1, 15)))
             .id(expectedId)
             .relationship(MaritalStatus.single)
             .build();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
@@ -62,7 +62,6 @@ public final class TypeConverter {
         JAVA_TO_SQL.put(JavaFieldType.STRING, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.ENUM, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.DATE, SQLiteDataType.TEXT);
-        JAVA_TO_SQL.put(JavaFieldType.JAVA_DATE, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.DATE_TIME, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.TIME, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.TIMESTAMP, SQLiteDataType.INTEGER);

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation dependency.androidx.nav.uiktx
     implementation dependency.androidx.nav.dynamicfeatures
 
+    testImplementation project(path: ':aws-api-appsync') // Used to reference Temporal types in tests.
     testImplementation project(path: ':testmodels')
     testImplementation(project(path: ':testutils')) {
         transitive = false

--- a/core/src/test/java/com/amplifyframework/core/model/ModelSchemaTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/ModelSchemaTest.java
@@ -45,10 +45,9 @@ public final class ModelSchemaTest {
      * The factory {@link ModelSchema#fromModelClass(Class)} will produce
      * an {@link ModelSchema} that meets our expectations for the {@link Person} model.
      * @throws AmplifyException from model schema parsing
-     * @throws ClassNotFoundException from Class.forName("com.amplifyframework.core.model.temporal.Temporal$Date")
      */
     @Test
-    public void modelSchemaIsGeneratedForPersonModel() throws AmplifyException, ClassNotFoundException {
+    public void modelSchemaIsGeneratedForPersonModel() throws AmplifyException {
         Map<String, ModelField> expectedFields = new HashMap<>();
         expectedFields.put("id", ModelField.builder()
             .targetType("ID")

--- a/core/src/test/java/com/amplifyframework/core/model/ModelSchemaTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/ModelSchemaTest.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.annotations.AuthRule;
 import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.testmodels.personcar.MaritalStatus;
 import com.amplifyframework.testmodels.personcar.Person;
 
@@ -70,7 +71,7 @@ public final class ModelSchemaTest {
         expectedFields.put("dob", ModelField.builder()
             .targetType("AWSDate")
             .name("dob")
-            .type(Class.forName("com.amplifyframework.core.model.temporal.Temporal$Date"))
+            .type(Temporal.Date.class)
             .build());
         expectedFields.put("age", ModelField.builder()
             .targetType("Int")

--- a/core/src/test/java/com/amplifyframework/core/model/ModelSchemaTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/ModelSchemaTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -45,9 +44,10 @@ public final class ModelSchemaTest {
      * The factory {@link ModelSchema#fromModelClass(Class)} will produce
      * an {@link ModelSchema} that meets our expectations for the {@link Person} model.
      * @throws AmplifyException from model schema parsing
+     * @throws ClassNotFoundException from Class.forName("com.amplifyframework.core.model.temporal.Temporal$Date")
      */
     @Test
-    public void modelSchemaIsGeneratedForPersonModel() throws AmplifyException {
+    public void modelSchemaIsGeneratedForPersonModel() throws AmplifyException, ClassNotFoundException {
         Map<String, ModelField> expectedFields = new HashMap<>();
         expectedFields.put("id", ModelField.builder()
             .targetType("ID")
@@ -70,7 +70,7 @@ public final class ModelSchemaTest {
         expectedFields.put("dob", ModelField.builder()
             .targetType("AWSDate")
             .name("dob")
-            .type(Date.class)
+            .type(Class.forName("com.amplifyframework.core.model.temporal.Temporal$Date"))
             .build());
         expectedFields.put("age", ModelField.builder()
             .targetType("Int")

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/personcar/Person.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/personcar/Person.java
@@ -22,8 +22,8 @@ import com.amplifyframework.core.model.annotations.Index;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
 import com.amplifyframework.core.model.query.predicate.QueryField;
+import com.amplifyframework.core.model.temporal.Temporal;
 
-import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -55,7 +55,7 @@ public final class Person implements Model {
     private final Integer age;
 
     @ModelField(targetType = "AWSDate")
-    private final Date dob;
+    private final Temporal.Date dob;
 
     @ModelField
     private final MaritalStatus relationship;
@@ -64,7 +64,7 @@ public final class Person implements Model {
                    String first_name,
                    String last_name,
                    Integer age,
-                   Date dob,
+                   Temporal.Date dob,
                    MaritalStatus relationship) {
         this.id = id;
         this.first_name = first_name;
@@ -161,7 +161,7 @@ public final class Person implements Model {
      * Returns the person's date of birth.
      * @return date of birth.
      */
-    public Date getDob() {
+    public Temporal.Date getDob() {
         return dob;
     }
 
@@ -251,7 +251,7 @@ public final class Person implements Model {
          * @param dob The person's date of birth.
          * @return next step.
          */
-        FinalStep dob(Date dob);
+        FinalStep dob(Temporal.Date dob);
 
         /**
          * Set the person's relationship status.
@@ -276,7 +276,7 @@ public final class Person implements Model {
         private String first_name;
         private String last_name;
         private Integer age;
-        private Date dob;
+        private Temporal.Date dob;
         private MaritalStatus relationship;
 
         /**
@@ -341,8 +341,8 @@ public final class Person implements Model {
          * @param dob The person's date of birth.
          * @return Current Builder instance, for fluent method chaining
          */
-        public FinalStep dob(Date dob) {
-            this.dob = dob == null ? null : new Date(dob.getTime());
+        public FinalStep dob(Temporal.Date dob) {
+            this.dob = dob == null ? null : new Temporal.Date(dob.toDate());
             return this;
         }
 
@@ -381,7 +381,7 @@ public final class Person implements Model {
                 String first_name,
                 String last_name,
                 Integer age,
-                Date dob,
+                Temporal.Date dob,
                 MaritalStatus relationship) {
             super.id(id);
             super.firstName(first_name)
@@ -412,7 +412,7 @@ public final class Person implements Model {
         }
 
         @Override
-        public NewBuilder dob(Date dob) {
+        public NewBuilder dob(Temporal.Date dob) {
             return (NewBuilder) super.dob(dob);
         }
 


### PR DESCRIPTION
Follow up to https://github.com/aws-amplify/amplify-android/pull/839.    

 - Removes unused code in `JavaFieldType` and `TypeConverter`
 - Updates related tests so that our test models use `Temporal.Date` instead of `java.lang.Date`, since that is what codegen uses.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
