### PR TITLE
chore: update to gradle plugin 4.1.1

### DIFF
--- a/aws-storage-s3/src/main/AndroidManifest.xml
+++ b/aws-storage-s3/src/main/AndroidManifest.xml
@@ -16,8 +16,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.amplifyframework.storage.s3" >
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
     <application>
         <service android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService" android:enabled="true" />
     </application>

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
     }
 }
 
@@ -56,7 +56,7 @@ ext {
     navigationVersion = '2.3.1'
     dependency = [
         android: [
-            desugartools: 'com.android.tools:desugar_jdk_libs:1.0.9',
+            desugartools: 'com.android.tools:desugar_jdk_libs:1.1.1',
         ],
         androidx: [
             v4support: 'androidx.legacy:legacy-support-v4:1.0.0',
@@ -124,8 +124,8 @@ private void configureAndroidLibrary(Project project) {
             multiDexEnabled true
             minSdkVersion rootProject.ext.minSdkVersion
             targetSdkVersion rootProject.ext.targetSdkVersion
-            versionCode rootProject.findProperty('VERSION_CODE').toInteger()
-            versionName rootProject.findProperty('VERSION_NAME')
+            buildConfigField 'int', 'VERSION_CODE', rootProject.findProperty('VERSION_CODE')
+            buildConfigField 'String', 'VERSION_NAME', "\"${rootProject.findProperty('VERSION_NAME')}\""
             testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
             consumerProguardFiles rootProject.file('configuration/consumer-rules.pro')
 


### PR DESCRIPTION
In 4.1.0, the [version properties are removed from the BuildConfig class in library projects](https://developer.android.com/studio/releases/gradle-plugin#version_properties_removed_from_buildconfig_class_in_library_projects
).   Our library currently uses `BuildConfig.VERSION_NAME` for building user agents, and for displaying the current library version in the developer menu.   In order to continue using this, I created custom `buildConfig` properties of the same name.

This also removes the `WRITE_EXTERNAL_STORAGE` permission from the S3 plugin's `AndroidManifest.xml`, since [it was deprecated in Android 11](https://developer.android.com/about/versions/11/privacy/storage#permissions-target-11).  If TransferUtility does rely on this permission, it's already broken for apps built with API 30 and above, irrespective of this PR.    From what I can tell though, TransferUtility should still work.  It creates a SQLite DB using [SQLiteOpenHelper](https://developer.android.com/reference/android/database/sqlite/SQLiteOpenHelper), which creates the DB in the app sandbox, so permissions should not be required.

This PR resolves https://github.com/aws-amplify/amplify-android/issues/896

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
