### PR TITLE
chore(aws-api): refactor owner-based auth unit tests

### DIFF
--- a/aws-api/src/test/java/com/amplifyframework/OwnerBasedAuthTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/OwnerBasedAuthTest.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.aws.AWSApiPlugin;
+import com.amplifyframework.api.aws.ApiAuthProviders;
+import com.amplifyframework.api.aws.ApiGraphQLRequestOptions;
+import com.amplifyframework.api.aws.AppSyncGraphQLRequest;
+import com.amplifyframework.api.aws.sigv4.CognitoUserPoolsAuthProvider;
+import com.amplifyframework.api.aws.sigv4.OidcAuthProvider;
+import com.amplifyframework.api.graphql.GraphQLOperation;
+import com.amplifyframework.api.graphql.GraphQLRequest;
+import com.amplifyframework.api.graphql.Operation;
+import com.amplifyframework.api.graphql.SubscriptionType;
+import com.amplifyframework.api.graphql.model.ModelSubscription;
+import com.amplifyframework.core.NoOpConsumer;
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.testmodels.ownerauth.OwnerAuth;
+import com.amplifyframework.testutils.EmptyAction;
+import com.amplifyframework.testutils.Resources;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests owner-based auth for Cognito User Pools and OIDC authorized APIs.
+ */
+@RunWith(RobolectricTestRunner.class)
+public final class OwnerBasedAuthTest {
+    private static final String GRAPHQL_API_WITH_API_KEY = "graphQlApi_apiKey";
+    private static final String GRAPHQL_API_WITH_COGNITO = "graphQlApi_cognito";
+    private static final String GRAPHQL_API_WITH_OIDC = "graphQlApi_oidc";
+
+    private MockWebServer webServer;
+    private HttpUrl baseUrl;
+    private AWSApiPlugin plugin;
+    private CognitoUserPoolsAuthProvider cognitoProvider;
+    private OidcAuthProvider oidcProvider;
+    private String apiName;
+
+    /**
+     * Sets up the test.
+     * @throws ApiException On failure to configure plugin
+     * @throws IOException On failure to start web server
+     */
+    @Before
+    public void setup() throws ApiException, IOException {
+        webServer = new MockWebServer();
+        webServer.start(8080);
+        baseUrl = webServer.url("/");
+        cognitoProvider = new FakeCognitoAuthProvider();
+        oidcProvider = new FakeOidcAuthProvider();
+        configurePlugin();
+    }
+
+    /**
+     * Stop the {@link MockWebServer} that was started in {@link #setup()}.
+     * @throws IOException On failure to shutdown the MockWebServer
+     */
+    @After
+    public void cleanup() throws IOException {
+        webServer.shutdown();
+    }
+
+    private void configurePlugin() throws ApiException {
+        ApiAuthProviders providers = ApiAuthProviders.builder()
+                .cognitoUserPoolsAuthProvider(cognitoProvider)
+                .oidcAuthProvider(oidcProvider)
+                .build();
+        JSONObject configuration = new JSONObject();
+        try {
+            configuration = configuration
+                .put(GRAPHQL_API_WITH_API_KEY, new JSONObject()
+                        .put("endpointType", "GraphQL")
+                        .put("endpoint", baseUrl.url())
+                        .put("region", "us-east-1")
+                        .put("authorizationType", "API_KEY")
+                        .put("apiKey", "FAKE-API-KEY"))
+                .put(GRAPHQL_API_WITH_COGNITO, new JSONObject()
+                        .put("endpointType", "GraphQL")
+                        .put("endpoint", baseUrl.url())
+                        .put("region", "us-east-1")
+                        .put("authorizationType", "AMAZON_COGNITO_USER_POOLS"))
+                .put(GRAPHQL_API_WITH_OIDC, new JSONObject()
+                        .put("endpointType", "GraphQL")
+                        .put("endpoint", baseUrl.url())
+                        .put("region", "us-east-1")
+                        .put("authorizationType", "OPENID_CONNECT"));
+        } catch (JSONException exception) {
+            // This shouldn't happen...
+        }
+
+        plugin = new AWSApiPlugin(providers);
+        plugin.configure(configuration, ApplicationProvider.getApplicationContext());
+    }
+
+    /**
+     * Test that owner argument fails to be appended to subscription request if
+     * the authorization mode is not OIDC compliant.
+     */
+    @Test
+    public void ownerArgumentNotAddedWithApiKey() {
+        // Set API to use API key auth mode
+        apiName = GRAPHQL_API_WITH_API_KEY;
+
+        // Attempting to subscribe to a model with owner-based auth with API key auth mode.
+        GraphQLRequest<OwnerAuth> request = ModelSubscription.onCreate(OwnerAuth.class);
+        GraphQLOperation<OwnerAuth> operation = subscribe(request);
+
+        // Subscription should fail at pre-processing
+        assertNull(operation);
+    }
+
+    /**
+     * Test that request is serialized as expected, with owner variable.
+     * @throws JSONException from JSONAssert.assertEquals
+     */
+    @Test
+    public void ownerArgumentIsAddedAndSerializedInRequest() throws JSONException {
+        // Set API to use Cognito User Pools auth mode
+        apiName = GRAPHQL_API_WITH_COGNITO;
+
+        GraphQLRequest<OwnerAuth> request = ModelSubscription.onCreate(OwnerAuth.class);
+        GraphQLOperation<OwnerAuth> operation = subscribe(request);
+
+        assertNotNull(operation);
+        JSONAssert.assertEquals(Resources.readAsString("request-owner-auth.json"),
+                operation.getRequest().getContent(),
+                true);
+    }
+
+    /**
+     * Verify that owner argument is required for all subscriptions if ModelOperation.READ is specified
+     * while using Cognito User Pools auth mode.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void ownerArgumentAddedForRestrictedReadWithUserPools() throws AmplifyException {
+        // Set API to use Cognito User Pools auth mode
+        apiName = GRAPHQL_API_WITH_COGNITO;
+
+        assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_UPDATE));
+        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_UPDATE));
+
+        assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_DELETE));
+        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_DELETE));
+
+        assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_CREATE));
+        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_CREATE));
+    }
+
+    /**
+     * Verify that owner argument is required for all subscriptions if ModelOperation.READ is specified
+     * while using OpenID Connect auth mode.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void ownerArgumentAddedForRestrictedReadWithOidc() throws AmplifyException {
+        // Set API to use OpenID Connect auth mode
+        apiName = GRAPHQL_API_WITH_OIDC;
+
+        assertTrue(isOwnerArgumentAdded(OwnerOidc.class, SubscriptionType.ON_UPDATE));
+        assertTrue(isOwnerArgumentAdded(OwnerOidc.class, SubscriptionType.ON_DELETE));
+        assertTrue(isOwnerArgumentAdded(OwnerOidc.class, SubscriptionType.ON_CREATE));
+    }
+
+    /**
+     * Verify owner argument is NOT required if the subscription type is not one of the restricted operations.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void ownerArgumentNotAddedIfOperationNotRestrictedWithUserPools() throws AmplifyException {
+        // Set API to use Cognito User Pools auth mode
+        apiName = GRAPHQL_API_WITH_COGNITO;
+
+        assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_UPDATE));
+        assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_UPDATE));
+        assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_UPDATE));
+
+        assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_DELETE));
+        assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_DELETE));
+        assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_DELETE));
+
+        assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_CREATE));
+        assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_CREATE));
+        assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_CREATE));
+    }
+
+    /**
+     * Verify owner argument is NOT added if authStrategy is not OWNER.
+     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
+     */
+    @Test
+    public void ownerArgumentNotAddedIfNotOwnerStrategy() throws AmplifyException {
+        // Set API to use Cognito User Pools auth mode
+        apiName = GRAPHQL_API_WITH_COGNITO;
+
+        assertFalse(isOwnerArgumentAdded(Group.class, SubscriptionType.ON_CREATE));
+        assertFalse(isOwnerArgumentAdded(Group.class, SubscriptionType.ON_UPDATE));
+        assertFalse(isOwnerArgumentAdded(Group.class, SubscriptionType.ON_DELETE));
+
+        assertFalse(isOwnerArgumentAdded(Public.class, SubscriptionType.ON_CREATE));
+        assertFalse(isOwnerArgumentAdded(Public.class, SubscriptionType.ON_UPDATE));
+        assertFalse(isOwnerArgumentAdded(Public.class, SubscriptionType.ON_DELETE));
+    }
+
+    private <M extends Model> boolean isOwnerArgumentAdded(Class<M> clazz, Operation operation)
+            throws AmplifyException {
+        GraphQLRequest<M> request = createRequest(clazz, operation);
+        GraphQLOperation<M> graphQLOperation = subscribe(request);
+
+        assertNotNull(graphQLOperation);
+        final String owner = (String) graphQLOperation.getRequest()
+            .getVariables()
+            .get("owner");
+        switch (apiName) {
+            case GRAPHQL_API_WITH_COGNITO:
+                return FakeCognitoAuthProvider.USERNAME.equals(owner);
+            case GRAPHQL_API_WITH_OIDC:
+                return FakeOidcAuthProvider.SUB.equals(owner);
+            case GRAPHQL_API_WITH_API_KEY:
+                return false;
+            default:
+                throw new RuntimeException("Invalid API is being used for this test.");
+        }
+    }
+
+    // Simple subscription request with given model class and operation
+    private <M extends Model> GraphQLRequest<M> createRequest(Class<M> clazz, Operation operation)
+            throws AmplifyException {
+        return AppSyncGraphQLRequest.builder()
+            .modelClass(clazz)
+            .operation(operation)
+            .requestOptions(new ApiGraphQLRequestOptions())
+            .responseType(clazz)
+            .build();
+    }
+
+    // Simple subscription with blank callbacks
+    private <M extends Model> GraphQLOperation<M> subscribe(GraphQLRequest<M> request) {
+        return plugin.subscribe(
+            apiName,
+            request,
+            NoOpConsumer.create(),
+            NoOpConsumer.create(),
+            NoOpConsumer.create(),
+            EmptyAction.create()
+        );
+    }
+
+    private static final class FakeCognitoAuthProvider implements CognitoUserPoolsAuthProvider {
+        private static final String USERNAME = "Facebook_100003287976754";
+        private static final String ID_TOKEN = "eyJraWQiOiJnMmtYXC8rSXRmNFwvcmwyODhBSTNCMk9kNDVsdEU4" +
+                "ZUtIZmF0RkNRWEVDMmM9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiI2YTRjZjMxMi01MWM5LTQyNjAtYjRh" +
+                "ZC0wMDdjMDdkZDdmMzMiLCJjb2duaXRvOmdyb3VwcyI6WyJ1cy13ZXN0LTJfejVWM1ZQa1h5X0ZhY2Vib29" +
+                "rIiwiQWRtaW4iXSwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJhd3MuY29nbml0by5zaWduaW4udX" +
+                "Nlci5hZG1pbiBwaG9uZSBvcGVuaWQgcHJvZmlsZSBlbWFpbCIsImF1dGhfdGltZSI6MTU5OTY4MTk2Mywia" +
+                "XNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJf" +
+                "ejVWM1ZQa1h5IiwiZXhwIjoxNTk5NzU3OTE3LCJpYXQiOjE1OTk3NTQzMTcsInZlcnNpb24iOjIsImp0aSI" +
+                "6ImQyNzYxMDg3LTliNmYtNDYzMS1iYWJjLTY0ZWQzM2UyNGQzMiIsImNsaWVudF9pZCI6IjNjZDdjcGJ1N2" +
+                "huYzlka2xoMmZsamg3am0xIiwidXNlcm5hbWUiOiJGYWNlYm9va18xMDAwMDMyODc5NzY3NTQifQ.FAKE-S" +
+                "IGNATURE";
+
+        @Override
+        public String getLatestAuthToken() {
+            return ID_TOKEN;
+        }
+
+        @Override
+        public String getUsername() {
+            return USERNAME;
+        }
+    }
+
+    private static final class FakeOidcAuthProvider implements OidcAuthProvider {
+        private static final String SUB = "google-oauth2|112385265530942831934";
+        private static final String ID_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkNxUDlx" +
+                "a1RQa2s5ZHVRN042SWFXVCJ9.eyJodHRwczovL215YXBwLmNvbS9jbGFpbXMvZ3JvdXBzIjpbImFkbWlucy" +
+                "JdLCJpc3MiOiJodHRwczovL3JhcGhraW0udXMuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8M" +
+                "TEyMzg1MjY1NTMwOTQyODMxOTM0IiwiYXVkIjoiNmpSUVJueFd6blg1N3Z5TTQwSmxHZXlGdGcwdnZaMkwi" +
+                "LCJpYXQiOjE2MDMzODU1MDAsImV4cCI6MTYwMzQyMTUwMCwibm9uY2UiOiJub25jZSJ9.FAKE-SIGNATURE";
+
+        @Override
+        public String getLatestAuthToken() {
+            return ID_TOKEN;
+        }
+    }
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER) })
+    private abstract static class Owner implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.CREATE)})
+    private abstract static class OwnerCreate implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.READ)})
+    private abstract static class OwnerRead implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.UPDATE)})
+    private abstract static class OwnerUpdate implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.DELETE)})
+    private abstract static class OwnerDelete implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, identityClaim = "sub") })
+    private abstract static class OwnerOidc implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.PUBLIC) })
+    private abstract static class Public implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.GROUPS)})
+    private abstract static class Group implements Model {}
+}

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
@@ -86,7 +86,6 @@ public final class AWSApiPluginTest {
     private MockWebServer webServer;
     private HttpUrl baseUrl;
     private AWSApiPlugin plugin;
-    private CognitoUserPoolsAuthProvider authProvider;
 
     /**
      * Sets up the test.
@@ -99,32 +98,16 @@ public final class AWSApiPluginTest {
         webServer = new MockWebServer();
         webServer.start(8080);
         baseUrl = webServer.url("/");
-        authProvider = mock(CognitoUserPoolsAuthProvider.class);
-        // Returns a sample access token with the username value of "Facebook_100003287976754"
-        when(authProvider.getLatestAuthToken()).thenReturn("eyJraWQiOiJnMmtYXC8rSXRmNFwvcmwyODhBSTNCMk9kNDVsdEU" +
-                        "4ZUtIZmF0RkNRWEVDMmM9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiI2YTRjZjMxMi01MWM5LTQyNjAtYjRhZC0wMDdj" +
-                        "MDdkZDdmMzMiLCJjb2duaXRvOmdyb3VwcyI6WyJ1cy13ZXN0LTJfejVWM1ZQa1h5X0ZhY2Vib29rIiwiQWRtaW4iXSwi" +
-                        "dG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJhd3MuY29nbml0by5zaWduaW4udXNlci5hZG1pbiBwaG9uZSBvcGVu" +
-                        "aWQgcHJvZmlsZSBlbWFpbCIsImF1dGhfdGltZSI6MTU5OTY4MTk2MywiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRw" +
-                        "LnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJfejVWM1ZQa1h5IiwiZXhwIjoxNTk5NzU3OTE3LCJpYXQi" +
-                        "OjE1OTk3NTQzMTcsInZlcnNpb24iOjIsImp0aSI6ImQyNzYxMDg3LTliNmYtNDYzMS1iYWJjLTY0ZWQzM2UyNGQzMiIs" +
-                        "ImNsaWVudF9pZCI6IjNjZDdjcGJ1N2huYzlka2xoMmZsamg3am0xIiwidXNlcm5hbWUiOiJGYWNlYm9va18xMDAwMDMy" +
-                        "ODc5NzY3NTQifQ.gtINNiuOhAPG5Z-4KgT7Hppw9wYyoVF8lvFhGdAWPi0c3sQvGpTLlBlgh8NqaELai84fTOTsQT4sH" +
-                        "YwP31ik58qrIp7QQ8IOU91mXy2i3-ygsIWGEetvNaMd5ICXhTWUxg7gpKxsJQbrtH88DkO3NxAQSpGoUzlkKzJILekNn" +
-                        "H5wC5drUocg_1yHTYfwsG23QVsm-cHvNsxkzRzjS3Gr18x5jTuhflr24yOGl_fdRas8-kA5q_vMuKclnNuxCztNHOBGk" +
-                        "h-sfTaOh6C-FstV2GOuwtEknlCQqLdJUVSMQO2M4hTScGPXOr2Gz9xTX9QY0D9eNL7806LYObm5nmRd7g");
 
         JSONObject configuration = new JSONObject()
             .put("graphQlApi", new JSONObject()
                 .put("endpointType", "GraphQL")
                 .put("endpoint", baseUrl.url())
                 .put("region", "us-east-1")
-                .put("authorizationType", "AMAZON_COGNITO_USER_POOLS")
-            );
+                .put("authorizationType", "API_KEY")
+                .put("apiKey", "FAKE-API-KEY"));
 
-        this.plugin = new AWSApiPlugin(ApiAuthProviders.builder()
-                .cognitoUserPoolsAuthProvider(authProvider)
-                .build());
+        this.plugin = new AWSApiPlugin();
         this.plugin.configure(configuration, ApplicationProvider.getApplicationContext());
     }
 
@@ -283,102 +266,4 @@ public final class AWSApiPluginTest {
         String selectedApi = plugin.getSelectedApiName(EndpointType.GRAPHQL);
         assertEquals("graphQlApi", selectedApi);
     }
-
-    /**
-     * Test that request is serialized as expected, with owner variable.
-     * @throws JSONException from JSONAssert.assertEquals
-     */
-    @Test
-    public void ownerArgumentIsAddedAndSerializedInRequest() throws JSONException {
-        GraphQLRequest<OwnerAuth> request = ModelSubscription.onCreate(OwnerAuth.class);
-        GraphQLOperation<OwnerAuth> operation = plugin.subscribe(request,
-                NoOpConsumer.create(),
-                NoOpConsumer.create(),
-                NoOpConsumer.create(),
-                EmptyAction.create());
-
-        JSONAssert.assertEquals(Resources.readAsString("request-owner-auth.json"),
-                operation.getRequest().getContent(),
-                true);
-    }
-
-    /**
-     * Verify that owner argument is required for all subscriptions if ModelOperation.READ is specified.
-     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
-     */
-    @Test
-    public void ownerArgumentAddedForRestrictedRead() throws AmplifyException {
-        assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_UPDATE));
-        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_UPDATE));
-
-        assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_DELETE));
-        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_DELETE));
-
-        assertTrue(isOwnerArgumentAdded(Owner.class, SubscriptionType.ON_CREATE));
-        assertTrue(isOwnerArgumentAdded(OwnerRead.class, SubscriptionType.ON_CREATE));
-    }
-
-    /**
-     * Verify owner argument is NOT required if the subscription type is not one of the restricted operations.
-     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
-     */
-    @Test
-    public void ownerArgumentNotAddedIfOperationNotRestricted() throws AmplifyException {
-        assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_UPDATE));
-        assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_UPDATE));
-        assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_UPDATE));
-
-        assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_DELETE));
-        assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_DELETE));
-        assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_DELETE));
-
-        assertFalse(isOwnerArgumentAdded(OwnerCreate.class, SubscriptionType.ON_CREATE));
-        assertFalse(isOwnerArgumentAdded(OwnerUpdate.class, SubscriptionType.ON_CREATE));
-        assertFalse(isOwnerArgumentAdded(OwnerDelete.class, SubscriptionType.ON_CREATE));
-    }
-
-    /**
-     * Verify owner argument is NOT added if authStrategy is not OWNER.
-     * @throws AmplifyException if a ModelSchema can't be derived from the Model class.
-     */
-    @Test
-    public void ownerArgumentNotAddedIfNotOwnerStrategy() throws AmplifyException {
-        assertFalse(isOwnerArgumentAdded(Group.class, SubscriptionType.ON_CREATE));
-    }
-
-    private boolean isOwnerArgumentAdded(Class<? extends Model> clazz, Operation operation)
-            throws AmplifyException {
-        AppSyncGraphQLRequest<Model> request = AppSyncGraphQLRequest.builder()
-                .modelClass(clazz)
-                .operation(operation)
-                .requestOptions(new ApiGraphQLRequestOptions())
-                .responseType(clazz)
-                .build();
-
-        GraphQLOperation<Model> graphQLOperation = plugin.subscribe(request,
-                NoOpConsumer.create(),
-                NoOpConsumer.create(),
-                NoOpConsumer.create(),
-                EmptyAction.create());
-
-        return "Facebook_100003287976754".equals(graphQLOperation.getRequest().getVariables().get("owner"));
-    }
-
-    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER) })
-    private abstract class Owner implements Model { }
-
-    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.CREATE)})
-    private abstract class OwnerCreate implements Model { }
-
-    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.READ)})
-    private abstract class OwnerRead implements Model { }
-
-    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.UPDATE)})
-    private abstract class OwnerUpdate implements Model { }
-
-    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER, operations = ModelOperation.DELETE)})
-    private abstract class OwnerDelete implements Model { }
-
-    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.GROUPS)})
-    private abstract class Group implements Model { }
 }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
@@ -17,34 +17,20 @@ package com.amplifyframework.api.aws;
 
 import androidx.test.core.app.ApplicationProvider;
 
-import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
-import com.amplifyframework.api.aws.sigv4.CognitoUserPoolsAuthProvider;
 import com.amplifyframework.api.events.ApiChannelEventName;
 import com.amplifyframework.api.events.ApiEndpointStatusChangeEvent;
-import com.amplifyframework.api.graphql.GraphQLOperation;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
-import com.amplifyframework.api.graphql.Operation;
 import com.amplifyframework.api.graphql.PaginatedResult;
-import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.api.graphql.model.ModelMutation;
 import com.amplifyframework.api.graphql.model.ModelPagination;
 import com.amplifyframework.api.graphql.model.ModelQuery;
-import com.amplifyframework.api.graphql.model.ModelSubscription;
 import com.amplifyframework.core.Consumer;
-import com.amplifyframework.core.NoOpConsumer;
-import com.amplifyframework.core.model.AuthStrategy;
-import com.amplifyframework.core.model.Model;
-import com.amplifyframework.core.model.ModelOperation;
-import com.amplifyframework.core.model.annotations.AuthRule;
-import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
-import com.amplifyframework.testmodels.ownerauth.OwnerAuth;
 import com.amplifyframework.testutils.Await;
-import com.amplifyframework.testutils.EmptyAction;
 import com.amplifyframework.testutils.HubAccumulator;
 import com.amplifyframework.testutils.Resources;
 import com.amplifyframework.testutils.random.RandomString;
@@ -56,7 +42,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -72,11 +57,8 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests the {@link AWSApiPlugin}.

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/auth/FakeJWTToken.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/auth/FakeJWTToken.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws.auth;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Utility class to easily generate a fake JWT token with desired header and payload.
+ * This class is not equipped to generate and append a valid signature to the token.
+ */
+public final class FakeJWTToken {
+    private final String token;
+
+    private FakeJWTToken(String token) {
+        this.token = token;
+    }
+
+    /**
+     * Get the generated JWT token string.
+     * @return the generated token
+     */
+    public String asString() {
+        return token;
+    }
+
+    /**
+     * Get the builder instance for constructing a token.
+     * @return the builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder instance to specify the contents of a generated JWT token.
+     */
+    public static final class Builder {
+        private static final String TOKEN_SEPARATOR = ".";
+        private static final String DEFAULT_SIGNATURE = "FAKE-SIGNATURE";
+        private JSONObject header;
+        private JSONObject payload;
+        private String signature;
+
+        private Builder() {
+            this.header = new JSONObject();
+            this.payload = new JSONObject();
+            this.signature = DEFAULT_SIGNATURE;
+        }
+
+        /**
+         * Sets the header and return self for chaining.
+         * @param header the token header json
+         * @return this builder instance
+         */
+        @NonNull
+        public Builder setHeader(@NonNull JSONObject header) {
+            this.header = Objects.requireNonNull(header);
+            return this;
+        }
+
+        /**
+         * Sets the payload and return self for chaining.
+         * @param payload the token payload json
+         * @return this builder instance
+         */
+        @NonNull
+        public Builder setPayload(@NonNull JSONObject payload) {
+            this.payload = Objects.requireNonNull(payload);
+            return this;
+        }
+
+        /**
+         * Put a key-value pair to the header and return self for chaining.
+         * If the key already exists, then update the value.
+         * @param key key to add to header
+         * @param value value that corresponds with the key
+         * @return this builder instance
+         */
+        @NonNull
+        public Builder putHeader(@NonNull String key, @NonNull String value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            try {
+                header.put(key, value);
+            } catch (JSONException exception) {
+                header.remove(key);
+                return putHeader(key, value);
+            }
+            return this;
+        }
+
+        /**
+         * Put a key-value pair to the payload and return self for chaining.
+         * If the key already exists, then update the value.
+         * @param key key to add to header
+         * @param value value that corresponds with the key
+         * @return this builder instance
+         */
+        @NonNull
+        public Builder putPayload(@NonNull String key, @NonNull String value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            try {
+                payload.put(key, value);
+            } catch (JSONException exception) {
+                payload.remove(key);
+                return putHeader(key, value);
+            }
+            return this;
+        }
+
+        /**
+         * Sets the signature string and return self for chaining.
+         * Defaults to "FAKE-SIGNATURE".
+         * @param signature the signature for validation
+         * @return this builder instance
+         */
+        @NonNull
+        public Builder setSignature(@NonNull String signature) {
+            this.signature = Objects.requireNonNull(signature);
+            return this;
+        }
+
+        /**
+         * Generate a fake JWT token with the contents of this builder.
+         * @return a fake JWT token
+         */
+        @NonNull
+        public FakeJWTToken build() {
+            String token = base64Encode(header) +
+                    TOKEN_SEPARATOR +
+                    base64Encode(payload) +
+                    TOKEN_SEPARATOR +
+                    signature;
+            return new FakeJWTToken(token);
+        }
+
+        private String base64Encode(JSONObject json) {
+            byte[] bytes = json.toString().getBytes(StandardCharsets.UTF_8);
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+    }
+}

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/auth/OwnerBasedAuthTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/auth/OwnerBasedAuthTest.java
@@ -286,21 +286,14 @@ public final class OwnerBasedAuthTest {
     }
 
     private static final class FakeCognitoAuthProvider implements CognitoUserPoolsAuthProvider {
-        private static final String USERNAME = "Facebook_100003287976754";
-        private static final String ID_TOKEN = "eyJraWQiOiJnMmtYXC8rSXRmNFwvcmwyODhBSTNCMk9kNDVsdEU4" +
-                "ZUtIZmF0RkNRWEVDMmM9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiI2YTRjZjMxMi01MWM5LTQyNjAtYjRh" +
-                "ZC0wMDdjMDdkZDdmMzMiLCJjb2duaXRvOmdyb3VwcyI6WyJ1cy13ZXN0LTJfejVWM1ZQa1h5X0ZhY2Vib29" +
-                "rIiwiQWRtaW4iXSwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJhd3MuY29nbml0by5zaWduaW4udX" +
-                "Nlci5hZG1pbiBwaG9uZSBvcGVuaWQgcHJvZmlsZSBlbWFpbCIsImF1dGhfdGltZSI6MTU5OTY4MTk2Mywia" +
-                "XNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJf" +
-                "ejVWM1ZQa1h5IiwiZXhwIjoxNTk5NzU3OTE3LCJpYXQiOjE1OTk3NTQzMTcsInZlcnNpb24iOjIsImp0aSI" +
-                "6ImQyNzYxMDg3LTliNmYtNDYzMS1iYWJjLTY0ZWQzM2UyNGQzMiIsImNsaWVudF9pZCI6IjNjZDdjcGJ1N2" +
-                "huYzlka2xoMmZsamg3am0xIiwidXNlcm5hbWUiOiJGYWNlYm9va18xMDAwMDMyODc5NzY3NTQifQ.FAKE-S" +
-                "IGNATURE";
+        private static final String USERNAME = "facebook-test-user";
 
         @Override
         public String getLatestAuthToken() {
-            return ID_TOKEN;
+            return FakeJWTToken.builder()
+                    .putPayload("username", USERNAME)
+                    .build()
+                    .asString();
         }
 
         @Override
@@ -310,16 +303,14 @@ public final class OwnerBasedAuthTest {
     }
 
     private static final class FakeOidcAuthProvider implements OidcAuthProvider {
-        private static final String SUB = "google-oauth2|112385265530942831934";
-        private static final String ID_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkNxUDlx" +
-                "a1RQa2s5ZHVRN042SWFXVCJ9.eyJodHRwczovL215YXBwLmNvbS9jbGFpbXMvZ3JvdXBzIjpbImFkbWlucy" +
-                "JdLCJpc3MiOiJodHRwczovL3JhcGhraW0udXMuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8M" +
-                "TEyMzg1MjY1NTMwOTQyODMxOTM0IiwiYXVkIjoiNmpSUVJueFd6blg1N3Z5TTQwSmxHZXlGdGcwdnZaMkwi" +
-                "LCJpYXQiOjE2MDMzODU1MDAsImV4cCI6MTYwMzQyMTUwMCwibm9uY2UiOiJub25jZSJ9.FAKE-SIGNATURE";
+        private static final String SUB = "google-test-user";
 
         @Override
         public String getLatestAuthToken() {
-            return ID_TOKEN;
+            return FakeJWTToken.builder()
+                    .putPayload("sub", SUB)
+                    .build()
+                    .asString();
         }
     }
 
@@ -346,4 +337,15 @@ public final class OwnerBasedAuthTest {
 
     @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.GROUPS)})
     private abstract static class Group implements Model {}
+
+    @ModelConfig(authRules = {
+            @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "http://myapp.com/claims/groups")
+    })
+    private abstract static class GroupCustomClaim implements Model {}
+
+    @ModelConfig(authRules = {
+            @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "http://app1.com/claims/groups"),
+            @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "http://app2.com/claims/groups")
+    })
+    private abstract static class GroupMultiClaims implements Model {}
 }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/auth/OwnerBasedAuthTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/auth/OwnerBasedAuthTest.java
@@ -13,10 +13,11 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework;
+package com.amplifyframework.api.aws.auth;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.aws.AWSApiPlugin;
 import com.amplifyframework.api.aws.ApiAuthProviders;

--- a/aws-api/src/test/resources/request-owner-auth.json
+++ b/aws-api/src/test/resources/request-owner-auth.json
@@ -1,6 +1,6 @@
 {
   "query": "subscription OnCreateOwnerAuth($owner: String!) {\n  onCreateOwnerAuth(owner: $owner) {\n    id\n    title\n  }\n}\n",
   "variables": {
-    "owner": "Facebook_100003287976754"
+    "owner": "facebook-test-user"
   }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -86,9 +86,9 @@ public final class AuthRule {
      * Used to specify a custom claim.
      * Defaults to "username" when using AuthStrategy.OWNER.
      *
-     * Note: CLI has been incorrectly generating a value of "cognito:username"
-     * so we also check for this incorrect default value and convert it to the
-     * proper default of "username".
+     * Note: An older version of the CLI incorrectly generated a value of "cognito:username"
+     * so we also check for this value and convert it to the proper default of "username" for 
+     * backwards compatibility.
      *
      * @return identity claim
      */

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -144,6 +144,8 @@ public final class AuthRule {
      */
     @NonNull
     public List<ModelOperation> getOperationsOrDefault() {
+        // Default to returning a list of every ModelOperation:
+        // CREATE, READ, UPDATE, DELETE
         return Immutable.of(Empty.check(operations)
             ? Arrays.asList(ModelOperation.values())
             : operations);
@@ -161,7 +163,7 @@ public final class AuthRule {
 
         AuthRule authRule = (AuthRule) object;
 
-        return ObjectsCompat.equals(authStrategy, authRule.authStrategy) &&
+        return authStrategy == authRule.authStrategy &&
                 ObjectsCompat.equals(ownerField, authRule.ownerField) &&
                 ObjectsCompat.equals(identityClaim, authRule.identityClaim) &&
                 ObjectsCompat.equals(groupsField, authRule.groupsField) &&

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -15,9 +15,11 @@
 
 package com.amplifyframework.core.model;
 
+import androidx.annotation.NonNull;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.util.Empty;
+import com.amplifyframework.util.Immutable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,12 +32,17 @@ import java.util.List;
  * documentation.</a>
  */
 public final class AuthRule {
+    private static final String DEFAULT_OWNER_FIELD = "owner";
+    private static final String DEFAULT_IDENTITY_CLAIM = "username";
+    private static final String DEFAULT_GROUPS_FIELD = "groups";
+    private static final String DEFAULT_GROUP_CLAIM = "cognito:groups";
+
     private final AuthStrategy authStrategy;
     private final String ownerField;
     private final String identityClaim;
+    private final String groupsField;
     private final String groupClaim;
     private final List<String> groups;
-    private final String groupsField;
     private final List<ModelOperation> operations;
 
     /**
@@ -57,39 +64,67 @@ public final class AuthRule {
      * Returns the type of strategy for this {@link AuthRule}.
      * @return the type of strategy for this {@link AuthRule}
      */
+    @NonNull
     public AuthStrategy getAuthStrategy() {
-        return this.authStrategy;
+        return authStrategy;
     }
 
     /**
-     * Used for owner authorization.  Defaults to "owner" when using AuthStrategy.OWNER.
+     * Used for owner authorization.
+     * Defaults to "owner" when using {@link AuthStrategy#OWNER}.
      *
      * @return name of a {@link ModelField} of type String which specifies the user which should have access
      */
+    @NonNull
     public String getOwnerFieldOrDefault() {
-        return Empty.check(this.ownerField) ? "owner" : this.ownerField;
+        return Empty.check(ownerField)
+            ? DEFAULT_OWNER_FIELD
+            : ownerField;
     }
 
     /**
-     * Used to specify a custom claim.  Defaults to "username" when using AuthStrategy.OWNER.
-     * CLI has been incorrectly generating a value of "cognito:username" so we also check for this incorrect default
-     * value and convert it to the proper default of "username".
+     * Used to specify a custom claim.
+     * Defaults to "username" when using AuthStrategy.OWNER.
+     *
+     * Note: CLI has been incorrectly generating a value of "cognito:username"
+     * so we also check for this incorrect default value and convert it to the
+     * proper default of "username".
      *
      * @return identity claim
      */
+    @NonNull
     public String getIdentityClaimOrDefault() {
-        return Empty.check(this.identityClaim) || "cognito:username".equals(this.identityClaim) ?
-                "username" :
-                this.identityClaim;
+        final String cliGeneratedIdentityClaim = "cognito:username";
+        return Empty.check(identityClaim) || cliGeneratedIdentityClaim.equals(identityClaim)
+            ? DEFAULT_IDENTITY_CLAIM
+            : identityClaim;
     }
 
     /**
-     * Used to specify a custom claim.   Defaults to "cognito:groups" when using AuthStrategy.GROUPS.
+     * Used for dynamic group authorization.
+     * Defaults to "groups" when using AuthStrategy.GROUPS.
+     *
+     * @return name of a {@link ModelField} of type String or array of Strings which specifies a group or list of groups
+     * which should have access.
+     */
+    @NonNull
+    public String getGroupsFieldOrDefault() {
+        return Empty.check(groupsField)
+            ? DEFAULT_GROUPS_FIELD
+            : groupsField;
+    }
+
+    /**
+     * Used to specify a custom claim.
+     * Defaults to "cognito:groups" when using AuthStrategy.GROUPS.
      *
      * @return group claim
      */
-    public String getGroupClaim() {
-        return this.groupClaim;
+    @NonNull
+    public String getGroupClaimOrDefault() {
+        return Empty.check(groupClaim)
+            ? DEFAULT_GROUP_CLAIM
+            : groupClaim;
     }
 
     /**
@@ -97,18 +132,9 @@ public final class AuthRule {
      *
      * @return array of groups which should have access
      */
+    @NonNull
     public List<String> getGroups() {
-        return this.groups;
-    }
-
-    /**
-     * Used for dynamic group authorization.  Defaults to "groups" when using AuthStrategy.GROUPS.
-     *
-     * @return name of a {@link ModelField} of type String or array of Strings which specifies a group or list of groups
-     * which should have access.
-     */
-    public String getGroupsFieldOrDefault() {
-        return Empty.check(this.groupsField) ? "groups" : this.groupsField;
+        return Immutable.of(groups);
     }
 
     /**
@@ -116,15 +142,11 @@ public final class AuthRule {
      * the list are not protected by default.
      * @return list of {@link ModelOperation}s for which this {@link AuthRule} should apply.
      */
+    @NonNull
     public List<ModelOperation> getOperationsOrDefault() {
-        if (Empty.check(this.operations)) {
-            return Arrays.asList(
-                    ModelOperation.CREATE,
-                    ModelOperation.UPDATE,
-                    ModelOperation.DELETE,
-                    ModelOperation.READ);
-        }
-        return this.operations;
+        return Immutable.of(Empty.check(operations)
+            ? Arrays.asList(ModelOperation.values())
+            : operations);
     }
 
     @Override
@@ -139,18 +161,26 @@ public final class AuthRule {
 
         AuthRule authRule = (AuthRule) object;
 
-        return authStrategy == authRule.authStrategy &&
+        return ObjectsCompat.equals(authStrategy, authRule.authStrategy) &&
                 ObjectsCompat.equals(ownerField, authRule.ownerField) &&
                 ObjectsCompat.equals(identityClaim, authRule.identityClaim) &&
+                ObjectsCompat.equals(groupsField, authRule.groupsField) &&
                 ObjectsCompat.equals(groupClaim, authRule.groupClaim) &&
                 ObjectsCompat.equals(groups, authRule.groups) &&
-                ObjectsCompat.equals(groupsField, authRule.groupsField) &&
                 ObjectsCompat.equals(operations, authRule.operations);
     }
 
     @Override
     public int hashCode() {
-        return ObjectsCompat.hash(authStrategy, ownerField, identityClaim, groupClaim, groups, groupsField, operations);
+        return ObjectsCompat.hash(
+                authStrategy,
+                ownerField,
+                identityClaim,
+                groupsField,
+                groupClaim,
+                groups,
+                operations
+        );
     }
 
     @Override
@@ -159,9 +189,9 @@ public final class AuthRule {
                 "authStrategy=" + authStrategy +
                 ", ownerField='" + ownerField + '\'' +
                 ", identityClaim='" + identityClaim + '\'' +
+                ", groupsField='" + groupsField + '\'' +
                 ", groupClaim='" + groupClaim + '\'' +
                 ", groups=" + groups + '\'' +
-                ", groupsField='" + groupsField + '\'' +
                 ", operations=" + operations + '\'' +
                 '}';
     }


### PR DESCRIPTION
*Description of changes:*
* Refactor `AuthRule` (remnant from #903)
* Isolated the owner-based auth related tests from `AWSApiPluginTest`
* Refactor test structure to allow testing for different types of auth modes
* Implement `FakeJWTToken` generator to replace potentially sensitive actual ID tokens
* Add unit tests to confirm that owner field is added correctly for OIDC usecase

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
