### PR TITLE
fix: fix field label in toString() of ModelField

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/model/ModelField.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelField.java
@@ -203,7 +203,7 @@ public final class ModelField {
     public String toString() {
         return "ModelField{" +
             "name='" + name + '\'' +
-            ", type='" + javaClassForValue + '\'' +
+            ", javaClassForValue='" + javaClassForValue + '\'' +
             ", targetType='" + targetType + '\'' +
             ", isRequired=" + isRequired +
             ", isArray=" + isArray +


### PR DESCRIPTION
When the formerly-existing `type` member was renamed to
`javaClassForValue`, the label in `toString()` was not updated.

Here's a fix for that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
