### PR TITLE
fix(aws-datastore): store schema float as a java double

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/types/JavaFieldType.java
@@ -47,6 +47,11 @@ public enum JavaFieldType {
     FLOAT(Float.class),
 
     /**
+     * Represents the double data type.
+     */
+    DOUBLE(Double.class),
+
+    /**
      * Represents the String data type.
      */
     STRING(String.class),

--- a/aws-api-appsync/src/main/java/com/amplifyframework/util/GsonObjectConverter.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/util/GsonObjectConverter.java
@@ -75,8 +75,10 @@ public final class GsonObjectConverter {
                     Number number = primitive.getAsNumber();
                     if (number.floatValue() == number.intValue()) {
                         return number.intValue();
-                    } else {
+                    } else if (number.floatValue() == number.doubleValue()) {
                         return number.floatValue();
+                    } else {
+                        return number.doubleValue();
                     }
                 } else if (primitive.isBoolean()) {
                     return primitive.getAsBoolean();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AWSAppSyncScalarType.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AWSAppSyncScalarType.java
@@ -44,6 +44,7 @@ public enum AWSAppSyncScalarType {
 
     /**
      * A signed double-precision fractional values as specified by IEEE 754.
+     * Note that this is distinct from a {@link java.lang.Float}, which stores a single precision value.
      * @see <a href="https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html#float">Float Scalar</a>
      */
     FLOAT("Float"),

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteDataType.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteDataType.java
@@ -33,8 +33,8 @@ public enum SQLiteDataType {
     INTEGER("INTEGER"),
 
     /**
-     * The value is a floating point value, stored as an 8-byte IEEE
-     * floating point number.
+     * The value is a floating point value, stored as an 8-byte ("double precision")
+     * IEEE floating point number.
      */
     REAL("REAL"),
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -91,6 +91,7 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
             case INTEGER:
             case LONG:
             case FLOAT:
+            case DOUBLE:
             case STRING:
                 // these types require no special treatment
                 return value;
@@ -172,6 +173,8 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
                     return cursor.getInt(columnIndex) != 0;
                 case FLOAT:
                     return cursor.getFloat(columnIndex);
+                case DOUBLE:
+                    return cursor.getDouble(columnIndex);
                 case LONG:
                     return cursor.getLong(columnIndex);
                 case DATE:

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -695,6 +695,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             statement.bindLong(columnIndex, (Integer) value);
         } else if (value instanceof Float) {
             statement.bindDouble(columnIndex, (Float) value);
+        } else if (value instanceof Double) {
+            statement.bindDouble(columnIndex, (Double) value);
         } else {
             throw new DataStoreException("", "");
         }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
@@ -42,6 +42,7 @@ public final class TypeConverter {
         JAVA_TO_SQL.put(JavaFieldType.LONG, SQLiteDataType.INTEGER);
         JAVA_TO_SQL.put(JavaFieldType.INTEGER, SQLiteDataType.INTEGER);
         JAVA_TO_SQL.put(JavaFieldType.FLOAT, SQLiteDataType.REAL);
+        JAVA_TO_SQL.put(JavaFieldType.DOUBLE, SQLiteDataType.REAL);
         JAVA_TO_SQL.put(JavaFieldType.STRING, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.ENUM, SQLiteDataType.TEXT);
         JAVA_TO_SQL.put(JavaFieldType.DATE, SQLiteDataType.TEXT);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncConflictUnhandledErrorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncConflictUnhandledErrorTest.java
@@ -119,9 +119,8 @@ public final class AppSyncConflictUnhandledErrorTest {
             AppSyncConflictUnhandledError.findFirst(Note.class, response.getErrors());
         assertNotNull(conflictUnhandledError);
 
-        // TODO: The JSON document has '1601499066604' as the time. These differ by 26604,
-        // also the TimeUnit appears to be wrong. Should be MILLISECONDS.
-        Temporal.Timestamp lastChangedAt = new Temporal.Timestamp(1601499040000L, TimeUnit.SECONDS);
+        // TODO: the TimeUnit appears to be wrong. Should be MILLISECONDS?
+        Temporal.Timestamp lastChangedAt = new Temporal.Timestamp(1601499066604L, TimeUnit.SECONDS);
         assertEquals(
             new ModelWithMetadata<>(
                 new Note("KoolId22", "Resurecting the dataz"),


### PR DESCRIPTION
The Amplify DataStore leverages GraphQL to define its data models.
Therefor, our intention is to support a strict superset of the primitive
types described by the GraphQL specification.

While implementing the DataStore, we overlooked that the GraphQL "Float"
type is a double-precision value. The SQL adapter is able to accomodate
this, currently. However, our Java codegen stores a float value, and we
look for values of Float type while serializing and deserializing object
data.

Unfortunately, we need to continue to support that behavior, since
customers will have Float values in their models. None-the-less, the
Flutter consumer of this library rightly wants to use the actual GraphQL
scalar types, and see the same behavior accross iOS and Android. As a
result of these constraints, we must support both types in the library,
for now.

The decision to express a floating point value as a Java Float or Double
will be taken from the type of the value in the model object. For our
Java models, it will be a Float. When Map data is passed from Flutter,
it will be a Double. Both SQL and AppSync will treat both as a double,
which is large enough to accomodate both types. Or in other words, both
types are supported, now.

The next step will be to update the Java codegen, so that it represents
GraphQL Float types as Java Doubles. This change will allow new
customers to use the fix, while we continue to support existing
customers' models.

Resolves: https://github.com/aws-amplify/amplify-android/issues/1031

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
