### PR TITLE
chore: simplify sqlcommandfactory

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
@@ -17,7 +17,6 @@ package com.amplifyframework.datastore.storage.sqlite;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
@@ -30,7 +29,6 @@ import java.util.Set;
  * {@link ModelSchema} and the {@link com.amplifyframework.core.model.Model}.
  */
 interface SQLCommandFactory {
-
     /**
      * Generates the CREATE TABLE SQL command from the {@link ModelSchema}.
      * @param modelSchema the schema of a {@link com.amplifyframework.core.model.Model}
@@ -75,25 +73,19 @@ interface SQLCommandFactory {
      * prepared statement that can be bound later with inputs.
      *
      * @param modelSchema schema of the model
-     * @param item the model instance
-     * @param <T> type of the model
      * @return the SQL command that encapsulates the UPDATE command
      */
     @NonNull
-    <T extends Model> SqlCommand updateFor(@NonNull ModelSchema modelSchema,
-                                           @NonNull T item,
-                                           @NonNull QueryPredicate predicate) throws DataStoreException;
+    SqlCommand updateFor(@NonNull ModelSchema modelSchema,
+                         @NonNull QueryPredicate predicate) throws DataStoreException;
 
     /**
      * Generates the DELETE command in a raw string representation.
      *
      * @param modelSchema schema of the model
-     * @param item the model instance
-     * @param <T> type of the model
      * @return the SQL command that encapsulates the DELETE command
      */
     @NonNull
-    <T extends Model> SqlCommand deleteFor(@NonNull ModelSchema modelSchema,
-                                           @NonNull T item,
-                                           @NonNull QueryPredicate predicate) throws DataStoreException;
+    SqlCommand deleteFor(@NonNull ModelSchema modelSchema,
+                         @NonNull QueryPredicate predicate) throws DataStoreException;
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -320,7 +320,8 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         stringBuilder.append(")");
         final String preparedInsertStatement = stringBuilder.toString();
         final SQLiteStatement compiledInsertStatement =
-                databaseConnectionHandle.compileStatement(preparedInsertStatement);
+                databaseConnectionHandle == null ?
+                null : databaseConnectionHandle.compileStatement(preparedInsertStatement);
         return new SqlCommand(table.getName(), preparedInsertStatement, columns,
                 Collections.emptyList(), compiledInsertStatement);
     }
@@ -334,9 +335,8 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
     @NonNull
     @WorkerThread
     @Override
-    public <T extends Model> SqlCommand updateFor(@NonNull ModelSchema modelSchema,
-                                                  @NonNull T item,
-                                                  @NonNull QueryPredicate predicate) throws DataStoreException {
+    public SqlCommand updateFor(@NonNull ModelSchema modelSchema,
+                                @NonNull QueryPredicate predicate) throws DataStoreException {
         final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("UPDATE")
@@ -373,7 +373,8 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
 
         final String preparedUpdateStatement = stringBuilder.toString();
         final SQLiteStatement compiledUpdateStatement =
-                databaseConnectionHandle.compileStatement(preparedUpdateStatement);
+                databaseConnectionHandle == null ?
+                null : databaseConnectionHandle.compileStatement(preparedUpdateStatement);
         return new SqlCommand(table.getName(),
                 preparedUpdateStatement,
                 columns,
@@ -387,24 +388,23 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
      */
     @NonNull
     @Override
-    public <T extends Model> SqlCommand deleteFor(@NonNull ModelSchema modelSchema,
-                                                  @NonNull T item,
-                                                  @NonNull QueryPredicate predicate) throws DataStoreException {
+    public SqlCommand deleteFor(@NonNull ModelSchema modelSchema,
+                                @NonNull QueryPredicate predicate) throws DataStoreException {
         final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
-        final StringBuilder stringBuilder = new StringBuilder();
         final SQLPredicate sqlPredicate = new SQLPredicate(predicate);
-        stringBuilder.append("DELETE FROM")
-                .append(SqlKeyword.DELIMITER)
-                .append(Wrap.inBackticks(table.getName()))
-                .append(SqlKeyword.DELIMITER)
-                .append(SqlKeyword.WHERE)
-                .append(SqlKeyword.DELIMITER)
-                .append(sqlPredicate)
-                .append(";");
 
-        final String preparedDeleteStatement = stringBuilder.toString();
+        final String preparedDeleteStatement =
+                "DELETE FROM" +
+                SqlKeyword.DELIMITER +
+                Wrap.inBackticks(table.getName()) +
+                SqlKeyword.DELIMITER +
+                SqlKeyword.WHERE +
+                SqlKeyword.DELIMITER +
+                sqlPredicate +
+                ";";
         final SQLiteStatement compiledDeleteStatement =
-                databaseConnectionHandle.compileStatement(preparedDeleteStatement);
+                databaseConnectionHandle == null ?
+                null : databaseConnectionHandle.compileStatement(preparedDeleteStatement);
         return new SqlCommand(table.getName(),
                 preparedDeleteStatement,
                 Collections.emptyList(),

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -288,7 +288,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     final QueryPredicate condition = !QueryPredicates.all().equals(predicate)
                         ? idCheck.and(predicate)
                         : idCheck;
-                    sqlCommand = sqlCommandFactory.updateFor(modelSchema, item, condition);
+                    sqlCommand = sqlCommandFactory.updateFor(modelSchema, condition);
                     if (!sqlCommand.hasCompiledSqlStatement()) {
                         onError.accept(new DataStoreException(
                             "Error in saving the model. No update statement " +
@@ -448,9 +448,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 final QueryPredicate condition = !QueryPredicates.all().equals(predicate)
                     ? idCheck.and(predicate)
                     : idCheck;
-                final SqlCommand sqlCommand = sqlCommandFactory.deleteFor(modelSchema, item, condition);
-                if (sqlCommand == null || sqlCommand.sqlStatement() == null
-                    || !sqlCommand.hasCompiledSqlStatement()) {
+                final SqlCommand sqlCommand = sqlCommandFactory.deleteFor(modelSchema, condition);
+                if (sqlCommand.sqlStatement() == null || !sqlCommand.hasCompiledSqlStatement()) {
                     onError.accept(new DataStoreException(
                         "No delete statement found for the Model: " + modelSchema.getName(),
                         AmplifyException.TODO_RECOVERY_SUGGESTION


### PR DESCRIPTION
The SQLCommandFactory had required model instances to form SQL commands.
However, these conditions may be specified by passed conditions,
instead, and the model instances aren't necessary.

Applies additional null-safety guaranteed in the SQLiteCommandFactory
implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
