### PR TITLE
Proposal for running hydration tasks in parallel

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -67,7 +67,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     }
 
     @Override
-    public <T extends Model> void save(
+    public synchronized <T extends Model> void save(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
             @NonNull final Consumer<StorageItemChange<T>> onSuccess,
@@ -78,7 +78,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
 
     @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.
     @Override
-    public <T extends Model> void save(
+    public synchronized <T extends Model> void save(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
             @NonNull final QueryPredicate predicate,
@@ -123,7 +123,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
 
     @SuppressWarnings("unchecked") // (T) item *is* checked, via isAssignableFrom().
     @Override
-    public <T extends Model> void query(
+    public synchronized <T extends Model> void query(
             @NonNull final Class<T> itemClass,
             @NonNull final QueryOptions options,
             @NonNull final Consumer<Iterator<T>> onSuccess,
@@ -140,7 +140,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     }
 
     @Override
-    public <T extends Model> void delete(
+    public synchronized <T extends Model> void delete(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
             @NonNull final Consumer<StorageItemChange<T>> onSuccess,
@@ -151,7 +151,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
 
     @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.
     @Override
-    public <T extends Model> void delete(
+    public synchronized <T extends Model> void delete(
             @NonNull final T item,
             @NonNull final StorageItemChange.Initiator initiator,
             @NonNull final QueryPredicate predicate,


### PR DESCRIPTION
Currently, hydration tasks run concurrently, not ideal for projects with many models with limited dependency. This PR attempts to run hydration tasks without dependencies or that have their dependency met in parallel.

Also had to synchronize access to `com.amplifyframework.datastore.storage.InMemoryStorageAdapter` to avoid `java.util.ConcurrentModificationException` which becomes an issue with concurrent access

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
