### PR TITLE
chore(rxbindings) second attempt to fix transient test failures

### DIFF
--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxStorageBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxStorageBindingTest.java
@@ -139,6 +139,7 @@ public final class RxStorageBindingTest {
         TestObserver<StorageTransferProgress> testProgressObserver = rxOperation.observeProgress().test();
         testObserver.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         testObserver.assertValues(result);
+        testProgressObserver.awaitCount(5);
         testProgressObserver.assertValueCount(5);
     }
 
@@ -204,6 +205,7 @@ public final class RxStorageBindingTest {
         TestObserver<StorageTransferProgress> testProgressObserver = rxOperation.observeProgress().test();
         testObserver.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         testObserver.assertValues(result);
+        testProgressObserver.awaitCount(5);
         testProgressObserver.assertValueCount(5);
     }
 
@@ -242,6 +244,7 @@ public final class RxStorageBindingTest {
         TestObserver<StorageTransferProgress> testProgressObserver = rxOperation.observeProgress().test();
         testObserver.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         testObserver.assertValues(result);
+        testProgressObserver.awaitCount(5);
         testProgressObserver.assertValueCount(5);
     }
 


### PR DESCRIPTION
The `awaitCount` method doesn't allow you to specific a timeout, but it does timeout after 5 seconds.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
