### PR TITLE
chore(aws-datastore): split out change type mapping

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/ItemChangeMapper.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/ItemChangeMapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.DataStoreItemChange;
+
+/**
+ * Utility to map {@link StorageItemChange}s to the customer-visible type, {@link DataStoreItemChange}.
+ */
+public final class ItemChangeMapper {
+    /**
+     * Converts an {@link StorageItemChange} into an {@link DataStoreItemChange}.
+     *
+     * @param storageItemChange A storage item change
+     * @param <T>               Type of data that was changed in the storage layer
+     * @return A data store item change representing the change in storage layer
+     */
+    public static <T extends Model> DataStoreItemChange<T> map(
+            @NonNull StorageItemChange<T> storageItemChange) throws DataStoreException {
+        return DataStoreItemChange.<T>builder()
+            .initiator(map(storageItemChange.initiator()))
+            .item(storageItemChange.item())
+            .itemClass(storageItemChange.itemClass())
+            .type(map(storageItemChange.type()))
+            .uuid(storageItemChange.changeId().toString())
+            .build();
+    }
+
+    private static DataStoreItemChange.Initiator map(StorageItemChange.Initiator initiator)
+            throws DataStoreException {
+        switch (initiator) {
+            case SYNC_ENGINE:
+                return DataStoreItemChange.Initiator.REMOTE;
+            case DATA_STORE_API:
+                return DataStoreItemChange.Initiator.LOCAL;
+            default:
+                throw new DataStoreException(
+                    "Unknown initiator of storage change: " + initiator,
+                    AmplifyException.TODO_RECOVERY_SUGGESTION
+                );
+        }
+    }
+
+    private static DataStoreItemChange.Type map(StorageItemChange.Type type)
+            throws DataStoreException {
+        switch (type) {
+            case DELETE:
+                return DataStoreItemChange.Type.DELETE;
+            case UPDATE:
+                return DataStoreItemChange.Type.UPDATE;
+            case CREATE:
+                return DataStoreItemChange.Type.CREATE;
+            default:
+                throw new DataStoreException(
+                    "Unknown type of storage change: " + type,
+                    AmplifyException.TODO_RECOVERY_SUGGESTION
+                );
+        }
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/ItemChangeMapper.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/ItemChangeMapper.java
@@ -26,12 +26,15 @@ import com.amplifyframework.datastore.DataStoreItemChange;
  * Utility to map {@link StorageItemChange}s to the customer-visible type, {@link DataStoreItemChange}.
  */
 public final class ItemChangeMapper {
+    private ItemChangeMapper() {}
+
     /**
      * Converts an {@link StorageItemChange} into an {@link DataStoreItemChange}.
      *
      * @param storageItemChange A storage item change
      * @param <T>               Type of data that was changed in the storage layer
      * @return A data store item change representing the change in storage layer
+     * @throws DataStoreException On failure to map corresponding fields for provided data
      */
     public static <T extends Model> DataStoreItemChange<T> map(
             @NonNull StorageItemChange<T> storageItemChange) throws DataStoreException {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/ItemChangeMapperTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/ItemChangeMapperTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage;
+
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
+import com.amplifyframework.datastore.DataStoreCategoryBehavior;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.DataStoreItemChange;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link ItemChangeMapper}.
+ */
+public final class ItemChangeMapperTest {
+    private String changeId;
+    private BlogOwner joe;
+
+    /**
+     * Set up some arranged data that is shared across @Tests.
+     */
+    @Before
+    public void setup() {
+        changeId = UUID.randomUUID().toString();
+        joe = BlogOwner.builder()
+            .name("Joe")
+            .build();
+    }
+    /**
+     * Try to map a {@link StorageItemChange} that is the result of a customer
+     * calling {@link DataStoreCategoryBehavior#save(Model, QueryPredicate, Consumer, Consumer)}
+     * to update an existing model.
+     * @throws DataStoreException
+     *         Not expected for the arranged data. Would only happen if object under test is faulty.
+     */
+    @Test
+    public void mapCustomerUpdate() throws DataStoreException {
+        assertEquals(
+            DataStoreItemChange.<BlogOwner>builder()
+                .initiator(DataStoreItemChange.Initiator.LOCAL)
+                .item(joe)
+                .itemClass(BlogOwner.class)
+                .uuid(changeId)
+                .type(DataStoreItemChange.Type.UPDATE)
+                .build(),
+            ItemChangeMapper.map(StorageItemChange.<BlogOwner>builder()
+                .changeId(changeId)
+                .initiator(StorageItemChange.Initiator.DATA_STORE_API)
+                .item(joe)
+                .itemClass(BlogOwner.class)
+                .predicate(QueryPredicates.all())
+                .type(StorageItemChange.Type.UPDATE)
+                .build())
+        );
+    }
+
+    /**
+     * Try to map a {@link StorageItemChange} that is the result of the cloud
+     * deleting a model through a subscription event.
+     */
+    @Test
+    public void mapCloudDeletion() throws DataStoreException {
+        assertEquals(
+            DataStoreItemChange.<BlogOwner>builder()
+                .initiator(DataStoreItemChange.Initiator.REMOTE)
+                .item(joe)
+                .itemClass(BlogOwner.class)
+                .uuid(changeId)
+                .type(DataStoreItemChange.Type.DELETE)
+                .build(),
+            ItemChangeMapper.map(StorageItemChange.<BlogOwner>builder()
+                .changeId(changeId)
+                .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
+                .item(joe)
+                .itemClass(BlogOwner.class)
+                .predicate(QueryPredicates.all())
+                .type(StorageItemChange.Type.DELETE)
+                .build())
+        );
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/ItemChangeMapperTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/ItemChangeMapperTest.java
@@ -48,6 +48,7 @@ public final class ItemChangeMapperTest {
             .name("Joe")
             .build();
     }
+
     /**
      * Try to map a {@link StorageItemChange} that is the result of a customer
      * calling {@link DataStoreCategoryBehavior#save(Model, QueryPredicate, Consumer, Consumer)}
@@ -79,6 +80,8 @@ public final class ItemChangeMapperTest {
     /**
      * Try to map a {@link StorageItemChange} that is the result of the cloud
      * deleting a model through a subscription event.
+     * @throws DataStoreException
+     *         Not expected for the arranged data. Would only happen if object under test is faulty.
      */
     @Test
     public void mapCloudDeletion() throws DataStoreException {


### PR DESCRIPTION
The `AWSDataStorePlugin` contained some logic to map from
`StorageItemChange` to `DataStoreItemChange`. This logic is needed to
convert between the `LocalStorageAdapter` APIs and the customer-exposed
`DataStoreCategoryBehavior` APIs.

In an effort to reduce the scope of responsibilities in
`AWSDataStorePlugin`, this conversion logic is split out into a new
`ItemChangeMapper` utility in the storage package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
