### PR TITLE
fix(aws-datastore): Add owner to SelectionSet for Flutter

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
@@ -348,6 +348,8 @@ public final class SelectionSet {
             return typeClass;
         }
 
+        // TODO: this method is tech debt. We added it to support usage of the library from Flutter.
+        // This version of the method needs to be unified with getModelFields(Class<? extends Model> clazz, int depth).
         private Set<SelectionSet> getModelFields(ModelSchema modelSchema, int depth) {
             if (depth < 0) {
                 return new HashSet<>();
@@ -375,6 +377,12 @@ public final class SelectionSet {
                     }
                 } else {
                     result.add(new SelectionSet(fieldName));
+                }
+                for (AuthRule authRule : modelSchema.getAuthRules()) {
+                    if (AuthStrategy.OWNER.equals(authRule.getAuthStrategy())) {
+                        result.add(new SelectionSet(authRule.getOwnerFieldOrDefault()));
+                        break;
+                    }
                 }
             }
             for (String fieldName : requestOptions.modelMetaFields()) {


### PR DESCRIPTION
When building selection sets to be dispatched to AppSync, the native
branch of the code was applying owner auth rules, but the Flutter branch
was not.

Resolves: https://github.com/aws-amplify/amplify-android/issues/1019

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
