### PR TITLE
fix(datastore) only fire DataStore Hub READY event if not already started

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -159,6 +159,10 @@ public final class Orchestrator {
      */
     public synchronized void start() throws DataStoreException {
         if (tryAcquireStartStopLock(LOCAL_OP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            if (isStarted()) {
+                startStopSemaphore.release();
+                return;
+            }
             disposables.add(transitionCompletable()
                 .doOnSubscribe(subscriber -> {
                     LOG.info("Starting the orchestrator.");


### PR DESCRIPTION
A common `DataStore` use case is to call `DataStore.query` after the `READY` event has fired, like this:

```
Amplify.Hub.subscribe(HubChannel.DATASTORE,
    { DataStoreChannelEventName.READY.toString().equals(it.name) },
    { query() }
)

fun query() {
    Amplify.DataStore.query(Blog::class.java,
        { LOG.debug("query succeeded") },
        { LOG.error("Error querying: " + it.message, it) }
    )
}
```

This results in an infinite loop though, because `query` calls `start`, which publishes another `READY` event, etc.

This PR modifies the `start` method to not fire the `READY` event if DataStore has already been previously started, so the READY event will only be fired once.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
