### PR TITLE
fix(aws-datastore): ignore foreign key error during sync

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -28,10 +28,10 @@ import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
+import com.amplifyframework.datastore.utils.ErrorInspector;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.logging.Logger;
-import com.amplifyframework.util.Error;
 
 import java.util.Objects;
 
@@ -114,7 +114,7 @@ final class Merger {
             // Remote store may not always respect the foreign key constraint, so
             // swallow any error caused by foreign key constraint violation.
             .onErrorComplete(failure -> {
-                if (!Error.containsCause(failure, SQLiteConstraintException.class)) {
+                if (!ErrorInspector.contains(failure, SQLiteConstraintException.class)) {
                     return false;
                 }
                 LOG.warn("Failed to sync due to foreign key constraint violation: " + modelWithMetadata, failure);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Merger.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.datastore.syncengine;
 
+import android.database.sqlite.SQLiteConstraintException;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.Amplify;
@@ -30,6 +31,7 @@ import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.logging.Logger;
+import com.amplifyframework.util.Error;
 
 import java.util.Objects;
 
@@ -108,6 +110,15 @@ final class Merger {
             .doOnComplete(() -> {
                 announceSuccessfulMerge(modelWithMetadata);
                 LOG.debug("Remote model update was sync'd down into local storage: " + modelWithMetadata);
+            })
+            // Remote store may not always respect the foreign key constraint, so
+            // swallow any error caused by foreign key constraint violation.
+            .onErrorComplete(failure -> {
+                if (!Error.containsCause(failure, SQLiteConstraintException.class)) {
+                    return false;
+                }
+                LOG.warn("Failed to sync due to foreign key constraint violation: " + modelWithMetadata, failure);
+                return true;
             })
             .doOnError(failure ->
                 LOG.warn("Failed to sync remote model into local storage: " + modelWithMetadata, failure)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/utils/ErrorInspector.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/utils/ErrorInspector.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.util;
+package com.amplifyframework.datastore.utils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -23,8 +23,8 @@ import java.util.Objects;
 /**
  * Utility class to provide helpful functions to use on throwable instances.
  */
-public final class Error {
-    private Error() {}
+public final class ErrorInspector {
+    private ErrorInspector() {}
 
     /**
      * Returns true if an error object was caused by a specific throwable type.
@@ -32,7 +32,7 @@ public final class Error {
      * @param causeType Class type of the error to look for in stacktrace.
      * @return true if an error object contains given cause.
      */
-    public static boolean containsCause(
+    public static boolean contains(
         @Nullable Throwable error,
         @NonNull Class<? extends Throwable> causeType
     ) {
@@ -41,7 +41,7 @@ public final class Error {
             return false;
         }
         try {
-            return causeType.isInstance(error) || containsCause(error.getCause(), causeType);
+            return causeType.isInstance(error) || contains(error.getCause(), causeType);
         } catch (Throwable unexpected) {
             // May encounter unexpected error during recursive search.
             // e.g. StackOverflowError, NoClassDefFoundError, etc.

--- a/core/src/main/java/com/amplifyframework/util/Error.java
+++ b/core/src/main/java/com/amplifyframework/util/Error.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.util;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Utility class to provide helpful functions to use on throwable instances.
+ */
+public final class Error {
+    private Error() {}
+
+    /**
+     * Returns true if an error object was caused by a specific throwable type.
+     * @param error Error object to perform the check on.
+     * @param causeType Class type of the error to look for in stacktrace.
+     * @return true if an error object contains given cause.
+     */
+    public static boolean containsCause(
+        @Nullable Throwable error,
+        @NonNull Class<? extends Throwable> causeType
+    ) {
+        Objects.requireNonNull(causeType);
+        if (error == null) {
+            return false;
+        }
+        try {
+            return causeType.isInstance(error) || containsCause(error.getCause(), causeType);
+        } catch (Throwable unexpected) {
+            // May encounter unexpected error during recursive search.
+            // e.g. StackOverflowError, NoClassDefFoundError, etc.
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
Partially addresses #1013 

By ignoring foreign key constraint violation during sync, #1013 issue no longer crashes DataStore.

Even with the best effort to ensure that the foreign key constraints are met on the client side, it is possible that the remote storage simply does not enforce foreign key violation. This guarantees the possibility of encountering a foreign key constraint violation during sync to be non-zero (e.g. cascading deletion failed halfway while publishing; a race condition arose from multi-device operation; or an entry was inserted directly to remote store). There are two options to deal with a failure during initial sync:

1. Issue a DELETE mutation on the orphaned remote model that caused the crash.
2. Ignore the error.

The first option is not ideal because this directly assumes that the orphaned entry in remote store is invalid, which may not always be true. DataStore client should _never_ delete customer data unless the DELETE operation was directly issued.

The second option is more feasible because it leaves the data safely in cloud while avoiding a fatal crash. Since it does not directly affect customer data, we do not need to provide an explicit error handler to the customer.


*Description of changes:*
Checks if sync failure was caused by SQLite constraint violation, and if so log the details and continue without crashing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
