### PR TITLE
Add access to orchestrator targetMode by DataStorePlugin

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -96,7 +96,8 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             sqliteStorageAdapter,
             AppSyncClient.via(api),
             () -> pluginConfiguration,
-            () -> api.getPlugins().isEmpty() ? Orchestrator.Mode.LOCAL_ONLY : Orchestrator.Mode.SYNC_VIA_API
+			() -> Orchestrator.Mode.LOCAL_ONLY
+            //() -> api.getPlugins().isEmpty() ? Orchestrator.Mode.LOCAL_ONLY : Orchestrator.Mode.SYNC_VIA_API
         );
         this.userProvidedConfiguration = userProvidedConfiguration;
     }
@@ -554,5 +555,20 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             .type(dataStoreItemChangeType)
             .uuid(storageItemChange.changeId().toString())
             .build();
+    }
+	
+    public void setOnlineMode()
+    {
+        //TODO: add check for api.getPlugins().isEmpty() as before and throw a DataStoreException if there is no API registered.
+        this.orchestrator.setTargetMode(Orchestrator.Mode.SYNC_VIA_API);
+        this.orchestrator.startApiSync();
+    }
+
+    public void setOfflineMode()
+    {
+        // I haven't tested if it's possible to set the datastore back to LOCAL_ONLY mode this way
+        // The idea is to set the datastore to offline mode when the network connection is not available
+        this.orchestrator.setTargetMode(Orchestrator.Mode.LOCAL_ONLY);
+        this.orchestrator.stopApiSyncBlocking();
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -321,7 +321,7 @@ public final class Orchestrator {
      * Start syncing models to and from a remote API.
      * @return A Completable that succeeds when API sync is enabled.
      */
-    private Completable startApiSync() {
+    public Completable startApiSync() {
         return Completable.create(emitter -> {
             LOG.info("Starting API synchronization mode.");
 
@@ -380,7 +380,7 @@ public final class Orchestrator {
      * Stop all model synchronization with the remote API.
      * A Completable that ends when API sync is stopped.
      */
-    private Completable stopApiSync() {
+    public Completable stopApiSync() {
         return Completable.fromAction(() -> {
             LOG.info("Stopping synchronization with remote API.");
             subscriptionProcessor.stopAllSubscriptionActivity();
@@ -408,5 +408,9 @@ public final class Orchestrator {
          * The orchestrator maintains components to actively sync data up and down.
          */
         SYNC_VIA_API
+    }
+	
+	public void setTargetMode(Mode syncViaApi) {
+        this.targetMode = ()->syncViaApi;
     }
 }


### PR DESCRIPTION
Start orchestrator in LOCAL_ONLY mode and allow the datastore user to set the orchestrator in online mode SYNC_VIA_API once he has successfully signed in by AWSCognitoAuthPlugin.

I might miss alot of things with this pull request or even break expected behaviour but it helps me to get the apiSync running when the user is not logged in before I start the activity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
