### PR TITLE
feat(Auth): Adds the ability to specify a custom browser for web UI sign in/out

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -1009,7 +1009,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
         @NonNull Consumer<AuthException> onException
     ) {
         HostedUIOptions.Builder optionsBuilder = HostedUIOptions.builder();
-        SignInUIOptions.Builder signInUIOptionsBuilders = SignInUIOptions.builder();
+        SignInUIOptions.Builder signInUIOptionsBuilder = SignInUIOptions.builder();
 
         if (options != null) {
             if (options.getScopes() != null) {
@@ -1032,7 +1032,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                 AWSCognitoAuthWebUISignInOptions cognitoOptions = (AWSCognitoAuthWebUISignInOptions) options;
                 optionsBuilder.idpIdentifier(cognitoOptions.getIdpIdentifier())
                         .federationProviderName(cognitoOptions.getFederationProviderName());
-                signInUIOptionsBuilders.browserPackage(cognitoOptions.getBrowserPackage());
+                signInUIOptionsBuilder.browserPackage(cognitoOptions.getBrowserPackage());
             }
 
             if (authProvider != null) {
@@ -1040,7 +1040,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             }
         }
 
-        SignInUIOptions signInUIOptions = signInUIOptionsBuilders
+        SignInUIOptions signInUIOptions = signInUIOptionsBuilder
                 .hostedUIOptions(optionsBuilder.build())
                 .build();
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignOutOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignOutOptions.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.auth.options.AuthSignOutOptions;
+
+/**
+ * Cognito extension of sign in options to add the platform specific fields.
+ */
+public final class AWSCognitoAuthSignOutOptions extends AuthSignOutOptions {
+    private final String browserPackage;
+
+    /**
+     * Advanced options for signing in.
+     * @param globalSignOut Sign out of all devices (do not use when signing out of a WebUI experience)
+     * @param browserPackage Specify which browser package should be used for signing out of an account which was signed
+     *                      into with a web UI experience (example value: "org.mozilla.firefox").
+     *                      Defaults to the Chrome package if not specified.
+     */
+    protected AWSCognitoAuthSignOutOptions(
+            boolean globalSignOut,
+            String browserPackage
+    ) {
+        super(globalSignOut);
+        this.browserPackage = browserPackage;
+    }
+
+    /**
+     * Optional browser package override to choose a browser app other than Chrome to launch web sign out.
+     * @return optional browser package override to choose a browser app other than Chrome to launch web sign out.
+     */
+    @Nullable
+    public String getBrowserPackage() {
+        return browserPackage;
+    }
+
+    /**
+     * Get a builder object.
+     * @return a builder object.
+     */
+    @NonNull
+    public static CognitoBuilder builder() {
+        return new CognitoBuilder();
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                isGlobalSignOut(),
+                getBrowserPackage()
+        );
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            AWSCognitoAuthSignOutOptions authSignOutOptions = (AWSCognitoAuthSignOutOptions) obj;
+            return ObjectsCompat.equals(isGlobalSignOut(), authSignOutOptions.isGlobalSignOut()) &&
+                    ObjectsCompat.equals(getBrowserPackage(), authSignOutOptions.getBrowserPackage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AWSCognitoAuthSignOutOptions{" +
+                "isGlobalSignOut=" + isGlobalSignOut() +
+                ", browserPackage=" + getBrowserPackage() +
+                '}';
+    }
+
+    /**
+     * The builder for this class.
+     */
+    public static final class CognitoBuilder extends Builder<CognitoBuilder> {
+        private String browserPackage;
+
+        /**
+         * Returns the type of builder this is to support proper flow with it being an extended class.
+         * @return the type of builder this is to support proper flow with it being an extended class.
+         */
+        @Override
+        public CognitoBuilder getThis() {
+            return this;
+        }
+
+        /**
+         * This can optionally be set to specify which browser package should perform the sign out action
+         * (e.g. "org.mozilla.firefox") in the case of an account which was signed in to from a web UI experience.
+         * Defaults to the Chrome package if not set.
+         *
+         * @param browserPackage String specifying the browser to open custom tabs.
+         * @return the instance of the builder.
+         */
+        public CognitoBuilder browserPackage(@NonNull String browserPackage) {
+            this.browserPackage = browserPackage;
+            return this;
+        }
+
+        /**
+         * Construct and return the object with the values set in the builder.
+         * @return a new instance of AWSCognitoAuthSignOutOptions with the values specified in the builder.
+         */
+        @NonNull
+        public AWSCognitoAuthSignOutOptions build() {
+            return new AWSCognitoAuthSignOutOptions(
+                    super.isGlobalSignOut(),
+                    browserPackage
+            );
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignOutOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignOutOptions.java
@@ -22,13 +22,13 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 
 /**
- * Cognito extension of sign in options to add the platform specific fields.
+ * Cognito extension of sign out options to add the platform specific fields.
  */
 public final class AWSCognitoAuthSignOutOptions extends AuthSignOutOptions {
     private final String browserPackage;
 
     /**
-     * Advanced options for signing in.
+     * Advanced options for signing out.
      * @param globalSignOut Sign out of all devices (do not use when signing out of a WebUI experience)
      * @param browserPackage Specify which browser package should be used for signing out of an account which was signed
      *                      into with a web UI experience (example value: "org.mozilla.firefox").
@@ -109,7 +109,7 @@ public final class AWSCognitoAuthSignOutOptions extends AuthSignOutOptions {
          * (e.g. "org.mozilla.firefox") in the case of an account which was signed in to from a web UI experience.
          * Defaults to the Chrome package if not set.
          *
-         * @param browserPackage String specifying the browser to open custom tabs.
+         * @param browserPackage String specifying the browser package to perform the web sign out action.
          * @return the instance of the builder.
          */
         public CognitoBuilder browserPackage(@NonNull String browserPackage) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthWebUISignInOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthWebUISignInOptions.java
@@ -31,6 +31,7 @@ import java.util.Map;
 public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptions {
     private final String idpIdentifier;
     private final String federationProviderName;
+    private final String browserPackage;
 
     /**
      * Advanced options for signing in via a hosted web ui.
@@ -41,6 +42,8 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
      * @param idpIdentifier The IdentityProvider identifier if using multiple instances of same identity provider.
      * @param federationProviderName If federating with Cognito Identity and using a provider lik Auth0 specify the
      *                               provider name, e.g. .auth0.com
+     * @param browserPackage Specify which browser package should be used for web sign in (e.g. "org.mozilla.firefox").
+     *                       Defaults to the Chrome package if not specified.
      */
     protected AWSCognitoAuthWebUISignInOptions(
             List<String> scopes,
@@ -48,11 +51,13 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
             Map<String, String> signOutQueryParameters,
             Map<String, String> tokenQueryParameters,
             String idpIdentifier,
-            String federationProviderName
+            String federationProviderName,
+            String browserPackage
     ) {
         super(scopes, signInQueryParameters, signOutQueryParameters, tokenQueryParameters);
         this.idpIdentifier = idpIdentifier;
         this.federationProviderName = federationProviderName;
+        this.browserPackage = browserPackage;
     }
 
     /**
@@ -74,6 +79,15 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
     }
 
     /**
+     * Optional browser package override to choose a browser app other than Chrome to launch web sign in.
+     * @return optional browser package override to choose a browser app other than Chrome to launch web sign in.
+     */
+    @Nullable
+    public String getBrowserPackage() {
+        return browserPackage;
+    }
+
+    /**
      * Returns a builder for this object.
      * @return a builder for this object.
      */
@@ -90,7 +104,8 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
                 getSignOutQueryParameters(),
                 getTokenQueryParameters(),
                 getIdpIdentifier(),
-                getFederationProviderName()
+                getFederationProviderName(),
+                getBrowserPackage()
         );
     }
 
@@ -107,7 +122,8 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
                     ObjectsCompat.equals(getSignOutQueryParameters(), webUISignInOptions.getSignOutQueryParameters()) &&
                     ObjectsCompat.equals(getTokenQueryParameters(), webUISignInOptions.getTokenQueryParameters()) &&
                     ObjectsCompat.equals(getIdpIdentifier(), webUISignInOptions.getIdpIdentifier()) &&
-                    ObjectsCompat.equals(getFederationProviderName(), webUISignInOptions.getFederationProviderName());
+                    ObjectsCompat.equals(getFederationProviderName(), webUISignInOptions.getFederationProviderName()) &&
+                    ObjectsCompat.equals(getBrowserPackage(), webUISignInOptions.getBrowserPackage());
         }
     }
 
@@ -120,6 +136,7 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
                 ", tokenQueryParameters=" + getTokenQueryParameters() +
                 ", idpIdentifier=" + getIdpIdentifier() +
                 ", federationProviderName=" + getFederationProviderName() +
+                ", browserPackage=" + getBrowserPackage() +
                 '}';
     }
 
@@ -129,6 +146,7 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
     public static final class CognitoBuilder extends Builder<CognitoBuilder> {
         private String idpIdentifier;
         private String federationProviderName;
+        private String browserPackage;
 
         /**
          * Constructs the builder.
@@ -170,6 +188,18 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
         }
 
         /**
+         * This can optionally be set to specify which browser package should perform the sign in action
+         * (e.g. "org.mozilla.firefox"). Defaults to the Chrome package if not set.
+         *
+         * @param browserPackage String specifying the browser to open custom tabs.
+         * @return the instance of the builder.
+         */
+        public CognitoBuilder browserPackage(@NonNull String browserPackage) {
+            this.browserPackage = browserPackage;
+            return this;
+        }
+
+        /**
          * Build the object.
          * @return a new instance of AWSCognitoAuthWebUISignInOptions.
          */
@@ -181,7 +211,8 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
                     Immutable.of(super.getSignOutQueryParameters()),
                     Immutable.of(super.getTokenQueryParameters()),
                     idpIdentifier,
-                    federationProviderName
+                    federationProviderName,
+                    browserPackage
             );
         }
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthWebUISignInOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthWebUISignInOptions.java
@@ -191,7 +191,7 @@ public final class AWSCognitoAuthWebUISignInOptions extends AuthWebUISignInOptio
          * This can optionally be set to specify which browser package should perform the sign in action
          * (e.g. "org.mozilla.firefox"). Defaults to the Chrome package if not set.
          *
-         * @param browserPackage String specifying the browser to open custom tabs.
+         * @param browserPackage String specifying the browser package to perform the web sign in action.
          * @return the instance of the builder.
          */
         public CognitoBuilder browserPackage(@NonNull String browserPackage) {

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthSignOutOptions.java
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthSignOutOptions.java
@@ -26,7 +26,7 @@ public class AuthSignOutOptions {
 
     /**
      * Advanced options for signing up.
-     * @param globalSignOut Sign out of all devices
+     * @param globalSignOut Sign out of all devices (do not use when signing out of a WebUI experience)
      */
     protected AuthSignOutOptions(
             boolean globalSignOut

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -28,6 +28,7 @@ import com.amplifyframework.auth.AuthSession;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.options.AuthSignInOptions;
+import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
@@ -387,6 +388,21 @@ public final class SynchronousAuth {
     public void signOut() throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
                 asyncDelegate.signOut(
+                    () -> onResult.accept(new Object()),
+                    onError
+                )
+        );
+    }
+
+    /**
+     * Sign out synchronously with options.
+     * @param options Advanced options for signing out
+     * @throws AuthException exception
+     */
+    public void signOut(AuthSignOutOptions options) throws AuthException {
+        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+                asyncDelegate.signOut(
+                    options,
                     () -> onResult.accept(new Object()),
                     onError
                 )

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -37,6 +37,7 @@ import com.amplifyframework.auth.result.AuthSignUpResult;
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.testutils.Await;
+import com.amplifyframework.testutils.VoidResult;
 
 import java.util.List;
 import java.util.Map;
@@ -245,7 +246,7 @@ public final class SynchronousAuth {
                 asyncDelegate.confirmResetPassword(
                     newPassword,
                     confirmationCode,
-                    () -> onResult.accept(new Object()),
+                    () -> onResult.accept(VoidResult.instance()),
                     onError
                 )
         );
@@ -267,7 +268,7 @@ public final class SynchronousAuth {
      */
     public void rememberDevice() throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.rememberDevice(() -> onResult.accept(new Object()), onError)
+                asyncDelegate.rememberDevice(() -> onResult.accept(VoidResult.instance()), onError)
         );
     }
 
@@ -277,7 +278,7 @@ public final class SynchronousAuth {
      */
     public void forgetDevice() throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.forgetDevice(() -> onResult.accept(new Object()), onError)
+                asyncDelegate.forgetDevice(() -> onResult.accept(VoidResult.instance()), onError)
         );
     }
 
@@ -288,7 +289,7 @@ public final class SynchronousAuth {
      */
     public void forgetDevice(@NonNull AuthDevice device) throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.forgetDevice(device, () -> onResult.accept(new Object()), onError)
+                asyncDelegate.forgetDevice(device, () -> onResult.accept(VoidResult.instance()), onError)
         );
     }
 
@@ -312,7 +313,8 @@ public final class SynchronousAuth {
             @NonNull String newPassword
     ) throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.updatePassword(oldPassword, newPassword, () -> onResult.accept(new Object()), onError)
+                asyncDelegate.updatePassword(oldPassword, newPassword,
+                    () -> onResult.accept(VoidResult.instance()), onError)
         );
     }
 
@@ -376,7 +378,7 @@ public final class SynchronousAuth {
                                      @NonNull String confirmationCode) throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) -> {
             asyncDelegate.confirmUserAttribute(
-                    attributeKey, confirmationCode, () -> onResult.accept(new Object()), onError
+                    attributeKey, confirmationCode, () -> onResult.accept(VoidResult.instance()), onError
             );
         });
     }
@@ -388,7 +390,7 @@ public final class SynchronousAuth {
     public void signOut() throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
                 asyncDelegate.signOut(
-                    () -> onResult.accept(new Object()),
+                    () -> onResult.accept(VoidResult.instance()),
                     onError
                 )
         );
@@ -403,7 +405,7 @@ public final class SynchronousAuth {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
                 asyncDelegate.signOut(
                     options,
-                    () -> onResult.accept(new Object()),
+                    () -> onResult.accept(VoidResult.instance()),
                     onError
                 )
         );


### PR DESCRIPTION
This ability was added to AWSMobileClient [in this PR ](https://github.com/aws-amplify/aws-sdk-android/pull/2152)so adding options in Amplify Auth to be passed through and gain the same capability. 

Fulfills #678 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
