### PR TITLE
fix(api): Add owner field to selection set if implicitly defined

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
@@ -22,6 +22,8 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.Operation;
 import com.amplifyframework.api.graphql.QueryType;
+import com.amplifyframework.core.model.AuthRule;
+import com.amplifyframework.core.model.AuthStrategy;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.types.JavaFieldType;
@@ -243,6 +245,12 @@ public final class SelectionSet {
                     result.add(new SelectionSet(fieldName, getNestedCustomTypeFields(getClassForField(field))));
                 } else {
                     result.add(new SelectionSet(fieldName, null));
+                }
+                for (AuthRule authRule : schema.getAuthRules()) {
+                    if (AuthStrategy.OWNER.equals(authRule.getAuthStrategy())) {
+                        result.add(new SelectionSet(authRule.getOwnerFieldOrDefault(), null));
+                        break;
+                    }
                 }
             }
             for (String fieldName : requestOptions.modelMetaFields()) {

--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
@@ -60,19 +60,28 @@ public final class SelectionSet {
     }
 
     /**
+     * Constructor for a leaf node (no children).
+     * @param value String value of the field.
+     */
+    public SelectionSet(String value) {
+        this(value, Collections.emptySet());
+    }
+
+    /**
      * Default constructor.
      * @param value String value of the field
      * @param nodes Set of child nodes
      */
-    public SelectionSet(String value, Set<SelectionSet> nodes) {
+    public SelectionSet(String value, @NonNull Set<SelectionSet> nodes) {
         this.value = value;
-        this.nodes = nodes;
+        this.nodes = Objects.requireNonNull(nodes);
     }
 
     /**
      * Returns child nodes.
      * @return child nodes
      */
+    @NonNull
     public Set<SelectionSet> getNodes() {
         return nodes;
     }
@@ -207,7 +216,7 @@ public final class SelectionSet {
             Set<SelectionSet> paginatedSet = new HashSet<>();
             paginatedSet.add(new SelectionSet(requestOptions.listField(), nodes));
             for (String metaField : requestOptions.paginationFields()) {
-                paginatedSet.add(new SelectionSet(metaField, null));
+                paginatedSet.add(new SelectionSet(metaField));
             }
             return paginatedSet;
         }
@@ -222,7 +231,7 @@ public final class SelectionSet {
             Set<SelectionSet> result = new HashSet<>();
 
             if (depth == 0 && LeafSerializationBehavior.JUST_ID.equals(requestOptions.leafSerializationBehavior())) {
-                result.add(new SelectionSet("id", null));
+                result.add(new SelectionSet("id"));
                 return result;
             }
 
@@ -244,17 +253,17 @@ public final class SelectionSet {
                 } else if (isCustomType(field)) {
                     result.add(new SelectionSet(fieldName, getNestedCustomTypeFields(getClassForField(field))));
                 } else {
-                    result.add(new SelectionSet(fieldName, null));
+                    result.add(new SelectionSet(fieldName));
                 }
                 for (AuthRule authRule : schema.getAuthRules()) {
                     if (AuthStrategy.OWNER.equals(authRule.getAuthStrategy())) {
-                        result.add(new SelectionSet(authRule.getOwnerFieldOrDefault(), null));
+                        result.add(new SelectionSet(authRule.getOwnerFieldOrDefault()));
                         break;
                     }
                 }
             }
             for (String fieldName : requestOptions.modelMetaFields()) {
-                result.add(new SelectionSet(fieldName, null));
+                result.add(new SelectionSet(fieldName));
             }
             return result;
         }
@@ -271,7 +280,7 @@ public final class SelectionSet {
                 if (isCustomType(field)) {
                     result.add(new SelectionSet(fieldName, getNestedCustomTypeFields(getClassForField(field))));
                 } else {
-                    result.add(new SelectionSet(fieldName, null));
+                    result.add(new SelectionSet(fieldName));
                 }
             }
             return result;

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
@@ -18,6 +18,8 @@ package com.amplifyframework.api.aws;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.QueryType;
 import com.amplifyframework.testmodels.commentsblog.Post;
+import com.amplifyframework.testmodels.ownerauth.OwnerAuth;
+import com.amplifyframework.testmodels.ownerauth.OwnerAuthExplicit;
 import com.amplifyframework.testmodels.parenting.Parent;
 import com.amplifyframework.testutils.Resources;
 
@@ -55,5 +57,33 @@ public class SelectionSetTest {
                 .requestOptions(new DefaultGraphQLRequestOptions())
                 .build();
         assertEquals(Resources.readAsString("selection-set-parent.txt"), selectionSet.toString() + "\n");
+    }
+
+    /**
+     * Test that owner field is added to selection set when a model has an @{link AuthStrategy.OWNER} auth strategy.
+     * @throws AmplifyException if a ModelSchema can't be derived from OwnerAuth.class
+     */
+    @Test
+    public void ownerFieldAddedForImplicitOwnerAuth() throws AmplifyException {
+        SelectionSet selectionSet = SelectionSet.builder()
+                .modelClass(OwnerAuth.class)
+                .operation(QueryType.GET)
+                .requestOptions(new DefaultGraphQLRequestOptions())
+                .build();
+        assertEquals(Resources.readAsString("selection-set-ownerauth.txt"), selectionSet.toString() + "\n");
+    }
+
+    /**
+     * Test that if owner field is explicitly defined on the model, the selection set is built without any errors.
+     * @throws AmplifyException if a ModelSchema can't be derived from OwnerAuth.class
+     */
+    @Test
+    public void ownerFieldNotAddedForExplicitOwnerAuth() throws AmplifyException {
+        SelectionSet selectionSet = SelectionSet.builder()
+                .modelClass(OwnerAuthExplicit.class)
+                .operation(QueryType.GET)
+                .requestOptions(new DefaultGraphQLRequestOptions())
+                .build();
+        assertEquals(Resources.readAsString("selection-set-ownerauth.txt"), selectionSet.toString() + "\n");
     }
 }

--- a/aws-api-appsync/src/test/resources/selection-set-ownerauth.txt
+++ b/aws-api-appsync/src/test/resources/selection-set-ownerauth.txt
@@ -1,0 +1,5 @@
+ {
+  id
+  owner
+  title
+}

--- a/aws-api/src/test/resources/request-owner-auth.json
+++ b/aws-api/src/test/resources/request-owner-auth.json
@@ -1,5 +1,5 @@
 {
-  "query": "subscription OnCreateOwnerAuth($owner: String!) {\n  onCreateOwnerAuth(owner: $owner) {\n    id\n    title\n  }\n}\n",
+  "query": "subscription OnCreateOwnerAuth($owner: String!) {\n  onCreateOwnerAuth(owner: $owner) {\n    id\n    owner\n    title\n  }\n}\n",
   "variables": {
     "owner": "Facebook_100003287976754"
   }

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/ownerauth/OwnerAuthExplicit.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/ownerauth/OwnerAuthExplicit.java
@@ -1,0 +1,198 @@
+package com.amplifyframework.testmodels.ownerauth;
+
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the OwnerAuthExplicit type in your schema. */
+@SuppressWarnings("all")
+@ModelConfig(pluralName = "OwnerAuthExplicits", authRules = {
+        @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+})
+public final class OwnerAuthExplicit implements Model {
+    public static final QueryField ID = field("id");
+    public static final QueryField TITLE = field("title");
+    public static final QueryField OWNER = field("owner");
+    private final @ModelField(targetType="ID", isRequired = true) String id;
+    private final @ModelField(targetType="String", isRequired = true) String title;
+    private final @ModelField(targetType="String") String owner;
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    private OwnerAuthExplicit(String id, String title, String owner) {
+        this.id = id;
+        this.title = title;
+        this.owner = owner;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if(obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            OwnerAuthExplicit ownerAuthExplicit = (OwnerAuthExplicit) obj;
+            return ObjectsCompat.equals(getId(), ownerAuthExplicit.getId()) &&
+                    ObjectsCompat.equals(getTitle(), ownerAuthExplicit.getTitle()) &&
+                    ObjectsCompat.equals(getOwner(), ownerAuthExplicit.getOwner());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return new StringBuilder()
+                .append(getId())
+                .append(getTitle())
+                .append(getOwner())
+                .toString()
+                .hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("OwnerAuthExplicit {")
+                .append("id=" + String.valueOf(getId()) + ", ")
+                .append("title=" + String.valueOf(getTitle()) + ", ")
+                .append("owner=" + String.valueOf(getOwner()))
+                .append("}")
+                .toString();
+    }
+
+    public static TitleStep builder() {
+        return new Builder();
+    }
+
+    /**
+     * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+     * This is a convenience method to return an instance of the object with only its ID populated
+     * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+     * in a relationship.
+     * @param id the id of the existing item this instance will represent
+     * @return an instance of this model with only ID populated
+     * @throws IllegalArgumentException Checks that ID is in the proper format
+     */
+    public static OwnerAuthExplicit justId(String id) {
+        try {
+            UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+        } catch (Exception exception) {
+            throw new IllegalArgumentException(
+                    "Model IDs must be unique in the format of UUID. This method is for creating instances " +
+                            "of an existing object with only its ID field for sending as a mutation parameter. When " +
+                            "creating a new object, use the standard builder method and leave the ID field blank."
+            );
+        }
+        return new OwnerAuthExplicit(
+                id,
+                null,
+                null
+        );
+    }
+
+    public CopyOfBuilder copyOfBuilder() {
+        return new CopyOfBuilder(id,
+                title,
+                owner);
+    }
+    public interface TitleStep {
+        BuildStep title(String title);
+    }
+
+
+    public interface BuildStep {
+        OwnerAuthExplicit build();
+        BuildStep id(String id) throws IllegalArgumentException;
+        BuildStep owner(String owner);
+    }
+
+
+    public static class Builder implements TitleStep, BuildStep {
+        private String id;
+        private String title;
+        private String owner;
+        @Override
+        public OwnerAuthExplicit build() {
+            String id = this.id != null ? this.id : UUID.randomUUID().toString();
+
+            return new OwnerAuthExplicit(
+                    id,
+                    title,
+                    owner);
+        }
+
+        @Override
+        public BuildStep title(String title) {
+            Objects.requireNonNull(title);
+            this.title = title;
+            return this;
+        }
+
+        @Override
+        public BuildStep owner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        /**
+         * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
+         * This should only be set when referring to an already existing object.
+         * @param id id
+         * @return Current Builder instance, for fluent method chaining
+         * @throws IllegalArgumentException Checks that ID is in the proper format
+         */
+        public BuildStep id(String id) throws IllegalArgumentException {
+            this.id = id;
+
+            try {
+                UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+            } catch (Exception exception) {
+                throw new IllegalArgumentException("Model IDs must be unique in the format of UUID.",
+                        exception);
+            }
+
+            return this;
+        }
+    }
+
+
+    public final class CopyOfBuilder extends Builder {
+        private CopyOfBuilder(String id, String title, String owner) {
+            super.id(id);
+            super.title(title)
+                    .owner(owner);
+        }
+
+        @Override
+        public CopyOfBuilder title(String title) {
+            return (CopyOfBuilder) super.title(title);
+        }
+
+        @Override
+        public CopyOfBuilder owner(String owner) {
+            return (CopyOfBuilder) super.owner(owner);
+        }
+    }
+
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/ownerauth/schema.graphql
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/ownerauth/schema.graphql
@@ -5,6 +5,14 @@ type OwnerAuth @model
   title: String!
 }
 
+type OwnerAuthExplicit @model
+@auth(rules: [{ allow: owner }])
+{
+  id: ID!
+  title: String!
+  owner: String
+}
+
 
 type OwnerAuthReadUpdateOnly @model
 @auth(rules: [{ allow: owner, operations: [create, delete] }])


### PR DESCRIPTION
This PR fixes a bug where subscriptions will not be received at all for the schema below.    The fix is to modify the request for mutations to include the owner field to the selection set.  This ensures that when the mutation is broadcast out to the subscription listeners, the owner field will be hydrated, so it won't be filtered out, because it will be able to validate that the user is authorized to view this object.

```
type Post @model @auth(rules: [{ allow: owner }])
{
  id: ID!
  title: String!
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
