### PR TITLE
Add Builder for AuthRule

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -54,6 +54,28 @@ public final class AuthRule {
     }
 
     /**
+     * Construct the AuthRule object from the builder.
+     * For internal use only.
+     */
+    private AuthRule(@NonNull AuthRule.Builder builder) {
+        this.authStrategy = builder.authStrategy;
+        this.ownerField = builder.ownerField;
+        this.identityClaim = builder.identityClaim;
+        this.groupClaim = builder.groupClaim;
+        this.groups = builder.groups;
+        this.groupsField = builder.groupsField;
+        this.operations = builder.operations;
+    }
+
+    /**
+     * Return the builder object.
+     * @return the builder object.
+     */
+    public static AuthRule.Builder builder() {
+        return new AuthRule.Builder();
+    }
+
+    /**
      * Returns the type of strategy for this {@link AuthRule}.
      * @return the type of strategy for this {@link AuthRule}
      */
@@ -160,5 +182,97 @@ public final class AuthRule {
                 ", groupsField='" + groupsField + '\'' +
                 ", operations=" + operations + '\'' +
                 '}';
+    }
+
+    /**
+     * Builder class for {@link AuthRule}.
+     */
+    public static final class Builder {
+        private AuthStrategy authStrategy;
+        private String ownerField;
+        private String identityClaim;
+        private String groupClaim;
+        private List<String> groups;
+        private String groupsField;
+        private List<ModelOperation> operations;
+
+        /**
+         * Sets the auth strategy of this rule.
+         * @param authStrategy AuthStrategy is the type of auth strategy to use.
+         * @return the association model with given name
+         */
+        public AuthRule.Builder authStrategy(AuthStrategy authStrategy) {
+            this.authStrategy = authStrategy;
+            return this;
+        }
+
+        /**
+         * Sets the owner field of this rule.
+         * @param ownerField OwnerField is the owner authorization.
+         * @return the association model with give target name
+         */
+        public AuthRule.Builder ownerField(String ownerField) {
+            this.ownerField = ownerField;
+            return this;
+        }
+
+        /**
+         * Sets the identity claim of this rule.
+         * @param identityClaim IdentityClaim specifies a custom claim.
+         * @return the association model with given associated name
+         */
+        public AuthRule.Builder identityClaim(String identityClaim) {
+            this.identityClaim = identityClaim;
+            return this;
+        }
+
+        /**
+         * Sets the group claim of this rule.
+         * @param groupClaim GroupClaim specified a custom claim.
+         * @return the association model with given associated type
+         */
+        public AuthRule.Builder groupClaim(String groupClaim) {
+            this.groupClaim = groupClaim;
+            return this;
+        }
+        
+        /**
+         * Sets the groups this rule applies to.
+         * @param groups Groups is static group authorization.
+         * @return the association model with given associated type
+         */
+        public AuthRule.Builder groups(List<String> groups) {
+            this.groups = groups;
+            return this;
+        }
+
+        /**
+         * Sets the groupsField of this rule.
+         * @param groupsField GroupsField is for dynamic group authorization.
+         * @return the association model with given associated type
+         */
+        public AuthRule.Builder groupsField(String groupsField) {
+            this.groupsField = groupsField;
+            return this;
+        }
+
+        /**
+         * Sets the operations allowed for this rule.
+         * @param operations Operations specifies which {@link ModelOperation}s are protected by this {@link AuthRule}.
+         * @return the association model with given associated type
+         */
+        public AuthRule.Builder operations(List<ModelOperation> operations) {
+            this.operations = operations;
+            return this;
+        }
+
+        /**
+         * Builds an immutable AuthRule instance using
+         * builder object.
+         * @return AuthRule instance
+         */
+        public AuthRule build() {
+            return new AuthRule(this);
+        }
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -74,6 +74,7 @@ public final class AuthRule {
      * Return the builder object.
      * @return the builder object.
      */
+    @NonNull
     public static AuthRule.Builder builder() {
         return new AuthRule.Builder();
     }

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -15,12 +15,15 @@
 
 package com.amplifyframework.core.model;
 
+import androidx.annotation.NonNull;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.util.Empty;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@link AuthRule} is used define an authorization rule for who can access and operate against a
@@ -194,15 +197,16 @@ public final class AuthRule {
         private String groupClaim;
         private List<String> groups;
         private String groupsField;
-        private List<ModelOperation> operations;
+        private List<ModelOperation> operations = new ArrayList<>();
 
         /**
          * Sets the auth strategy of this rule.
          * @param authStrategy AuthStrategy is the type of auth strategy to use.
          * @return the association model with given name
          */
-        public AuthRule.Builder authStrategy(AuthStrategy authStrategy) {
-            this.authStrategy = authStrategy;
+        @NonNull
+        public AuthRule.Builder authStrategy(@NonNull AuthStrategy authStrategy) {
+            this.authStrategy = Objects.requireNonNull(authStrategy);
             return this;
         }
 
@@ -211,8 +215,9 @@ public final class AuthRule {
          * @param ownerField OwnerField is the owner authorization.
          * @return the association model with give target name
          */
-        public AuthRule.Builder ownerField(String ownerField) {
-            this.ownerField = ownerField;
+        @NonNull
+        public AuthRule.Builder ownerField(@NonNull String ownerField) {
+            this.ownerField = Objects.requireNonNull(ownerField);
             return this;
         }
 
@@ -221,8 +226,9 @@ public final class AuthRule {
          * @param identityClaim IdentityClaim specifies a custom claim.
          * @return the association model with given associated name
          */
-        public AuthRule.Builder identityClaim(String identityClaim) {
-            this.identityClaim = identityClaim;
+        @NonNull
+        public AuthRule.Builder identityClaim(@NonNull String identityClaim) {
+            this.identityClaim = Objects.requireNonNull(identityClaim);
             return this;
         }
 
@@ -231,8 +237,9 @@ public final class AuthRule {
          * @param groupClaim GroupClaim specified a custom claim.
          * @return the association model with given associated type
          */
-        public AuthRule.Builder groupClaim(String groupClaim) {
-            this.groupClaim = groupClaim;
+        @NonNull
+        public AuthRule.Builder groupClaim(@NonNull String groupClaim) {
+            this.groupClaim = Objects.requireNonNull(groupClaim);
             return this;
         }
         
@@ -241,8 +248,9 @@ public final class AuthRule {
          * @param groups Groups is static group authorization.
          * @return the association model with given associated type
          */
-        public AuthRule.Builder groups(List<String> groups) {
-            this.groups = groups;
+        @NonNull
+        public AuthRule.Builder groups(@NonNull List<String> groups) {
+            this.groups = Objects.requireNonNull(groups);
             return this;
         }
 
@@ -251,8 +259,9 @@ public final class AuthRule {
          * @param groupsField GroupsField is for dynamic group authorization.
          * @return the association model with given associated type
          */
-        public AuthRule.Builder groupsField(String groupsField) {
-            this.groupsField = groupsField;
+        @NonNull
+        public AuthRule.Builder groupsField(@NonNull String groupsField) {
+            this.groupsField = Objects.requireNonNull(groupsField);
             return this;
         }
 
@@ -261,8 +270,9 @@ public final class AuthRule {
          * @param operations Operations specifies which {@link ModelOperation}s are protected by this {@link AuthRule}.
          * @return the association model with given associated type
          */
-        public AuthRule.Builder operations(List<ModelOperation> operations) {
-            this.operations = operations;
+        @NonNull
+        public AuthRule.Builder operations(@NonNull List<ModelOperation> operations) {
+            this.operations = Objects.requireNonNull(operations);
             return this;
         }
 
@@ -272,6 +282,7 @@ public final class AuthRule {
          * @return AuthRule instance
          */
         public AuthRule build() {
+            Objects.requireNonNull(this.authStrategy);
             return new AuthRule(this);
         }
     }

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -281,6 +281,7 @@ public final class AuthRule {
          * builder object.
          * @return AuthRule instance
          */
+        @NonNull
         public AuthRule build() {
             Objects.requireNonNull(this.authStrategy);
             return new AuthRule(this);


### PR DESCRIPTION
PR for Datastore module of Amplify Flutter 

Provides a public constructor for AuthRule. 

When transmitting ModelSchema from Dart to Android, we need to recreate the AuthRule object.  However the existing API only allows AuthRule objects to be created from the annotation object.. 