### PR TITLE
(fix) Fail early and throw useful exception if customer forgets to call Amplify.configure

### DIFF
--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentConfigureTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentConfigureTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito;
+
+import android.content.Context;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.auth.AuthCategory;
+import com.amplifyframework.auth.AuthCategoryConfiguration;
+import com.amplifyframework.auth.AuthException;
+import com.amplifyframework.util.UserAgent;
+
+import com.amazonaws.mobile.client.AWSMobileClient;
+import com.amazonaws.mobile.client.Callback;
+import com.amazonaws.mobile.client.UserState;
+import com.amazonaws.mobile.client.UserStateDetails;
+import com.amazonaws.mobile.config.AWSConfiguration;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verifies that AWSCognitoAuthPlugin configure correctly configures an AWSMobileClient, or fails if the
+ * AWSMobileClient fails to initialize.
+ *
+ * The @Before method creates an AuthCategory, but does not configure or initialize it.  That is done in the tests
+ * themselves.   Conversely, the @Before method in {@link AuthComponentTest} sets up a "configured" AuthCategory
+ * for testing the AuthCategoryBehavior methods.  This difference in the @Before method implementation is why configure
+ * is tested in this separate test class.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AuthComponentConfigureTest {
+    private static final String PLUGIN_KEY = "awsCognitoAuthPlugin";
+    // User sub value here should match the one encoded in the access token above
+    private static final String USER_SUB = "69bc252b-dd07-41c0-b1db-a46066b8ef51";
+    private AWSMobileClient mobileClient;
+    private AuthCategory authCategory;
+
+    /**
+     * Get all setup for the future tests with mocks and a standard response for tokens.
+     * @throws AmplifyException If add plugin fails
+     */
+    @Before
+    public void setup() throws AmplifyException {
+        mobileClient = mock(AWSMobileClient.class);
+        authCategory = new AuthCategory();
+        authCategory.addPlugin(new AWSCognitoAuthPlugin(mobileClient, USER_SUB));
+    }
+
+    /**
+     * Tests that the configure method of the Auth wrapper of AWSMobileClient (AMC) calls AMC.initialize() with the
+     * passed in context, a new AWSConfiguration object containing the passed in JSONObject, and a callback object
+     * which causes configure to complete successfully in the onResult case.
+     * @throws AmplifyException an exception wrapping the exception returned in onError of AMC.initialize()
+     * @throws JSONException has to be declared as part of creating a test JSON object
+     */
+    @Test
+    public void testConfigure() throws AmplifyException, JSONException {
+        UserStateDetails userStateDetails = new UserStateDetails(UserState.SIGNED_OUT, null);
+        Context context = getApplicationContext();
+        JSONObject pluginConfig = new JSONObject().put("TestKey", "TestVal");
+        pluginConfig.put("UserAgentOverride", UserAgent.string());
+        JSONObject json = new JSONObject().put("plugins",
+                new JSONObject().put(
+                        PLUGIN_KEY,
+                        pluginConfig
+                )
+        );
+        AuthCategoryConfiguration authConfig = new AuthCategoryConfiguration();
+        authConfig.populateFromJSON(json);
+
+        doAnswer(invocation -> {
+            Callback<UserStateDetails> callback = invocation.getArgument(2);
+            callback.onResult(userStateDetails);
+            return null;
+        }).when(mobileClient).initialize(any(), any(), any());
+
+        authCategory.configure(authConfig, context);
+
+        ArgumentCaptor<AWSConfiguration> awsConfigCaptor = ArgumentCaptor.forClass(AWSConfiguration.class);
+        verify(mobileClient).initialize(eq(context), awsConfigCaptor.capture(), any());
+        String returnedConfig = awsConfigCaptor.getValue().toString();
+        String inputConfig = pluginConfig.toString();
+        // Strip the opening and closing braces from the test input and ensure that the key/value pair is included
+        // in the returned aws config.
+        assertTrue(returnedConfig.contains(inputConfig.substring(1, inputConfig.length() - 1)));
+    }
+
+    /**
+     * If {@link AWSMobileClient} emits an error during initialization, the
+     * {@link com.amplifyframework.auth.AuthPlugin#configure(JSONObject, Context)} method should wrap that exception
+     * in an {@link AuthException} and throw it on its calling thread.
+     * @throws AmplifyException the exception expected to be thrown when configuration fails.
+     * @throws JSONException has to be declared as part of creating a test JSON object
+     */
+    @Test(expected = AuthException.class)
+    public void testConfigureExceptionHandling() throws AmplifyException, JSONException {
+        JSONObject pluginConfig = new JSONObject().put("TestKey", "TestVal");
+        JSONObject json = new JSONObject().put("plugins",
+                new JSONObject().put(
+                        PLUGIN_KEY,
+                        pluginConfig
+                )
+        );
+        AuthCategoryConfiguration authConfig = new AuthCategoryConfiguration();
+        authConfig.populateFromJSON(json);
+
+        doAnswer(invocation -> {
+            Callback<UserStateDetails> callback = invocation.getArgument(2);
+            callback.onError(new Exception());
+            return null;
+        }).when(mobileClient).initialize(any(), any(), any());
+
+        authCategory.configure(authConfig, getApplicationContext());
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -66,7 +66,6 @@ import com.amazonaws.mobile.client.results.SignInState;
 import com.amazonaws.mobile.client.results.SignUpResult;
 import com.amazonaws.mobile.client.results.Tokens;
 import com.amazonaws.mobile.client.results.UserCodeDeliveryDetails;
-import com.amazonaws.mobile.config.AWSConfiguration;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -141,25 +140,16 @@ public final class AuthComponentTest {
     /**
      * Get all setup for the future tests with mocks and a standard response for tokens.
      * @throws AmplifyException If add plugin fails
+     * @throws JSONException has to be declared as part of creating a test JSON object
      */
     @Before
-    public void setup() throws AmplifyException {
+    public void setup() throws AmplifyException, JSONException {
         mobileClient = mock(AWSMobileClient.class);
         authCategory = new AuthCategory();
         authCategory.addPlugin(new AWSCognitoAuthPlugin(mobileClient, USER_SUB));
-        synchronousAuth = SynchronousAuth.delegatingTo(authCategory);
-    }
 
-    /**
-     * Tests that the configure method of the Auth wrapper of AWSMobileClient (AMC) calls AMC.initialize() with the
-     * passed in context, a new AWSConfiguration object containing the passed in JSONObject, and a callback object
-     * which causes configure to complete successfully in the onResult case.
-     * @throws AmplifyException an exception wrapping the exception returned in onError of AMC.initialize()
-     * @throws JSONException has to be declared as part of creating a test JSON object
-     */
-    @Test
-    public void testConfigure() throws AmplifyException, JSONException {
-        UserStateDetails userStateDetails = new UserStateDetails(UserState.SIGNED_OUT, null);
+        Map<String, String> additionalInfoMap = Collections.singletonMap("token", ACCESS_TOKEN);
+        UserStateDetails userStateDetails = new UserStateDetails(UserState.SIGNED_IN, additionalInfoMap);
         Context context = getApplicationContext();
         JSONObject pluginConfig = new JSONObject().put("TestKey", "TestVal");
         pluginConfig.put("UserAgentOverride", UserAgent.string());
@@ -179,42 +169,9 @@ public final class AuthComponentTest {
         }).when(mobileClient).initialize(any(), any(), any());
 
         authCategory.configure(authConfig, context);
+        authCategory.initialize(context);
+        synchronousAuth = SynchronousAuth.delegatingTo(authCategory);
 
-        ArgumentCaptor<AWSConfiguration> awsConfigCaptor = ArgumentCaptor.forClass(AWSConfiguration.class);
-        verify(mobileClient).initialize(eq(context), awsConfigCaptor.capture(), any());
-        String returnedConfig = awsConfigCaptor.getValue().toString();
-        String inputConfig = pluginConfig.toString();
-        // Strip the opening and closing braces from the test input and ensure that the key/value pair is included
-        // in the returned aws config.
-        assertTrue(returnedConfig.contains(inputConfig.substring(1, inputConfig.length() - 1)));
-    }
-
-    /**
-     * If {@link AWSMobileClient} emits an error during initialization, the
-     * {@link com.amplifyframework.auth.AuthPlugin#configure(JSONObject, Context)} method should wrap that exception
-     * in an {@link AuthException} and throw it on its calling thread.
-     * @throws AmplifyException the exception expected to be thrown when configuration fails.
-     * @throws JSONException has to be declared as part of creating a test JSON object
-     */
-    @Test(expected = AuthException.class)
-    public void testConfigureExceptionHandling() throws AmplifyException, JSONException {
-        JSONObject pluginConfig = new JSONObject().put("TestKey", "TestVal");
-        JSONObject json = new JSONObject().put("plugins",
-                new JSONObject().put(
-                        PLUGIN_KEY,
-                        pluginConfig
-                )
-        );
-        AuthCategoryConfiguration authConfig = new AuthCategoryConfiguration();
-        authConfig.populateFromJSON(json);
-
-        doAnswer(invocation -> {
-            Callback<UserStateDetails> callback = invocation.getArgument(2);
-            callback.onError(new Exception());
-            return null;
-        }).when(mobileClient).initialize(any(), any(), any());
-
-        authCategory.configure(authConfig, getApplicationContext());
     }
 
     /**
@@ -1124,6 +1081,7 @@ public final class AuthComponentTest {
     @Test
     public void getCurrentUser() {
         doAnswer(invocation -> USERNAME).when(mobileClient).getUsername();
+
         AuthUser user = authCategory.getCurrentUser();
 
         assertEquals(USER_SUB, user.getUserId());

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -1081,7 +1081,6 @@ public final class AuthComponentTest {
     @Test
     public void getCurrentUser() {
         doAnswer(invocation -> USERNAME).when(mobileClient).getUsername();
-
         AuthUser user = authCategory.getCurrentUser();
 
         assertEquals(USER_SUB, user.getUserId());

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -324,7 +324,6 @@ public final class AWSDataStorePluginTest {
     private ApiCategory mockApiCategoryWithGraphQlApi() throws AmplifyException {
         ApiCategory mockApiCategory = spy(ApiCategory.class);
         ApiPlugin<?> mockApiPlugin = mock(ApiPlugin.class);
-
         when(mockApiPlugin.getPluginKey()).thenReturn(MOCK_API_PLUGIN_NAME);
         when(mockApiPlugin.getCategoryType()).thenReturn(CategoryType.API);
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -19,6 +19,7 @@ import android.content.Context;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategory;
+import com.amplifyframework.api.ApiCategoryConfiguration;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiPlugin;
 import com.amplifyframework.api.events.ApiChannelEventName;
@@ -323,6 +324,7 @@ public final class AWSDataStorePluginTest {
     private ApiCategory mockApiCategoryWithGraphQlApi() throws AmplifyException {
         ApiCategory mockApiCategory = spy(ApiCategory.class);
         ApiPlugin<?> mockApiPlugin = mock(ApiPlugin.class);
+
         when(mockApiPlugin.getPluginKey()).thenReturn(MOCK_API_PLUGIN_NAME);
         when(mockApiPlugin.getCategoryType()).thenReturn(CategoryType.API);
 
@@ -366,6 +368,8 @@ public final class AWSDataStorePluginTest {
             any(Action.class)
         );
         mockApiCategory.addPlugin(mockApiPlugin);
+        mockApiCategory.configure(new ApiCategoryConfiguration(), getApplicationContext());
+        mockApiCategory.initialize(getApplicationContext());
         return mockApiCategory;
     }
 

--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -92,9 +92,9 @@ public final class Amplify {
     // We are relying on the ordering of this data-structure, for configuration.
     private static LinkedHashMap<CategoryType, Category<? extends Plugin<?>>> buildCategoriesMap() {
         final LinkedHashMap<CategoryType, Category<? extends Plugin<?>>> categories = new LinkedHashMap<>();
+        categories.put(CategoryType.AUTH, Auth); // This must be before ANALYTICS, API, STORAGE, & PREDICTIONS
         categories.put(CategoryType.ANALYTICS, Analytics);
         categories.put(CategoryType.API, API);
-        categories.put(CategoryType.AUTH, Auth);
         categories.put(CategoryType.LOGGING, Logging);
         categories.put(CategoryType.STORAGE, Storage);
         categories.put(CategoryType.HUB, Hub);

--- a/core/src/main/java/com/amplifyframework/core/category/Category.java
+++ b/core/src/main/java/com/amplifyframework/core/category/Category.java
@@ -181,7 +181,7 @@ public abstract class Category<P extends Plugin<?>> implements CategoryTypeable 
         P plugin = plugins.get(pluginKey);
         if (plugin == null) {
             throw new IllegalStateException(
-                    "Tried to get a plugin but that plugin was not present. " +
+                "Tried to get a plugin but that plugin was not present. " +
                             "Check if the plugin was added originally or perhaps was already removed."
             );
         } else if (!isConfigured()) {

--- a/core/src/main/java/com/amplifyframework/core/category/Category.java
+++ b/core/src/main/java/com/amplifyframework/core/category/Category.java
@@ -30,6 +30,7 @@ import com.amplifyframework.util.Immutable;
 
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -44,6 +45,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *            support, e.g. StoragePlugin, AnalyticsPlugin, etc.
  */
 public abstract class Category<P extends Plugin<?>> implements CategoryTypeable {
+
     /**
      * Map of the { pluginKey => plugin } object.
      */
@@ -172,18 +174,21 @@ public abstract class Category<P extends Plugin<?>> implements CategoryTypeable 
      * Retrieve a plugin by its key.
      * @param pluginKey A key that identifies a plugin implementation
      * @return The plugin object associated to pluginKey, if registered
-     * @throws IllegalStateException If the requested plugin does not exist
+     * @throws IllegalStateException If the requested plugin does not exist, or has not been configured.
      */
     @NonNull
     public final P getPlugin(@NonNull final String pluginKey) throws IllegalStateException {
         P plugin = plugins.get(pluginKey);
-        if (plugin != null) {
-            return plugin;
-        } else {
+        if (plugin == null) {
             throw new IllegalStateException(
-                "Tried to get a plugin but that plugin was not present. " +
-                "Check if the plugin was added originally or perhaps was already removed."
+                    "Tried to get a plugin but that plugin was not present. " +
+                            "Check if the plugin was added originally or perhaps was already removed."
             );
+        } else if (!isConfigured()) {
+            throw new IllegalStateException(
+                    "Tried to get a plugin before it was configured.  Make sure you call Amplify.configure() first.");
+        } else {
+            return plugin;
         }
     }
 
@@ -216,14 +221,24 @@ public abstract class Category<P extends Plugin<?>> implements CategoryTypeable 
                 "Tried to get a default plugin but there are more than one to choose from in this category. " +
                 "Call getPlugin(pluginKey) to choose the specific plugin you want to use in this case."
             );
+        } else if (!isConfigured()) {
+            throw new IllegalStateException(
+                    "Tried to get a plugin before it was configured.  Make sure you call Amplify.configure() first.");
         }
-
         return getPlugins().iterator().next();
     }
 
     /**
-     * Gets the current state of the category.
-     * @return Current category state
+     * Returns whether the category has been configured.
+     * @return whether the category has been configured.
+     */
+    protected synchronized boolean isConfigured() {
+        return Arrays.asList(State.CONFIGURED, State.INITIALIZING, State.INITIALIZED).contains(state.get());
+    }
+
+    /**
+     * Returns whether the category has been initialized.
+     * @return whether the category has been initialized.
      */
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     protected synchronized boolean isInitialized() {

--- a/core/src/main/java/com/amplifyframework/core/category/Category.java
+++ b/core/src/main/java/com/amplifyframework/core/category/Category.java
@@ -182,7 +182,7 @@ public abstract class Category<P extends Plugin<?>> implements CategoryTypeable 
         if (plugin == null) {
             throw new IllegalStateException(
                 "Tried to get a plugin but that plugin was not present. " +
-                            "Check if the plugin was added originally or perhaps was already removed."
+                    "Check if the plugin was added originally or perhaps was already removed."
             );
         } else if (!isConfigured()) {
             throw new IllegalStateException(

--- a/core/src/main/java/com/amplifyframework/core/category/Category.java
+++ b/core/src/main/java/com/amplifyframework/core/category/Category.java
@@ -182,7 +182,7 @@ public abstract class Category<P extends Plugin<?>> implements CategoryTypeable 
         if (plugin == null) {
             throw new IllegalStateException(
                 "Tried to get a plugin but that plugin was not present. " +
-                    "Check if the plugin was added originally or perhaps was already removed."
+                "Check if the plugin was added originally or perhaps was already removed."
             );
         } else if (!isConfigured()) {
             throw new IllegalStateException(

--- a/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
+++ b/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
@@ -27,6 +27,7 @@ import org.robolectric.annotation.Config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+
 /**
  * Tests the top-level {@link Amplify} facade.
  */
@@ -41,11 +42,10 @@ public class AmplifyTest {
     public void pluginCanBeAddedAndRemoved() throws AmplifyException {
         // Arrange a plugin
         final SimpleLoggingPlugin loggingPlugin = SimpleLoggingPlugin.instance();
-
         // Add it, and assert that it was added...
         Amplify.addPlugin(loggingPlugin);
         assertEquals(1, Amplify.Logging.getPlugins().size());
-        assertEquals(loggingPlugin, Amplify.Logging.getPlugin(loggingPlugin.getPluginKey()));
+        assertEquals(loggingPlugin, Amplify.Logging.getPlugins().iterator().next());
 
         // Remove it, make sure it's not there anymore.
         Amplify.removePlugin(loggingPlugin);

--- a/core/src/test/java/com/amplifyframework/core/category/CategoryTest.java
+++ b/core/src/test/java/com/amplifyframework/core/category/CategoryTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 /**
@@ -155,5 +156,23 @@ public final class CategoryTest {
             .escapeHatch(null)
             .categoryType(categoryType)
             .build());
+    }
+
+    /**
+     * Attempts to use a plugin should throw an IllegalStateException if a customer forgets to call Amplify.configure().
+     * @throws AmplifyException on category.configure()
+     */
+    @Test
+    public void cantGetPluginBeforeConfigured() throws AmplifyException {
+        FakeCategory category = new FakeCategory(CategoryType.API);
+        String pluginKey = RandomString.string();
+        category.addPlugin(FakePlugin.builder()
+                .pluginKey(pluginKey)
+                .categoryType(CategoryType.API)
+                .escapeHatch(new Object())
+                .build());
+        // category.configure has not been called yet, so getSelectedPlugin and getPlugin below will throw an exception
+        assertThrows(IllegalStateException.class, () -> category.getSelectedPlugin());
+        assertThrows(IllegalStateException.class, () -> category.getPlugin(pluginKey));
     }
 }


### PR DESCRIPTION
 - Fixes https://github.com/aws-amplify/amplify-android/issues/868 by throwing a useful exception if customer tries to use a plugin before calling Amplify.configure(). 
 - One consequence of this new exception being thrown is that plugins need to be configured in a particular order now.  That is, Auth must be configured _before_ Analytics, API, Storage, and Predictions now.  I accomplished this by moving `Auth` to the top of the list of the `Amplify.buildCategoriesMap()` method.    Previously, the API category was actually being configured before the Auth category.  During configuration of API, it actually grabs a reference to the Auth plugin, and saves a reference to the Auth escape hatch, the `AWSMobileClient`.   At this point, the `AWSMobileClient` is instantiated, but not initialized.  The `AWSApiPlugin` only saves a reference to it during configuration, so the fact that initialization happens later is actually okay, for now.  That said, if the `AWSApiPlugin` configure method is modified in the future to call any methods on the `AWSMobileClient`, it could cause issues that would be hard to debug.  This PR adds some safety to ensure that no plugin is used before it is configured.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
