### PR TITLE
chore: add a bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,24 +7,14 @@ assignees: ''
 
 ---
 
-This bug report uses [Markdown fomatting](https://guides.github.com/features/mastering-markdown/). Please use [syntax highlighting](https://docs.github.com/en/free-pro-team@latest/github/writing-on-github/creating-and-highlighting-code-blocks#fenced-code-blocks) for any code/logs.
+Please search the [existing issues](https://github.com/aws-amplify/amplify-android/search?q=%22your%20search%20query%20goes%20here%22) first.  If your issue is not reported yet, create one with the following information:
 
-Please include the following information:
+1. A **short** description
+2. The version of Amplify Android you're using
+3. The **code** you're using to call Amplify Android
+4. Any relevant [logs](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#getting-more-output)
+5. Any relevant guides or documentation you're referencing
+6. For API or DataStore issues, your `schema.graphql`
 
-0. A **short description** of the problem
-1. The version of Amplify Android you're using
-2. What you're trying to accomplish
-3. What you expected to happen
-4. What you observed to happen, instead
-5. Steps to reproduce the issue
-6. The **code** you're using to call Amplify Android
-7. Your `app/src/main/res/raw/amplifyconfiguration.json` (Please change any unique ids to `XXXX`.)
-8. **[Logs](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#getting-more-output)** and screenshots of the observed behavior
+Please use [syntax highlighting](https://docs.github.com/en/free-pro-team@latest/github/writing-on-github/creating-and-highlighting-code-blocks#fenced-code-blocks) for any code/logs.
 
-While might also include the following, if applicable:
-
-1. The type of Android device you're using
-2. Screenshots of the issue
-3. Any relevant guides or documentation you're referencing
-
-Please look through our existing issues to see if your issue is already described. You can [search through our issues here](https://github.com/aws-amplify/amplify-android/search?q=%22your%20search%20query%20goes%20here%22).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'Bug'
+assignees: ''
+
+---
+
+This bug report uses [Markdown fomatting](https://guides.github.com/features/mastering-markdown/). Please use [syntax highlighting](https://docs.github.com/en/free-pro-team@latest/github/writing-on-github/creating-and-highlighting-code-blocks#fenced-code-blocks) for any code/logs.
+
+Please include the following information:
+
+0. A **short description** of the problem
+1. The version of Amplify Android you're using
+2. What you're trying to accomplish
+3. What you expected to happen
+4. What you observed to happen, instead
+5. Steps to reproduce the issue
+6. The **code** you're using to call Amplify Android
+7. Your `app/src/main/res/raw/amplifyconfiguration.json` (Please change any unique ids to `XXXX`.)
+8. **[Logs](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#getting-more-output)** and screenshots of the observed behavior
+
+While might also include the following, if applicable:
+
+1. The type of Android device you're using
+2. Screenshots of the issue
+3. Any relevant guides or documentation you're referencing
+
+Please look through our existing issues to see if your issue is already described. You can [search through our issues here](https://github.com/aws-amplify/amplify-android/search?q=%22your%20search%20query%20goes%20here%22).


### PR DESCRIPTION
A few questions for the Android team:

1. A meta-proposal: _should_ we even bother with a template?
2. If so, is this the right amount of direction to provide, or is it too wordy, already?

You can see a rendered version of the template [here](https://github.com/aws-amplify/amplify-android/blob/ae3f599d2e1b9d2c51469adae9ba911a72155a7e/.github/ISSUE_TEMPLATE/bug_report.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
