### PR TITLE
fix(aws-datastore): null modelName in OutboxMutationProcessed

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/BasicCloudSyncInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/BasicCloudSyncInstrumentationTest.java
@@ -129,8 +129,9 @@ public final class BasicCloudSyncInstrumentationTest {
         BlogOwner localCharley = BlogOwner.builder()
             .name("Charley Crockett")
             .build();
+        String modelName = BlogOwner.class.getSimpleName();
         HubAccumulator publishedMutationsAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(localCharley), 1)
+            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, localCharley.getId()), 1)
                 .start();
 
         // Save Charley Crockett, a guy who has a blog, into the DataStore.
@@ -166,7 +167,7 @@ public final class BasicCloudSyncInstrumentationTest {
 
         // Start watching locally, to see if it shows up on the client.
         HubAccumulator receiptAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(jameson), 1)
+            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(jameson.getId()), 1)
                 .start();
 
         // Act: create the model in the cloud

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/HybridAssociationSyncInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/HybridAssociationSyncInstrumentationTest.java
@@ -160,7 +160,7 @@ public final class HybridAssociationSyncInstrumentationTest {
 
         // Setup an accumulator so we know when there has been a publication.
         HubAccumulator ownerAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(owner), 1)
+            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(ownerModelName, owner.getId()), 1)
                 .start();
         hybridBehaviors.save(serializedOwner);
         ownerAccumulator.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -196,7 +196,7 @@ public final class HybridAssociationSyncInstrumentationTest {
 
         // Save the blog
         HubAccumulator blogAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(blog), 1)
+            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(blogSchemaName, blog.getId()), 1)
                 .start();
         hybridBehaviors.save(serializedBlog);
         blogAccumulator.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -230,7 +230,7 @@ public final class HybridAssociationSyncInstrumentationTest {
         ModelSchema ownerSchema = schemaProvider.modelSchemas().get(ownerModelName);
         assertNotNull(ownerSchema);
         HubAccumulator ownerAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(owner), 1)
+            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(owner.getId()), 1)
                 .start();
         appSync.create(owner, ownerSchema);
         ownerAccumulator.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -256,7 +256,7 @@ public final class HybridAssociationSyncInstrumentationTest {
         ModelSchema blogSchema = schemaProvider.modelSchemas().get(blogModelName);
         assertNotNull(blogSchema);
         HubAccumulator blogAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(blog), 1)
+            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(blog.getId()), 1)
                 .start();
         appSync.create(blog, blogSchema);
         blogAccumulator.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/HybridTemporalSyncInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/HybridTemporalSyncInstrumentationTest.java
@@ -137,7 +137,7 @@ public final class HybridTemporalSyncInstrumentationTest {
             .modelSchema(modelSchema)
             .build();
         HubAccumulator publicationAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(sentModel), 1)
+            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelSchema.getName(), sentModel.getId()), 1)
                 .start();
         hybridBehaviors.save(sentModel);
         publicationAccumulator.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -162,7 +162,7 @@ public final class HybridTemporalSyncInstrumentationTest {
         // Save a meeting, remotely. Wait for it to show up locally.
         Meeting meeting = createMeeting();
         HubAccumulator receiptAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(meeting), 1)
+            HubAccumulator.create(HubChannel.DATASTORE, receiptOf(meeting.getId()), 1)
                 .start();
         appSync.create(meeting, modelSchema);
         receiptAccumulator.awaitFirst(TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/OutboxMutationEvent.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/OutboxMutationEvent.java
@@ -24,7 +24,6 @@ import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
-import com.amplifyframework.datastore.appsync.SerializedModel;
 
 import java.util.Objects;
 
@@ -64,27 +63,24 @@ public final class OutboxMutationEvent<M extends Model> {
      * sync metadata.
      * This format will be used for representing a pending mutation that has
      * successfully undergone cloud publication.
+     * @param modelName Name of the model that has been processed (e.g., "Blog".)
      * @param modelWithMetadata Processed model with its sync metadata.
      * @param <M> Class type of the model.
      * @return Outbox mutation event with sync metadata.
      */
     @NonNull
-    public static <M extends Model> OutboxMutationEvent<M> fromModelWithMetadata(
-            @NonNull ModelWithMetadata<M> modelWithMetadata) {
+    public static <M extends Model> OutboxMutationEvent<M> create(
+            @NonNull String modelName, @NonNull ModelWithMetadata<M> modelWithMetadata) {
+        Objects.requireNonNull(modelName);
         Objects.requireNonNull(modelWithMetadata);
-        final M model = modelWithMetadata.getModel();
 
-        final String modelName;
-        if (model instanceof SerializedModel) {
-            modelName = ((SerializedModel) model).getModelName();
-        } else {
-            modelName = model.getClass().getSimpleName();
-        }
-
+        M model = modelWithMetadata.getModel();
         ModelMetadata metadata = modelWithMetadata.getSyncMetadata();
+
         Integer version = metadata.getVersion();
         Temporal.Timestamp lastChangedAt = metadata.getLastChangedAt();
         Boolean deleted = metadata.isDeleted();
+
         OutboxMutationEventElement<M> element =
             new OutboxMutationEventElement<>(model, version, lastChangedAt, deleted);
 


### PR DESCRIPTION
When the `MutationProcessor` successfully processes an item from the
Mutation Outbox, it will publish an `OutboxMutationProcessed` event to the
Hub.

The AppSync response itself contains no information about *what type* of
model has just been published. That information is only available before
making the request.

As a consequence, we cannot inspect the model name from the AppSync
response, and instead, we should pull it out of the `MutationProcessor`'s
request context.

To validate this fix, the various instrumentation tests are updated to
use the `getModelName()` code path on the `OutboxMutationProcessed` event.

Resolves: https://github.com/aws-amplify/amplify-android/issues/1012

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
