### PR TITLE
fix: consider deletion predicate when requested

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -386,6 +386,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         start(() -> sqliteStorageAdapter.delete(
             item,
             StorageItemChange.Initiator.DATA_STORE_API,
+            predicate,
             itemDeletion -> {
                 try {
                     onItemDeleted.accept(ItemChangeMapper.map(itemDeletion));

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -129,21 +129,6 @@ public interface LocalStorageAdapter {
     );
 
     /**
-     * Deletes an item from storage.
-     * @param <T> The type of item being deleted
-     * @param item Item to delete
-     * @param initiator An identification of the actor who initiated this deletion
-     * @param onSuccess A callback that will be invoked when deletion succeeds
-     * @param onError A callback that will be invoked when deletion fails with an error
-     */
-    <T extends Model> void delete(
-            @NonNull T item,
-            @NonNull StorageItemChange.Initiator initiator,
-            @NonNull Consumer<StorageItemChange<T>> onSuccess,
-            @NonNull Consumer<DataStoreException> onError
-    );
-
-    /**
      * Deletes an item from storage only if the data being deleted meets the
      * specific conditions. A {@link Consumer} will be invoked when the
      * save operation is completed, to notify the caller of success or failure.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -406,19 +406,6 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     /**
      * {@inheritDoc}
      */
-    @Override
-    public <T extends Model> void delete(
-            @NonNull T item,
-            @NonNull StorageItemChange.Initiator initiator,
-            @NonNull Consumer<StorageItemChange<T>> onSuccess,
-            @NonNull Consumer<DataStoreException> onError
-    ) {
-        delete(item, initiator, QueryPredicates.all(), onSuccess, onError);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @SuppressWarnings("unchecked") // item.getClass() has Class<?>, but we assume Class<T>
     @Override
     public <T extends Model> void delete(
@@ -430,6 +417,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     ) {
         Objects.requireNonNull(item);
         Objects.requireNonNull(initiator);
+        Objects.requireNonNull(predicate);
         Objects.requireNonNull(onSuccess);
         Objects.requireNonNull(onError);
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -23,6 +23,7 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
@@ -135,6 +136,7 @@ final class Merger {
                 () -> localStorageAdapter.delete(
                     model,
                     StorageItemChange.Initiator.SYNC_ENGINE,
+                    QueryPredicates.all(),
                     storageItemChange -> {
                         onStorageItemChange.accept(storageItemChange);
                         emitter.onComplete();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -151,6 +151,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
             storage.delete(
                 converter.toRecord(pendingMutation),
                 StorageItemChange.Initiator.SYNC_ENGINE,
+                QueryPredicates.all(),
                 ignored -> {
                     mutationQueue.removeById(pendingMutation.getMutationId());
                     inFlightMutations.remove(pendingMutationId);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -139,16 +139,6 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
         onSuccess.accept(result.iterator());
     }
 
-    @Override
-    public <T extends Model> void delete(
-            @NonNull final T item,
-            @NonNull final StorageItemChange.Initiator initiator,
-            @NonNull final Consumer<StorageItemChange<T>> onSuccess,
-            @NonNull final Consumer<DataStoreException> onError
-    ) {
-        delete(item, initiator, QueryPredicates.all(), onSuccess, onError);
-    }
-
     @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.
     @Override
     public <T extends Model> void delete(


### PR DESCRIPTION
The `DataStoreCategoryBehavior` provides a `delete(...)` method which
evaluates a predicate condition. This condition was never being passed
to the `LocalStorageAdapter`, though. It was just ignored.

This fix wires the predicate into the `LocalStorageAdapter` so that it
will actually be considered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
