### PR TITLE
feat(datastore) selective sync

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
@@ -206,7 +206,8 @@ public final class AppSyncClientInstrumentationTest {
         // Run sync on Blogs
         // TODO: This is currently a pretty worthless test - mainly for setting a debug point and manually inspecting
         // When you call sync with a null lastSync it gives only one entry per object (the latest state)
-        Iterable<ModelWithMetadata<Blog>> blogSyncResult = sync(api.buildSyncRequest(blogSchema, null, 1000));
+        Iterable<ModelWithMetadata<Blog>> blogSyncResult =
+                sync(api.buildSyncRequest(blogSchema, null, 1000, QueryPredicates.all()));
         assertTrue(blogSyncResult.iterator().hasNext());
 
         // Run sync on Posts
@@ -214,7 +215,7 @@ public final class AppSyncClientInstrumentationTest {
         // When you call sync with a lastSyncTime it gives you one entry per version of that object which was created
         // since that time.
         Iterable<ModelWithMetadata<Post>> postSyncResult =
-                sync(api.buildSyncRequest(postSchema, startTimeSeconds, 1000));
+                sync(api.buildSyncRequest(postSchema, startTimeSeconds, 1000, QueryPredicates.all()));
         assertTrue(postSyncResult.iterator().hasNext());
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
@@ -177,9 +177,10 @@ public final class DataStoreConfiguration {
     }
 
     /**
-     * Returns a QueryPredicate that should be used to filter the data that is synced.
+     * Returns a QueryPredicate that should be used to filter data received from AppSync,
+     * either during a base sync or over the real-time subscription.
      * @param modelClass Class of the {@link Model}.
-     * @return a QueryPredicate that should be used to filter the data that is synced.
+     * @return a QueryPredicate that should be used to filter the data received from AppSync
      */
     @NonNull
     public QueryPredicate getSyncQueryPredicate(Class<? extends Model> modelClass) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
@@ -22,8 +22,6 @@ import androidx.annotation.VisibleForTesting;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.model.Model;
-import com.amplifyframework.core.model.query.predicate.QueryPredicate;
-import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -177,23 +175,9 @@ public final class DataStoreConfiguration {
     }
 
     /**
-     * Returns a QueryPredicate that should be used to filter data received from AppSync,
-     * either during a base sync or over the real-time subscription.
-     * @param modelName class name of the {@link Model}.
-     * @return a QueryPredicate that should be used to filter the data received from AppSync
-     */
-    @NonNull
-    public QueryPredicate getSyncQueryPredicate(String modelName) {
-        DataStoreSyncExpression expression = syncExpressions.get(modelName);
-        if (expression != null) {
-            return expression.resolvePredicate();
-        }
-        return QueryPredicates.all();
-    }
-
-    /**
-     * Returns the Map of all {@link DataStoreSyncExpression}s used for filtering the data that is synced.
-     * @return the Map of all {@link DataStoreSyncExpression}s used for filtering the data that is synced.
+     * Returns the Map of all {@link DataStoreSyncExpression}s used to filter data received from AppSync, either during
+     * a sync or over the real-time subscription.
+     * @return the Map of all {@link DataStoreSyncExpression}s.
      */
     @NonNull
     public Map<String, DataStoreSyncExpression> getSyncExpressions() {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
@@ -50,7 +50,7 @@ public final class DataStoreConfiguration {
     private final DataStoreConflictHandler conflictHandler;
     private final Integer syncMaxRecords;
     private final Integer syncPageSize;
-    private final Map<Class<? extends Model>, DataStoreSyncExpression> syncExpressions;
+    private final Map<String, DataStoreSyncExpression> syncExpressions;
     private final Long syncIntervalInMinutes;
 
     private DataStoreConfiguration(Builder builder) {
@@ -179,12 +179,12 @@ public final class DataStoreConfiguration {
     /**
      * Returns a QueryPredicate that should be used to filter data received from AppSync,
      * either during a base sync or over the real-time subscription.
-     * @param modelClass Class of the {@link Model}.
+     * @param modelName class name of the {@link Model}.
      * @return a QueryPredicate that should be used to filter the data received from AppSync
      */
     @NonNull
-    public QueryPredicate getSyncQueryPredicate(Class<? extends Model> modelClass) {
-        DataStoreSyncExpression expression = syncExpressions.get(modelClass);
+    public QueryPredicate getSyncQueryPredicate(String modelName) {
+        DataStoreSyncExpression expression = syncExpressions.get(modelName);
         if (expression != null) {
             return expression.resolvePredicate();
         }
@@ -196,7 +196,7 @@ public final class DataStoreConfiguration {
      * @return the Map of all {@link DataStoreSyncExpression}s used for filtering the data that is synced.
      */
     @NonNull
-    public Map<Class<? extends Model>, DataStoreSyncExpression> getSyncExpressions() {
+    public Map<String, DataStoreSyncExpression> getSyncExpressions() {
         return this.syncExpressions;
     }
 
@@ -263,7 +263,7 @@ public final class DataStoreConfiguration {
         private Long syncIntervalInMinutes;
         private Integer syncMaxRecords;
         private Integer syncPageSize;
-        private Map<Class<? extends Model>, DataStoreSyncExpression> syncExpressions;
+        private Map<String, DataStoreSyncExpression> syncExpressions;
         private boolean ensureDefaults;
         private JSONObject pluginJson;
         private DataStoreConfiguration userProvidedConfiguration;
@@ -351,7 +351,7 @@ public final class DataStoreConfiguration {
         public Builder syncExpression(@NonNull Class<? extends Model> modelClass,
                                       @NonNull DataStoreSyncExpression syncExpression) {
             this.syncExpressions.put(
-                    Objects.requireNonNull(modelClass),
+                    Objects.requireNonNull(modelClass).getSimpleName(),
                     Objects.requireNonNull(syncExpression)
             );
             return Builder.this;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreSyncExpression.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreSyncExpression.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore;
+
+import com.amplifyframework.core.Action;
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+
+/**
+ * Used to specify a QueryPredicate for a {@link Model} that will filter what is synced to the client.  A DataStore
+ * customer should provide their implementation to the {@link DataStoreConfiguration} while
+ * constructing the DataStore plugin using {@link AWSDataStorePlugin#AWSDataStorePlugin(DataStoreConfiguration)}.
+ */
+public interface DataStoreSyncExpression {
+    /**
+     * This will be called each time DataStore is started.  This allows the QueryPredicate to be modified at runtime,
+     * by calling {@link DataStoreCategoryBehavior#stop(Action, Consumer)} followed by
+     * {@link DataStoreCategoryBehavior#start(Action, Consumer)}.
+     * @return QueryPredicate to filter what is synced.
+     */
+    QueryPredicate resolvePredicate();
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSync.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSync.java
@@ -54,6 +54,7 @@ public interface AppSync {
      * @param modelSchema The schema of the Model we are listening on
      * @param lastSync The time you last synced - all changes since this time are retrieved.
      * @param syncPageSize limit for number of records to return per page.
+     * @param queryPredicate QueryPredicate to filter the records returned.
      * @return A {@link GraphQLRequest} for making a sync query
      * @throws DataStoreException on error building GraphQLRequest due to inability to obtain model schema.
      */
@@ -61,7 +62,8 @@ public interface AppSync {
     <T extends Model> GraphQLRequest<PaginatedResult<ModelWithMetadata<T>>> buildSyncRequest(
             @NonNull ModelSchema modelSchema,
             @Nullable Long lastSync,
-            @Nullable Integer syncPageSize
+            @Nullable Integer syncPageSize,
+            @NonNull QueryPredicate queryPredicate
     ) throws DataStoreException;
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
@@ -74,8 +74,9 @@ public final class AppSyncClient implements AppSync {
     public <T extends Model> GraphQLRequest<PaginatedResult<ModelWithMetadata<T>>> buildSyncRequest(
             @NonNull ModelSchema modelSchema,
             @Nullable Long lastSync,
-            @Nullable Integer syncPageSize) throws DataStoreException {
-        return AppSyncRequestFactory.buildSyncRequest(modelSchema, lastSync, syncPageSize);
+            @Nullable Integer syncPageSize,
+            @NonNull QueryPredicate queryPredicate) throws DataStoreException {
+        return AppSyncRequestFactory.buildSyncRequest(modelSchema, lastSync, syncPageSize, queryPredicate);
     }
 
     @NonNull

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -26,6 +26,7 @@ import com.amplifyframework.api.graphql.QueryType;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.query.predicate.BeginsWithQueryOperator;
 import com.amplifyframework.core.model.query.predicate.BetweenQueryOperator;
 import com.amplifyframework.core.model.query.predicate.ContainsQueryOperator;
@@ -101,8 +102,7 @@ final class AppSyncRequestFactory {
                 builder.variable("limit", "Int", limit);
             }
             if (!QueryPredicates.all().equals(predicate)) {
-                String modelName = ModelSchema.fromModelClass(modelClass).getName();
-                String filterType = "Model" + Casing.capitalizeFirst(modelName) + "FilterInput";
+                String filterType = "Model" + Casing.capitalizeFirst(modelClass.getSimpleName()) + "FilterInput";
                 builder.variable("filter", filterType, parsePredicate(predicate));
             }
             return builder.build();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -80,7 +80,8 @@ final class AppSyncRequestFactory {
     static <T> AppSyncGraphQLRequest<T> buildSyncRequest(
             @NonNull final ModelSchema modelSchema,
             @Nullable final Long lastSync,
-            @Nullable final Integer limit)
+            @Nullable final Integer limit,
+            @NonNull final QueryPredicate predicate)
             throws DataStoreException {
         try {
             AppSyncGraphQLRequest.Builder builder = AppSyncGraphQLRequest.builder()
@@ -99,7 +100,11 @@ final class AppSyncRequestFactory {
             if (limit != null) {
                 builder.variable("limit", "Int", limit);
             }
-
+            if (!QueryPredicates.all().equals(predicate)) {
+                String modelName = ModelSchema.fromModelClass(modelClass).getName();
+                String filterType = "Model" + Casing.capitalizeFirst(modelName) + "FilterInput";
+                builder.variable("filter", filterType, parsePredicate(predicate));
+            }
             return builder.build();
         } catch (AmplifyException amplifyException) {
             throw new DataStoreException("Failed to get fields for model.",
@@ -170,7 +175,6 @@ final class AppSyncRequestFactory {
             throw new DataStoreException("Failed to get fields for model.",
                     amplifyException, "Validate your model file.");
         }
-
     }
 
     static Map<String, Object> parsePredicate(QueryPredicate queryPredicate) throws DataStoreException {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -26,7 +26,6 @@ import com.amplifyframework.api.graphql.QueryType;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
-import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.query.predicate.BeginsWithQueryOperator;
 import com.amplifyframework.core.model.query.predicate.BetweenQueryOperator;
 import com.amplifyframework.core.model.query.predicate.ContainsQueryOperator;
@@ -102,7 +101,7 @@ final class AppSyncRequestFactory {
                 builder.variable("limit", "Int", limit);
             }
             if (!QueryPredicates.all().equals(predicate)) {
-                String filterType = "Model" + Casing.capitalizeFirst(modelClass.getSimpleName()) + "FilterInput";
+                String filterType = "Model" + Casing.capitalizeFirst(modelSchema.getName()) + "FilterInput";
                 builder.variable("filter", filterType, parsePredicate(predicate));
             }
             return builder.build();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -120,7 +120,12 @@ public final class Orchestrator {
             .merger(merger)
             .dataStoreConfigurationProvider(dataStoreConfigurationProvider)
             .build();
-        this.subscriptionProcessor = new SubscriptionProcessor(appSync, modelProvider, merger);
+        this.subscriptionProcessor = SubscriptionProcessor.builder()
+                .appSync(appSync)
+                .modelProvider(modelProvider)
+                .merger(merger)
+                .dataStoreConfigurationProvider(dataStoreConfigurationProvider)
+                .build();
         this.storageObserver = new StorageObserver(localStorageAdapter, mutationOutbox);
         this.currentMode = new AtomicReference<>(Mode.STOPPED);
         this.targetMode = targetMode;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/QueryPredicateProvider.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/QueryPredicateProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.Pair;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
+import com.amplifyframework.datastore.DataStoreConfiguration;
+import com.amplifyframework.datastore.DataStoreConfigurationProvider;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.DataStoreSyncExpression;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import io.reactivex.rxjava3.core.Observable;
+
+/**
+ * Maintains a Map of QueryPredicates for each {@link Model} for the current DataStore session.
+ */
+final class QueryPredicateProvider {
+    private final DataStoreConfigurationProvider dataStoreConfigurationProvider;
+    private final Map<String, QueryPredicate> predicateMap = new HashMap<>();
+
+    /**
+     * Constructs a QueryPredicateProvider.
+     * @param dataStoreConfigurationProvider a DataStoreConfigurationProvider.
+     */
+    QueryPredicateProvider(DataStoreConfigurationProvider dataStoreConfigurationProvider) {
+        this.dataStoreConfigurationProvider = dataStoreConfigurationProvider;
+    }
+
+    /**
+     * Evaluates any client provided {@link DataStoreSyncExpression}s and caches the resolved {@link QueryPredicate}s
+     * for use in the current DataStore session. These are used to filter data received from AppSync, either during a
+     * sync or over the real-time subscription.  This is called once each time DataStore is started.
+     *
+     * @throws DataStoreException on error obtaining the {@link DataStoreConfiguration}.
+     */
+    public void resolvePredicates() throws DataStoreException {
+        Map<String, DataStoreSyncExpression> expressions =
+                dataStoreConfigurationProvider.getConfiguration().getSyncExpressions();
+        predicateMap.clear();
+        predicateMap.putAll(Observable.fromIterable(expressions.entrySet())
+                .map(entry -> Pair.create(entry.getKey(), entry.getValue().resolvePredicate()))
+                .toMap(pair -> pair.first, pair -> pair.second)
+                .blockingGet());
+    }
+
+    /**
+     * Returns the {@link QueryPredicate} for the given modelName.
+     * @param modelName name of the {@link Model}.
+     * @return the {@link QueryPredicate} for the given modelName.
+     */
+    @NonNull
+    public QueryPredicate getPredicate(@NonNull String modelName) {
+        QueryPredicate predicate = predicateMap.get(Objects.requireNonNull(modelName));
+        if (predicate == null) {
+            predicate = QueryPredicates.all();
+        }
+        return predicate;
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -214,8 +214,8 @@ final class SubscriptionProcessor {
         .observeOn(Schedulers.io())
         .map(SubscriptionProcessor::unwrapResponse)
         .filter(modelWithMetadata -> {
-            Class<? extends Model> clazz = modelSchema.getModelClass();
-            QueryPredicate predicate = dataStoreConfigurationProvider.getConfiguration().getSyncQueryPredicate(clazz);
+            QueryPredicate predicate =
+                    dataStoreConfigurationProvider.getConfiguration().getSyncQueryPredicate(modelSchema.getName());
             return predicate.evaluate(modelWithMetadata.getModel());
         })
         .map(modelWithMetadata -> SubscriptionEvent.<T>builder()

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -79,10 +79,10 @@ final class SubscriptionProcessor {
      * @param builder A SubscriptionProcessor Builder.
      */
     private SubscriptionProcessor(Builder builder) {
-        this.appSync = Objects.requireNonNull(builder.appSync);
-        this.modelProvider = Objects.requireNonNull(builder.modelProvider);
-        this.merger = Objects.requireNonNull(builder.merger);
-        this.dataStoreConfigurationProvider = Objects.requireNonNull(builder.dataStoreConfigurationProvider);
+        this.appSync = builder.appSync;
+        this.modelProvider = builder.modelProvider;
+        this.merger = builder.merger;
+        this.dataStoreConfigurationProvider = builder.dataStoreConfigurationProvider;
         this.ongoingOperationsDisposable = new CompositeDisposable();
 
         // Operation times out after 10 seconds. If there are more than 5 models,
@@ -346,7 +346,7 @@ final class SubscriptionProcessor {
         @NonNull
         @Override
         public BuildStep dataStoreConfigurationProvider(DataStoreConfigurationProvider dataStoreConfigurationProvider) {
-            this.dataStoreConfigurationProvider = dataStoreConfigurationProvider;
+            this.dataStoreConfigurationProvider = Objects.requireNonNull(dataStoreConfigurationProvider);
             return Builder.this;
         }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -381,5 +381,4 @@ final class SubscriptionProcessor {
         @NonNull
         SubscriptionProcessor build();
     }
-
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -69,20 +69,16 @@ final class SyncProcessor {
     private final Merger merger;
     private final DataStoreConfigurationProvider dataStoreConfigurationProvider;
     private final String[] modelNames;
+    private final QueryPredicateProvider queryPredicateProvider;
 
-    private SyncProcessor(
-            ModelProvider modelProvider,
-            ModelSchemaRegistry modelSchemaRegistry,
-            SyncTimeRegistry syncTimeRegistry,
-            AppSync appSync,
-            Merger merger,
-            DataStoreConfigurationProvider dataStoreConfigurationProvider) {
-        this.modelProvider = Objects.requireNonNull(modelProvider);
-        this.modelSchemaRegistry = Objects.requireNonNull(modelSchemaRegistry);
-        this.syncTimeRegistry = Objects.requireNonNull(syncTimeRegistry);
-        this.appSync = Objects.requireNonNull(appSync);
-        this.merger = Objects.requireNonNull(merger);
-        this.dataStoreConfigurationProvider = dataStoreConfigurationProvider;
+    private SyncProcessor(Builder builder) {
+        this.modelProvider = builder.modelProvider;
+        this.modelSchemaRegistry = builder.modelSchemaRegistry;
+        this.syncTimeRegistry = builder.syncTimeRegistry;
+        this.appSync = builder.appSync;
+        this.merger = builder.merger;
+        this.dataStoreConfigurationProvider = builder.dataStoreConfigurationProvider;
+        this.queryPredicateProvider = builder.queryPredicateProvider;
         this.modelNames =
             ForEach.inCollection(modelProvider.modelSchemas().values(), ModelSchema::getName)
                 .toArray(new String[0]);
@@ -213,8 +209,7 @@ final class SyncProcessor {
             throws DataStoreException {
         final Long lastSyncTimeAsLong = syncTime.exists() ? syncTime.toLong() : null;
         final Integer syncPageSize = dataStoreConfigurationProvider.getConfiguration().getSyncPageSize();
-        QueryPredicate predicate =
-                dataStoreConfigurationProvider.getConfiguration().getSyncQueryPredicate(schema.getName());
+        QueryPredicate predicate = queryPredicateProvider.getPredicate(schema.getName());
         // Create a BehaviorProcessor, and set the default value to a GraphQLRequest that fetches the first page.
         BehaviorProcessor<GraphQLRequest<PaginatedResult<ModelWithMetadata<T>>>> processor =
                 BehaviorProcessor.createDefault(
@@ -265,13 +260,15 @@ final class SyncProcessor {
      * Builds instances of {@link SyncProcessor}s.
      */
     public static final class Builder implements ModelProviderStep, ModelSchemaRegistryStep,
-            SyncTimeRegistryStep, AppSyncStep, MergerStep, DataStoreConfigurationProviderStep, BuildStep {
+            SyncTimeRegistryStep, AppSyncStep, MergerStep, DataStoreConfigurationProviderStep,
+            QueryPredicateProviderStep, BuildStep {
         private ModelProvider modelProvider;
         private ModelSchemaRegistry modelSchemaRegistry;
         private SyncTimeRegistry syncTimeRegistry;
         private AppSync appSync;
         private Merger merger;
         private DataStoreConfigurationProvider dataStoreConfigurationProvider;
+        private QueryPredicateProvider queryPredicateProvider;
 
         @NonNull
         @Override
@@ -310,7 +307,7 @@ final class SyncProcessor {
 
         @NonNull
         @Override
-        public BuildStep dataStoreConfigurationProvider(
+        public QueryPredicateProviderStep dataStoreConfigurationProvider(
             DataStoreConfigurationProvider dataStoreConfigurationProvider) {
             this.dataStoreConfigurationProvider = dataStoreConfigurationProvider;
             return Builder.this;
@@ -318,15 +315,15 @@ final class SyncProcessor {
 
         @NonNull
         @Override
+        public BuildStep queryPredicateProvider(QueryPredicateProvider queryPredicateProvider) {
+            this.queryPredicateProvider = Objects.requireNonNull(queryPredicateProvider);
+            return Builder.this;
+        }
+
+        @NonNull
+        @Override
         public SyncProcessor build() {
-            return new SyncProcessor(
-                modelProvider,
-                modelSchemaRegistry,
-                syncTimeRegistry,
-                appSync,
-                merger,
-                dataStoreConfigurationProvider
-            );
+            return new SyncProcessor(this);
         }
     }
 
@@ -357,7 +354,13 @@ final class SyncProcessor {
 
     interface DataStoreConfigurationProviderStep {
         @NonNull
-        BuildStep dataStoreConfigurationProvider(DataStoreConfigurationProvider dataStoreConfiguration);
+        QueryPredicateProviderStep dataStoreConfigurationProvider(
+                DataStoreConfigurationProvider dataStoreConfiguration);
+    }
+
+    interface QueryPredicateProviderStep {
+        @NonNull
+        BuildStep queryPredicateProvider(QueryPredicateProvider queryPredicateProvider);
     }
 
     interface BuildStep {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -214,7 +214,7 @@ final class SyncProcessor {
         final Long lastSyncTimeAsLong = syncTime.exists() ? syncTime.toLong() : null;
         final Integer syncPageSize = dataStoreConfigurationProvider.getConfiguration().getSyncPageSize();
         QueryPredicate predicate =
-                dataStoreConfigurationProvider.getConfiguration().getSyncQueryPredicate(schema.getModelClass());
+                dataStoreConfigurationProvider.getConfiguration().getSyncQueryPredicate(schema.getName());
         // Create a BehaviorProcessor, and set the default value to a GraphQLRequest that fetches the first page.
         BehaviorProcessor<GraphQLRequest<PaginatedResult<ModelWithMetadata<T>>>> processor =
                 BehaviorProcessor.createDefault(

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
@@ -123,7 +123,7 @@ public final class DataStoreConfigurationTest {
 
         assertEquals(dummyConflictHandler, dataStoreConfiguration.getConflictHandler());
         assertEquals(errorHandler, dataStoreConfiguration.getErrorHandler());
-        assertEquals(Collections.singletonMap(BlogOwner.class, syncExpression),
+        assertEquals(Collections.singletonMap(BlogOwner.class.getSimpleName(), syncExpression),
                 dataStoreConfiguration.getSyncExpressions());
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
@@ -21,6 +21,7 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.DataStoreConfiguration.ConfigKey;
 import com.amplifyframework.datastore.DataStoreConflictHandler.AlwaysApplyRemoteHandler;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -28,6 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -56,6 +58,7 @@ public final class DataStoreConfigurationTest {
 
         assertTrue(dataStoreConfiguration.getConflictHandler() instanceof AlwaysApplyRemoteHandler);
         assertTrue(dataStoreConfiguration.getErrorHandler() instanceof DefaultDataStoreErrorHandler);
+        assertEquals(Collections.emptyMap(), dataStoreConfiguration.getSyncExpressions());
     }
 
     /**
@@ -80,11 +83,12 @@ public final class DataStoreConfigurationTest {
 
         assertTrue(dataStoreConfiguration.getConflictHandler() instanceof AlwaysApplyRemoteHandler);
         assertTrue(dataStoreConfiguration.getErrorHandler() instanceof DefaultDataStoreErrorHandler);
+        assertEquals(Collections.emptyMap(), dataStoreConfiguration.getSyncExpressions());
     }
 
     /**
      * When building a configuration from both a config file and a configuration object,
-     * default values should be overriden, and the provided ones shall be used, instead.
+     * default values should be overridden, and the provided ones shall be used, instead.
      * @throws JSONException While arranging config file JSON
      * @throws DataStoreException While building DataStoreConfiguration instances via build()
      */
@@ -96,11 +100,13 @@ public final class DataStoreConfigurationTest {
         DummyConflictHandler dummyConflictHandler = new DummyConflictHandler();
         DataStoreErrorHandler errorHandler = DefaultDataStoreErrorHandler.instance();
 
+        DataStoreSyncExpression syncExpression = () -> BlogOwner.ID.beginsWith("a");
         DataStoreConfiguration configObject = DataStoreConfiguration
             .builder()
             .syncMaxRecords(expectedSyncMaxRecords)
             .conflictHandler(dummyConflictHandler)
             .errorHandler(errorHandler)
+            .syncExpression(BlogOwner.class, syncExpression)
             .build();
 
         JSONObject jsonConfigFromFile = new JSONObject()
@@ -116,6 +122,8 @@ public final class DataStoreConfigurationTest {
 
         assertEquals(dummyConflictHandler, dataStoreConfiguration.getConflictHandler());
         assertEquals(errorHandler, dataStoreConfiguration.getErrorHandler());
+        assertEquals(Collections.singletonMap(BlogOwner.class, syncExpression),
+                dataStoreConfiguration.getSyncExpressions());
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
@@ -22,6 +22,7 @@ import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.DataStoreConfiguration.ConfigKey;
 import com.amplifyframework.datastore.DataStoreConflictHandler.AlwaysApplyRemoteHandler;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testutils.random.RandomString;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -100,7 +101,7 @@ public final class DataStoreConfigurationTest {
         DummyConflictHandler dummyConflictHandler = new DummyConflictHandler();
         DataStoreErrorHandler errorHandler = DefaultDataStoreErrorHandler.instance();
 
-        DataStoreSyncExpression syncExpression = () -> BlogOwner.ID.beginsWith("a");
+        DataStoreSyncExpression syncExpression = () -> BlogOwner.ID.beginsWith(RandomString.string());
         DataStoreConfiguration configObject = DataStoreConfiguration
             .builder()
             .syncMaxRecords(expectedSyncMaxRecords)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
@@ -29,12 +29,15 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.async.NoOpCancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testutils.Varargs;
 import com.amplifyframework.testutils.random.RandomString;
 
 import org.mockito.ArgumentMatcher;
+import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Stubber;
 
 import java.util.Arrays;
@@ -464,8 +467,9 @@ public final class AppSyncMocking {
                 ModelSchema schema = invocation.getArgument(0);
                 Long lastSync = invocation.getArgument(1);
                 Integer syncPageSize = invocation.getArgument(2);
-                return AppSyncRequestFactory.buildSyncRequest(schema, lastSync, syncPageSize);
-            }).when(appSync).buildSyncRequest(any(), any(), any());
+                QueryPredicate queryPredicate = invocation.getArgument(3);
+                return AppSyncRequestFactory.buildSyncRequest(schema, lastSync, syncPageSize, queryPredicate);
+            }).when(appSync).buildSyncRequest(any(), any(), any(), any());
             return this;
         }
 
@@ -531,7 +535,7 @@ public final class AppSyncMocking {
             if (nextToken != null) {
                 ModelSchema schema = ModelSchema.fromModelClass(modelClass);
                 requestForNextResult =
-                    AppSyncRequestFactory.buildSyncRequest(schema, null, null)
+                    AppSyncRequestFactory.buildSyncRequest(schema, null, null, QueryPredicates.all())
                         .newBuilder()
                         .variable("nextToken", "String", nextToken)
                         .build();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
@@ -37,7 +37,6 @@ import com.amplifyframework.testutils.Varargs;
 import com.amplifyframework.testutils.random.RandomString;
 
 import org.mockito.ArgumentMatcher;
-import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Stubber;
 
 import java.util.Arrays;

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMockingTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMockingTest.java
@@ -23,6 +23,7 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.predicate.MatchAllQueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.AppSyncMocking.SyncConfigurator;
@@ -73,7 +74,7 @@ public final class AppSyncMockingTest {
         AppSyncMocking.sync(appSync).mockFailure(failure);
 
         GraphQLRequest<PaginatedResult<ModelWithMetadata<BlogOwner>>> request =
-            appSync.buildSyncRequest(schema, null, 100);
+            appSync.buildSyncRequest(schema, null, 100, QueryPredicates.all());
         Single
             .create(emitter -> appSync.sync(request, emitter::onSuccess, emitter::onError))
             .test()
@@ -97,7 +98,7 @@ public final class AppSyncMockingTest {
         // Build a request object. This will itself test the mockSuccessResponse(),
         // since that method configures this call to return a meaningful result.
         GraphQLRequest<PaginatedResult<ModelWithMetadata<BlogOwner>>> request =
-            appSync.buildSyncRequest(schema, null, 100);
+            appSync.buildSyncRequest(schema, null, 100, QueryPredicates.all());
 
         // Lastly, when we actually call sync, we should see the expected response,
         // As a result of the mockSuccessResponse() on the AppSyncMocking.

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
@@ -19,6 +19,7 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
@@ -60,7 +61,7 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
         JSONAssert.assertEquals(
             Resources.readAsString("base-sync-request-document-for-blog-owner.txt"),
-            AppSyncRequestFactory.buildSyncRequest(schema, null, null).getContent(),
+            AppSyncRequestFactory.buildSyncRequest(schema, null, null, QueryPredicates.all()).getContent(),
             true
         );
     }
@@ -75,9 +76,9 @@ public final class AppSyncRequestFactoryTest {
     public void validateCustomTypeRequestGenerationForBaseSync() throws AmplifyException, JSONException {
         ModelSchema schema = ModelSchema.fromModelClass(Parent.class);
         JSONAssert.assertEquals(
-                Resources.readAsString("base-sync-request-document-for-parent.txt"),
-                AppSyncRequestFactory.buildSyncRequest(schema, null, null).getContent(),
-                true
+            Resources.readAsString("base-sync-request-document-for-parent.txt"),
+            AppSyncRequestFactory.buildSyncRequest(schema, null, null, QueryPredicates.all()).getContent(),
+            true
         );
     }
 
@@ -91,8 +92,8 @@ public final class AppSyncRequestFactoryTest {
     public void validateRequestGenerationForDeltaSync() throws AmplifyException, JSONException {
         ModelSchema schema = ModelSchema.fromModelClass(Post.class);
         JSONAssert.assertEquals(Resources.readAsString("delta-sync-request-document-for-post.txt"),
-                AppSyncRequestFactory.buildSyncRequest(schema, 123123123L, null).getContent(),
-                true);
+            AppSyncRequestFactory.buildSyncRequest(schema, 123123123L, null, QueryPredicates.all()).getContent(),
+            true);
     }
 
     /**
@@ -106,7 +107,7 @@ public final class AppSyncRequestFactoryTest {
         Integer limit = 1000;
         ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
         final GraphQLRequest<Iterable<Post>> request =
-                AppSyncRequestFactory.buildSyncRequest(schema, null, limit);
+                AppSyncRequestFactory.buildSyncRequest(schema, null, limit, QueryPredicates.all());
         JSONAssert.assertEquals(Resources.readAsString("base-sync-request-paginating-blog-owners.txt"),
                 request.getContent(),
                 true);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/QueryPredicateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/QueryPredicateTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
+import com.amplifyframework.datastore.DataStoreConfiguration;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.DataStoreSyncExpression;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testutils.random.RandomString;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryPredicateTest {
+    private QueryPredicateProvider queryPredicateProvider;
+    private QueryPredicate expectedPredicate;
+    private DataStoreSyncExpression blogSyncExpression;
+
+    /**
+     * Setup the queryPredicateProvider.
+     * @throws DataStoreException on failure to build {@link DataStoreConfiguration}
+     */
+    @Before
+    public void setup() throws DataStoreException {
+        expectedPredicate = BlogOwner.NAME.beginsWith(RandomString.string());
+        blogSyncExpression = () -> expectedPredicate;
+        DataStoreConfiguration dataStoreConfiguration = DataStoreConfiguration.builder()
+                .syncExpression(BlogOwner.class, blogSyncExpression)
+                .build();
+        queryPredicateProvider = new QueryPredicateProvider(() -> dataStoreConfiguration);
+    }
+
+    /**
+     * Verify getPredicate() returns QueryPredicates.all() before the resolvePredicates() is called.
+     */
+    @Test
+    public void getPredicateReturnsAllBeforeResolve() {
+        // Before the predicates have been resolved, verify that the provider just returns QueryPredicates.all().
+        assertEquals(QueryPredicates.all(), queryPredicateProvider.getPredicate(BlogOwner.class.getSimpleName()));
+    }
+
+    /**
+     * Verify getPredicate() returns the expected {@link QueryPredicate}.
+     * @throws DataStoreException on failure to call resolvePredicates.
+     */
+    @Test
+    public void getPredicateReturnsResolvedPredicate() throws DataStoreException {
+        // Act
+        queryPredicateProvider.resolvePredicates();
+
+        // Now expect the QueryPredicate to be returned.
+        assertEquals(expectedPredicate, queryPredicateProvider.getPredicate(BlogOwner.class.getSimpleName()));
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
@@ -77,22 +77,26 @@ public final class SubscriptionProcessorTest {
 
     /**
      * Sets up an {@link SubscriptionProcessor} and associated test dependencies.
+     * @throws DataStoreException on error building the {@link DataStoreConfiguration}
      */
     @Before
-    public void setup() {
+    public void setup() throws DataStoreException {
         ModelProvider modelProvider = AmplifyModelProvider.getInstance();
         modelSchemaRegistry = ModelSchemaRegistry.instance();
         modelSchemaRegistry.register(modelProvider.modelSchemas());
         this.modelSchemas = sortedModels(modelProvider);
         this.appSync = mock(AppSync.class);
         this.merger = mock(Merger.class);
+        DataStoreConfiguration dataStoreConfiguration = DataStoreConfiguration.builder()
+                .syncExpression(BlogOwner.class, () -> BlogOwner.NAME.beginsWith("John"))
+                .build();
+        QueryPredicateProvider queryPredicateProvider = new QueryPredicateProvider(() -> dataStoreConfiguration);
+        queryPredicateProvider.resolvePredicates();
         this.subscriptionProcessor = SubscriptionProcessor.builder()
                 .appSync(appSync)
                 .modelProvider(modelProvider)
                 .merger(merger)
-                .dataStoreConfigurationProvider(() -> DataStoreConfiguration.builder()
-                        .syncExpression(BlogOwner.class, () -> BlogOwner.NAME.beginsWith("John"))
-                        .build())
+                .queryPredicateProvider(queryPredicateProvider)
                 .build();
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
@@ -86,7 +86,8 @@ public final class SubscriptionProcessorTest {
         this.modelSchemas = sortedModels(modelProvider);
         this.appSync = mock(AppSync.class);
         this.merger = mock(Merger.class);
-        this.subscriptionProcessor = SubscriptionProcessor.builder().appSync(appSync)
+        this.subscriptionProcessor = SubscriptionProcessor.builder()
+                .appSync(appSync)
                 .modelProvider(modelProvider)
                 .merger(merger)
                 .dataStoreConfigurationProvider(() -> DataStoreConfiguration.builder()

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
@@ -28,6 +28,7 @@ import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.datastore.DataStoreConfiguration;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.AppSync;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
@@ -54,6 +55,7 @@ import java.util.concurrent.TimeUnit;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -84,7 +86,13 @@ public final class SubscriptionProcessorTest {
         this.modelSchemas = sortedModels(modelProvider);
         this.appSync = mock(AppSync.class);
         this.merger = mock(Merger.class);
-        this.subscriptionProcessor = new SubscriptionProcessor(appSync, modelProvider, merger);
+        this.subscriptionProcessor = SubscriptionProcessor.builder().appSync(appSync)
+                .modelProvider(modelProvider)
+                .merger(merger)
+                .dataStoreConfigurationProvider(() -> DataStoreConfiguration.builder()
+                        .syncExpression(BlogOwner.class, () -> BlogOwner.NAME.beginsWith("John"))
+                        .build())
+                .build();
     }
 
     private List<ModelSchema> sortedModels(ModelProvider modelProvider) {
@@ -139,12 +147,36 @@ public final class SubscriptionProcessorTest {
      */
     @Test
     public void dataMergedWhenBufferDrained() throws DataStoreException, InterruptedException {
+        assertTrue(isDataMergedWhenBufferDrainedForBlogOwnerNamed("John P. Stetson, Jr."));
+    }
+
+    /**
+     * Verify that data not matching the configured sync query predicate does NOT get merged.  Since
+     * DataStoreConfiguration built in {@link #setup()} has a syncExpression specifying that the BlogOwner name
+     * must start with "John", this test verifies that a BlogOwner named "Paul Hudson" does NOT get merged.
+     * @throws DataStoreException On failure to arrange mocking
+     * @throws InterruptedException On failure to await latch
+     */
+    @Test
+    public void dataIsFilteredIfSyncExpressionExists() throws DataStoreException, InterruptedException {
+        assertFalse(isDataMergedWhenBufferDrainedForBlogOwnerNamed("Paul Hudson"));
+    }
+
+    /**
+     * Return whether a response with a BlogOwner with the given name gets merged with the merger.
+     * @param name name of the BlogOwner returned in the subscription
+     * @return whether the data was merged
+     * @throws DataStoreException On failure to arrange mocking
+     * @throws InterruptedException On failure to await latch
+     */
+    private boolean isDataMergedWhenBufferDrainedForBlogOwnerNamed(String name) 
+            throws DataStoreException, InterruptedException {
         // By default, start the subscriptions up.
         arrangeStartedSubscriptions(appSync, modelSchemas, SubscriptionType.values());
 
         // Arrange some subscription data
         BlogOwner model = BlogOwner.builder()
-            .name("John P. Stetson, Jr.")
+            .name(name)
             .build();
         ModelMetadata modelMetadata = new ModelMetadata(model.getId(), false, 1, Temporal.Timestamp.now());
         ModelWithMetadata<BlogOwner> modelWithMetadata = new ModelWithMetadata<>(model, modelMetadata);
@@ -159,14 +191,14 @@ public final class SubscriptionProcessorTest {
         doAnswer(invocation -> {
             latch.countDown();
             return Completable.complete();
-        }).when(merger).merge(eq(modelWithMetadata));
+        }).when(merger).merge(eq(response.getData()));
 
         // Start draining....
         subscriptionProcessor.startSubscriptions();
         subscriptionProcessor.startDrainingMutationBuffer(EmptyAction.create());
 
         // Was the data merged?
-        assertTrue(latch.await(OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        return latch.await(OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/aws-datastore/src/test/resources/sync-request-with-predicate.txt
+++ b/aws-datastore/src/test/resources/sync-request-with-predicate.txt
@@ -1,0 +1,29 @@
+{
+  "query": "query SyncBlogOwners($filter: ModelBlogOwnerFilterInput, $lastSync: AWSTimestamp, $limit: Int) {
+  syncBlogOwners(filter: $filter, lastSync: $lastSync, limit: $limit) {
+    items {
+      _deleted
+      _lastChangedAt
+      _version
+      blog {
+        id
+      }
+      id
+      name
+      wea
+    }
+    nextToken
+    startedAt
+  }
+}
+",
+  "variables": {
+    "filter": {
+      "name": {
+        "beginsWith": "J"
+      }
+    },
+    "limit": 342,
+    "lastSync": 123412341
+  }
+}


### PR DESCRIPTION
This PR adds the selective sync feature to DataStore, which consists of the following parts:
 - **Configuration**: Clients configure a `DataStoreSyncExpression`, which can resolve a `QueryPredicate`. 
 - **Sync**: Sync requests sent to AppSync include this `QueryPredicate`, so that data is filtered out server side.
 - **Subscriptions**:  AppSync's subscription operation does not currently support a `filter` argument, so this PR filters out incoming subscriptions that don't match the predicate on the client side.  In the future, if AppSync adds this, we can switch to server-side filtering, which will help reduce network traffic on the subscription socket.
 - **Runtime Modification**: Clients can force a re-evaluation of their `DataStoreSyncExpression` at runtime by calling `DataStore.stop()`, `DataStore.start()`, if they wish to modify the filter to obtain a different set of data.

DX:
```
Amplify.addPlugin(new AWSDataStorePlugin(DataStoreConfiguration.builder()
    .syncExpression(Blog.class, () -> Blog.NAME.equals("foo"))
    .syncExpression(Post.class, () -> Post.TITLE.beginsWith("bar"))
    .syncExpression(Comment.class, () -> Comment.CONTENT.contains("baz"))
    .build()));
Amplify.configure(context);
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
