### PR TITLE
feat(datastore) swallow unauthorized errors for subscriptions

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
@@ -281,9 +281,9 @@ public final class AppSyncClient implements AppSync {
 
         final Consumer<GraphQLResponse<ModelWithMetadata<T>>> responseConsumer = response -> {
             if (response.hasErrors()) {
-                onSubscriptionFailure.accept(new DataStoreException(
-                    "Bad subscription data for " + clazz.getSimpleName() + ": " + response.getErrors(),
-                    AmplifyException.TODO_RECOVERY_SUGGESTION
+                onSubscriptionFailure.accept(new DataStoreException.GraphQLResponseException(
+                    "Subscription error for " + clazz.getSimpleName() + ": " + response.getErrors(),
+                    response.getErrors()
                 ));
             } else {
                 onNextResponse.accept(response);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncExtensions.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncExtensions.java
@@ -142,7 +142,12 @@ public final class AppSyncExtensions {
          * Example: Conflict resolution with an Optimistic Concurrency conflict handler.
          * Or, Lambda conflict handler returned with REJECT.
          */
-        CONFLICT_UNHANDLED("ConflictUnhandled");
+        CONFLICT_UNHANDLED("ConflictUnhandled"),
+
+        /**
+         * An Unauthorized error will occur if the provided credentials are not authorized for the requested operation.
+         */
+        UNAUTHORIZED("Unauthorized");
 
         private final String value;
 

--- a/core/src/main/java/com/amplifyframework/AmplifyException.java
+++ b/core/src/main/java/com/amplifyframework/AmplifyException.java
@@ -117,7 +117,7 @@ public class AmplifyException extends Exception {
      */
     @Override
     public String toString() {
-        return "AmplifyException {" +
+        return getClass().getSimpleName() + "{" +
                 "message=" + getMessage() +
                 ", cause=" + getCause() +
                 ", recoverySuggestion=" + getRecoverySuggestion() +

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreException.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreException.java
@@ -20,6 +20,7 @@ import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.GraphQLResponse;
+import com.amplifyframework.util.Immutable;
 
 import java.util.List;
 import java.util.Objects;
@@ -81,7 +82,7 @@ public class DataStoreException extends AmplifyException {
          */
         @NonNull
         public List<GraphQLResponse.Error> getErrors() {
-            return errors;
+            return Immutable.of(errors);
         }
 
         @Override

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreException.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreException.java
@@ -16,13 +16,18 @@
 package com.amplifyframework.datastore;
 
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.graphql.GraphQLResponse;
+
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Exception thrown by DataStore category plugins.
  */
-public final class DataStoreException extends AmplifyException {
+public class DataStoreException extends AmplifyException {
 
     private static final long serialVersionUID = 1L;
 
@@ -50,5 +55,62 @@ public final class DataStoreException extends AmplifyException {
             @NonNull final String recoverySuggestion
     ) {
         super(message, recoverySuggestion);
+    }
+
+    /**
+     * Exception thrown by DataStore category plugins used to represent a GraphQLResponse containing errors.
+     */
+    public static final class GraphQLResponseException extends DataStoreException {
+        private static final long serialVersionUID = 1L;
+
+        private final List<GraphQLResponse.Error> errors;
+
+        /**
+         * Constructs a new exception using the provided message and list of errors.
+         * @param message Explains the reason for the exception
+         * @param errors List of errors from GraphQLResponse
+         */
+        public GraphQLResponseException(String message, @NonNull List<GraphQLResponse.Error> errors) {
+            super(message, "See attached list of GraphQLResponse.Error objects.");
+            this.errors = Objects.requireNonNull(errors);
+        }
+
+        /**
+         * Returns the errors.
+         * @return the errors.
+         */
+        @NonNull
+        public List<GraphQLResponse.Error> getErrors() {
+            return errors;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (object == null || getClass() != object.getClass()) {
+                return false;
+            }
+            if (!super.equals(object)) {
+                return false;
+            }
+            GraphQLResponseException that = (GraphQLResponseException) object;
+            return ObjectsCompat.equals(errors, that.errors);
+        }
+
+        @Override
+        public int hashCode() {
+            return ObjectsCompat.hash(super.hashCode(), errors);
+        }
+
+        @Override
+        public String toString() {
+            return "GraphQLResponseException{" +
+                    "message=" + getMessage() +
+                    ", errors=" + errors +
+                    ", recoverySuggestion=" + getRecoverySuggestion() +
+                    '}';
+        }
     }
 }


### PR DESCRIPTION
When a user is not authorized to read a model, an Unauthorized error is returned when trying to start a subscription.   This error is emitted on the `SubscriptionProcessor` buffer, which results in all subscriptions being cancelled.  To allow these users to still use DataStore, with a subset of models, this PR modifies this behavior to swallow Unauthorized errors before they reach the buffer.   Other types of errors will still be emitted and result in the same behavior.   

Specific changes:
 - Added a subclass of `DataStoreException`, `DataStoreException.GraphQLResponseException`, so we can hold the `List<GraphQLResponse.Error>` objects from the response.
 - When the subscription's `onFailure` callback is called, emit it to the buffer iff it's _not_ an Unauthorized exception.
 - Updated `SubscriptionEndpoint` to stop waiting for a "start_ack" message after receiving an "error", and ensured that the `onStart()` callback is _not_ called.  Without this change, the timeout after not getting a "start_ack" was blowing everything up.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
