### PR TITLE
recursively build joins for multilevel nested models

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -24,6 +24,7 @@ import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testmodels.commentsblog.Comment;
 import com.amplifyframework.testmodels.commentsblog.Post;
 import com.amplifyframework.testmodels.commentsblog.PostStatus;
 
@@ -144,6 +145,46 @@ public final class SQLiteStorageAdapterQueryTest {
 
         final List<Blog> blogs = adapter.query(Blog.class);
         assertTrue(blogs.contains(blog));
+    }
+
+    /**
+     * Test that querying the saved item with a foreign key
+     * also populates that instance variable with object.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void querySavedDataWithMultiLevelJoins() throws DataStoreException {
+        final BlogOwner blogOwner = BlogOwner.builder()
+            .name("Alan Turing")
+            .build();
+
+        final Blog blog = Blog.builder()
+            .name("Alan's Software Blog")
+            .owner(blogOwner)
+            .build();
+
+        final Post post = Post.builder()
+            .title("Alan's first post")
+            .status(PostStatus.ACTIVE)
+            .rating(2)
+            .blog(blog)
+            .build();
+
+        final Comment comment = Comment.builder()
+            .content("Alan's first comment")
+            .post(post)
+            .build();
+
+        adapter.save(blogOwner);
+        adapter.save(blog);
+        adapter.save(post);
+        adapter.save(comment);
+
+        final List<Comment> comments = adapter.query(Comment.class);
+        assertTrue(comments.contains(comment));
+        assertEquals(comments.get(0).getPost(), post);
+        assertEquals(comments.get(0).getPost().getBlog(), blog);
+        assertEquals(comments.get(0).getPost().getBlog().getOwner(), blogOwner);
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -157,7 +157,7 @@ public class SqlCommandTest {
      * Verifies that the correct SQL bindings are generated when specifying the
      * {@link Page#startingAt(int)} and {@link QueryPaginationInput#withLimit(Integer)}
      * page details.
-     * @throws DataStoreException From {@link SQLCommandFactory#queryFor(ModelSchema, QueryOptions)} 
+     * @throws DataStoreException From {@link SQLCommandFactory#queryFor(ModelSchema, QueryOptions)}
      */
     @Test
     public void queryWithCustomPaginationInput() throws DataStoreException {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently joins only transverse the first level for nested models. This PR attempts to make SQLiteCommandFactory build joins for models with more than one level of nesting.

A potential gotcha for deeply nested models is the performance hit so we may want to make how deep we follow nesting configurable in DatastoreConfiguration and set and document a default limit.

A related Important fix here is the order of the limit and order by clause "The ORDER BY clause should appear before the LIMIT clause" or it results in an error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
