### PR TITLE
fix(aws-datastore): deleting nonexistent model instance no longer fails

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
@@ -120,6 +120,28 @@ public final class SQLiteStorageAdapterDeleteTest {
     }
 
     /**
+     * Test deleting nonexistent model from the database.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void deleteNonexistentModelDoesNotFail() throws DataStoreException {
+        final BlogOwner john = BlogOwner.builder()
+                .name("John")
+                .build();
+
+        // Try deleting John without saving first
+        adapter.delete(john);
+
+        // Try deleting John again, this time with a true condition
+        QueryPredicate matching = BlogOwner.NAME.eq(john.getName());
+        adapter.delete(john, matching);
+
+        // Try deleting John again, this time with a false condition
+        QueryPredicate mismatch = BlogOwner.NAME.ne(john.getName());
+        adapter.delete(john, mismatch);
+    }
+
+    /**
      * Test delete with predicate. Conditional delete is useful for making sure that
      * no data is removed with outdated assumptions.
      * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -481,6 +481,20 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 final SQLiteTable sqliteTable = SQLiteTable.fromSchema(modelSchema);
                 final String primaryKeyName = sqliteTable.getPrimaryKeyColumnName();
 
+                if (!dataExistsInSQLiteTable(sqliteTable.getName(), primaryKeyName, item.getId())) {
+                    LOG.warn(modelName + " model with id = " + item.getId() + " does not exist.");
+                    // Pass back item change instance without publishing it.
+                    onSuccess.accept(StorageItemChange.<T>builder()
+                        .changeId(item.getId())
+                        .item(item)
+                        .modelSchema(modelSchema)
+                        .type(StorageItemChange.Type.DELETE)
+                        .predicate(predicate)
+                        .initiator(initiator)
+                        .build());
+                    return;
+                }
+
                 LOG.debug("Deleting item in table: " + sqliteTable.getName() +
                     " identified by ID: " + item.getId());
 
@@ -499,32 +513,28 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     return;
                 }
 
-                DataStoreException problem = null;
                 synchronized (sqlCommand.getCompiledSqlStatement()) {
                     final SQLiteStatement compiledSqlStatement = sqlCommand.getCompiledSqlStatement();
                     compiledSqlStatement.clearBindings();
                     bindStatementToValues(sqlCommand, null);
                     // executeUpdateDelete returns the number of rows affected.
                     final int rowsDeleted = compiledSqlStatement.executeUpdateDelete();
-                    if (rowsDeleted != 1) {
-                        problem = new DataStoreException(
-                            "Wanted to delete one row, but deleted " + rowsDeleted + " rows.",
-                            "This is likely a bug. Please report to AWS."
-                        );
-                    }
                     compiledSqlStatement.clearBindings();
-                    if (problem != null) {
-                        throw problem;
+                    if (rowsDeleted == 0) {
+                        throw new DataStoreException(
+                            "Failed to meet condition. Model was not deleted.",
+                            "Please verify the current state of saved item."
+                        );
                     }
                 }
                 final StorageItemChange<T> change = StorageItemChange.<T>builder()
-                    .changeId(item.getId())
-                    .item(item)
-                    .modelSchema(modelSchema)
-                    .type(StorageItemChange.Type.DELETE)
-                    .predicate(predicate)
-                    .initiator(initiator)
-                    .build();
+                        .changeId(item.getId())
+                        .item(item)
+                        .modelSchema(modelSchema)
+                        .type(StorageItemChange.Type.DELETE)
+                        .predicate(predicate)
+                        .initiator(initiator)
+                        .build();
                 itemChangeSubject.onNext(change);
                 onSuccess.accept(change);
             } catch (DataStoreException dataStoreException) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -528,13 +528,13 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     }
                 }
                 final StorageItemChange<T> change = StorageItemChange.<T>builder()
-                        .changeId(item.getId())
-                        .item(item)
-                        .modelSchema(modelSchema)
-                        .type(StorageItemChange.Type.DELETE)
-                        .predicate(predicate)
-                        .initiator(initiator)
-                        .build();
+                    .changeId(item.getId())
+                    .item(item)
+                    .modelSchema(modelSchema)
+                    .type(StorageItemChange.Type.DELETE)
+                    .predicate(predicate)
+                    .initiator(initiator)
+                    .build();
                 itemChangeSubject.onNext(change);
                 onSuccess.accept(change);
             } catch (DataStoreException dataStoreException) {


### PR DESCRIPTION
*Description of changes:*
SQLiteStorageAdapter now checks if item exists before attempting delete. If not, then operation "succeeds" and returns a dummy item change instance, but does not publish any change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
