### PR TITLE
chore(aws-datastore): remove superfluous save overload

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -66,22 +66,6 @@ public interface LocalStorageAdapter {
     );
 
     /**
-     * Save an item into local storage. A {@link Consumer} will be invoked when the
-     * save operation is completed, to notify the caller of success or error.
-     * @param <T> The type of the item being stored
-     * @param item the item to save into the repository
-     * @param initiator An identification of the actor who initiated this save
-     * @param onSuccess A callback that will be invoked if the save succeeds
-     * @param onError A callback that will be invoked if the save fails with an error
-     */
-    <T extends Model> void save(
-            @NonNull T item,
-            @NonNull StorageItemChange.Initiator initiator,
-            @NonNull Consumer<StorageItemChange<T>> onSuccess,
-            @NonNull Consumer<DataStoreException> onError
-    );
-
-    /**
      * Save an item into local storage only if the data being overwritten meets the
      * specific conditions. A {@link Consumer} will be invoked when the
      * save operation is completed, to notify the caller of success or failure.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/PersistentModelVersion.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/PersistentModelVersion.java
@@ -21,6 +21,7 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 
@@ -90,6 +91,7 @@ public final class PersistentModelVersion implements Model {
             localStorageAdapter.save(
                 persistentModelVersion,
                 StorageItemChange.Initiator.DATA_STORE_API,
+                QueryPredicates.all(),
                 ignored -> emitter.onSuccess(persistentModelVersion),
                 emitter::onError
             )

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -243,22 +243,6 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     public <T extends Model> void save(
             @NonNull T item,
             @NonNull StorageItemChange.Initiator initiator,
-            @NonNull Consumer<StorageItemChange<T>> onSuccess,
-            @NonNull Consumer<DataStoreException> onError) {
-        Objects.requireNonNull(item);
-        Objects.requireNonNull(initiator);
-        Objects.requireNonNull(onSuccess);
-        Objects.requireNonNull(onError);
-        save(item, initiator, QueryPredicates.all(), onSuccess, onError);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T extends Model> void save(
-            @NonNull T item,
-            @NonNull StorageItemChange.Initiator initiator,
             @NonNull QueryPredicate predicate,
             @NonNull Consumer<StorageItemChange<T>> onSuccess,
             @NonNull Consumer<DataStoreException> onError) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -23,6 +23,7 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
@@ -152,6 +153,7 @@ final class Merger {
             localStorageAdapter.save(
                 model,
                 StorageItemChange.Initiator.SYNC_ENGINE,
+                QueryPredicates.all(),
                 storageItemChange -> {
                     onStorageItemChange.accept(storageItemChange);
                     emitter.onComplete();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -113,6 +113,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
             storage.save(
                 converter.toRecord(pendingMutation),
                 StorageItemChange.Initiator.SYNC_ENGINE,
+                QueryPredicates.all(),
                 saved -> {
                     // The return value is StorageItemChange, referring to a PersistentRecord
                     // that was saved. We could "unwrap" a PendingMutation from that PersistentRecord,

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncTimeRegistry.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncTimeRegistry.java
@@ -22,6 +22,7 @@ import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange.Initiator;
@@ -66,6 +67,7 @@ final class SyncTimeRegistry {
             localStorageAdapter.save(
                 metadata,
                 Initiator.SYNC_ENGINE,
+                QueryPredicates.all(),
                 saveResult -> emitter.onComplete(),
                 emitter::onError
             )
@@ -82,6 +84,7 @@ final class SyncTimeRegistry {
             localStorageAdapter.save(
                 metadata,
                 Initiator.SYNC_ENGINE,
+                QueryPredicates.all(),
                 saveResult -> emitter.onComplete(),
                 emitter::onError
             )

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -66,16 +66,6 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
     ) {
     }
 
-    @Override
-    public <T extends Model> void save(
-            @NonNull final T item,
-            @NonNull final StorageItemChange.Initiator initiator,
-            @NonNull final Consumer<StorageItemChange<T>> onSuccess,
-            @NonNull final Consumer<DataStoreException> onError
-    ) {
-        save(item, initiator, QueryPredicates.all(), onSuccess, onError);
-    }
-
     @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.
     @Override
     public <T extends Model> void save(


### PR DESCRIPTION
In the `DataStoreCategoryBehavior`, it is useful to have different
versions of save, delete, query, that consider or do *not* consider
query predicates.

However, `LocalStorageAdapter` is an internal interface. It does *not*
need convenience overloads in the same way that the public API does.
Instead, we can absorb the small inconvenience of passing
`QueryPredicates.all()` to a predicate-aware `save(...)` API, on the
`LocalStorageAdapter`, to the benefit of having a smaller, more
manageable API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
