### PR TITLE
[aws-api] Fix DELETE calls not working with v4 signer

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncSigV4SignerInterceptor.java
@@ -227,8 +227,12 @@ public final class AppSyncSigV4SignerInterceptor implements Interceptor {
 
         //Set the URL and Method
         okReqBuilder.url(req.url());
-        final RequestBody requestBody = req.body() != null ?
-                RequestBody.create(bodyBytes, JSON_MEDIA_TYPE) : null;
+        final RequestBody requestBody;
+        if (req.body() != null && req.body().contentLength() > 0) {
+            requestBody = RequestBody.create(bodyBytes, JSON_MEDIA_TYPE);
+        } else {
+            requestBody = null;
+        }
 
         okReqBuilder.method(req.method(), requestBody);
 


### PR DESCRIPTION
`OkHttp3` sets the body of a `DELETE` call to a byte array of length 0. The
v4 signer interceptor only checks if the body is null and if its not it sets the
content type to `application/json`. This causes an invalid REST request to
be created. Fixed by expanding the check to also make sure the body has a
content length greater than 0.

Github Issue: https://github.com/aws-amplify/amplify-android/issues/1028

Tested in the app that had the original problem and verified to fix the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
