### PR TITLE
chore(aws-datastore): clarify hub event names

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AWSDataStorePluginInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AWSDataStorePluginInstrumentedTest.java
@@ -30,7 +30,7 @@ import com.amplifyframework.datastore.appsync.AppSyncClient;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.appsync.SynchronousAppSync;
-import com.amplifyframework.datastore.syncengine.PendingMutation;
+import com.amplifyframework.datastore.syncengine.OutboxMutationEvent;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.hub.HubEventFilter;
@@ -195,34 +195,42 @@ public final class AWSDataStorePluginInstrumentedTest {
     private <T extends Model> HubEventFilter publicationOf(T model) {
         return event -> {
             DataStoreChannelEventName actualEventName = DataStoreChannelEventName.fromString(event.getName());
-            if (!DataStoreChannelEventName.PUBLISHED_TO_CLOUD.equals(actualEventName)) {
+            if (!DataStoreChannelEventName.OUTBOX_MUTATION_PROCESSED.equals(actualEventName)) {
                 return false;
             }
-            @SuppressWarnings("unchecked")
-            PendingMutation<T> pendingMutation = (PendingMutation<T>) event.getData();
-            if (pendingMutation == null) {
-                return false;
-            } else if (!model.getClass().isAssignableFrom(pendingMutation.getMutatedItem().getClass())) {
-                return false;
-            }
-            return model.getId().equals(pendingMutation.getMutatedItem().getId());
+            return hasModelData(model, (OutboxMutationEvent<? extends Model>) event.getData());
         };
     }
 
     private <T extends Model> HubEventFilter receiptOf(T model) {
         return event -> {
             DataStoreChannelEventName actualEventName = DataStoreChannelEventName.fromString(event.getName());
-            if (!DataStoreChannelEventName.RECEIVED_FROM_CLOUD.equals(actualEventName)) {
+            if (!DataStoreChannelEventName.SUBSCRIPTION_DATA_PROCESSED.equals(actualEventName)) {
                 return false;
             }
-            @SuppressWarnings("unchecked")
-            ModelWithMetadata<T> modelWithMetadata = (ModelWithMetadata<T>) event.getData();
-            if (modelWithMetadata == null) {
-                return false;
-            } else if (!model.getClass().isAssignableFrom(modelWithMetadata.getModel().getClass())) {
-                return false;
-            }
-            return model.getId().equals(modelWithMetadata.getModel().getId());
+            return hasModelData(model, (ModelWithMetadata<? extends Model>) event.getData());
         };
+    }
+
+    private static <T extends Model> boolean hasModelData(
+            T model, OutboxMutationEvent<? extends Model> mutationEvent) {
+        if (mutationEvent == null) {
+            return false;
+        }
+        if (!model.getClass().isAssignableFrom(mutationEvent.getModel())) {
+            return false;
+        }
+        String actualId = mutationEvent.getElement().getModel().getId();
+        return model.getId().equals(actualId);
+    }
+
+    private static <T extends Model> boolean hasModelData(
+            T model, ModelWithMetadata<? extends Model> modelWithMetadata) {
+        if (modelWithMetadata == null) {
+            return false;
+        } else if (!model.getClass().isAssignableFrom(modelWithMetadata.getModel().getClass())) {
+            return false;
+        }
+        return model.getId().equals(modelWithMetadata.getModel().getId());
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -121,7 +121,7 @@ final class Merger {
      */
     private <T extends Model> void announceSuccessfulMerge(ModelWithMetadata<T> modelWithMetadata) {
         Amplify.Hub.publish(HubChannel.DATASTORE,
-            HubEvent.create(DataStoreChannelEventName.RECEIVED_FROM_CLOUD, modelWithMetadata)
+            HubEvent.create(DataStoreChannelEventName.SUBSCRIPTION_DATA_PROCESSED, modelWithMetadata)
         );
     }
 
@@ -179,23 +179,5 @@ final class Merger {
                 onNotPresent.call();
             }
         }, failure -> onNotPresent.call());
-    }
-
-    /**
-     * The strategy to use while merging. Whether to consider the contents of the mutation
-     * outbox before saving data locally, or, to ignore it.
-     */
-    enum MergeStrategy {
-        /**
-         * When merging, the contents of the mutation outbox will *not* be considered.
-         */
-        IGNORE_PENDING_MUTATIONS,
-
-        /**
-         * When merging, the contents of the mutation outbox will be considered.
-         * If there is already a pending mutation in the mutation outbox, for a model of the
-         * same ID as the model being merged -- then the merge will *not* modify the existing model.
-         */
-        CONSIDER_PENDING_MUTATIONS
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -239,7 +239,7 @@ public final class AWSDataStorePluginTest {
         }).when(mockApiPlugin).mutate(any(), any(), any());
 
         HubAccumulator apiInteractionObserver =
-            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD, 1)
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.OUTBOX_MUTATION_PROCESSED, 1)
                 .start();
 
         // Save person 1
@@ -272,7 +272,7 @@ public final class AWSDataStorePluginTest {
         assertRemoteSubscriptionsStarted();
 
         apiInteractionObserver =
-            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISHED_TO_CLOUD, 1)
+            HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.OUTBOX_MUTATION_PROCESSED, 1)
                 .start();
 
         // Save person 2

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -17,7 +17,6 @@ package com.amplifyframework.datastore.syncengine;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.GraphQLBehavior;
-import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
@@ -47,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.core.Observable;
 
-import static com.amplifyframework.datastore.syncengine.TestHubEventFilters.publicationOf;
+import static com.amplifyframework.datastore.syncengine.TestHubEventFilters.isProcessed;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -125,8 +124,8 @@ public final class OrchestratorTest {
 
         orchestratorInitObserver.await(10, TimeUnit.SECONDS);
         HubAccumulator accumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(susan), 1)
-                          .start();
+            HubAccumulator.create(HubChannel.DATASTORE, isProcessed(susan), 1)
+                  .start();
         // Act: Put BlogOwner into storage, and wait for it to complete.
         SynchronousStorageAdapter.delegatingTo(localStorageAdapter).save(susan);
 
@@ -135,8 +134,9 @@ public final class OrchestratorTest {
             Collections.singletonList(susan),
             Observable.fromIterable(accumulator.await(10, TimeUnit.SECONDS))
                 .map(HubEvent::getData)
-                .map(data -> (PendingMutation<BlogOwner>) data)
-                .map(PendingMutation::getMutatedItem)
+                .map(data -> (OutboxMutationEvent<BlogOwner>) data)
+                .map(OutboxMutationEvent::getElement)
+                .map(ModelWithMetadata::getModel)
                 .toList()
                 .blockingGet()
         );
@@ -146,12 +146,9 @@ public final class OrchestratorTest {
 
     /**
      * Verify preventing concurrent state transitions from happening.
-     * @throws AmplifyException Not expected.
      */
-    @SuppressWarnings("unchecked") // Casting any(GraphQLRequest.class)
     @Test
-    public void preventConcurrentStateTransitions() throws AmplifyException {
-
+    public void preventConcurrentStateTransitions() {
         // Arrange: orchestrator is running
         orchestrator.start();
 
@@ -161,7 +158,7 @@ public final class OrchestratorTest {
         orchestrator.start();
 
         orchestratorInitObserver.await(10, TimeUnit.SECONDS);
-        verify(mockApi, times(1)).query(any(GraphQLRequest.class), any(), any());
+        verify(mockApi, times(1)).query(any(), any(), any());
 
         assertTrue(orchestrator.stop().blockingAwait(5, TimeUnit.SECONDS));
     }

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreChannelEventName.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreChannelEventName.java
@@ -31,18 +31,9 @@ import java.util.Objects;
  */
 public enum DataStoreChannelEventName {
     /**
-     * An item in the local storage has been published to the cloud.
-     * An event that uses this value for {@link HubEvent#getName()} will contain a model object
-     * in the {@link HubEvent#getData()}.
+     * The DataStore as a whole (not just the sync piece) is ready. At this point all data is available.
      */
-    PUBLISHED_TO_CLOUD("published_to_cloud"),
-
-    /**
-     * A model was updated locally, from a model version that was received from the cloud.
-     * An event that uses this value for {@link HubEvent#getName()} will contain a model object
-     * in the {@link HubEvent#getData()}.
-     */
-    RECEIVED_FROM_CLOUD("received_from_cloud"),
+    READY("ready"),
 
     /**
      * Indicates that the network is active or not.
@@ -51,14 +42,16 @@ public enum DataStoreChannelEventName {
     NETWORK_STATUS("networkStatus"),
 
     /**
-     * The websocket connection has been established and all the graphql subscriptions too.
+     * The WebSocket connection has been established, in addition to all of the GraphQL
+     * subscriptions it hosts.
      */
     SUBSCRIPTIONS_ESTABLISHED("subscriptionsEstablished"),
 
     /**
-     * The DataStore as a whole (not just the sync piece) is ready. At this point all data is available.
+     * The server sent the client data over the WebSocket subscription. The data was
+     * successfully melded back into the local store.
      */
-    READY("ready"),
+    SUBSCRIPTION_DATA_PROCESSED("subscriptionDataProcessed"),
 
     /**
      * Notifies if there are mutations in the outbox.

--- a/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
@@ -86,7 +86,8 @@ public final class HubAccumulator {
     /**
      * Creates a {@link HubAccumulator} that accumulates events arriving on a particular channel,
      * whose event name is the given enum value (as string). For example, the accumulator
-     * created as below will match all events with name {@link DataStoreChannelEventName#PUBLISHED_TO_CLOUD}:
+     * created as below will match all events with name
+     * {@link DataStoreChannelEventName#OUTBOX_MUTATION_PROCESSED}:
      *
      *   HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.PUBLISH_TO_CLOUD);
      *


### PR DESCRIPTION
The `DataStoreChannelEventName` enumeration contained two generations of
event names:

 1. An initial set, which included `RECEIVED_FROM_CLOUD`, and
    `PUBLISHED_TO_CLOUD`;
 2. A larger set, containing many more, exposing various internal
    details of the synchronization engine.

The later work partly duplicated the original work.

This commit *removes* the `PUBLISHED_TO_CLOUD`, which was duplicated by
the `OUTBOX_MUTATION_PROCESSED`,  and *renames* the
`RECEIVED_FROM_CLOUD` event to `SUBSCRIPTION_DATA_PROCESSED`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
