### PR TITLE
chore: improve missing config error messages

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
+++ b/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
@@ -236,7 +236,7 @@ public final class AmplifyConfiguration {
         } catch (Resources.ResourceLoadingException resourceLoadingException) {
             throw new AmplifyException(
                 "Failed to read JSON from resource = " + configFileResourceId, resourceLoadingException,
-                "If you are attempting to load a custom configuration file, please that it exists " +
+                "If you are attempting to load a custom configuration file, please ensure that it exists " +
                     "in your application project under app/src/main/res/raw/<YOUR_CUSTOM_CONFIG_FILE>."
             );
         }
@@ -314,4 +314,3 @@ public final class AmplifyConfiguration {
         }
     }
 }
-

--- a/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
+++ b/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
@@ -112,7 +112,7 @@ public final class AmplifyConfiguration {
     @SuppressWarnings("WeakerAccess")
     @NonNull
     public static AmplifyConfiguration fromConfigFile(@NonNull Context context) throws AmplifyException {
-        return builder(context, Resources.getRawResourceId(context, DEFAULT_IDENTIFIER)).build();
+        return builder(context).build();
     }
 
     /**
@@ -206,7 +206,16 @@ public final class AmplifyConfiguration {
      */
     @NonNull
     public static Builder builder(@NonNull Context context) throws AmplifyException {
-        return builder(context, Resources.getRawResourceId(context, DEFAULT_IDENTIFIER));
+        try {
+            @RawRes final int resourceId = Resources.getRawResourceId(context, DEFAULT_IDENTIFIER);
+            return builder(context, resourceId);
+        } catch (Resources.ResourceLoadingException resourceLoadingException) {
+            throw new AmplifyException(
+                "Failed to load the " + DEFAULT_IDENTIFIER + " configuration file.", resourceLoadingException,
+                "Is there an Amplify configuration file present in your app project, under " +
+                    "./app/src/main/res/raw/" + DEFAULT_IDENTIFIER + "?"
+            );
+        }
     }
 
     /**
@@ -219,11 +228,18 @@ public final class AmplifyConfiguration {
      * @throws AmplifyException If there is a problem in the config file
      */
     @NonNull
-    public static Builder builder(
-            @NonNull Context context,
-            @RawRes int configFileResourceId
-    ) throws AmplifyException {
-        return builder(Resources.readJsonResourceFromId(Objects.requireNonNull(context), configFileResourceId));
+    public static Builder builder(@NonNull Context context, @RawRes int configFileResourceId)
+            throws AmplifyException {
+        Objects.requireNonNull(context);
+        try {
+            return builder(Resources.readJsonResourceFromId(context, configFileResourceId));
+        } catch (Resources.ResourceLoadingException resourceLoadingException) {
+            throw new AmplifyException(
+                "Failed to read JSON from resource = " + configFileResourceId, resourceLoadingException,
+                "If you are attempting to load a custom configuration file, please that it exists " +
+                    "in your application project under app/src/main/res/raw/<YOUR_CUSTOM_CONFIG_FILE>."
+            );
+        }
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/EnvironmentInfo.java
@@ -76,7 +76,15 @@ public final class EnvironmentInfo {
      */
     public String getDeveloperEnvironmentInfo(@NonNull Context context) throws AmplifyException {
         Context appContext = Objects.requireNonNull(context).getApplicationContext();
-        JSONObject envInfo = Resources.readJsonResource(appContext, DEV_ENV_INFO_FILE_NAME);
+        final JSONObject envInfo;
+        try {
+            envInfo = Resources.readJsonResource(appContext, DEV_ENV_INFO_FILE_NAME);
+        } catch (Resources.ResourceLoadingException resourceLoadingException) {
+            throw new AmplifyException(
+                "Failed to find " + DEV_ENV_INFO_FILE_NAME + ".", resourceLoadingException,
+                "Please ensure it is present in your project."
+            );
+        }
         StringBuilder formattedEnvInfo = new StringBuilder();
         for (String envItem : devEnvironmentItems.keySet()) {
             if (envInfo.has(envItem)) {


### PR DESCRIPTION
The Amplify documentation suggests to configure the library with this
call:
```kotlin
Amplify.configure(applicationContext)
```
When configured in this way, the library will attempt to load a file
from the the user's application project. The file is expected to live at
`app/src/main/res/raw/amplifyconfiguration.json`.

If this file is *not* present, the previous error message was not very
helpful. This commit updates the error message, to give the user a
direct call to action.

This PR also updates a few related resource loading messages, to make
their error cases more clear.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
