### PR TITLE
chore: remove codecov bade from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
  <a href="https://discord.gg/jWVbPfC" target="_blank">
    <img src="https://img.shields.io/discord/308323056592486420?logo=discord" alt="Discord Chat" />  
  </a>
- <a href="https://codecov.io/gh/aws-amplify/amplify-android">
-   <img src="https://codecov.io/gh/aws-amplify/amplify-android/branch/main/graph/badge.svg" />
- </a>
 
 -------------------------------------------------------
 


### PR DESCRIPTION
It hasn't been working for a few months. An out-of-date badge that always shows poor coverage isn't helping anyone.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
