### PR TITLE
chore(aws-api): move owner-based auth logic out of plugin

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -281,12 +281,14 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             return null;
         }
 
-        GraphQLRequest<R> request = graphQLRequest;
-        AuthorizationType authType = clientDetails.getApiConfiguration().getAuthorizationType();
+        final GraphQLRequest<R> authDecoratedRequest;
 
         // Decorate the request according to the auth rule parameters.
         try {
-            request = authRuleProcessor.process(request, authType);
+            AuthorizationType authType = clientDetails
+                    .getApiConfiguration()
+                    .getAuthorizationType();
+            authDecoratedRequest = authRuleProcessor.process(graphQLRequest, authType);
         } catch (ApiException exception) {
             onSubscriptionFailure.accept(exception);
             return null;
@@ -294,7 +296,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
 
         SubscriptionOperation<R> operation = SubscriptionOperation.<R>builder()
             .subscriptionEndpoint(clientDetails.getSubscriptionEndpoint())
-            .graphQlRequest(request)
+            .graphQlRequest(authDecoratedRequest)
             .responseFactory(gqlResponseFactory)
             .executorService(executorService)
             .onSubscriptionStart(onSubscriptionEstablished)

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -21,13 +21,10 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.util.ObjectsCompat;
 
-import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiPlugin;
+import com.amplifyframework.api.aws.auth.AuthRuleProcessor;
 import com.amplifyframework.api.aws.operation.AWSRestOperation;
-import com.amplifyframework.api.aws.sigv4.CognitoUserPoolsAuthProvider;
-import com.amplifyframework.api.aws.sigv4.DefaultCognitoUserPoolsAuthProvider;
-import com.amplifyframework.api.aws.sigv4.OidcAuthProvider;
 import com.amplifyframework.api.events.ApiEndpointStatusChangeEvent;
 import com.amplifyframework.api.events.ApiEndpointStatusChangeEvent.ApiEndpointStatus;
 import com.amplifyframework.api.graphql.GraphQLOperation;
@@ -41,7 +38,6 @@ import com.amplifyframework.api.rest.RestResponse;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.Consumer;
-import com.amplifyframework.core.model.AuthRule;
 import com.amplifyframework.core.model.AuthStrategy;
 import com.amplifyframework.core.model.ModelOperation;
 import com.amplifyframework.hub.HubChannel;
@@ -49,14 +45,12 @@ import com.amplifyframework.util.UserAgent;
 
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.exceptions.CognitoParameterInvalidException;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoJWTParser;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -84,6 +78,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     private final GraphQLResponse.Factory gqlResponseFactory;
     private final ApiAuthProviders authProvider;
     private final ExecutorService executorService;
+    private final AuthRuleProcessor authRuleProcessor;
 
     private final Set<String> restApis;
     private final Set<String> gqlApis;
@@ -112,6 +107,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         this.restApis = new HashSet<>();
         this.gqlApis = new HashSet<>();
         this.executorService = Executors.newCachedThreadPool();
+        this.authRuleProcessor = new AuthRuleProcessor(authProvider);
     }
 
     @NonNull
@@ -277,70 +273,23 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             @NonNull Action onSubscriptionComplete) {
         final ClientDetails clientDetails = apiDetails.get(apiName);
         if (clientDetails == null) {
-            onSubscriptionFailure.accept(
-                    new ApiException(
-                            "No client information for API named " + apiName,
-                            "Check your amplify configuration to make sure there " +
-                                    "is a correctly configured section for " + apiName
-                    )
-            );
+            onSubscriptionFailure.accept(new ApiException(
+                    "No client information for API named " + apiName,
+                    "Check your amplify configuration to make sure there " +
+                            "is a correctly configured section for " + apiName
+            ));
             return null;
         }
 
         GraphQLRequest<R> request = graphQLRequest;
-        if (request instanceof AppSyncGraphQLRequest) {
-            try {
-                AppSyncGraphQLRequest<R> appSyncRequest = (AppSyncGraphQLRequest<R>) request;
-                AuthRule ownerRuleWithReadRestriction = null;
-                Map<String, Set<String>> readAuthorizedGroupsMap = new HashMap<>();
+        AuthorizationType authType = clientDetails.getApiConfiguration().getAuthorizationType();
 
-                // Note that we are intentionally supporting only one owner rule with a READ operation at this time.
-                // If there is more than one, the operation will fail because AppSync generates a parameter for each
-                // one. The question then is which one do we pass. JavaScript currently doesn't support this use case
-                // and it's not clear what a good solution would be until AppSync supports real time filters.
-                for (AuthRule authRule : appSyncRequest.getModelSchema().getAuthRules()) {
-                    if (isReadRestrictingOwner(authRule)) {
-                        if (ownerRuleWithReadRestriction == null) {
-                            ownerRuleWithReadRestriction = authRule;
-                        } else {
-                            onSubscriptionFailure.accept(new ApiException("Detected multiple owner type auth rules " +
-                                    "with a READ operation", "We currently do not support this use case. Please " +
-                                    "limit your type to just one owner auth rule with a READ operation restriction."));
-                            return null;
-                        }
-                    } else if (isReadRestrictingStaticGroup(authRule)) {
-                        // Group read-restricting groups by the claim name
-                        String groupClaim = authRule.getGroupClaimOrDefault();
-                        List<String> groups = authRule.getGroups();
-                        Set<String> readAuthorizedGroups = readAuthorizedGroupsMap.get(groupClaim);
-                        if (readAuthorizedGroups != null) {
-                            readAuthorizedGroups.addAll(groups);
-                        } else {
-                            readAuthorizedGroupsMap.put(groupClaim, new HashSet<>(groups));
-                        }
-                    }
-                }
-
-                // We only add the owner parameter to the subscription if there is an owner rule with a READ restriction
-                // and either there are no group auth rules with read access or there are but the user isn't in any of
-                // them.
-                final AuthorizationType authType = clientDetails
-                        .getApiConfiguration()
-                        .getAuthorizationType();
-                if (ownerRuleWithReadRestriction != null
-                        && userNotInReadRestrictingGroups(readAuthorizedGroupsMap, authType)) {
-                    String idClaim = ownerRuleWithReadRestriction.getIdentityClaimOrDefault();
-                    String key = ownerRuleWithReadRestriction.getOwnerFieldOrDefault();
-                    String value = getIdentityValue(idClaim, authType);
-                    request = appSyncRequest.newBuilder()
-                            .variable(key, "String!", value)
-                            .build();
-                }
-            } catch (AmplifyException exception) {
-                onSubscriptionFailure.accept(new ApiException("Failed to set owner field on AppSyncGraphQLRequest",
-                        exception, "See attached exception for details."));
-                return null;
-            }
+        // Decorate the request according to the auth rule parameters.
+        try {
+            request = authRuleProcessor.process(request, authType);
+        } catch (ApiException exception) {
+            onSubscriptionFailure.accept(exception);
+            return null;
         }
 
         SubscriptionOperation<R> operation = SubscriptionOperation.<R>builder()
@@ -355,105 +304,6 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             .build();
         operation.start();
         return operation;
-    }
-
-    private boolean isReadRestrictingOwner(AuthRule authRule) {
-        return AuthStrategy.OWNER.equals(authRule.getAuthStrategy())
-            && authRule.getOperationsOrDefault().contains(ModelOperation.READ);
-    }
-
-    private boolean isReadRestrictingStaticGroup(AuthRule authRule) {
-        return AuthStrategy.GROUPS.equals(authRule.getAuthStrategy())
-            && !authRule.getGroups().isEmpty()
-            && authRule.getOperationsOrDefault().contains(ModelOperation.READ);
-    }
-
-    private String getIdentityValue(String identityClaim, AuthorizationType authType) throws ApiException {
-        try {
-            return CognitoJWTParser
-                    .getPayload(getAuthToken(authType))
-                    .getString(identityClaim);
-        } catch (JSONException | CognitoParameterInvalidException error) {
-            throw new ApiException(
-                    "Attempted to subscribe to a model with owner-based authorization without " + identityClaim + " " +
-                            "which was specified (or defaulted to) as the identity claim.",
-                    "If you did not specify a custom identityClaim in your schema, make sure you are logged in. If " +
-                            "you did, check that the value you specified in your schema is present in the access key."
-            );
-        }
-    }
-
-    private ArrayList<String> getUserGroups(String groupClaim, AuthorizationType authType) throws ApiException {
-        ArrayList<String> groups = new ArrayList<>();
-        try {
-            JSONObject accessToken = CognitoJWTParser
-                    .getPayload(getAuthToken(authType));
-            if (accessToken.has(groupClaim)) {
-                JSONArray jsonGroups = accessToken.getJSONArray(groupClaim);
-                for (int index = 0; index < jsonGroups.length(); index++) {
-                    groups.add(jsonGroups.getString(index));
-                }
-            }
-        } catch (JSONException | CognitoParameterInvalidException error) {
-            throw new ApiException(
-                    "Failed to parse group claim from the token.",
-                    AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
-            );
-        }
-
-        return groups;
-    }
-
-    private boolean userNotInReadRestrictingGroups(
-            Map<String, Set<String>> readAuthorizedGroupsMap,
-            AuthorizationType authType
-    ) throws ApiException {
-        // Iterate through map of "group claim" -> "read-restricting groups from that claim". e.g.
-        // {
-        //   "https://myapp.com/claims/groups" -> {Admins}
-        //   "https://differentapp.com/claims/groups" -> {Moderators, Editors}
-        // }
-        for (Map.Entry<String, Set<String>> entry : readAuthorizedGroupsMap.entrySet()) {
-            String groupClaim = entry.getKey();
-            // Get a list of groups that user belongs in for a given claim.
-            // e.g. [Admins, User]
-            List<String> userGroups = getUserGroups(groupClaim, authType);
-            Set<String> readAuthorizedGroups = entry.getValue();
-            // If user belongs in any group for a given group claim, return false.
-            if (!Collections.disjoint(userGroups, readAuthorizedGroups)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private String getAuthToken(AuthorizationType authType) throws ApiException {
-        switch (authType) {
-            case AMAZON_COGNITO_USER_POOLS:
-                CognitoUserPoolsAuthProvider cognitoProvider = authProvider.getCognitoUserPoolsAuthProvider();
-                if (cognitoProvider == null) {
-                    cognitoProvider = new DefaultCognitoUserPoolsAuthProvider();
-                }
-                return cognitoProvider.getLatestAuthToken();
-            case OPENID_CONNECT:
-                OidcAuthProvider oidcProvider = authProvider.getOidcAuthProvider();
-                if (oidcProvider == null) {
-                    throw new ApiException(
-                        "OidcAuthProvider interface is not implemented.",
-                        "Configure AWSApiPlugin with ApiAuthProviders containing an implementation of " +
-                            "OidcAuthProvider interface that can vend a valid JWT token."
-                    );
-                }
-                return oidcProvider.getLatestAuthToken();
-            case API_KEY:
-            case AWS_IAM:
-            case NONE:
-            default:
-                throw new ApiException(
-                    "Failed to obtain access token from the configured auth provider.",
-                    "Verify that the API is configured with either Cognito User Pools or OpenID Connect."
-                );
-        }
     }
 
     @Nullable

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/auth/AuthRuleProcessor.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/auth/AuthRuleProcessor.java
@@ -38,7 +38,12 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Processor that can decorate an AppSync-compliant GraphQL request with additional variables
@@ -78,7 +83,7 @@ public final class AuthRuleProcessor {
 
         AppSyncGraphQLRequest<R> appSyncRequest = (AppSyncGraphQLRequest<R>) request;
         AuthRule ownerRuleWithReadRestriction = null;
-        ArrayList<String> readAuthorizedGroups = new ArrayList<>();
+        Map<String, Set<String>> readAuthorizedGroupsMap = new HashMap<>();
 
         // Note that we are intentionally supporting only one owner rule with a READ operation at this time.
         // If there is more than one, the operation will fail because AppSync generates a parameter for each
@@ -90,13 +95,20 @@ public final class AuthRuleProcessor {
                     ownerRuleWithReadRestriction = authRule;
                 } else {
                     throw new ApiException(
-                            "Detected multiple owner type auth rules with a READ operation",
-                            "We currently do not support this use case. Please limit your type to just one " +
-                                    "owner auth rule with a READ operation restriction."
-                    );
+                        "Detected multiple owner type auth rules with a READ operation",
+                        "We currently do not support this use case. Please limit your type to just one owner " +
+                            "auth rule with a READ operation restriction.");
                 }
             } else if (isReadRestrictingStaticGroup(authRule)) {
-                readAuthorizedGroups.addAll(authRule.getGroups());
+                // Group read-restricting groups by the claim name
+                String groupClaim = authRule.getGroupClaimOrDefault();
+                List<String> groups = authRule.getGroups();
+                Set<String> readAuthorizedGroups = readAuthorizedGroupsMap.get(groupClaim);
+                if (readAuthorizedGroups != null) {
+                    readAuthorizedGroups.addAll(groups);
+                } else {
+                    readAuthorizedGroupsMap.put(groupClaim, new HashSet<>(groups));
+                }
             }
         }
 
@@ -104,21 +116,19 @@ public final class AuthRuleProcessor {
         // and either there are no group auth rules with read access or there are but the user isn't in any of
         // them.
         if (ownerRuleWithReadRestriction != null
-                && (readAuthorizedGroups.isEmpty()
-                || Collections.disjoint(readAuthorizedGroups, getUserGroups(authType)))
-        ) {
+                && userNotInReadRestrictingGroups(readAuthorizedGroupsMap, authType)) {
             String idClaim = ownerRuleWithReadRestriction.getIdentityClaimOrDefault();
             String key = ownerRuleWithReadRestriction.getOwnerFieldOrDefault();
             String value = getIdentityValue(idClaim, authType);
 
             try {
                 return appSyncRequest.newBuilder()
-                        .variable(key, "String!", value)
-                        .build();
+                    .variable(key, "String!", value)
+                    .build();
             } catch (AmplifyException exception) {
                 throw new ApiException(
-                        "Failed to set owner field on AppSyncGraphQLRequest", exception,
-                        "See attached exception for details.");
+                    "Failed to set owner field on AppSyncGraphQLRequest", exception,
+                    "See attached exception for details.");
             }
         }
 
@@ -132,63 +142,67 @@ public final class AuthRuleProcessor {
 
     private boolean isReadRestrictingStaticGroup(AuthRule authRule) {
         return AuthStrategy.GROUPS.equals(authRule.getAuthStrategy())
-                && authRule.getGroups() != null && !authRule.getGroups().isEmpty()
+                && !authRule.getGroups().isEmpty()
                 && authRule.getOperationsOrDefault().contains(ModelOperation.READ);
     }
 
     private String getIdentityValue(String identityClaim, AuthorizationType authType) throws ApiException {
-        String identityValue = null;
-
         try {
-            identityValue = CognitoJWTParser
+            return CognitoJWTParser
                     .getPayload(getAuthToken(authType))
                     .getString(identityClaim);
         } catch (JSONException | CognitoParameterInvalidException error) {
-            // Could not read identity value from the token...
-            // Exception will be thrown so do nothing for now
-        }
-
-        if (identityValue == null || identityValue.isEmpty()) {
             throw new ApiException(
-                    "Attempted to subscribe to a model with owner based authorization without " + identityClaim + " " +
-                            "which was specified (or defaulted to) as the identity claim.",
-                    "If you did not specify a custom identityClaim in your schema, make sure you are logged in. If " +
-                            "you did, check that the value you specified in your schema is present in the access key."
+                "Attempted to subscribe to a model with owner-based authorization without " + identityClaim + " " +
+                    "which was specified (or defaulted to) as the identity claim.",
+                "If you did not specify a custom identityClaim in your schema, make sure you are logged in. If " +
+                    "you did, check that the value you specified in your schema is present in the access key."
             );
         }
-
-        return identityValue;
     }
 
-    private ArrayList<String> getUserGroups(AuthorizationType authType) throws ApiException {
-        // Custom groups claim isn't supported yet.
-        if (!AuthorizationType.AMAZON_COGNITO_USER_POOLS.equals(authType)) {
-            throw new ApiException("Custom groups claim is not supported yet.",
-                    "Please use Amazon Cognito User Pools to authorize your API.");
-        }
-
+    private ArrayList<String> getUserGroups(String groupClaim, AuthorizationType authType) throws ApiException {
         ArrayList<String> groups = new ArrayList<>();
-        final String GROUPS_KEY = "cognito:groups";
-
         try {
-            JSONObject accessToken = CognitoJWTParser.getPayload(getAuthToken(authType));
-
-            if (accessToken.has(GROUPS_KEY)) {
-                JSONArray jsonGroups = accessToken.getJSONArray(GROUPS_KEY);
-
-                for (int i = 0; i < jsonGroups.length(); i++) {
-                    groups.add(jsonGroups.getString(i));
+            JSONObject accessToken = CognitoJWTParser
+                    .getPayload(getAuthToken(authType));
+            if (accessToken.has(groupClaim)) {
+                JSONArray jsonGroups = accessToken.getJSONArray(groupClaim);
+                for (int index = 0; index < jsonGroups.length(); index++) {
+                    groups.add(jsonGroups.getString(index));
                 }
             }
         } catch (JSONException | CognitoParameterInvalidException error) {
             throw new ApiException(
-                    "Failed to parse groups from auth rule.",
-                    error,
-                    "This should never happen - see attached exception for more details and report to us on GitHub."
+                "Failed to parse group claim from the token.",
+                AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
             );
         }
 
         return groups;
+    }
+
+    private boolean userNotInReadRestrictingGroups(
+            Map<String, Set<String>> readAuthorizedGroupsMap,
+            AuthorizationType authType
+    ) throws ApiException {
+        // Iterate through map of "group claim" -> "read-restricting groups from that claim". e.g.
+        // {
+        //   "https://myapp.com/claims/groups" -> {Admins}
+        //   "https://differentapp.com/claims/groups" -> {Moderators, Editors}
+        // }
+        for (Map.Entry<String, Set<String>> entry : readAuthorizedGroupsMap.entrySet()) {
+            String groupClaim = entry.getKey();
+            // Get a list of groups that user belongs in for a given claim.
+            // e.g. [Admins, User]
+            List<String> userGroups = getUserGroups(groupClaim, authType);
+            Set<String> readAuthorizedGroups = entry.getValue();
+            // If user belongs in any group for a given group claim, return false.
+            if (!Collections.disjoint(userGroups, readAuthorizedGroups)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private String getAuthToken(AuthorizationType authType) throws ApiException {
@@ -203,9 +217,9 @@ public final class AuthRuleProcessor {
                 OidcAuthProvider oidcProvider = authProvider.getOidcAuthProvider();
                 if (oidcProvider == null) {
                     throw new ApiException(
-                            "OidcAuthProvider interface is not implemented.",
-                            "Configure AWSApiPlugin with ApiAuthProviders containing an implementation of " +
-                                    "OidcAuthProvider interface that can vend a valid JWT token."
+                        "OidcAuthProvider interface is not implemented.",
+                        "Configure AWSApiPlugin with ApiAuthProviders containing an implementation of " +
+                            "OidcAuthProvider interface that can vend a valid JWT token."
                     );
                 }
                 return oidcProvider.getLatestAuthToken();
@@ -214,8 +228,10 @@ public final class AuthRuleProcessor {
             case NONE:
             default:
                 throw new ApiException(
-                        "Failed to obtain access token from the configured auth provider.",
-                        "Verify that the API is configured with either Cognito User Pools or OpenID Connect."
+                    "Tried to use owner/group-based authorization on an API that is not configured " +
+                        "with either Cognito User Pools or OpenID Connect.",
+                    "Verify that the API is configured with either Cognito User Pools or OpenID Connect. @auth " +
+                        "with owner/group-based authorization is not supported for other modes."
                 );
         }
     }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/auth/AuthRuleProcessor.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/auth/AuthRuleProcessor.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws.auth;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.aws.ApiAuthProviders;
+import com.amplifyframework.api.aws.AppSyncGraphQLRequest;
+import com.amplifyframework.api.aws.AuthorizationType;
+import com.amplifyframework.api.aws.sigv4.CognitoUserPoolsAuthProvider;
+import com.amplifyframework.api.aws.sigv4.DefaultCognitoUserPoolsAuthProvider;
+import com.amplifyframework.api.aws.sigv4.OidcAuthProvider;
+import com.amplifyframework.api.graphql.GraphQLRequest;
+import com.amplifyframework.core.model.AuthRule;
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.ModelOperation;
+
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.exceptions.CognitoParameterInvalidException;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoJWTParser;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Objects;
+
+/**
+ * Processor that can decorate an AppSync-compliant GraphQL request with additional variables
+ * that are required for owner-based or group-based authorization.
+ */
+public final class AuthRuleProcessor {
+    private final ApiAuthProviders authProvider;
+
+    /**
+     * Constructs a new instance of GraphQL request's auth rule processor.
+     * @param authProvider the auth providers to authorize requests
+     */
+    public AuthRuleProcessor(@NonNull ApiAuthProviders authProvider) {
+        this.authProvider = Objects.requireNonNull(authProvider);
+    }
+
+    /**
+     * Decorate given GraphQL request instance with additional variables for owner-based or
+     * group-based authorization.
+     *
+     * This will only work if the request is compliant with the AppSync specifications.
+     * @param request an instance of {@link GraphQLRequest}.
+     * @param authType the mode of authorization being used to authorize the request
+     * @param <R> The type of data contained in the GraphQLResponse expected from this request.
+     * @return the input request with additional variables that specify model's owner and/or
+     *          groups
+     * @throws ApiException If an error is encountered while processing the auth rules associated
+     *          with the request or if the authorization fails
+     */
+    public <R> GraphQLRequest<R> process(
+            @NonNull GraphQLRequest<R> request,
+            @NonNull AuthorizationType authType
+    ) throws ApiException {
+        if (!(request instanceof AppSyncGraphQLRequest)) {
+            return request;
+        }
+
+        AppSyncGraphQLRequest<R> appSyncRequest = (AppSyncGraphQLRequest<R>) request;
+        AuthRule ownerRuleWithReadRestriction = null;
+        ArrayList<String> readAuthorizedGroups = new ArrayList<>();
+
+        // Note that we are intentionally supporting only one owner rule with a READ operation at this time.
+        // If there is more than one, the operation will fail because AppSync generates a parameter for each
+        // one. The question then is which one do we pass. JavaScript currently doesn't support this use case
+        // and it's not clear what a good solution would be until AppSync supports real time filters.
+        for (AuthRule authRule : appSyncRequest.getModelSchema().getAuthRules()) {
+            if (isReadRestrictingOwner(authRule)) {
+                if (ownerRuleWithReadRestriction == null) {
+                    ownerRuleWithReadRestriction = authRule;
+                } else {
+                    throw new ApiException(
+                            "Detected multiple owner type auth rules with a READ operation",
+                            "We currently do not support this use case. Please limit your type to just one " +
+                                    "owner auth rule with a READ operation restriction."
+                    );
+                }
+            } else if (isReadRestrictingStaticGroup(authRule)) {
+                readAuthorizedGroups.addAll(authRule.getGroups());
+            }
+        }
+
+        // We only add the owner parameter to the subscription if there is an owner rule with a READ restriction
+        // and either there are no group auth rules with read access or there are but the user isn't in any of
+        // them.
+        if (ownerRuleWithReadRestriction != null
+                && (readAuthorizedGroups.isEmpty()
+                || Collections.disjoint(readAuthorizedGroups, getUserGroups(authType)))
+        ) {
+            String idClaim = ownerRuleWithReadRestriction.getIdentityClaimOrDefault();
+            String key = ownerRuleWithReadRestriction.getOwnerFieldOrDefault();
+            String value = getIdentityValue(idClaim, authType);
+
+            try {
+                return appSyncRequest.newBuilder()
+                        .variable(key, "String!", value)
+                        .build();
+            } catch (AmplifyException exception) {
+                throw new ApiException(
+                        "Failed to set owner field on AppSyncGraphQLRequest", exception,
+                        "See attached exception for details.");
+            }
+        }
+
+        return request;
+    }
+
+    private boolean isReadRestrictingOwner(AuthRule authRule) {
+        return AuthStrategy.OWNER.equals(authRule.getAuthStrategy())
+                && authRule.getOperationsOrDefault().contains(ModelOperation.READ);
+    }
+
+    private boolean isReadRestrictingStaticGroup(AuthRule authRule) {
+        return AuthStrategy.GROUPS.equals(authRule.getAuthStrategy())
+                && authRule.getGroups() != null && !authRule.getGroups().isEmpty()
+                && authRule.getOperationsOrDefault().contains(ModelOperation.READ);
+    }
+
+    private String getIdentityValue(String identityClaim, AuthorizationType authType) throws ApiException {
+        String identityValue = null;
+
+        try {
+            identityValue = CognitoJWTParser
+                    .getPayload(getAuthToken(authType))
+                    .getString(identityClaim);
+        } catch (JSONException | CognitoParameterInvalidException error) {
+            // Could not read identity value from the token...
+            // Exception will be thrown so do nothing for now
+        }
+
+        if (identityValue == null || identityValue.isEmpty()) {
+            throw new ApiException(
+                    "Attempted to subscribe to a model with owner based authorization without " + identityClaim + " " +
+                            "which was specified (or defaulted to) as the identity claim.",
+                    "If you did not specify a custom identityClaim in your schema, make sure you are logged in. If " +
+                            "you did, check that the value you specified in your schema is present in the access key."
+            );
+        }
+
+        return identityValue;
+    }
+
+    private ArrayList<String> getUserGroups(AuthorizationType authType) throws ApiException {
+        // Custom groups claim isn't supported yet.
+        if (!AuthorizationType.AMAZON_COGNITO_USER_POOLS.equals(authType)) {
+            throw new ApiException("Custom groups claim is not supported yet.",
+                    "Please use Amazon Cognito User Pools to authorize your API.");
+        }
+
+        ArrayList<String> groups = new ArrayList<>();
+        final String GROUPS_KEY = "cognito:groups";
+
+        try {
+            JSONObject accessToken = CognitoJWTParser.getPayload(getAuthToken(authType));
+
+            if (accessToken.has(GROUPS_KEY)) {
+                JSONArray jsonGroups = accessToken.getJSONArray(GROUPS_KEY);
+
+                for (int i = 0; i < jsonGroups.length(); i++) {
+                    groups.add(jsonGroups.getString(i));
+                }
+            }
+        } catch (JSONException | CognitoParameterInvalidException error) {
+            throw new ApiException(
+                    "Failed to parse groups from auth rule.",
+                    error,
+                    "This should never happen - see attached exception for more details and report to us on GitHub."
+            );
+        }
+
+        return groups;
+    }
+
+    private String getAuthToken(AuthorizationType authType) throws ApiException {
+        switch (authType) {
+            case AMAZON_COGNITO_USER_POOLS:
+                CognitoUserPoolsAuthProvider cognitoProvider = authProvider.getCognitoUserPoolsAuthProvider();
+                if (cognitoProvider == null) {
+                    cognitoProvider = new DefaultCognitoUserPoolsAuthProvider();
+                }
+                return cognitoProvider.getLatestAuthToken();
+            case OPENID_CONNECT:
+                OidcAuthProvider oidcProvider = authProvider.getOidcAuthProvider();
+                if (oidcProvider == null) {
+                    throw new ApiException(
+                            "OidcAuthProvider interface is not implemented.",
+                            "Configure AWSApiPlugin with ApiAuthProviders containing an implementation of " +
+                                    "OidcAuthProvider interface that can vend a valid JWT token."
+                    );
+                }
+                return oidcProvider.getLatestAuthToken();
+            case API_KEY:
+            case AWS_IAM:
+            case NONE:
+            default:
+                throw new ApiException(
+                        "Failed to obtain access token from the configured auth provider.",
+                        "Verify that the API is configured with either Cognito User Pools or OpenID Connect."
+                );
+        }
+    }
+}

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/auth/AuthRuleRequestDecorator.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/auth/AuthRuleRequestDecorator.java
@@ -49,14 +49,14 @@ import java.util.Set;
  * Processor that can decorate an AppSync-compliant GraphQL request with additional variables
  * that are required for owner-based or group-based authorization.
  */
-public final class AuthRuleProcessor {
+public final class AuthRuleRequestDecorator {
     private final ApiAuthProviders authProvider;
 
     /**
      * Constructs a new instance of GraphQL request's auth rule processor.
      * @param authProvider the auth providers to authorize requests
      */
-    public AuthRuleProcessor(@NonNull ApiAuthProviders authProvider) {
+    public AuthRuleRequestDecorator(@NonNull ApiAuthProviders authProvider) {
         this.authProvider = Objects.requireNonNull(authProvider);
     }
 
@@ -73,7 +73,7 @@ public final class AuthRuleProcessor {
      * @throws ApiException If an error is encountered while processing the auth rules associated
      *          with the request or if the authorization fails
      */
-    public <R> GraphQLRequest<R> process(
+    public <R> GraphQLRequest<R> decorate(
             @NonNull GraphQLRequest<R> request,
             @NonNull AuthorizationType authType
     ) throws ApiException {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/auth/AuthRuleRequestDecoratorTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/auth/AuthRuleRequestDecoratorTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws.auth;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.aws.ApiAuthProviders;
+import com.amplifyframework.api.aws.ApiGraphQLRequestOptions;
+import com.amplifyframework.api.aws.AppSyncGraphQLRequest;
+import com.amplifyframework.api.aws.AuthorizationType;
+import com.amplifyframework.api.aws.sigv4.CognitoUserPoolsAuthProvider;
+import com.amplifyframework.api.aws.sigv4.OidcAuthProvider;
+import com.amplifyframework.api.graphql.GraphQLRequest;
+import com.amplifyframework.api.graphql.Operation;
+import com.amplifyframework.api.graphql.SubscriptionType;
+import com.amplifyframework.api.graphql.model.ModelSubscription;
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+
+import org.json.JSONArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests that auth rule decorator can correctly decorate a request given an auth rule.
+ */
+@RunWith(RobolectricTestRunner.class)
+public final class AuthRuleRequestDecoratorTest {
+    private AuthRuleRequestDecorator decorator;
+
+    /**
+     * Sets up the test.
+     */
+    @Before
+    public void setup() {
+        ApiAuthProviders authProviders = ApiAuthProviders.builder()
+                .cognitoUserPoolsAuthProvider(new FakeCognitoAuthProvider())
+                .oidcAuthProvider(new FakeOidcAuthProvider())
+                .build();
+        decorator = new AuthRuleRequestDecorator(authProviders);
+    }
+
+    /**
+     * Test that auth rule request decorator returns the same request if there
+     * is no auth rule associated with it.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void requestPassThroughForNoAuth() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.AMAZON_COGNITO_USER_POOLS;
+
+        // NoAuth class does not have use @auth directive
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<NoAuth> originalRequest = createRequest(NoAuth.class, subscriptionType);
+            GraphQLRequest<NoAuth> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertEquals(originalRequest, modifiedRequest);
+        }
+    }
+
+    /**
+     * Test that owner argument fails to be appended to subscription request if
+     * the authorization mode is not OIDC compliant.
+     * @throws ApiException if request contains unsupported auth rule
+     */
+    @Test(expected = ApiException.class)
+    public void ownerArgumentNotAddedWithApiKey() throws ApiException {
+        decorator.decorate(ModelSubscription.onCreate(Owner.class), AuthorizationType.API_KEY);
+    }
+
+    /**
+     * Test that owner argument fails to be appended to subscription request if
+     * the authorization mode is not OIDC compliant.
+     * @throws ApiException if request contains unsupported auth rule
+     */
+    @Test(expected = ApiException.class)
+    public void ownerArgumentNotAddedWithAwsIam() throws ApiException {
+        decorator.decorate(ModelSubscription.onCreate(Owner.class), AuthorizationType.AWS_IAM);
+    }
+
+    /**
+     * Verify that owner argument is required for all subscriptions if ModelOperation.READ is specified
+     * while using Cognito User Pools auth mode.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void ownerArgumentAddedForRestrictedReadWithUserPools() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.AMAZON_COGNITO_USER_POOLS;
+        final String expectedOwner = FakeCognitoAuthProvider.USERNAME;
+
+        // Owner class has restriction on every operation including READ
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<Owner> originalRequest = createRequest(Owner.class, subscriptionType);
+            GraphQLRequest<Owner> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertEquals(expectedOwner, getOwnerField(modifiedRequest));
+        }
+
+        // OwnerRead class only has restriction on READ
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerRead> originalRequest = createRequest(OwnerRead.class, subscriptionType);
+            GraphQLRequest<OwnerRead> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertEquals(expectedOwner, getOwnerField(modifiedRequest));
+        }
+    }
+
+    /**
+     * Verify that owner argument is required for all subscriptions if ModelOperation.READ is specified
+     * while using OpenID Connect auth mode.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void ownerArgumentAddedForRestrictedReadWithOidc() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.OPENID_CONNECT;
+        final String expectedOwner = FakeOidcAuthProvider.SUB;
+
+        // OwnerOidc class has restriction on every operation including READ
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerOidc> originalRequest = createRequest(OwnerOidc.class, subscriptionType);
+            GraphQLRequest<OwnerOidc> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertEquals(expectedOwner, getOwnerField(modifiedRequest));
+        }
+    }
+
+    /**
+     * Verify owner argument is NOT required if the subscription type is not one of the restricted operations.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void ownerArgumentNotAddedForNonRestrictedReadWithUserPools() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.AMAZON_COGNITO_USER_POOLS;
+
+        // OwnerCreate class only has restriction on CREATE
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerCreate> originalRequest = createRequest(OwnerCreate.class, subscriptionType);
+            GraphQLRequest<OwnerCreate> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
+
+        // OwnerUpdate class only has restriction on UPDATE
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerUpdate> originalRequest = createRequest(OwnerUpdate.class, subscriptionType);
+            GraphQLRequest<OwnerUpdate> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
+
+        // OwnerDelete class only has restriction on DELETE
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerDelete> originalRequest = createRequest(OwnerDelete.class, subscriptionType);
+            GraphQLRequest<OwnerDelete> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
+    }
+
+    /**
+     * Verify owner argument is NOT added if authStrategy is not OWNER.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void ownerArgumentNotAddedForNonOwnerBasedAuth() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.AMAZON_COGNITO_USER_POOLS;
+
+        // Public class opens up every operation to the public
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<Public> originalRequest = createRequest(Public.class, subscriptionType);
+            GraphQLRequest<Public> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
+
+        // Private class only allows the correct IAM user
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<Private> originalRequest = createRequest(Private.class, subscriptionType);
+            GraphQLRequest<Private> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
+
+        // Group class only has group-based auth enabled
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<Group> originalRequest = createRequest(Group.class, subscriptionType);
+            GraphQLRequest<Group> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
+    }
+
+    @Test
+    public void ownerArgumentAddedIfOwnerIsNotInGroupWithUserPools() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.AMAZON_COGNITO_USER_POOLS;
+        final String expectedOwner = FakeCognitoAuthProvider.USERNAME;
+
+        // OwnerNotInGroup class uses combined owner and group-based auth,
+        // but user is not in the read-restricted group.
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerNotInGroup> originalRequest = createRequest(OwnerNotInGroup.class, subscriptionType);
+            GraphQLRequest<OwnerNotInGroup> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertEquals(expectedOwner, getOwnerField(modifiedRequest));
+        }
+    }
+
+    @Test
+    public void ownerArgumentNotAddedIfOwnerIsInGroupWithUserPools() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.AMAZON_COGNITO_USER_POOLS;
+
+        // OwnerInGroup class uses combined owner and group-based auth,
+        // and user is in the read-restricted group.
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerInGroup> originalRequest = createRequest(OwnerInGroup.class, subscriptionType);
+            GraphQLRequest<OwnerInGroup> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
+    }
+
+    @Test
+    public void ownerArgumentAddedIfOwnerIsNotInCustomGroup() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.OPENID_CONNECT;
+        final String expectedOwner = FakeOidcAuthProvider.SUB;
+
+        // OwnerNotInCustomGroup class uses combined owner and group-based auth,
+        // but user is not in the read-restricted custom group.
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerNotInCustomGroup> originalRequest = createRequest(OwnerNotInCustomGroup.class, subscriptionType);
+            GraphQLRequest<OwnerNotInCustomGroup> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertEquals(expectedOwner, getOwnerField(modifiedRequest));
+        }
+    }
+
+    @Test
+    public void ownerArgumentNotAddedIfOwnerIsInCustomGroup() throws AmplifyException {
+        final AuthorizationType mode = AuthorizationType.OPENID_CONNECT;
+
+        // OwnerInCustomGroup class uses combined owner and group-based auth,
+        // and user is in the read-restricted custom group.
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<OwnerInCustomGroup> originalRequest = createRequest(OwnerInCustomGroup.class, subscriptionType);
+            GraphQLRequest<OwnerInCustomGroup> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
+    }
+
+    private <M extends Model> String getOwnerField(GraphQLRequest<M> request) {
+        if (request.getVariables().containsKey("owner")) {
+            return (String) request.getVariables().get("owner");
+        }
+        return null;
+    }
+
+    // Simple subscription request with given model class and operation
+    private <M extends Model> GraphQLRequest<M> createRequest(Class<M> clazz, Operation operation)
+            throws AmplifyException {
+        return AppSyncGraphQLRequest.builder()
+                .modelClass(clazz)
+                .operation(operation)
+                .requestOptions(new ApiGraphQLRequestOptions())
+                .responseType(clazz)
+                .build();
+    }
+
+    private static final class FakeCognitoAuthProvider implements CognitoUserPoolsAuthProvider {
+        private static final String USERNAME = "facebook-test-user";
+        private static final List<String> GROUPS = Collections.singletonList("Admins");
+
+        @Override
+        public String getLatestAuthToken() {
+            return FakeJWTToken.builder()
+                    .putPayload("username", USERNAME)
+                    .putPayload("cognito:groups", new JSONArray(GROUPS))
+                    .build()
+                    .asString();
+        }
+
+        @Override
+        public String getUsername() {
+            return USERNAME;
+        }
+    }
+
+    private static final class FakeOidcAuthProvider implements OidcAuthProvider {
+        private static final String SUB = "google-test-user";
+        private static final String APP_1_GROUP_CLAIM = "http://app1.com/claims/groups";
+        private static final String APP_2_GROUP_CLAIM = "http://app2.com/claims/groups";
+        private static final List<String> APP_1_GROUPS = Collections.singletonList("Admins");
+        private static final List<String> APP_2_GROUPS = Collections.singletonList("Editors");
+
+        @Override
+        public String getLatestAuthToken() {
+            return FakeJWTToken.builder()
+                    .putPayload("sub", SUB)
+                    .putPayload(APP_1_GROUP_CLAIM, new JSONArray(APP_1_GROUPS))
+                    .putPayload(APP_2_GROUP_CLAIM, new JSONArray(APP_2_GROUPS))
+                    .build()
+                    .asString();
+        }
+    }
+
+    @ModelConfig
+    private abstract static class NoAuth implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.PUBLIC) })
+    private abstract static class Public implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.PRIVATE) })
+    private abstract static class Private implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER) })
+    private abstract static class Owner implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.CREATE)})
+    private abstract static class OwnerCreate implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.READ)})
+    private abstract static class OwnerRead implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.UPDATE)})
+    private abstract static class OwnerUpdate implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.DELETE)})
+    private abstract static class OwnerDelete implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, identityClaim = "sub") })
+    private abstract static class OwnerOidc implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.GROUPS, groups = "Admins") })
+    private abstract static class Group implements Model {}
+
+    @ModelConfig(authRules = {
+        @AuthRule(allow = AuthStrategy.OWNER),
+        @AuthRule(allow = AuthStrategy.GROUPS, groups = "Admins")
+    })
+    private abstract static class OwnerInGroup implements Model {}
+
+    @ModelConfig(authRules = {
+        @AuthRule(allow = AuthStrategy.OWNER),
+        @AuthRule(allow = AuthStrategy.GROUPS, groups = "Editors")
+    })
+    private abstract static class OwnerNotInGroup implements Model {}
+
+    @ModelConfig(authRules = {
+        @AuthRule(allow = AuthStrategy.OWNER, identityClaim = "sub"),
+        @AuthRule(
+            allow = AuthStrategy.GROUPS,
+            groupClaim = FakeOidcAuthProvider.APP_1_GROUP_CLAIM,
+            groups = "Admins"
+        )
+    })
+    private abstract static class OwnerInCustomGroup implements Model {}
+
+    @ModelConfig(authRules = {
+        @AuthRule(allow = AuthStrategy.OWNER, identityClaim = "sub"),
+        @AuthRule(
+            allow = AuthStrategy.GROUPS,
+            groupClaim = FakeOidcAuthProvider.APP_1_GROUP_CLAIM,
+            groups = "Editors"
+        )
+    })
+    private abstract static class OwnerNotInCustomGroup implements Model {}
+}

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/auth/FakeJWTToken.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/auth/FakeJWTToken.java
@@ -117,14 +117,14 @@ public final class FakeJWTToken {
          * @return this builder instance
          */
         @NonNull
-        public Builder putPayload(@NonNull String key, @NonNull String value) {
+        public Builder putPayload(@NonNull String key, @NonNull Object value) {
             Objects.requireNonNull(key);
             Objects.requireNonNull(value);
             try {
                 payload.put(key, value);
             } catch (JSONException exception) {
                 payload.remove(key);
-                return putHeader(key, value);
+                return putPayload(key, value);
             }
             return this;
         }


### PR DESCRIPTION
*Description of changes:*
Simple refactor to move the owner-based auth logic out of API plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
