### PR TITLE
fix(aws-datastore): conditional insert no longer succeeds

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterSaveTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterSaveTest.java
@@ -201,6 +201,35 @@ public final class SQLiteStorageAdapterSaveTest {
     }
 
     /**
+     * Test save with predicate. Conditional insert is not viable since conditional write
+     * applies predicate to existing data. Insert is only performed if there isn't any existing
+     * data. Save operation should fail.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    @SuppressWarnings("ThrowableNotThrown")
+    public void saveModelWithPredicateFailsInsert() throws DataStoreException {
+        final BlogOwner john = BlogOwner.builder()
+                .name("John")
+                .build();
+        final BlogOwner jane = BlogOwner.builder()
+                .name("Jane")
+                .build();
+        final BlogOwner mark = BlogOwner.builder()
+                .name("Mark")
+                .build();
+
+        // Try inserting with predicate
+        final QueryPredicate predicate = BlogOwner.NAME.beginsWith("J");
+        adapter.saveExpectingError(john, predicate);
+        adapter.saveExpectingError(jane, predicate);
+        adapter.saveExpectingError(mark, predicate);
+
+        // Nothing was saved
+        assertTrue(adapter.query(BlogOwner.class).isEmpty());
+    }
+
+    /**
      * Test save with predicate. Conditional write is useful for making sure that
      * no data is overwritten with outdated assumptions.
      * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -285,6 +285,14 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                         return;
                     }
                     modelConflictStrategy = ModelConflictStrategy.OVERWRITE_EXISTING;
+                } else if (!QueryPredicates.all().equals(predicate)) {
+                    // insert not permitted with a condition
+                    onError.accept(new DataStoreException(
+                        "Conditional update must be performed against an already existing data. " +
+                            "Insertion is not permitted while using a predicate.",
+                        "Please save without specifying a predicate."
+                    ));
+                    return;
                 } else {
                     // insert model in SQLite
                     type = StorageItemChange.Type.CREATE;


### PR DESCRIPTION
*Description of changes:*
Conditional write is useful for making sure that no data is written without being sure of the condition of existing data. This also means that _conditional insert_ cannot be performed since insertion only happens when there _is_ no existing data.

Currently, Android DataStore ignores user-provided predicates when performing an insertion and successfully carries out the operation. This PR modifies the behavior so that an insertion triggers error callback if _any_ condition has been provided by the user.

Resolves: https://github.com/aws-amplify/amplify-android/issues/1034

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
