### PR TITLE
chore: carry some annotations down to implementations

### DIFF
--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/DefaultGraphQLRequestOptions.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/DefaultGraphQLRequestOptions.java
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.api.aws;
 
+import androidx.annotation.NonNull;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -22,16 +24,19 @@ public final class DefaultGraphQLRequestOptions implements GraphQLRequestOptions
     private static final String ITEMS_KEY = "items";
     private static final String NEXT_TOKEN_KEY = "nextToken";
 
+    @NonNull
     @Override
     public List<String> paginationFields() {
         return Collections.singletonList(NEXT_TOKEN_KEY);
     }
 
+    @NonNull
     @Override
     public List<String> modelMetaFields() {
         return Collections.emptyList();
     }
 
+    @NonNull
     @Override
     public String listField() {
         return ITEMS_KEY;
@@ -42,6 +47,7 @@ public final class DefaultGraphQLRequestOptions implements GraphQLRequestOptions
         return 2;
     }
 
+    @NonNull
     @Override
     public LeafSerializationBehavior leafSerializationBehavior() {
         return LeafSerializationBehavior.ALL_FIELDS;

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/ApiGraphQLRequestOptions.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/ApiGraphQLRequestOptions.java
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.api.aws;
 
+import androidx.annotation.NonNull;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -25,16 +27,19 @@ public final class ApiGraphQLRequestOptions implements GraphQLRequestOptions {
     private static final String ITEMS_KEY = "items";
     private static final String NEXT_TOKEN_KEY = "nextToken";
 
+    @NonNull
     @Override
     public List<String> paginationFields() {
         return Collections.singletonList(NEXT_TOKEN_KEY);
     }
 
+    @NonNull
     @Override
     public List<String> modelMetaFields() {
         return Collections.emptyList();
     }
 
+    @NonNull
     @Override
     public String listField() {
         return ITEMS_KEY;
@@ -45,6 +50,7 @@ public final class ApiGraphQLRequestOptions implements GraphQLRequestOptions {
         return 2;
     }
 
+    @NonNull
     @Override
     public LeafSerializationBehavior leafSerializationBehavior() {
         return LeafSerializationBehavior.ALL_FIELDS;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/DataStoreGraphQLRequestOptions.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/DataStoreGraphQLRequestOptions.java
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.datastore.appsync;
 
+import androidx.annotation.NonNull;
+
 import com.amplifyframework.api.aws.GraphQLRequestOptions;
 import com.amplifyframework.api.aws.LeafSerializationBehavior;
 
@@ -32,16 +34,19 @@ public final class DataStoreGraphQLRequestOptions implements GraphQLRequestOptio
     private static final String VERSION_KEY = "_version";
     private static final String LAST_CHANGED_AT_KEY = "_lastChangedAt";
 
+    @NonNull
     @Override
     public List<String> paginationFields() {
         return Arrays.asList(NEXT_TOKEN_KEY, STARTED_AT_KEY);
     }
 
+    @NonNull
     @Override
     public List<String> modelMetaFields() {
         return Arrays.asList(VERSION_KEY, DELETED_KEY, LAST_CHANGED_AT_KEY);
     }
 
+    @NonNull
     @Override
     public String listField() {
         return ITEMS_KEY;
@@ -52,6 +57,7 @@ public final class DataStoreGraphQLRequestOptions implements GraphQLRequestOptio
         return 1;
     }
 
+    @NonNull
     @Override
     public LeafSerializationBehavior leafSerializationBehavior() {
         return LeafSerializationBehavior.JUST_ID;


### PR DESCRIPTION
Return types on GraphQLRequestOptions wear @NonNull annotations, but the
implementing classes did not also do so.

This is quick touchup to add them to the implementing classes, too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
