### PR TITLE
chore(aws-datastore): rename model registration method

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
@@ -95,7 +95,7 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
         // Initialize StorageAdapter with models
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.clear();
-        modelSchemaRegistry.load(modelProvider.models());
+        modelSchemaRegistry.register(modelProvider.models());
         sqliteStorageAdapter = SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
         List<ModelSchema> firstResults = Await.result(
             SQLITE_OPERATION_TIMEOUT_MS,

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/TestStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/TestStorageAdapter.java
@@ -47,7 +47,7 @@ final class TestStorageAdapter {
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.clear();
         try {
-            modelSchemaRegistry.load(modelProvider.models());
+            modelSchemaRegistry.register(modelProvider.models());
         } catch (AmplifyException modelSchemaLoadingFailure) {
             throw new RuntimeException(modelSchemaLoadingFailure);
         }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/syncengine/MutationPersistenceInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/syncengine/MutationPersistenceInstrumentationTest.java
@@ -74,7 +74,7 @@ public final class MutationPersistenceInstrumentationTest {
         ModelProvider modelProvider = SimpleModelProvider.withRandomVersion(BlogOwner.class);
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.clear();
-        modelSchemaRegistry.load(modelProvider.models());
+        modelSchemaRegistry.register(modelProvider.models());
 
         LocalStorageAdapter localStorageAdapter =
             SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -181,7 +181,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                  * Any exception raised during this when inspecting the Model classes
                  * through reflection will be notified via the `onError` callback.
                  */
-                modelSchemaRegistry.load(modelsProvider.models());
+                modelSchemaRegistry.register(modelsProvider.models());
 
                 /*
                  * Create the CREATE TABLE and CREATE INDEX commands for each of the

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -99,7 +99,7 @@ public final class OrchestratorTest {
         ModelProvider modelProvider = SimpleModelProvider.withRandomVersion(BlogOwner.class);
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.clear();
-        modelSchemaRegistry.load(modelProvider.models());
+        modelSchemaRegistry.register(modelProvider.models());
 
         orchestrator =
             new Orchestrator(modelProvider,

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
@@ -89,7 +89,7 @@ public final class SubscriptionProcessorTest {
 
     private static List<Class<? extends Model>> sortedModels(ModelProvider modelProvider) throws AmplifyException {
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
-        modelSchemaRegistry.load(modelProvider.models());
+        modelSchemaRegistry.register(modelProvider.models());
         TopologicalOrdering topologicalOrdering =
             TopologicalOrdering.forRegisteredModels(modelSchemaRegistry, modelProvider);
         Comparator<Class<? extends Model>> comparator = (one, two) -> {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -116,7 +116,7 @@ public final class SyncProcessorTest {
     private void initSyncProcessor(int syncMaxRecords) throws AmplifyException {
         ModelSchemaRegistry modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.clear();
-        modelSchemaRegistry.load(modelProvider.models());
+        modelSchemaRegistry.register(modelProvider.models());
 
         InMemoryStorageAdapter inMemoryStorageAdapter = InMemoryStorageAdapter.create();
         this.storageAdapter = SynchronousStorageAdapter.delegatingTo(inMemoryStorageAdapter);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TopologicalOrderingTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TopologicalOrderingTest.java
@@ -46,7 +46,7 @@ public final class TopologicalOrderingTest {
 
         final ModelSchemaRegistry registry = ModelSchemaRegistry.instance();
         registry.clear();
-        registry.load(provider.models());
+        registry.register(provider.models());
 
         // Find the schema that the registry created for each of the models.
         ModelSchema commentSchema = findSchema(registry, Comment.class);

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchemaRegistry.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchemaRegistry.java
@@ -36,11 +36,11 @@ public final class ModelSchemaRegistry {
     }
 
     /**
-     * Create the ModelSchema objects for all Model classes.
+     * Computes ModelSchema for each of the provided models, and registers them.
      * @param models the set that contains all the Model classes.
      * @throws AmplifyException if unable to create a Model Schema for a model
      */
-    public synchronized void load(@NonNull Set<Class<? extends Model>> models) throws AmplifyException {
+    public synchronized void register(@NonNull Set<Class<? extends Model>> models) throws AmplifyException {
         for (Class<? extends Model> modelClass : models) {
             final String modelClassName = modelClass.getSimpleName();
             final ModelSchema modelSchema = ModelSchema.fromModelClass(modelClass);


### PR DESCRIPTION
The ModelSchemaRegistry currently has a method named load(...). But, its
a ModelSchemaRegistry, not a ModelSchemaLoader.

Fix the naming.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
