### PR TITLE
fix: align datastore config builder methods to ios

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -307,7 +307,7 @@ final class MutationProcessor {
         final DataStoreConflictHandler conflictHandler;
         try {
             DataStoreConfiguration configuration = configurationProvider.getConfiguration();
-            conflictHandler = configuration.getDataStoreConflictHandler();
+            conflictHandler = configuration.getConflictHandler();
         } catch (DataStoreException badConfigurationProvider) {
             return Single.error(badConfigurationProvider);
         }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -157,7 +157,7 @@ final class SyncProcessor {
             .doOnError(failureToSync -> {
                 LOG.warn("Initial cloud sync failed.", failureToSync);
                 DataStoreErrorHandler dataStoreErrorHandler =
-                    dataStoreConfigurationProvider.getConfiguration().getDataStoreErrorHandler();
+                    dataStoreConfigurationProvider.getConfiguration().getErrorHandler();
                 dataStoreErrorHandler.accept(new DataStoreException(
                     "Initial cloud sync failed.", failureToSync,
                     "Check your internet connection."

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
@@ -52,8 +52,8 @@ public final class DataStoreConfigurationTest {
         assertEquals(DataStoreConfiguration.DEFAULT_SYNC_PAGE_SIZE,
             dataStoreConfiguration.getSyncPageSize().intValue());
 
-        assertTrue(dataStoreConfiguration.getDataStoreConflictHandler() instanceof ApplyRemoteConflictHandler);
-        assertTrue(dataStoreConfiguration.getDataStoreErrorHandler() instanceof DefaultDataStoreErrorHandler);
+        assertTrue(dataStoreConfiguration.getConflictHandler() instanceof ApplyRemoteConflictHandler);
+        assertTrue(dataStoreConfiguration.getErrorHandler() instanceof DefaultDataStoreErrorHandler);
     }
 
     /**
@@ -76,8 +76,8 @@ public final class DataStoreConfigurationTest {
         assertEquals(DataStoreConfiguration.DEFAULT_SYNC_PAGE_SIZE,
             dataStoreConfiguration.getSyncPageSize().longValue());
 
-        assertTrue(dataStoreConfiguration.getDataStoreConflictHandler() instanceof ApplyRemoteConflictHandler);
-        assertTrue(dataStoreConfiguration.getDataStoreErrorHandler() instanceof DefaultDataStoreErrorHandler);
+        assertTrue(dataStoreConfiguration.getConflictHandler() instanceof ApplyRemoteConflictHandler);
+        assertTrue(dataStoreConfiguration.getErrorHandler() instanceof DefaultDataStoreErrorHandler);
     }
 
     /**
@@ -97,8 +97,8 @@ public final class DataStoreConfigurationTest {
         DataStoreConfiguration configObject = DataStoreConfiguration
             .builder()
             .syncMaxRecords(expectedSyncMaxRecords)
-            .dataStoreConflictHandler(dummyConflictHandler)
-            .dataStoreErrorHandler(errorHandler)
+            .conflictHandler(dummyConflictHandler)
+            .errorHandler(errorHandler)
             .build();
 
         JSONObject jsonConfigFromFile = new JSONObject()
@@ -112,8 +112,8 @@ public final class DataStoreConfigurationTest {
         assertEquals(DataStoreConfiguration.DEFAULT_SYNC_PAGE_SIZE,
             dataStoreConfiguration.getSyncPageSize().longValue());
 
-        assertEquals(dummyConflictHandler, dataStoreConfiguration.getDataStoreConflictHandler());
-        assertEquals(errorHandler, dataStoreConfiguration.getDataStoreErrorHandler());
+        assertEquals(dummyConflictHandler, dataStoreConfiguration.getConflictHandler());
+        assertEquals(errorHandler, dataStoreConfiguration.getErrorHandler());
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -195,7 +195,7 @@ public final class MutationProcessorTest {
         };
         when(configurationProvider.getConfiguration())
             .thenReturn(DataStoreConfiguration.builder()
-                .dataStoreConflictHandler(handler)
+                .conflictHandler(handler)
                 .build()
             );
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -128,10 +128,10 @@ public final class SyncProcessorTest {
 
         DataStoreConfiguration dataStoreConfiguration = DataStoreConfiguration
             .builder()
-            .syncIntervalInMinutes(BASE_SYNC_INTERVAL_MINUTES)
+            .syncInterval(BASE_SYNC_INTERVAL_MINUTES, TimeUnit.MINUTES)
             .syncMaxRecords(syncMaxRecords)
             .syncPageSize(1_000)
-            .dataStoreErrorHandler(dataStoreException -> errorHandlerCallCount++)
+            .errorHandler(dataStoreException -> errorHandlerCallCount++)
             .build();
 
         this.syncProcessor = SyncProcessor.builder()


### PR DESCRIPTION
The following options are changed on the `DataStoreConfiguration.builder()`:

1. `dataStoreErrorHandler` -> `errorHandler`
2. `dataStoreConflictHandler` -> `conflictHandler`
3. `syncIntervalInMinutes` -> `syncInterval` (with required TimeUnit arg)

The corresponding accessor methods on the `DataStoreConfiguration` are also updated.

**Note:** This is technically a breaking change, but we don't have the `DataStoreConfiguration` usage documented anywhere, yet. So this is a good time to make the change, before we do.

Related: https://github.com/aws-amplify/docs/pull/2547

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
