### PR TITLE
fix: adaptive timeouts should apply for Flutter too

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -139,7 +139,7 @@ public final class Orchestrator {
         // then 2 seconds are added to the timer per additional model count.
         this.adjustedTimeoutSeconds = Math.max(
             NETWORK_OP_TIMEOUT_SECONDS,
-            TIMEOUT_SECONDS_PER_MODEL * modelProvider.models().size()
+            TIMEOUT_SECONDS_PER_MODEL * modelProvider.modelNames().size()
         );
         this.startStopSemaphore = new Semaphore(1);
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -90,7 +90,7 @@ final class SubscriptionProcessor {
         // then 2 seconds are added to the timer per additional model count.
         this.adjustedTimeoutSeconds = Math.max(
             NETWORK_OP_TIMEOUT_SECONDS,
-            TIMEOUT_SECONDS_PER_MODEL * modelProvider.models().size()
+            TIMEOUT_SECONDS_PER_MODEL * modelProvider.modelNames().size()
         );
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -111,7 +111,7 @@ public final class SyncProcessorTest {
         modelClasses.addAll(SystemModelsProviderFactory.create().models());
         modelClasses.addAll(AmplifyModelProvider.getInstance().models());
         this.modelProvider = SimpleModelProvider.instance(UUID.randomUUID().toString(), modelClasses);
-        modelCount = modelProvider.models().size();
+        modelCount = modelProvider.modelNames().size();
 
         this.appSync = mock(AppSync.class);
         this.errorHandlerCallCount = 0;


### PR DESCRIPTION
The sync engine uses "adaptive" timeouts, that scale up or down
depending on the number of models that need to be sync'd.

To determine the number of models, `modelProvider.models().size()` was
being used. This will return 0 when being used from Flutter. Instead, we
can consider `modelProvider.modelNames().size()`, which will work for
both ModelSchema and Model-based usages of the DataStore.

Refer: https://github.com/aws-amplify/amplify-android/issues/854

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
