### PR TITLE
 fix(aws-predictions): expose label instances' bounding boxes

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSRekognitionService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSRekognitionService.java
@@ -52,7 +52,6 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.rekognition.AmazonRekognitionClient;
 import com.amazonaws.services.rekognition.model.Attribute;
-import com.amazonaws.services.rekognition.model.BoundingBox;
 import com.amazonaws.services.rekognition.model.ComparedFace;
 import com.amazonaws.services.rekognition.model.DetectFacesRequest;
 import com.amazonaws.services.rekognition.model.DetectFacesResult;

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSRekognitionService.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSRekognitionService.java
@@ -52,6 +52,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.rekognition.AmazonRekognitionClient;
 import com.amazonaws.services.rekognition.model.Attribute;
+import com.amazonaws.services.rekognition.model.BoundingBox;
 import com.amazonaws.services.rekognition.model.ComparedFace;
 import com.amazonaws.services.rekognition.model.DetectFacesRequest;
 import com.amazonaws.services.rekognition.model.DetectFacesResult;
@@ -65,6 +66,7 @@ import com.amazonaws.services.rekognition.model.Face;
 import com.amazonaws.services.rekognition.model.FaceDetail;
 import com.amazonaws.services.rekognition.model.FaceMatch;
 import com.amazonaws.services.rekognition.model.Image;
+import com.amazonaws.services.rekognition.model.Instance;
 import com.amazonaws.services.rekognition.model.ModerationLabel;
 import com.amazonaws.services.rekognition.model.Parent;
 import com.amazonaws.services.rekognition.model.RecognizeCelebritiesRequest;
@@ -205,10 +207,15 @@ final class AWSRekognitionService {
             for (Parent parent : rekognitionLabel.getParents()) {
                 parents.add(parent.getName());
             }
+            List<RectF> boxes = new ArrayList<>();
+            for (Instance instance : rekognitionLabel.getInstances()) {
+                boxes.add(RekognitionResultTransformers.fromBoundingBox(instance.getBoundingBox()));
+            }
             Label amplifyLabel = Label.builder()
                     .value(rekognitionLabel.getName())
                     .confidence(rekognitionLabel.getConfidence())
                     .parentLabels(parents)
+                    .boxes(boxes)
                     .build();
             labels.add(amplifyLabel);
         }

--- a/core/src/main/java/com/amplifyframework/predictions/models/Label.java
+++ b/core/src/main/java/com/amplifyframework/predictions/models/Label.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.predictions.models;
 
+import android.graphics.RectF;
 import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
@@ -34,10 +35,12 @@ public final class Label extends ImageFeature<String> {
     public static final String FEATURE_TYPE = Label.class.getSimpleName();
 
     private final List<String> parentLabels;
+    private final List<RectF> boxes;
 
     private Label(final Builder builder) {
         super(builder);
         this.parentLabels = builder.getParentLabels();
+        this.boxes = builder.getBoxes();
     }
 
     @Override
@@ -67,6 +70,16 @@ public final class Label extends ImageFeature<String> {
     }
 
     /**
+     * Gets the list of bounding boxes containing objects for
+     * this label.
+     * @return the list of bounding boxes
+     */
+    @NonNull
+    public List<RectF> getBoxes() {
+        return boxes;
+    }
+
+    /**
      * Gets a builder to construct label feature.
      * @return a new builder
      */
@@ -80,9 +93,11 @@ public final class Label extends ImageFeature<String> {
      */
     public static final class Builder extends ImageFeature.Builder<Builder, Label, String> {
         private List<String> parentLabels;
+        private List<RectF> boxes;
 
         private Builder() {
             this.parentLabels = new ArrayList<>();
+            this.boxes = new ArrayList<>();
         }
 
         /**
@@ -107,6 +122,17 @@ public final class Label extends ImageFeature<String> {
         }
 
         /**
+         * Sets the list of bounding boxes and return this builder.
+         * @param boxes the list of bounding boxes
+         * @return this builder instance
+         */
+        @NonNull
+        public Builder boxes(@NonNull List<RectF> boxes) {
+            this.boxes = Objects.requireNonNull(boxes);
+            return this;
+        }
+
+        /**
          * Construct a new instance of {@link Label} from
          * the values assigned to this builder.
          * @return An instance of {@link Label}
@@ -119,6 +145,11 @@ public final class Label extends ImageFeature<String> {
         @NonNull
         List<String> getParentLabels() {
             return Objects.requireNonNull(parentLabels);
+        }
+
+        @NonNull
+        List<RectF> getBoxes() {
+            return Objects.requireNonNull(boxes);
         }
     }
 }

--- a/core/src/main/java/com/amplifyframework/predictions/models/Label.java
+++ b/core/src/main/java/com/amplifyframework/predictions/models/Label.java
@@ -18,6 +18,8 @@ package com.amplifyframework.predictions.models;
 import android.graphics.RectF;
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.util.Immutable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -144,12 +146,12 @@ public final class Label extends ImageFeature<String> {
 
         @NonNull
         List<String> getParentLabels() {
-            return Objects.requireNonNull(parentLabels);
+            return Objects.requireNonNull(Immutable.of(parentLabels));
         }
 
         @NonNull
         List<RectF> getBoxes() {
-            return Objects.requireNonNull(boxes);
+            return Objects.requireNonNull(Immutable.of(boxes));
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Exposed bounding boxes for objects of identified label. This property is already available in [iOS](https://github.com/aws-amplify/amplify-ios/blob/eb5b7ff98ae9ac090dc8c71e374b8f3bcb0ee472/Amplify/Categories/Predictions/Result/IdentifyLabelsResult.swift#L23) and [JS](https://github.com/aws-amplify/amplify-js/blob/e85640a4e18fa1d55411038fee58919ad73121fa/packages/predictions/src/types/Predictions.ts#L236) libraries, but was not included in Android library as an undersight.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
