### PR TITLE
fix(aws-datastore): checkstyle and integration tests fix

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -196,11 +196,18 @@ public final class SQLiteStorageAdapterQueryTest {
     public void querySavedDataWithNumericalPredicates() throws DataStoreException {
         final List<Post> savedModels = new ArrayList<>();
         final int numModels = 10;
+
+        BlogOwner blogOwner = BlogOwner.builder().name("Test Dummy").build();
+        adapter.save(blogOwner);
+        Blog blog = Blog.builder().name("Blogging for Dummies").owner(blogOwner).build();
+        adapter.save(blog);
+
         for (int counter = 0; counter < numModels; counter++) {
             final Post post = Post.builder()
                 .title("titlePrefix:" + counter)
                 .status(PostStatus.INACTIVE)
                 .rating(counter)
+                .blog(blog)
                 .build();
             adapter.save(post);
             savedModels.add(post);
@@ -235,12 +242,20 @@ public final class SQLiteStorageAdapterQueryTest {
     @Test
     public void querySavedDataWithStringPredicates() throws DataStoreException {
         final List<Post> savedModels = new ArrayList<>();
+
+
+        BlogOwner blogOwner = BlogOwner.builder().name("Test Dummy").build();
+        adapter.save(blogOwner);
+        Blog blog = Blog.builder().name("Blogging for Dummies").owner(blogOwner).build();
+        adapter.save(blog);
+
         final int numModels = 10;
         for (int counter = 0; counter < numModels; counter++) {
             final Post post = Post.builder()
                 .title(counter + "-title")
                 .status(PostStatus.INACTIVE)
                 .rating(counter)
+                .blog(blog)
                 .build();
             adapter.save(post);
             savedModels.add(post);

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -242,8 +242,7 @@ public final class SQLiteStorageAdapterQueryTest {
     @Test
     public void querySavedDataWithStringPredicates() throws DataStoreException {
         final List<Post> savedModels = new ArrayList<>();
-
-
+        
         BlogOwner blogOwner = BlogOwner.builder().name("Test Dummy").build();
         adapter.save(blogOwner);
         Blog blog = Blog.builder().name("Blogging for Dummies").owner(blogOwner).build();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -26,7 +26,6 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
-import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 
 import java.util.ArrayList;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The SQL statement generated after merging #892 requires that we seed some test data to satisfy the join conditions (See diff below). I modified a couple of the tests to create Blog and BlogOwner records.


**Before**
```sql
SELECT `Post`.`id` AS `Post_id`, 
    `Post`.`rating` AS `Post_rating`, 
    `Post`.`status` AS `Post_status`, 
    `Post`.`title` AS `Post_title`, 
    `Post`.`postBlogId` AS `Post_postBlogId`, 
    `Blog`.`id` AS `Blog_id`, 
    `Blog`.`name` AS `Blog_name`, 
    `Blog`.`blogOwnerId` AS `Blog_blogOwnerId` 
FROM `Post` LEFT JOIN `Blog` ON `Post`.`postBlogId`=`Blog`.`id` 
WHERE ((rating >= ? AND rating < ?) OR (rating = ? AND rating != ?));
```

**After**
```sql
SELECT `Post`.`id` AS `Post_id`, 
    `Post`.`rating` AS `Post_rating`, 
    `Post`.`status` AS `Post_status`, 
    `Post`.`title` AS `Post_title`, 
    `Post`.`postBlogId` AS `Post_postBlogId`, 
    `Blog`.`id` AS `Blog_id`, 
    `Blog`.`name` AS `Blog_name`, 
    `Blog`.`blogOwnerId` AS `Blog_blogOwnerId`, 
    `BlogOwner`.`id` AS `BlogOwner_id`, 
    `BlogOwner`.`name` AS `BlogOwner_name`, 
    `BlogOwner`.`wea` AS `BlogOwner_wea` 
FROM `Post` LEFT JOIN `Blog` ON `Post`.`postBlogId`=`Blog`.`id`
INNER JOIN `BlogOwner` ON `Blog`.`blogOwnerId`=`BlogOwner`.`id` 
WHERE ((rating >= ? AND rating < ?) OR (rating = ? AND rating != ?));
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
