### PR TITLE
feat(aws-api): support owner-based auth with oidc

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -47,6 +47,7 @@ import com.amplifyframework.core.model.ModelOperation;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.util.UserAgent;
 
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.exceptions.CognitoParameterInvalidException;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoJWTParser;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -371,7 +372,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             identityValue = CognitoJWTParser
                     .getPayload(getAuthToken(authType))
                     .getString(identityClaim);
-        } catch (JSONException error) {
+        } catch (JSONException | CognitoParameterInvalidException error) {
             // Could not read identity value from the token...
             // Exception will be thrown so do nothing for now
         }
@@ -403,7 +404,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
                     groups.add(jsonGroups.getString(i));
                 }
             }
-        } catch (JSONException error) {
+        } catch (JSONException | CognitoParameterInvalidException error) {
             throw new ApiException(
                     "Failed to parse groups from auth rule.",
                     error,
@@ -415,7 +416,6 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     }
 
     private String getAuthToken(AuthorizationType authType) throws ApiException {
-        final String token;
         switch (authType) {
             case AMAZON_COGNITO_USER_POOLS:
                 CognitoUserPoolsAuthProvider cognitoProvider = authProvider.getCognitoUserPoolsAuthProvider();

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -390,7 +390,12 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     }
 
     private ArrayList<String> getUserGroups(AuthorizationType authType) throws ApiException {
-        // TODO: this doesn't work with OIDC right now. Implement custom groups claim.
+        // Custom groups claim isn't supported yet.
+        if (!AuthorizationType.AMAZON_COGNITO_USER_POOLS.equals(authType)) {
+            throw new ApiException("Custom groups claim is not supported yet.",
+                    "Please use Amazon Cognito User Pools to authorize your API.");
+        }
+
         ArrayList<String> groups = new ArrayList<>();
         final String GROUPS_KEY = "cognito:groups";
 

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
@@ -119,8 +119,7 @@ public final class AWSApiPluginTest {
                 .put("endpointType", "GraphQL")
                 .put("endpoint", baseUrl.url())
                 .put("region", "us-east-1")
-                .put("authorizationType", "API_KEY")
-                .put("apiKey", "api-key")
+                .put("authorizationType", "AMAZON_COGNITO_USER_POOLS")
             );
 
         this.plugin = new AWSApiPlugin(ApiAuthProviders.builder()


### PR DESCRIPTION
*Description of changes:*
Owner-based auth currently works only for Cognito User Pools. This PR lets the plugin determine which auth provider to obtain the JWT token from instead of always assuming Cognito User Pools.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
