### PR TITLE
fix(amplify-tools): Add --forcePush to init

### DIFF
--- a/amplify-tools/amplify-tools-gradle-plugin/src/main/groovy/com/amplifyframework/tools/gradle/plugin/AmplifyTools.groovy
+++ b/amplify-tools/amplify-tools-gradle-plugin/src/main/groovy/com/amplifyframework/tools/gradle/plugin/AmplifyTools.groovy
@@ -153,7 +153,8 @@ class AmplifyTools implements Plugin<Project> {
                         commandLine amplify, 'init',
                                 '--amplify', amplifyConfig,
                                 '--providers', providersConfig,
-                                '--yes'
+                                '--yes',
+                                '--forcePush'
                     }
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CLI requires that we use `forcePush` if we want to deploy changes during the init command. This PR incorporates this change into the build tools to address issues users found while walking through the getting started guide.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
