### PR TITLE
fix(aws-datastore): keep observations active despite errors

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -312,7 +312,6 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 itemChangeSubject.onNext(change);
                 onSuccess.accept(change);
             } catch (DataStoreException dataStoreException) {
-                itemChangeSubject.onError(dataStoreException);
                 onError.accept(dataStoreException);
             } catch (Exception someOtherTypeOfException) {
                 String modelToString = getModelName(item) + "[id=" + item.getId() + "]";
@@ -320,7 +319,6 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     "Error in saving the model: " + modelToString,
                     someOtherTypeOfException, "See attached exception for details."
                 );
-                itemChangeSubject.onError(dataStoreException);
                 onError.accept(dataStoreException);
             }
         });
@@ -530,14 +528,12 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 itemChangeSubject.onNext(change);
                 onSuccess.accept(change);
             } catch (DataStoreException dataStoreException) {
-                itemChangeSubject.onError(dataStoreException);
                 onError.accept(dataStoreException);
             } catch (Exception someOtherTypeOfException) {
                 DataStoreException dataStoreException = new DataStoreException(
                     "Error in deleting the model.", someOtherTypeOfException,
                     "See attached exception for details."
                 );
-                itemChangeSubject.onError(dataStoreException);
                 onError.accept(dataStoreException);
             }
         });


### PR DESCRIPTION
Currently, any error on the `save(...)` or `delete(...)` methods will cause
the observation channel to terminate. Better would be to keep it alive, so
that it can continue to emit new updates. If and when there is an error
saving or deleting, that error will be communicated by the error
callback on at the call site. Future work may add a new error event type
that could be emitted by the `observe(...)` API.

Resolves: https://github.com/aws-amplify/amplify-android/issues/984

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
