### PR TITLE
feature: parallelize integ test config downloads

### DIFF
--- a/scripts/pull_backend_config_from_s3
+++ b/scripts/pull_backend_config_from_s3
@@ -73,6 +73,8 @@ readonly end_index=$(($source_array_size - 1))
 for index in $(seq $start_index $end_index); do
     aws s3 cp \
         "s3://$config_bucket/${targets[$index]}" \
-        "${targets[$index]}"
+        "${targets[$index]}" &
 done
+
+wait
 


### PR DESCRIPTION
As a developer, I want the integration test config files to be
downloaded quickly. To help with this, we can grab them all in parallel,
and then wait to terminate the script until the last job has completed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
