### PR TITLE
feat(datastore) Add start and stop, and stop starting on configure and clear

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -247,7 +247,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
                         () -> onComplete.call(),
                         throwable -> onError.accept(new DataStoreException("Request failed because DataStore is not " +
                                 "initialized.", throwable, "Retry your request."))
-                );
+            );
     }
 
     /**
@@ -274,9 +274,9 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         waitForInitialization(() -> orchestrator.stop()
                 .subscribeOn(Schedulers.io())
                 .subscribe(
-                        onComplete::call,
-                        error -> onError.accept(new DataStoreException("Failed to stop DataStore.", error,
-                                "Retry your request."))), onError);
+                    onComplete::call,
+                    error -> onError.accept(new DataStoreException("Failed to stop DataStore.", error,
+                            "Retry your request."))), onError);
     }
 
     /**
@@ -293,8 +293,8 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         stop(() -> Completable.create(emitter -> sqliteStorageAdapter.clear(emitter::onComplete, emitter::onError))
                         .subscribeOn(Schedulers.io())
                         .subscribe(onComplete::call,
-                                throwable -> onError.accept(new DataStoreException("Clear operation failed",
-                                        throwable, AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION))),
+                            throwable -> onError.accept(new DataStoreException("Clear operation failed",
+                                    throwable, AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION))),
                 onError);
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -54,7 +54,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
@@ -223,7 +222,6 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
                 initError, AmplifyException.TODO_RECOVERY_SUGGESTION
             );
         }
-        orchestrator.start();
     }
 
     /**
@@ -287,7 +285,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull QueryPredicate predicate,
             @NonNull Consumer<DataStoreItemChange<T>> onItemSaved,
             @NonNull Consumer<DataStoreException> onFailureToSave) {
-        beforeOperation(() -> sqliteStorageAdapter.save(
+        start(() -> sqliteStorageAdapter.save(
             item,
             StorageItemChange.Initiator.DATA_STORE_API,
             predicate,
@@ -299,7 +297,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
                 }
             },
             onFailureToSave
-        ));
+        ), onFailureToSave);
     }
 
     /**
@@ -322,7 +320,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull QueryPredicate predicate,
             @NonNull Consumer<DataStoreItemChange<T>> onItemDeleted,
             @NonNull Consumer<DataStoreException> onFailureToDelete) {
-        beforeOperation(() -> sqliteStorageAdapter.delete(
+        start(() -> sqliteStorageAdapter.delete(
             item,
             StorageItemChange.Initiator.DATA_STORE_API,
             itemDeletion -> {
@@ -333,7 +331,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
                 }
             },
             onFailureToDelete
-        ));
+        ), onFailureToDelete);
     }
 
     /**
@@ -344,7 +342,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull Class<T> itemClass,
             @NonNull Consumer<Iterator<T>> onQueryResults,
             @NonNull Consumer<DataStoreException> onQueryFailure) {
-        beforeOperation(() -> sqliteStorageAdapter.query(itemClass, onQueryResults, onQueryFailure));
+        start(() -> sqliteStorageAdapter.query(itemClass, onQueryResults, onQueryFailure), onQueryFailure);
     }
 
     /**
@@ -365,8 +363,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull QueryOptions options,
             @NonNull Consumer<Iterator<T>> onQueryResults,
             @NonNull Consumer<DataStoreException> onQueryFailure) {
-        beforeOperation(() ->
-                sqliteStorageAdapter.query(itemClass, options, onQueryResults, onQueryFailure));
+        start(() -> sqliteStorageAdapter.query(itemClass, options, onQueryResults, onQueryFailure), onQueryFailure);
     }
 
     @Override
@@ -375,7 +372,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull Consumer<DataStoreItemChange<? extends Model>> onDataStoreItemChange,
             @NonNull Consumer<DataStoreException> onObservationFailure,
             @NonNull Action onObservationCompleted) {
-        beforeOperation(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
+        start(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
             itemChange -> {
                 try {
                     onDataStoreItemChange.accept(toDataStoreItemChange(itemChange));
@@ -385,7 +382,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             },
             onObservationFailure,
             onObservationCompleted
-        )));
+        )), onObservationFailure);
     }
 
     @Override
@@ -395,7 +392,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull Consumer<DataStoreItemChange<T>> onDataStoreItemChange,
             @NonNull Consumer<DataStoreException> onObservationFailure,
             @NonNull Action onObservationCompleted) {
-        beforeOperation(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
+        start(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
             itemChange -> {
                 try {
                     if (itemChange.itemClass().equals(itemClass)) {
@@ -409,7 +406,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             },
             onObservationFailure,
             onObservationCompleted
-        )));
+        )), onObservationFailure);
     }
 
     @Override
@@ -420,7 +417,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull Consumer<DataStoreItemChange<T>> onDataStoreItemChange,
             @NonNull Consumer<DataStoreException> onObservationFailure,
             @NonNull Action onObservationCompleted) {
-        beforeOperation(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
+        start(() -> onObservationStarted.accept(sqliteStorageAdapter.observe(
             itemChange -> {
                 try {
                     if (itemChange.itemClass().equals(itemClass) && itemChange.item().getId().equals(uniqueId)) {
@@ -434,7 +431,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             },
             onObservationFailure,
             onObservationCompleted
-        )));
+        )), onObservationFailure);
     }
 
     @Override
@@ -449,60 +446,65 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     }
 
     /**
-     * Stops all synchronization processes and invokes
-     * the clear method of the underlying storage
-     * adapter. Any items pending synchronization in the outbound queue will
-     * be lost. Synchronization processes will be restarted on the
+     * {@inheritDoc}
+     */
+    @Override
+    public void start(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
+        waitForInitialization(() -> {
+            try {
+                orchestrator.start();
+            } catch (DataStoreException exception) {
+                onError.accept(exception);
+                return;
+            }
+            onComplete.call();
+        }, onError);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void stop(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
+        waitForInitialization(() -> orchestrator.stop()
+            .subscribeOn(Schedulers.io())
+            .subscribe(
+                onComplete::call,
+                error -> onError.accept(new DataStoreException("Failed to stop DataStore.", error,
+                        "Retry your request."))), onError);
+    }
+
+    /**
+     * Stops all synchronization processes and invokes the clear method of the underlying storage adapter. Any items
+     * pending synchronization in the outbound queue will be lost. Synchronization processes will be restarted on the
      * next interaction with the DataStore.
+     *
      * @param onComplete Invoked if the call is successful.
      * @param onError Invoked if not successful
      */
     @SuppressWarnings("unused")
     @Override
-    public void clear(@NonNull Action onComplete,
-                      @NonNull Consumer<DataStoreException> onError) {
-        // We shouldn't call beforeOperation when clearing the DataStore. The
-        // only thing we have to wait for is the category initialization latch.
-        boolean isCategoryInitialized = false;
-        try {
-            isCategoryInitialized = categoryInitializationsPending.await(LIFECYCLE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException exception) {
-            LOG.warn("Execution interrupted while waiting for DataStore to be initialized.");
-        }
-        if (!isCategoryInitialized) {
-            onError.accept(new DataStoreException("DataStore not ready to be cleared.", "Retry your request."));
-            return;
-        }
-        Disposable disposable = orchestrator.stop()
-            .subscribeOn(Schedulers.io())
-            .andThen(Completable.fromAction(() -> sqliteStorageAdapter.clear(() -> {
-                // Invoke the consumer's callback once the clear operation is finished.
-                onComplete.call();
-                // Kick off the orchestrator asynchronously.
-                orchestrator.start();
-            }, onError)))
-            .subscribe(
-                () -> LOG.debug("Clear operation completed."),
-                throwable -> LOG.warn("Clear operation failed", throwable)
-            );
+    public void clear(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
+        stop(() -> Completable.create(emitter -> sqliteStorageAdapter.clear(emitter::onComplete, emitter::onError))
+                .subscribeOn(Schedulers.io())
+                .subscribe(onComplete::call,
+                    throwable -> onError.accept(new DataStoreException("Clear operation failed",
+                            throwable, AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION))),
+                onError);
     }
 
-    private void beforeOperation(@NonNull final Runnable runnable) {
-        try {
-            Completable.fromAction(
-                () -> {
-                    categoryInitializationsPending.await();
-                    orchestrator.start();
-                })
-                .andThen(Completable.fromRunnable(runnable))
-                .blockingAwait(LIFECYCLE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (Throwable throwable) {
-            if (!orchestrator.isStarted()) {
-                LOG.warn("Failed to execute request because DataStore is not fully initialized.");
-            } else {
-                LOG.warn("Failed to execute request due to an unexpected error.", throwable);
-            }
-        }
+    private void waitForInitialization(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
+        Completable.create(emitter -> {
+            categoryInitializationsPending.await();
+            emitter.onComplete();
+        })
+            .timeout(LIFECYCLE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .subscribeOn(Schedulers.io())
+            .subscribe(
+                    () -> onComplete.call(),
+                    throwable -> onError.accept(new DataStoreException("Request failed because DataStore is not " +
+                            "initialized.", throwable, "Retry your request."))
+            );
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -82,7 +82,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("SameParameterValue")
 @RunWith(RobolectricTestRunner.class)
 public final class AWSDataStorePluginTest {
-    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:datastore-test");
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:datastore:test");
 
     private static final String MOCK_API_PLUGIN_NAME = "MockApiPlugin";
     private Context context;
@@ -125,7 +125,7 @@ public final class AWSDataStorePluginTest {
      */
     @Test
     public void startInLocalMode() throws AmplifyException {
-//        //Configure DataStore with an empty config (All defaults)
+        // Configure DataStore with an empty config (All defaults)
         HubAccumulator dataStoreReadyObserver =
             HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1).start();
         ApiCategory emptyApiCategory = spy(ApiCategory.class);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -41,6 +41,7 @@ import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.model.SimpleModelProvider;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
+import com.amplifyframework.logging.Logger;
 import com.amplifyframework.testmodels.personcar.AmplifyCliGeneratedModelProvider;
 import com.amplifyframework.testmodels.personcar.Person;
 import com.amplifyframework.testutils.HubAccumulator;
@@ -56,7 +57,9 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava3.core.Observable;
@@ -79,6 +82,8 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("SameParameterValue")
 @RunWith(RobolectricTestRunner.class)
 public final class AWSDataStorePluginTest {
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:datastore-test");
+
     private static final String MOCK_API_PLUGIN_NAME = "MockApiPlugin";
     private Context context;
     private ModelProvider modelProvider;
@@ -102,24 +107,36 @@ public final class AWSDataStorePluginTest {
     }
 
     /**
-     * Configuring and initializing the plugin succeeds without freezing or
-     * crashing the calling thread. Basic. 🙄
+     * Configuring and initializing the plugin succeeds without freezing or crashing the calling thread. Basic. 🙄
+     * @throws AmplifyException On failure to configure or initialize plugin.
+     */
+    @Test
+    public void configureAndInitialize() throws AmplifyException {
+        //Configure DataStore with an empty config (All defaults)
+        ApiCategory emptyApiCategory = spy(ApiCategory.class);
+        AWSDataStorePlugin standAloneDataStorePlugin = new AWSDataStorePlugin(modelProvider, emptyApiCategory);
+        standAloneDataStorePlugin.configure(new JSONObject(), context);
+        standAloneDataStorePlugin.initialize(context);
+    }
+
+    /**
+     * Starting the plugin in local mode (no API plugin) works without freezing or crashing the calling thread.
      * @throws AmplifyException Not expected; on failure to configure of initialize plugin.
      */
     @Test
-    public void configureAndInitializeInLocalMode() throws AmplifyException {
-        //Configure DataStore with an empty config (All defaults)
+    public void startInLocalMode() throws AmplifyException {
+//        //Configure DataStore with an empty config (All defaults)
         HubAccumulator dataStoreReadyObserver =
-            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1)
-                .start();
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1).start();
         ApiCategory emptyApiCategory = spy(ApiCategory.class);
         AWSDataStorePlugin standAloneDataStorePlugin = new AWSDataStorePlugin(modelProvider, emptyApiCategory);
         SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(standAloneDataStorePlugin);
         standAloneDataStorePlugin.configure(new JSONObject(), context);
         standAloneDataStorePlugin.initialize(context);
-
         // Trick the DataStore since it's not getting initialized as part of the Amplify.initialize call chain
         Amplify.Hub.publish(HubChannel.DATASTORE, HubEvent.create(InitializationStatus.SUCCEEDED));
+
+        synchronousDataStore.start();
 
         dataStoreReadyObserver.await();
         assertSyncProcessorNotStarted(emptyApiCategory);
@@ -132,13 +149,12 @@ public final class AWSDataStorePluginTest {
     }
 
     /**
-     * Configuring and initialization the plugin when in API sync mode succeeds without
-     * freezing or crashing the calling thread.
+     * Starting the plugin when in API sync mode succeeds without freezing or crashing the calling thread.
      * @throws JSONException on failure to arrange plugin config
      * @throws AmplifyException on failure to arrange API plugin via Amplify facade
      */
     @Test
-    public void configureAndInitializeInApiMode() throws JSONException, AmplifyException {
+    public void startInApiMode() throws JSONException, AmplifyException {
         HubAccumulator dataStoreReadyObserver =
             HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1)
                 .start();
@@ -152,8 +168,13 @@ public final class AWSDataStorePluginTest {
         JSONObject dataStorePluginJson = new JSONObject()
             .put("syncIntervalInMinutes", 60);
         AWSDataStorePlugin awsDataStorePlugin = new AWSDataStorePlugin(modelProvider, mockApiCategory);
+        SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(awsDataStorePlugin);
         awsDataStorePlugin.configure(dataStorePluginJson, context);
         awsDataStorePlugin.initialize(context);
+        // Trick the DataStore since it's not getting initialized as part of the Amplify.initialize call chain
+        Amplify.Hub.publish(HubChannel.DATASTORE, HubEvent.create(InitializationStatus.SUCCEEDED));
+
+        synchronousDataStore.start();
 
         dataStoreReadyObserver.await();
         subscriptionsEstablishedObserver.await();
@@ -204,7 +225,7 @@ public final class AWSDataStorePluginTest {
      * @throws AmplifyException on failure to arrange API plugin via Amplify facade
      */
     @Test
-    public void clearStopsSyncUntilNextInteraction() throws AmplifyException, JSONException {
+    public void clearStopsSyncAndDeletesDatabase() throws AmplifyException, JSONException {
         ApiCategory mockApiCategory = mockApiCategoryWithGraphQlApi();
         ApiPlugin<?> mockApiPlugin = mockApiCategory.getPlugin(MOCK_API_PLUGIN_NAME);
         JSONObject dataStorePluginJson = new JSONObject()
@@ -216,12 +237,6 @@ public final class AWSDataStorePluginTest {
 
         // Trick the DataStore since it's not getting initialized as part of the Amplify.initialize call chain
         Amplify.Hub.publish(HubChannel.DATASTORE, HubEvent.create(InitializationStatus.SUCCEEDED));
-
-        HubAccumulator orchestratorInitObserver =
-            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1)
-                .start();
-        orchestratorInitObserver.await();
-        assertRemoteSubscriptionsStarted();
 
         // Setup objects
         Person person1 = createPerson("Test", "Dummy I");
@@ -261,29 +276,118 @@ public final class AWSDataStorePluginTest {
             return mock(GraphQLOperation.class);
         }).when(mockApiPlugin).mutate(any(), any(), any());
 
-        orchestratorInitObserver =
-            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1)
-                .start();
-
+        // Do the thing!
         synchronousDataStore.clear();
+
         assertRemoteSubscriptionsCancelled();
 
+        apiInteractionObserver =
+                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD, 1).start();
+        HubAccumulator orchestratorInitObserver =
+                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1).start();
+
+        // Interact with the DataStore after the clear
+        synchronousDataStore.save(person2);
+
+        // Verify person 2 was published to the cloud
+        apiInteractionObserver.await();
+
+        // Verify the orchestrator started back up and subscriptions are active.
         orchestratorInitObserver.await();
         assertRemoteSubscriptionsStarted();
 
-        apiInteractionObserver =
-            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD, 1)
-                .start();
-
-        // Save person 2
-        synchronousDataStore.save(person2);
         Person result2 = synchronousDataStore.get(Person.class, person2.getId());
         assertEquals(person2, result2);
 
-        apiInteractionObserver.await();
-
         verify(mockApiCategory, atLeastOnce())
             .mutate(argThat(getMatcherFor(person2)), any(), any());
+    }
+
+    /**
+     * Verify that when the stop method is called, the following happens
+     * - All remote synchronization processes are stopped
+     * - On the next interaction with the DataStore, the synchronization processes are restarted.
+     * @throws JSONException on failure to arrange plugin config
+     * @throws AmplifyException on failure to arrange API plugin via Amplify facade
+     */
+    @Test
+    public void stopStopsSyncUntilNextInteraction() throws AmplifyException, JSONException {
+        ApiCategory mockApiCategory = mockApiCategoryWithGraphQlApi();
+        ApiPlugin<?> mockApiPlugin = mockApiCategory.getPlugin(MOCK_API_PLUGIN_NAME);
+        JSONObject dataStorePluginJson = new JSONObject()
+                .put("syncIntervalInMinutes", 60);
+        AWSDataStorePlugin awsDataStorePlugin = new AWSDataStorePlugin(modelProvider, mockApiCategory);
+        SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(awsDataStorePlugin);
+        awsDataStorePlugin.configure(dataStorePluginJson, context);
+        awsDataStorePlugin.initialize(context);
+
+        // Trick the DataStore since it's not getting initialized as part of the Amplify.initialize call chain
+        Amplify.Hub.publish(HubChannel.DATASTORE, HubEvent.create(InitializationStatus.SUCCEEDED));
+
+        // Setup objects
+        Person person1 = createPerson("Test", "Dummy I");
+        Person person2 = createPerson("Test", "Dummy II");
+
+        // Mock responses for person 1
+        doAnswer(invocation -> {
+            int indexOfResponseConsumer = 1;
+            Consumer<GraphQLResponse<ModelWithMetadata<Person>>> onResponse =
+                    invocation.getArgument(indexOfResponseConsumer);
+            ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1, Temporal.Timestamp.now());
+            ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person1, modelMetadata);
+            onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
+            return mock(GraphQLOperation.class);
+        }).when(mockApiPlugin).mutate(any(), any(), any());
+
+        HubAccumulator apiInteractionObserver =
+                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD, 1)
+                        .start();
+
+        // Save person 1
+        synchronousDataStore.save(person1);
+        Person result1 = synchronousDataStore.get(Person.class, person1.getId());
+        assertEquals(person1, result1);
+
+        apiInteractionObserver.await();
+        verify(mockApiCategory).mutate(argThat(getMatcherFor(person1)), any(), any());
+
+        // Mock responses for person 2
+        doAnswer(invocation -> {
+            int indexOfResponseConsumer = 1;
+            Consumer<GraphQLResponse<ModelWithMetadata<Person>>> onResponse =
+                    invocation.getArgument(indexOfResponseConsumer);
+            ModelMetadata modelMetadata = new ModelMetadata(person2.getId(), false, 1, Temporal.Timestamp.now());
+            ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person2, modelMetadata);
+            onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
+            return mock(GraphQLOperation.class);
+        }).when(mockApiPlugin).mutate(any(), any(), any());
+
+        // Do the thing!
+        synchronousDataStore.stop();
+
+        assertRemoteSubscriptionsCancelled();
+
+        apiInteractionObserver =
+                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD, 1).start();
+        HubAccumulator orchestratorInitObserver =
+                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1).start();
+
+        // Interact with the DataStore after the stop
+        synchronousDataStore.save(person2);
+
+        // Verify person 2 was published to the cloud
+        apiInteractionObserver.await();
+
+        // Verify the orchestrator started back up and subscriptions are active.
+        orchestratorInitObserver.await();
+        assertRemoteSubscriptionsStarted();
+
+        // Verify person 1 and 2 are in the DataStore
+        List<Person> results = synchronousDataStore.list(Person.class);
+        assertEquals(Arrays.asList(person1, person2), results);
+
+        verify(mockApiCategory, atLeastOnce())
+                .mutate(argThat(getMatcherFor(person2)), any(), any());
     }
 
     private void assertRemoteSubscriptionsCancelled() {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -127,7 +127,8 @@ public final class AWSDataStorePluginTest {
     public void startInLocalMode() throws AmplifyException {
         // Configure DataStore with an empty config (All defaults)
         HubAccumulator dataStoreReadyObserver =
-            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1).start();
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1)
+                .start();
         ApiCategory emptyApiCategory = spy(ApiCategory.class);
         AWSDataStorePlugin standAloneDataStorePlugin = new AWSDataStorePlugin(modelProvider, emptyApiCategory);
         SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(standAloneDataStorePlugin);
@@ -282,9 +283,11 @@ public final class AWSDataStorePluginTest {
         assertRemoteSubscriptionsCancelled();
 
         apiInteractionObserver =
-                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD, 1).start();
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.OUTBOX_MUTATION_PROCESSED, 1)
+                .start();
         HubAccumulator orchestratorInitObserver =
-                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1).start();
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1)
+                .start();
 
         // Interact with the DataStore after the clear
         synchronousDataStore.save(person2);
@@ -340,8 +343,8 @@ public final class AWSDataStorePluginTest {
         }).when(mockApiPlugin).mutate(any(), any(), any());
 
         HubAccumulator apiInteractionObserver =
-                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD, 1)
-                        .start();
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.OUTBOX_MUTATION_PROCESSED, 1)
+                .start();
 
         // Save person 1
         synchronousDataStore.save(person1);
@@ -368,9 +371,11 @@ public final class AWSDataStorePluginTest {
         assertRemoteSubscriptionsCancelled();
 
         apiInteractionObserver =
-                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.OUTBOX_MUTATION_PROCESSED, 1).start();
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.OUTBOX_MUTATION_PROCESSED, 1)
+                .start();
         HubAccumulator orchestratorInitObserver =
-                HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1).start();
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1)
+                .start();
 
         // Interact with the DataStore after the stop
         synchronousDataStore.save(person2);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.DataStoreConfiguration;
+import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.AppSyncClient;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
@@ -50,6 +51,7 @@ import io.reactivex.rxjava3.core.Observable;
 import static com.amplifyframework.datastore.syncengine.TestHubEventFilters.publicationOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -156,7 +158,13 @@ public final class OrchestratorTest {
         orchestrator.start();
 
         // Try to start it in a new thread.
-        new Thread(() -> orchestrator.start()).start();
+        new Thread(() -> {
+            try {
+                orchestrator.start();
+            } catch (DataStoreException exception) {
+                fail("Error occurred starting the orchestrator." + exception);
+            }
+        }).start();
         // Try to start it again on a current thread.
         orchestrator.start();
 

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -183,6 +183,16 @@ public final class DataStoreCategory
             onObservationStarted, onDataStoreItemChange, onObservationFailure, onObservationCompleted);
     }
 
+    @Override
+    public void start(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
+        getSelectedPlugin().start(onComplete, onError);
+    }
+
+    @Override
+    public void stop(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
+        getSelectedPlugin().stop(onComplete, onError);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -227,7 +227,29 @@ public interface DataStoreCategoryBehavior {
     );
 
     /**
-     * Resets the underlying DataStore to its pre-initialized state such that no data remains on the local
+     * Starts the DataStore.  This only needs to be called if you wish to start eagerly.  If you don't call it,
+     * it will be called automatically prior to executing any other operations (#query, #save, #delete, #observe).
+     *
+     * @param onComplete Invoked after DataStore is initialized.  This does not block until subscriptions and
+     *                  sync are complete.  To block until sync and subscriptions are complete, use
+     *                   Amplify.Hub.subscribe to listen for the DataStoreChannelEventName.READY event on
+     *                   HubChannel.DATASTORE.
+     * @param onError Invoked if an exception occurs.
+     */
+    void start(@NonNull Action onComplete,
+               @NonNull Consumer<DataStoreException> onError);
+
+    /**
+     * Stops the underlying DataStore, resetting the plugin to the initialized state.
+     *
+     * @param onComplete Invoked if the call is successful.
+     * @param onError Invoked if an exception occurs.
+     */
+    void stop(@NonNull Action onComplete,
+              @NonNull Consumer<DataStoreException> onError);
+
+    /**
+     * Stops the underlying DataStore, resetting the plugin to the initialized state, and deletes all data on the local
      * device. Every implementation of this behavior may have its own interpretation of what clear means.
      * This is meant to be a destructive operation that allows for safe disposal of data stored locally.
      *

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -227,8 +227,10 @@ public interface DataStoreCategoryBehavior {
     );
 
     /**
-     * Starts the DataStore.  This only needs to be called if you wish to start eagerly.  If you don't call it,
-     * it will be called automatically prior to executing any other operations (#query, #save, #delete, #observe).
+     * Starts the DataStore's synchronization with a remote system, if DataStore is configured to support
+     * remote synchronization. This only needs to be called if you wish to start the synchronization eagerly.
+     * If you don't call start(), the synchronization will start automatically, prior to executing any other
+     * operations (#query, #save, #delete, #observe).
      *
      * @param onComplete Invoked after DataStore is initialized.  This does not block until subscriptions and
      *                  sync are complete.  To block until sync and subscriptions are complete, use

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
@@ -127,6 +127,16 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
     }
 
     @Override
+    public Completable start() {
+        return VoidBehaviors.toCompletable(dataStore::start);
+    }
+
+    @Override
+    public Completable stop() {
+        return VoidBehaviors.toCompletable(dataStore::stop);
+    }
+
+    @Override
     public Completable clear() {
         return VoidBehaviors.toCompletable(dataStore::clear);
     }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreCategoryBehavior.java
@@ -177,6 +177,23 @@ public interface RxDataStoreCategoryBehavior {
     );
 
     /**
+     * Starts the DataStore.  This only needs to be called if you wish to start eagerly.  If you don't call it,
+     * it will be called automatically prior to executing any other operations (#query, #save, #delete, #observe).
+     *
+     * @return A {@link Completable} which emits success after DataStore is initialized.  This does not block until
+     * subscriptions and sync are complete.  To block until sync and subscriptions are complete, use
+     * Amplify.Hub.subscribe to listen for the DataStoreChannelEventName.READY event on HubChannel.DATASTORE.
+     */
+    Completable start();
+
+    /**
+     * Stops the underlying DataStore, resetting the plugin to the initialized state.
+     *
+     *  @return A {@link Completable} which emits success upon successful stop of DataStore, emits an error, otherwise
+     */
+    Completable stop();
+
+    /**
      * Resets the underlying DataStore to its pre-initialized state such that no data remains on the local
      * device. Every implementation of this behavior may have its own interpretation of what clear means.
      * This is meant to be a destructive operation that allows for safe disposal of data stored locally.

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxDataStoreBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxDataStoreBindingTest.java
@@ -374,6 +374,104 @@ public final class RxDataStoreBindingTest {
     }
 
     /**
+     * The Rx binding for the DataStore's start() method will propagate failures
+     * faithfully from the underlying delegate.
+     * @throws InterruptedException If interrupted while test observer is awaiting terminal event
+     */
+    @Test
+    public void startFailsWhenCategoryBehaviorDoes() throws InterruptedException {
+        // Arrange a failure in the category behavior
+        DataStoreException expectedFailure = new DataStoreException("Expected", "Failure");
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            final int positionOfOnFailure = 1;
+            Consumer<DataStoreException> onFailure = invocation.getArgument(positionOfOnFailure);
+            onFailure.accept(expectedFailure);
+            return null; // "void"
+        }).when(delegate).start(anyAction(), anyConsumer());
+
+        // Act: start the store.
+        TestObserver<Void> observer = rxDataStore.start().test();
+
+        // Assert: failure propagates through binding.
+        observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertError(expectedFailure);
+    }
+
+    /**
+     * The Rx binding for the DataStore's start() method will propagate success
+     * faithfully from the underlying delegate.
+     * @throws InterruptedException If interrupted while test observer is awaiting terminal event
+     */
+    @Test
+    public void startSucceedsWhenCategoryBehaviorDoes() throws InterruptedException {
+        // Arrange success in the category behavior
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            final int positionOfOnSuccess = 0;
+            Action onSuccess = invocation.getArgument(positionOfOnSuccess);
+            onSuccess.call();
+            return null; // "void"
+        }).when(delegate).start(anyAction(), anyConsumer());
+
+        // Act: start the store.
+        TestObserver<Void> observer = rxDataStore.start().test();
+
+        // Assert: success propagates through binding.
+        observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertComplete();
+    }
+
+    /**
+     * The Rx binding for the DataStore's stop() method will propagate failures
+     * faithfully from the underlying delegate.
+     * @throws InterruptedException If interrupted while test observer is awaiting terminal event
+     */
+    @Test
+    public void stopFailsWhenCategoryBehaviorDoes() throws InterruptedException {
+        // Arrange a failure in the category behavior
+        DataStoreException expectedFailure = new DataStoreException("Expected", "Failure");
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            final int positionOfOnFailure = 1;
+            Consumer<DataStoreException> onFailure = invocation.getArgument(positionOfOnFailure);
+            onFailure.accept(expectedFailure);
+            return null; // "void"
+        }).when(delegate).stop(anyAction(), anyConsumer());
+
+        // Act: stop the store.
+        TestObserver<Void> observer = rxDataStore.stop().test();
+
+        // Assert: failure propagates through binding.
+        observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertError(expectedFailure);
+    }
+
+    /**
+     * The Rx binding for the DataStore's stop() method will propagate success
+     * faithfully from the underlying delegate.
+     * @throws InterruptedException If interrupted while test observer is awaiting terminal event
+     */
+    @Test
+    public void stopSucceedsWhenCategoryBehaviorDoes() throws InterruptedException {
+        // Arrange success in the category behavior
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            final int positionOfOnSuccess = 0;
+            Action onSuccess = invocation.getArgument(positionOfOnSuccess);
+            onSuccess.call();
+            return null; // "void"
+        }).when(delegate).stop(anyAction(), anyConsumer());
+
+        // Act: stop the store.
+        TestObserver<Void> observer = rxDataStore.stop().test();
+
+        // Assert: success propagates through binding.
+        observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertComplete();
+    }
+
+    /**
      * The Rx binding for the DataStore's clear() method will propagate failures
      * faithfully from the underlying delegate.
      * @throws InterruptedException If interrupted while test observer is awaiting terminal event

--- a/testutils/src/main/java/com/amplifyframework/testutils/VoidResult.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/VoidResult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils;
+
+/**
+ * Result placeholder to be used when there is no value emitted from a task, but we are interested in the completion of
+ * the task.
+ */
+public final class VoidResult {
+    private static VoidResult voidResultInstance;
+
+    private VoidResult() {}
+
+    /**
+     * Returns the default instance.
+     * @return the default instance.
+     */
+    public static VoidResult instance() {
+        if (voidResultInstance == null) {
+            voidResultInstance = new VoidResult();
+        }
+        return voidResultInstance;
+    }
+}

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousDataStore.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousDataStore.java
@@ -15,7 +15,6 @@
 
 package com.amplifyframework.testutils.sync;
 
-import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.Model;
@@ -23,6 +22,7 @@ import com.amplifyframework.datastore.DataStoreCategoryBehavior;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.DataStoreItemChange;
 import com.amplifyframework.testutils.Await;
+import com.amplifyframework.testutils.VoidResult;
 import com.amplifyframework.util.Immutable;
 
 import java.util.ArrayList;
@@ -31,8 +31,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-
-import io.reactivex.rxjava3.core.Completable;
 
 /**
  * A utility to facilitate synchronous calls to the Amplify DataStore category.
@@ -108,15 +106,27 @@ public final class SynchronousDataStore {
     }
 
     /**
-     * Call the clear method of the underlying DataStore implementation.
+     * Calls the start method of the underlying DataStore implementation.
+     * @throws DataStoreException On failure to start data store.
      */
-    @SuppressLint("CheckResult")
-    public void clear() {
-        Completable.fromSingle(single -> {
-            asyncDelegate.clear(() -> {
-                single.onSuccess(true);
-            }, single::onError);
-        }).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    public void start() throws DataStoreException {
+        await((onComplete, onError) -> asyncDelegate.start(() -> onComplete.accept(VoidResult.instance()), onError));
+    }
+
+    /**
+     * Call the clear method of the underlying DataStore implementation.
+     * @throws DataStoreException On failure to clear data store.
+     */
+    public void clear() throws DataStoreException {
+        await((onComplete, onError) -> asyncDelegate.clear(() -> onComplete.accept(VoidResult.instance()), onError));
+    }
+
+    /**
+     * Calls the save method of the underlying DataStore implementation.
+     * @throws DataStoreException On failure to stop data store.
+     */
+    public void stop() throws DataStoreException {
+        await((onComplete, onError) -> asyncDelegate.stop(() -> onComplete.accept(VoidResult.instance()), onError));
     }
 
     // Syntax fluff to get rid of type bounds at location of call
@@ -132,5 +142,11 @@ public final class SynchronousDataStore {
             Await.ResultErrorEmitter<Iterator<T>, DataStoreException> resultErrorEmitter)
             throws DataStoreException {
         return Await.result(resultErrorEmitter);
+    }
+
+    // Syntax fluff to get rid of type bounds at location of call
+    private void await(Await.ResultErrorEmitter<VoidResult, DataStoreException> resultErrorEmitter)
+            throws DataStoreException {
+        Await.result(resultErrorEmitter);
     }
 }


### PR DESCRIPTION
Summary
 - Added `void DataStore::start(Action onComplete, Consumer<DataStoreException> onError)` API 
 - Added `void DataStore::stop(Action onComplete, Consumer<DataStoreException> onError)` API
 - Added `Completable RxDataStore::start()` and `Completable RxDataStore::stop()` API
 - Modified `DataStore::configure()` so that it does not call start anymore
 - Modified `DataStore::clear()` so that it does not call start anymore
 - The following scenarios now bubble up an exception to the user provided `Consumer<DataStoreException>`, instead of just logging a warning:
   - [Timeout acquiring lock in Orchestrator::start()](https://github.com/aws-amplify/amplify-android/blob/89ed53d3f2b887c6b23439c776be133fa1ac0819/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java#L181)
   - [Timeout starting DataStore](https://github.com/aws-amplify/amplify-android/blob/c612d56181ba4a686ff2da4fc8a8913050f9863f/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java#L501)
   - [Any other unexpected error while starting DataStore](https://github.com/aws-amplify/amplify-android/blob/c612d56181ba4a686ff2da4fc8a8913050f9863f/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java#L503)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
