### PR TITLE
fix(datastore) release startStopSemaphore when start returns, not when API sync completes

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -97,7 +97,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             sqliteStorageAdapter,
             AppSyncClient.via(api),
             () -> pluginConfiguration,
-            () -> !api.getPlugins().isEmpty()
+            () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API
         );
         this.userProvidedConfiguration = userProvidedConfiguration;
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -263,6 +263,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     public void stop(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
         waitForInitialization()
             .andThen(orchestrator.stop())
+            .subscribeOn(Schedulers.io())
             .subscribe(
                 onComplete::call,
                 error -> onError.accept(new DataStoreException("Failed to stop DataStore.", error, "Retry."))

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -97,7 +97,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             sqliteStorageAdapter,
             AppSyncClient.via(api),
             () -> pluginConfiguration,
-            () -> api.getPlugins().isEmpty() ? Orchestrator.Mode.LOCAL_ONLY : Orchestrator.Mode.SYNC_VIA_API
+            () -> !api.getPlugins().isEmpty()
         );
         this.userProvidedConfiguration = userProvidedConfiguration;
     }
@@ -235,18 +235,11 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         ));
     }
 
-    private void waitForInitialization(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
-        Completable.create(emitter -> {
-            categoryInitializationsPending.await();
-            emitter.onComplete();
-        })
-                .timeout(LIFECYCLE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-                .subscribeOn(Schedulers.io())
-                .subscribe(
-                        onComplete::call,
-                        throwable -> onError.accept(new DataStoreException("Request failed because DataStore is not " +
-                                "initialized.", throwable, "Retry your request."))
-            );
+    private Completable waitForInitialization() {
+        return Completable.fromAction(() -> categoryInitializationsPending.await())
+            .timeout(LIFECYCLE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .subscribeOn(Schedulers.io())
+            .doOnError(error -> LOG.error("DataStore initialization timed out.", error));
     }
 
     /**
@@ -254,15 +247,13 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
      */
     @Override
     public void start(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
-        waitForInitialization(() -> {
-            try {
-                orchestrator.start();
-            } catch (DataStoreException exception) {
-                onError.accept(exception);
-                return;
-            }
-            onComplete.call();
-        }, onError);
+        waitForInitialization()
+            .andThen(orchestrator.start())
+            .subscribeOn(Schedulers.io())
+            .subscribe(
+                onComplete::call,
+                error -> onError.accept(new DataStoreException("Failed to start DataStore.", error, "Retry."))
+            );
     }
 
     /**
@@ -270,12 +261,12 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
      */
     @Override
     public void stop(@NonNull Action onComplete, @NonNull Consumer<DataStoreException> onError) {
-        waitForInitialization(() -> orchestrator.stop()
-                .subscribeOn(Schedulers.io())
-                .subscribe(
-                    onComplete::call,
-                    error -> onError.accept(new DataStoreException("Failed to stop DataStore.", error,
-                            "Retry your request."))), onError);
+        waitForInitialization()
+            .andThen(orchestrator.stop())
+            .subscribe(
+                onComplete::call,
+                error -> onError.accept(new DataStoreException("Failed to stop DataStore.", error, "Retry."))
+            );
     }
 
     /**
@@ -294,19 +285,6 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
                             throwable -> onError.accept(new DataStoreException("Clear operation failed",
                                     throwable, AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION))),
                 onError);
-    }
-
-    /**
-     * Terminate use of the plugin.
-     */
-    synchronized void terminate() {
-        try {
-            orchestrator.stop()
-                .andThen(Completable.fromAction(sqliteStorageAdapter::terminate))
-                .blockingAwait(LIFECYCLE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (Throwable throwable) {
-            LOG.warn("An error occurred while terminating the DataStore plugin.", throwable);
-        }
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -62,7 +62,7 @@ import static org.mockito.Mockito.verify;
  */
 @RunWith(RobolectricTestRunner.class)
 public final class OrchestratorTest {
-    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore:test");
 
     private Orchestrator orchestrator;
     private HubAccumulator orchestratorInitObserver;


### PR DESCRIPTION
 - Fixes #1010 ("Unable to acquire orchestrator lock. Transition currently in progress") (also reported in https://github.com/aws-amplify/amplify-android/issues/977#issuecomment-737041548). Previously, if you call two DataStore operations right after each other, the second one would usually fail.  Each operation calls start, which previously required obtaining a semaphore, within a 2 second timeout.  Previously, the semaphore was locked until the API sync completed, but with this PR, the lock is released as soon as the storage observer is initialized (which only takes a few milliseconds).  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
