### PR TITLE
chore(aws-storage-s3): add plugin-specific options

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
+import com.amplifyframework.core.BuildConfig;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.storage.StorageAccessLevel;
@@ -45,6 +46,7 @@ import com.amplifyframework.storage.s3.operation.AWSS3StorageGetPresignedUrlOper
 import com.amplifyframework.storage.s3.operation.AWSS3StorageListOperation;
 import com.amplifyframework.storage.s3.operation.AWSS3StorageRemoveOperation;
 import com.amplifyframework.storage.s3.operation.AWSS3StorageUploadFileOperation;
+import com.amplifyframework.storage.s3.options.AWSS3StorageUploadFileOptions;
 import com.amplifyframework.storage.s3.request.AWSS3StorageDownloadFileRequest;
 import com.amplifyframework.storage.s3.request.AWSS3StorageGetPresignedUrlRequest;
 import com.amplifyframework.storage.s3.request.AWSS3StorageListRequest;
@@ -314,7 +316,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
                         : defaultAccessLevel,
                 options.getTargetIdentityId(),
                 options.getContentType(),
-                options.getServerSideEncryption(),
+                options instanceof AWSS3StorageUploadFileOptions
+                        ? ((AWSS3StorageUploadFileOptions) options).getServerSideEncryption()
+                        : ServerSideEncryption.NONE,
                 options.getMetadata()
         );
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
-import com.amplifyframework.core.BuildConfig;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.storage.StorageAccessLevel;

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/ServerSideEncryption.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/ServerSideEncryption.java
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.storage;
+package com.amplifyframework.storage.s3;
 
 /**
- * Represents storage server side encryption method type.
+ * Represents server side encryption method types that are supported by AWS S3.
  */
-public enum StorageServerSideEncryption {
+public enum ServerSideEncryption {
     /**
      * AES256 encryption.
      */
@@ -36,7 +36,7 @@ public enum StorageServerSideEncryption {
 
     private final String name;
 
-    StorageServerSideEncryption(String name) {
+    ServerSideEncryption(String name) {
         this.name = name;
     }
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
@@ -24,11 +24,11 @@ import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.storage.StorageChannelEventName;
 import com.amplifyframework.storage.StorageException;
-import com.amplifyframework.storage.StorageServerSideEncryption;
 import com.amplifyframework.storage.operation.StorageUploadFileOperation;
 import com.amplifyframework.storage.result.StorageTransferProgress;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 import com.amplifyframework.storage.s3.CognitoAuthProvider;
+import com.amplifyframework.storage.s3.ServerSideEncryption;
 import com.amplifyframework.storage.s3.request.AWSS3StorageUploadFileRequest;
 import com.amplifyframework.storage.s3.service.StorageService;
 import com.amplifyframework.storage.s3.utils.S3Keys;
@@ -111,8 +111,8 @@ public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOper
         objectMetadata.setUserMetadata(getRequest().getMetadata());
         objectMetadata.setContentType(getRequest().getContentType());
 
-        StorageServerSideEncryption storageServerSideEncryption = getRequest().getServerSideEncryption();
-        if (!StorageServerSideEncryption.NONE.equals(storageServerSideEncryption)) {
+        ServerSideEncryption storageServerSideEncryption = getRequest().getServerSideEncryption();
+        if (!ServerSideEncryption.NONE.equals(storageServerSideEncryption)) {
             objectMetadata.setSSEAlgorithm(storageServerSideEncryption.getName());
         }
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageDownloadFileOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageDownloadFileOptions.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.storage.s3.options;
 
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.storage.options.StorageDownloadFileOptions;
 
@@ -64,6 +65,36 @@ public final class AWSS3StorageDownloadFileOptions extends StorageDownloadFileOp
     @NonNull
     public static AWSS3StorageDownloadFileOptions defaultInstance() {
         return builder().build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof AWSS3StorageDownloadFileOptions)) {
+            return false;
+        } else {
+            AWSS3StorageDownloadFileOptions that = (AWSS3StorageDownloadFileOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId()
+        );
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AWSS3StorageDownloadFileOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                '}';
     }
 
     /**

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageDownloadFileOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageDownloadFileOptions.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.options;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.storage.options.StorageDownloadFileOptions;
+
+/**
+ * Options to specify attributes of object download operation from an AWS S3 bucket.
+ */
+public final class AWSS3StorageDownloadFileOptions extends StorageDownloadFileOptions {
+
+    private AWSS3StorageDownloadFileOptions(final Builder builder) {
+        super(builder);
+    }
+
+    /**
+     * Factory method to create a new instance of the
+     * {@link Builder}.  The builder can be
+     * used to configure properties and then construct a new immutable
+     * instance of the storage options that are specific to AWS S3.
+     * @return An instance of the {@link Builder}
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Factory method to create builder which is configured to prepare
+     * object instances with the same field values as the provided
+     * options. This can be used as a starting ground to create a
+     * new clone of the provided options, which shares some common
+     * configuration.
+     * @param options Options to populate into a new builder configuration
+     * @return A Builder instance that has been configured using the
+     *         values in the provided options
+     */
+    @NonNull
+    public static Builder from(@NonNull final AWSS3StorageDownloadFileOptions options) {
+        return builder()
+            .accessLevel(options.getAccessLevel())
+            .targetIdentityId(options.getTargetIdentityId());
+    }
+
+    /**
+     * Constructs a default instance of the {@link AWSS3StorageDownloadFileOptions}.
+     * @return default instance of AWSS3StorageDownloadFileOptions
+     */
+    @NonNull
+    public static AWSS3StorageDownloadFileOptions defaultInstance() {
+        return builder().build();
+    }
+
+    /**
+     * A utility that can be used to configure and construct immutable
+     * instances of the {@link AWSS3StorageDownloadFileOptions}, by chaining
+     * fluent configuration method calls.
+     */
+    public static final class Builder extends StorageDownloadFileOptions.Builder<Builder> {
+        @Override
+        @NonNull
+        public AWSS3StorageDownloadFileOptions build() {
+            return new AWSS3StorageDownloadFileOptions(this);
+        }
+    }
+}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageGetPresignedUrlOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageGetPresignedUrlOptions.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.options;
+
+import android.annotation.SuppressLint;
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.storage.options.StorageGetUrlOptions;
+
+/**
+ * Options to specify attributes of presigned URL generation from an AWS S3 bucket.
+ */
+public final class AWSS3StorageGetPresignedUrlOptions extends StorageGetUrlOptions {
+
+    private AWSS3StorageGetPresignedUrlOptions(final Builder builder) {
+        super(builder);
+    }
+
+    /**
+     * Returns a new Builder instance that can be used to configure
+     * and build a new immutable instance of AWSS3StorageGetPresignedUrlOptions.
+     * @return a new builder instance
+     */
+    @SuppressLint("SyntheticAccessor")
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Factory method to create builder which is configured to prepare
+     * object instances with the same field values as the provided
+     * options. This can be used as a starting ground to create a
+     * new clone of the provided options, which shares some common
+     * configuration.
+     * @param options Options to populate into a new builder configuration
+     * @return A Builder instance that has been configured using the
+     *         values in the provided options
+     */
+    @NonNull
+    public static Builder from(@NonNull AWSS3StorageGetPresignedUrlOptions options) {
+        return builder()
+            .accessLevel(options.getAccessLevel())
+            .targetIdentityId(options.getTargetIdentityId())
+            .expires(options.getExpires());
+    }
+
+    /**
+     * Constructs a default instance of the {@link StorageGetUrlOptions}.
+     * @return default instance of StorageGetUrlOptions
+     */
+    @NonNull
+    public static AWSS3StorageGetPresignedUrlOptions defaultInstance() {
+        return builder().build();
+    }
+
+    /**
+     * A utility that can be used to configure and construct immutable
+     * instances of the {@link AWSS3StorageGetPresignedUrlOptions}, by chaining
+     * fluent configuration method calls.
+     */
+    public static final class Builder extends StorageGetUrlOptions.Builder<Builder> {
+        @Override
+        @NonNull
+        public AWSS3StorageGetPresignedUrlOptions build() {
+            return new AWSS3StorageGetPresignedUrlOptions(this);
+        }
+    }
+}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageGetPresignedUrlOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageGetPresignedUrlOptions.java
@@ -17,6 +17,7 @@ package com.amplifyframework.storage.s3.options;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.storage.options.StorageGetUrlOptions;
 
@@ -65,6 +66,39 @@ public final class AWSS3StorageGetPresignedUrlOptions extends StorageGetUrlOptio
     @NonNull
     public static AWSS3StorageGetPresignedUrlOptions defaultInstance() {
         return builder().build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof AWSS3StorageGetPresignedUrlOptions)) {
+            return false;
+        } else {
+            AWSS3StorageGetPresignedUrlOptions that = (AWSS3StorageGetPresignedUrlOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId()) &&
+                    ObjectsCompat.equals(getExpires(), that.getExpires());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId(),
+                getExpires()
+        );
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AWSS3StorageGetPresignedUrlOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                ", expires=" + getExpires() +
+                '}';
     }
 
     /**

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageListOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageListOptions.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.storage.s3.options;
 
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.storage.options.StorageListOptions;
 
@@ -64,6 +65,36 @@ public final class AWSS3StorageListOptions extends StorageListOptions {
     @NonNull
     public static AWSS3StorageListOptions defaultInstance() {
         return builder().build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof AWSS3StorageListOptions)) {
+            return false;
+        } else {
+            AWSS3StorageListOptions that = (AWSS3StorageListOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId()
+        );
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AWSS3StorageListOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                '}';
     }
 
     /**

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageListOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageListOptions.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.options;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.storage.options.StorageListOptions;
+
+/**
+ * Options to specify attributes of object listing operation from an AWS S3 bucket.
+ */
+public final class AWSS3StorageListOptions extends StorageListOptions {
+
+    private AWSS3StorageListOptions(final Builder builder) {
+        super(builder);
+    }
+
+    /**
+     * Factory method to create a new instance of the
+     * {@link Builder}.  The builder can be
+     * used to configure properties and then construct a new immutable
+     * instance of the storage options that are specific to AWS S3.
+     * @return An instance of the {@link Builder}
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Factory method to create builder which is configured to prepare
+     * object instances with the same field values as the provided
+     * options. This can be used as a starting ground to create a
+     * new clone of the provided options, which shares some common
+     * configuration.
+     * @param options Options to populate into a new builder configuration
+     * @return A Builder instance that has been configured using the
+     *         values in the provided options
+     */
+    @NonNull
+    public static Builder from(@NonNull final AWSS3StorageListOptions options) {
+        return builder()
+            .accessLevel(options.getAccessLevel())
+            .targetIdentityId(options.getTargetIdentityId());
+    }
+
+    /**
+     * Constructs a default instance of the {@link AWSS3StorageListOptions}.
+     * @return default instance of AWSS3StorageListOptions
+     */
+    @NonNull
+    public static AWSS3StorageListOptions defaultInstance() {
+        return builder().build();
+    }
+
+    /**
+     * A utility that can be used to configure and construct immutable
+     * instances of the {@link AWSS3StorageListOptions}, by chaining
+     * fluent configuration method calls.
+     */
+    public static final class Builder extends StorageListOptions.Builder<Builder> {
+        @Override
+        @NonNull
+        public AWSS3StorageListOptions build() {
+            return new AWSS3StorageListOptions(this);
+        }
+    }
+}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageRemoveOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageRemoveOptions.java
@@ -17,6 +17,7 @@ package com.amplifyframework.storage.s3.options;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.storage.options.StorageRemoveOptions;
 
@@ -65,6 +66,36 @@ public final class AWSS3StorageRemoveOptions extends StorageRemoveOptions {
     @NonNull
     public static AWSS3StorageRemoveOptions defaultInstance() {
         return builder().build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof AWSS3StorageRemoveOptions)) {
+            return false;
+        } else {
+            AWSS3StorageRemoveOptions that = (AWSS3StorageRemoveOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId()
+        );
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AWSS3StorageRemoveOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                '}';
     }
 
     /**

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageRemoveOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageRemoveOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -13,35 +13,32 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.storage.options;
+package com.amplifyframework.storage.s3.options;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
-/**
- * Options to specify attributes of remove API invocation.
- */
-public class StorageRemoveOptions extends StorageOptions {
+import com.amplifyframework.storage.options.StorageRemoveOptions;
 
-    /**
-     * Constructs a StorageRemoveOptions instance with the
-     * attributes from builder instance.
-     * @param builder the builder with configured attributes
-     */
-    protected StorageRemoveOptions(final Builder<?> builder) {
-        super(builder.getAccessLevel(), builder.getTargetIdentityId());
+/**
+ * Options to specify attributes of object deletion operation from an AWS S3 bucket.
+ */
+public final class AWSS3StorageRemoveOptions extends StorageRemoveOptions {
+
+    private AWSS3StorageRemoveOptions(final Builder builder) {
+        super(builder);
     }
 
     /**
      * Factory method to create a new instance of the
-     * {@link StorageRemoveOptions.Builder}.  The builder can be
+     * {@link Builder}.  The builder can be
      * used to configure properties and then construct a new immutable
-     * instance of the StorageRemoveOptions.
-     * @return An instance of the {@link StorageRemoveOptions.Builder}
+     * instance of the AWSS3StorageRemoveOptions.
+     * @return An instance of the {@link Builder}
      */
     @NonNull
-    public static Builder<?> builder() {
-        return new Builder<>();
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
@@ -55,38 +52,32 @@ public class StorageRemoveOptions extends StorageOptions {
      *         values in the provided options
      */
     @NonNull
-    public static Builder<?> from(@NonNull final StorageRemoveOptions options) {
+    public static Builder from(@NonNull final AWSS3StorageRemoveOptions options) {
         return builder()
             .accessLevel(options.getAccessLevel())
             .targetIdentityId(options.getTargetIdentityId());
     }
 
     /**
-     * Constructs a default instance of the {@link StorageRemoveOptions}.
-     * @return default instance of StorageRemoveOptions
+     * Constructs a default instance of the {@link AWSS3StorageRemoveOptions}.
+     * @return default instance of AWSS3StorageRemoveOptions
      */
     @NonNull
-    public static StorageRemoveOptions defaultInstance() {
+    public static AWSS3StorageRemoveOptions defaultInstance() {
         return builder().build();
     }
 
     /**
      * A utility that can be used to configure and construct immutable
-     * instances of the {@link StorageRemoveOptions}, by chaining
+     * instances of the {@link AWSS3StorageRemoveOptions}, by chaining
      * fluent configuration method calls.
-     * @param <B> the type of builder to chain with
      */
-    public static class Builder<B extends Builder<B>> extends StorageOptions.Builder<B, StorageRemoveOptions> {
-        /**
-         * Returns an instance of StorageRemoveOptions with the parameters
-         * specified by this builder.
-         * @return a configured instance of StorageRemoveOptions
-         */
+    public static final class Builder extends StorageRemoveOptions.Builder<Builder> {
         @SuppressLint("SyntheticAccessor")
         @Override
         @NonNull
-        public StorageRemoveOptions build() {
-            return new StorageRemoveOptions(this);
+        public AWSS3StorageRemoveOptions build() {
+            return new AWSS3StorageRemoveOptions(this);
         }
     }
 }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.options;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.storage.options.StorageUploadFileOptions;
+import com.amplifyframework.storage.s3.ServerSideEncryption;
+
+import java.util.Objects;
+
+/**
+ * Options to specify attributes of object upload operation to an AWS S3 bucket.
+ */
+public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOptions {
+    private final ServerSideEncryption serverSideEncryption;
+
+    private AWSS3StorageUploadFileOptions(final Builder builder) {
+        super(builder);
+        this.serverSideEncryption = builder.getServerSideEncryption();
+    }
+
+    /**
+     * Server side encryption algorithm.
+     * @return Server side encryption algorithm
+     */
+    @NonNull
+    public ServerSideEncryption getServerSideEncryption() {
+        return serverSideEncryption;
+    }
+
+    /**
+     * Factory method to create a new instance of the
+     * {@link Builder}.  The builder can be
+     * used to configure properties and then construct a new immutable
+     * instance of the storage options that are specific to AWS S3.
+     * @return An instance of the {@link Builder}
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Factory method to create builder which is configured to prepare
+     * object instances with the same field values as the provided
+     * options. This can be used as a starting ground to create a
+     * new clone of the provided options, which shares some common
+     * configuration.
+     * @param options Options to populate into a new builder configuration
+     * @return A Builder instance that has been configured using the
+     *         values in the provided options
+     */
+    @NonNull
+    public static Builder from(@NonNull final AWSS3StorageUploadFileOptions options) {
+        return builder()
+            .accessLevel(options.getAccessLevel())
+            .targetIdentityId(options.getTargetIdentityId())
+            .contentType(options.getContentType())
+            .serverSideEncryption(options.getServerSideEncryption())
+            .metadata(options.getMetadata());
+    }
+
+    /**
+     * Constructs a default instance of the {@link AWSS3StorageUploadFileOptions}.
+     * @return default instance of AWSS3StorageUploadFileOptions
+     */
+    @NonNull
+    public static AWSS3StorageUploadFileOptions defaultInstance() {
+        return builder().build();
+    }
+
+    /**
+     * A utility that can be used to configure and construct immutable
+     * instances of the {@link AWSS3StorageUploadFileOptions}, by chaining
+     * fluent configuration method calls.
+     */
+    public static final class Builder extends StorageUploadFileOptions.Builder<Builder> {
+        private ServerSideEncryption serverSideEncryption;
+
+        private Builder() {
+            super();
+            this.serverSideEncryption = ServerSideEncryption.NONE;
+        }
+
+        /**
+         * Configures the server side encryption algorithm for a new AWSS3StorageUploadFileOptions instance.
+         * @param serverSideEncryption server side encryption algorithm
+         * @return Current Builder instance for fluent chaining
+         */
+        @NonNull
+        public Builder serverSideEncryption(@NonNull ServerSideEncryption serverSideEncryption) {
+            this.serverSideEncryption = Objects.requireNonNull(serverSideEncryption);
+            return this;
+        }
+
+        @NonNull
+        ServerSideEncryption getServerSideEncryption() {
+            return serverSideEncryption;
+        }
+
+        @Override
+        @NonNull
+        public AWSS3StorageUploadFileOptions build() {
+            return new AWSS3StorageUploadFileOptions(this);
+        }
+    }
+}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.storage.s3.options;
 
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.storage.options.StorageUploadFileOptions;
 import com.amplifyframework.storage.s3.ServerSideEncryption;
@@ -81,6 +82,45 @@ public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOption
     @NonNull
     public static AWSS3StorageUploadFileOptions defaultInstance() {
         return builder().build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof AWSS3StorageUploadFileOptions)) {
+            return false;
+        } else {
+            AWSS3StorageUploadFileOptions that = (AWSS3StorageUploadFileOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId()) &&
+                    ObjectsCompat.equals(getContentType(), that.getContentType()) &&
+                    ObjectsCompat.equals(getServerSideEncryption(), that.getServerSideEncryption()) &&
+                    ObjectsCompat.equals(getMetadata(), that.getMetadata());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId(),
+                getContentType(),
+                getServerSideEncryption(),
+                getMetadata()
+        );
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AWSS3StorageUploadFileOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                ", contentType=" + getContentType() +
+                ", serverSideEncryption=" + getServerSideEncryption().getName() +
+                ", metadata=" + getMetadata() +
+                '}';
     }
 
     /**

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadFileRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadFileRequest.java
@@ -19,7 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.storage.StorageAccessLevel;
-import com.amplifyframework.storage.StorageServerSideEncryption;
+import com.amplifyframework.storage.s3.ServerSideEncryption;
 
 import java.io.File;
 import java.util.HashMap;
@@ -35,7 +35,7 @@ public final class AWSS3StorageUploadFileRequest {
     private final StorageAccessLevel accessLevel;
     private final String targetIdentityId;
     private final String contentType;
-    private final StorageServerSideEncryption serverSideEncryption;
+    private final ServerSideEncryption serverSideEncryption;
     private final Map<String, String> metadata;
 
     /**
@@ -55,7 +55,7 @@ public final class AWSS3StorageUploadFileRequest {
             @NonNull StorageAccessLevel accessLevel,
             @Nullable String targetIdentityId,
             @Nullable String contentType,
-            @NonNull StorageServerSideEncryption serverSideEncryption,
+            @NonNull ServerSideEncryption serverSideEncryption,
             @Nullable Map<String, String> metadata
     ) {
         this.key = key;
@@ -120,7 +120,7 @@ public final class AWSS3StorageUploadFileRequest {
      * @return server side encryption algorithm
      */
     @NonNull
-    public StorageServerSideEncryption getServerSideEncryption() {
+    public ServerSideEncryption getServerSideEncryption() {
         return serverSideEncryption;
     }
 

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageDownloadFileOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageDownloadFileOptions.java
@@ -21,9 +21,14 @@ import androidx.annotation.NonNull;
 /**
  * Options to specify attributes of get API invocation.
  */
-public final class StorageDownloadFileOptions extends StorageOptions {
+public class StorageDownloadFileOptions extends StorageOptions {
 
-    private StorageDownloadFileOptions(final Builder builder) {
+    /**
+     * Constructs a StorageDownloadFileOptions instance with the
+     * attributes from builder instance.
+     * @param builder the builder with configured attributes
+     */
+    protected StorageDownloadFileOptions(final Builder<?> builder) {
         super(builder.getAccessLevel(), builder.getTargetIdentityId());
     }
 
@@ -35,8 +40,8 @@ public final class StorageDownloadFileOptions extends StorageOptions {
      * @return An instance of the {@link StorageDownloadFileOptions.Builder}
      */
     @NonNull
-    public static Builder builder() {
-        return new Builder();
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
     /**
@@ -50,9 +55,10 @@ public final class StorageDownloadFileOptions extends StorageOptions {
      *         values in the provided options
      */
     @NonNull
-    public static Builder from(@NonNull final StorageDownloadFileOptions options) {
-        return builder().accessLevel(options.getAccessLevel())
-                .targetIdentityId(options.getTargetIdentityId());
+    public static Builder<?> from(@NonNull final StorageDownloadFileOptions options) {
+        return builder()
+            .accessLevel(options.getAccessLevel())
+            .targetIdentityId(options.getTargetIdentityId());
     }
 
     /**
@@ -68,8 +74,14 @@ public final class StorageDownloadFileOptions extends StorageOptions {
      * A utility that can be used to configure and construct immutable
      * instances of the {@link StorageDownloadFileOptions}, by chaining
      * fluent configuration method calls.
+     * @param <B> the type of builder to chain with
      */
-    public static final class Builder extends StorageOptions.Builder<Builder, StorageDownloadFileOptions> {
+    public static class Builder<B extends Builder<B>> extends StorageOptions.Builder<B, StorageDownloadFileOptions> {
+        /**
+         * Returns an instance of StorageDownloadFileOptions with the parameters
+         * specified by this builder.
+         * @return a configured instance of StorageDownloadFileOptions
+         */
         @SuppressLint("SyntheticAccessor")
         @Override
         @NonNull

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageDownloadFileOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageDownloadFileOptions.java
@@ -17,6 +17,7 @@ package com.amplifyframework.storage.options;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 /**
  * Options to specify attributes of get API invocation.
@@ -68,6 +69,45 @@ public class StorageDownloadFileOptions extends StorageOptions {
     @NonNull
     public static StorageDownloadFileOptions defaultInstance() {
         return builder().build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof StorageDownloadFileOptions)) {
+            return false;
+        } else {
+            StorageDownloadFileOptions that = (StorageDownloadFileOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public String toString() {
+        return "StorageDownloadFileOptions {" +
+            "accessLevel=" + getAccessLevel() +
+            ", targetIdentityId=" + getTargetIdentityId() +
+            '}';
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageGetUrlOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageGetUrlOptions.java
@@ -17,6 +17,7 @@ package com.amplifyframework.storage.options;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 /**
  * Options to specify attributes of get URL API invocation.
@@ -78,6 +79,48 @@ public class StorageGetUrlOptions extends StorageOptions {
     @NonNull
     public static StorageGetUrlOptions defaultInstance() {
         return builder().build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof StorageGetUrlOptions)) {
+            return false;
+        } else {
+            StorageGetUrlOptions that = (StorageGetUrlOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId()) &&
+                    ObjectsCompat.equals(getExpires(), that.getExpires());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId(),
+                getExpires()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public String toString() {
+        return "StorageGetUrlOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                ", expires=" + getExpires() +
+                '}';
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageGetUrlOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageGetUrlOptions.java
@@ -21,10 +21,15 @@ import androidx.annotation.NonNull;
 /**
  * Options to specify attributes of get URL API invocation.
  */
-public final class StorageGetUrlOptions extends StorageOptions {
+public class StorageGetUrlOptions extends StorageOptions {
     private final int expires;
 
-    private StorageGetUrlOptions(final Builder builder) {
+    /**
+     * Constructs a StorageGetUrlOptions instance with the
+     * attributes from builder instance.
+     * @param builder the builder with configured attributes
+     */
+    protected StorageGetUrlOptions(final Builder<?> builder) {
         super(builder.getAccessLevel(), builder.getTargetIdentityId());
         this.expires = builder.getExpires();
     }
@@ -44,8 +49,8 @@ public final class StorageGetUrlOptions extends StorageOptions {
      */
     @SuppressLint("SyntheticAccessor")
     @NonNull
-    public static Builder builder() {
-        return new Builder();
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
     /**
@@ -59,7 +64,7 @@ public final class StorageGetUrlOptions extends StorageOptions {
      *         values in the provided options
      */
     @NonNull
-    public static Builder from(@NonNull StorageGetUrlOptions options) {
+    public static Builder<?> from(@NonNull StorageGetUrlOptions options) {
         return builder()
             .accessLevel(options.getAccessLevel())
             .targetIdentityId(options.getTargetIdentityId())
@@ -79,8 +84,9 @@ public final class StorageGetUrlOptions extends StorageOptions {
      * A utility that can be used to configure and construct immutable
      * instances of the {@link StorageGetUrlOptions}, by chaining
      * fluent configuration method calls.
+     * @param <B> the type of builder to chain with
      */
-    public static final class Builder extends StorageOptions.Builder<Builder, StorageGetUrlOptions> {
+    public static class Builder<B extends Builder<B>> extends StorageOptions.Builder<B, StorageGetUrlOptions> {
         private int expires;
 
         /**
@@ -89,13 +95,14 @@ public final class StorageGetUrlOptions extends StorageOptions {
          * @param expires Amount of seconds until URL expires
          * @return Current Builder instance, for fluent method chaining
          */
-        @SuppressWarnings("WeakerAccess")
-        public Builder expires(int expires) {
+        @SuppressWarnings({"unchecked", "WeakerAccess"})
+        @NonNull
+        public final B expires(int expires) {
             this.expires = expires;
-            return this;
+            return (B) this;
         }
 
-        int getExpires() {
+        final int getExpires() {
             return expires;
         }
 

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageListOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageListOptions.java
@@ -17,6 +17,7 @@ package com.amplifyframework.storage.options;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 /**
  * Options to specify attributes of list API invocation.
@@ -67,6 +68,45 @@ public class StorageListOptions extends StorageOptions {
     @NonNull
     public static StorageListOptions defaultInstance() {
         return builder().build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof StorageListOptions)) {
+            return false;
+        } else {
+            StorageListOptions that = (StorageListOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public String toString() {
+        return "StorageListOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                '}';
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageListOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageListOptions.java
@@ -21,9 +21,14 @@ import androidx.annotation.NonNull;
 /**
  * Options to specify attributes of list API invocation.
  */
-public final class StorageListOptions extends StorageOptions {
+public class StorageListOptions extends StorageOptions {
 
-    private StorageListOptions(final Builder builder) {
+    /**
+     * Constructs a StorageListOptions instance with the
+     * attributes from builder instance.
+     * @param builder the builder with configured attributes
+     */
+    protected StorageListOptions(final Builder<?> builder) {
         super(builder.getAccessLevel(), builder.getTargetIdentityId());
     }
 
@@ -33,8 +38,8 @@ public final class StorageListOptions extends StorageOptions {
      * @return Builder used to construct {@link StorageListOptions}
      */
     @NonNull
-    public static Builder builder() {
-        return new Builder();
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
     /**
@@ -48,9 +53,10 @@ public final class StorageListOptions extends StorageOptions {
      *         values in the provided options
      */
     @NonNull
-    public static Builder from(@NonNull final StorageListOptions options) {
-        return builder().accessLevel(options.getAccessLevel())
-                .targetIdentityId(options.getTargetIdentityId());
+    public static Builder<?> from(@NonNull final StorageListOptions options) {
+        return builder()
+            .accessLevel(options.getAccessLevel())
+            .targetIdentityId(options.getTargetIdentityId());
     }
 
     /**
@@ -66,8 +72,14 @@ public final class StorageListOptions extends StorageOptions {
     /**
      * Used to construct instance of StorageListOptions via
      * fluent configuration methods.
+     * @param <B> the type of builder to chain with
      */
-    public static final class Builder extends StorageOptions.Builder<Builder, StorageListOptions> {
+    public static class Builder<B extends Builder<B>> extends StorageOptions.Builder<B, StorageListOptions> {
+        /**
+         * Returns an instance of StorageListOptions with the parameters
+         * specified by this builder.
+         * @return a configured instance of StorageListOptions
+         */
         @SuppressLint("SyntheticAccessor")
         @Override
         @NonNull

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageRemoveOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageRemoveOptions.java
@@ -17,6 +17,7 @@ package com.amplifyframework.storage.options;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 /**
  * Options to specify attributes of remove API invocation.
@@ -68,6 +69,45 @@ public class StorageRemoveOptions extends StorageOptions {
     @NonNull
     public static StorageRemoveOptions defaultInstance() {
         return builder().build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof StorageRemoveOptions)) {
+            return false;
+        } else {
+            StorageRemoveOptions that = (StorageRemoveOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public String toString() {
+        return "StorageRemoveOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                '}';
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageUploadFileOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageUploadFileOptions.java
@@ -19,7 +19,6 @@ import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.amplifyframework.storage.StorageServerSideEncryption;
 import com.amplifyframework.util.Immutable;
 
 import java.util.HashMap;
@@ -29,15 +28,18 @@ import java.util.Objects;
 /**
  * Options to specify attributes of put API invocation.
  */
-public final class StorageUploadFileOptions extends StorageOptions {
+public class StorageUploadFileOptions extends StorageOptions {
     private final String contentType;
-    private final StorageServerSideEncryption serverSideEncryption;
     private final Map<String, String> metadata;
 
-    private StorageUploadFileOptions(final Builder builder) {
+    /**
+     * Constructs a StorageUploadFileOptions instance with the
+     * attributes from builder instance.
+     * @param builder the builder with configured attributes
+     */
+    protected StorageUploadFileOptions(final Builder<?> builder) {
         super(builder.getAccessLevel(), builder.getTargetIdentityId());
         this.contentType = builder.getContentType();
-        this.serverSideEncryption = builder.getServerSideEncryption();
         this.metadata = builder.getMetadata();
     }
 
@@ -48,15 +50,6 @@ public final class StorageUploadFileOptions extends StorageOptions {
     @Nullable
     public String getContentType() {
         return contentType;
-    }
-
-    /**
-     * Server side encryption algorithm.
-     * @return Server side encryption algorithm
-     */
-    @NonNull
-    public StorageServerSideEncryption getServerSideEncryption() {
-        return serverSideEncryption;
     }
 
     /**
@@ -75,8 +68,8 @@ public final class StorageUploadFileOptions extends StorageOptions {
      */
     @SuppressLint("SyntheticAccessor")
     @NonNull
-    public static Builder builder() {
-        return new Builder();
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
     /**
@@ -90,11 +83,12 @@ public final class StorageUploadFileOptions extends StorageOptions {
      *         values in the provided options
      */
     @NonNull
-    public static Builder from(@NonNull final StorageUploadFileOptions options) {
-        return builder().accessLevel(options.getAccessLevel())
-                .targetIdentityId(options.getTargetIdentityId())
-                .contentType(options.getContentType())
-                .metadata(options.getMetadata());
+    public static Builder<?> from(@NonNull final StorageUploadFileOptions options) {
+        return builder()
+            .accessLevel(options.getAccessLevel())
+            .targetIdentityId(options.getTargetIdentityId())
+            .contentType(options.getContentType())
+            .metadata(options.getMetadata());
     }
 
     /**
@@ -110,14 +104,17 @@ public final class StorageUploadFileOptions extends StorageOptions {
      * Use to configure and build immutable instances of the
      * StorageUploadFileOptions, using fluent of property configuration
      * methods.
+     * @param <B> the type of builder to chain with
      */
-    public static final class Builder extends StorageOptions.Builder<Builder, StorageUploadFileOptions> {
+    @SuppressWarnings({"unchecked", "WeakerAccess"})
+    public static class Builder<B extends Builder<B>> extends StorageOptions.Builder<B, StorageUploadFileOptions> {
         private String contentType;
-        private StorageServerSideEncryption serverSideEncryption;
         private Map<String, String> metadata;
 
-        private Builder() {
-            this.serverSideEncryption = StorageServerSideEncryption.NONE;
+        /**
+         * Constructs a new Builder for StorageUploadFileOptions.
+         */
+        protected Builder() {
             this.metadata = new HashMap<>();
         }
 
@@ -126,23 +123,10 @@ public final class StorageUploadFileOptions extends StorageOptions {
          * @param contentType Content type
          * @return Current Builder instance for fluent chaining
          */
-        @SuppressWarnings("WeakerAccess")
         @NonNull
-        public Builder contentType(@Nullable String contentType) {
+        public final B contentType(@Nullable String contentType) {
             this.contentType = contentType;
-            return this;
-        }
-
-        /**
-         * Configures the server side encryption algorithm for a new StorageUploadFileOptions instance.
-         * @param serverSideEncryption server side encryption algorithm
-         * @return Current Builder instance for fluent chaining
-         */
-        @SuppressWarnings("WeakerAccess")
-        @NonNull
-        public Builder serverSideEncryption(@NonNull StorageServerSideEncryption serverSideEncryption) {
-            this.serverSideEncryption = Objects.requireNonNull(serverSideEncryption);
-            return this;
+            return (B) this;
         }
 
         /**
@@ -151,23 +135,18 @@ public final class StorageUploadFileOptions extends StorageOptions {
          * @return Current Builder instance for fluent method chaining
          */
         @NonNull
-        public Builder metadata(@NonNull Map<String, String> metadata) {
+        public final B metadata(@NonNull Map<String, String> metadata) {
             this.metadata = new HashMap<>(Objects.requireNonNull(metadata));
-            return this;
+            return (B) this;
         }
 
         @Nullable
-        String getContentType() {
+        final String getContentType() {
             return contentType;
         }
 
         @NonNull
-        StorageServerSideEncryption getServerSideEncryption() {
-            return serverSideEncryption;
-        }
-
-        @NonNull
-        Map<String, String> getMetadata() {
+        final Map<String, String> getMetadata() {
             return Immutable.of(metadata);
         }
 

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageUploadFileOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageUploadFileOptions.java
@@ -18,6 +18,7 @@ package com.amplifyframework.storage.options;
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.util.Immutable;
 
@@ -98,6 +99,51 @@ public class StorageUploadFileOptions extends StorageOptions {
     @NonNull
     public static StorageUploadFileOptions defaultInstance() {
         return builder().build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof StorageUploadFileOptions)) {
+            return false;
+        } else {
+            StorageUploadFileOptions that = (StorageUploadFileOptions) obj;
+            return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
+                    ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId()) &&
+                    ObjectsCompat.equals(getContentType(), that.getContentType()) &&
+                    ObjectsCompat.equals(getMetadata(), that.getMetadata());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getAccessLevel(),
+                getTargetIdentityId(),
+                getContentType(),
+                getMetadata()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public String toString() {
+        return "StorageUploadFileOptions {" +
+                "accessLevel=" + getAccessLevel() +
+                ", targetIdentityId=" + getTargetIdentityId() +
+                ", contentType=" + getContentType() +
+                ", metadata=" + getMetadata() +
+                '}';
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
Previously, Storage category did not have operation options available at a plugin level, which made it difficult to implement new options parameters without exposing it at a category level. This PR introduces plugin-level options for Storage operations so that AWS S3 specific parameters such as SSE (see #886) can be passed to an operation at a plugin-level.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
