### PR TITLE
Have query operations not block if lock not acquired

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -395,7 +395,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull Consumer<DataStoreItemChange<T>> onDataStoreItemChange,
             @NonNull Consumer<DataStoreException> onObservationFailure,
             @NonNull Action onObservationCompleted) {
-        beforeOperationReadyStorageAndOrchestrator(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
+        beforeOperationReadyStorage(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
             itemChange -> {
                 try {
                     if (itemChange.itemClass().equals(itemClass)) {
@@ -420,7 +420,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull Consumer<DataStoreItemChange<T>> onDataStoreItemChange,
             @NonNull Consumer<DataStoreException> onObservationFailure,
             @NonNull Action onObservationCompleted) {
-        beforeOperationReadyStorageAndOrchestrator(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
+        beforeOperationReadyStorage(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
             itemChange -> {
                 try {
                     if (itemChange.itemClass().equals(itemClass) && itemChange.item().getId().equals(uniqueId)) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -155,9 +155,26 @@ public final class Orchestrator {
     /**
      * Start performing sync operations between the local storage adapter
      * and the remote GraphQL endpoint.
+     *
+     * If locked, waits for 2 seconds to acquire a lock before exiting
      */
-    public synchronized void start() {
-        if (tryAcquireStartStopLock(LOCAL_OP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+    public void start() {
+        attemptStart(LOCAL_OP_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * Attempts to start orchestrator however immediately exists if another process has a lock.
+     */
+    public void startWithBehaviorExitImmediatelyIfTransitioning() {
+        attemptStart(0);
+    }
+
+    /**
+     * Start performing sync operations between the local storage adapter
+     * and the remote GraphQL endpoint.
+     */
+    private void attemptStart(@NonNull final long lockAcquireTimeoutSeconds) {
+        if (tryAcquireStartStopLock(lockAcquireTimeoutSeconds, TimeUnit.SECONDS)) {
             disposables.add(transitionCompletable()
                 .doOnSubscribe(subscriber -> {
                     LOG.info("Starting the orchestrator.");

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -56,6 +56,7 @@ public final class Orchestrator {
     private static final long TIMEOUT_SECONDS_PER_MODEL = 2;
     private static final long NETWORK_OP_TIMEOUT_SECONDS = 10;
     private static final long LOCAL_OP_TIMEOUT_SECONDS = 2;
+    private static final long NO_WAIT_TIMEOUT = 0;
 
     private final SubscriptionProcessor subscriptionProcessor;
     private final SyncProcessor syncProcessor;
@@ -166,7 +167,7 @@ public final class Orchestrator {
      * Attempts to start orchestrator however immediately exists if another process has a lock.
      */
     public void startWithBehaviorExitImmediatelyIfTransitioning() {
-        attemptStart(0);
+        attemptStart(NO_WAIT_TIMEOUT);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Related to  #876 and tries to address the ff:

Have query operations not block if lock not acquired, currently, it blocks for 2 seconds.

Proposes removing synchronizing `com.amplifyframework.datastore.syncengine.Orchestrator#start` because of the ff concerns:
-  does synchronized make all CRUD operations effectively sequential given it a prerequisite for CRUD operations through the AWSDataStorePlugin? Is that a practical restriction?

- does it lead to a chain of suspended threads? Say we are in transition and at the same time make 5 queries on different threads concurrently... all are suspended while we wait for each in sequentially to try acquire to timeout after 2 seconds or acquire a thread... does that 5th call wait in the worse scenario for 5*2 seconds?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
