### PR TITLE
chore(api) remove responseType from GraphQLOperation, since we already know it from the GraphQLRequest

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
@@ -136,7 +136,7 @@ public final class AppSyncGraphQLOperation<R> extends GraphQLOperation<R> {
             }
 
             try {
-                onResponse.accept(wrapResponse(jsonResponse, getResponseType()));
+                onResponse.accept(wrapResponse(jsonResponse));
                 //TODO: Dispatch to hub
             } catch (ApiException exception) {
                 onFailure.accept(exception);

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
@@ -55,9 +55,9 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
     }
 
     @Override
-    public <T> GraphQLResponse<T> buildResponse(GraphQLRequest<T> request, String responseJson, Type typeOfT)
+    public <T> GraphQLResponse<T> buildResponse(GraphQLRequest<T> request, String responseJson)
             throws ApiException {
-        Type responseType = TypeMaker.getParameterizedType(GraphQLResponse.class, typeOfT);
+        Type responseType = TypeMaker.getParameterizedType(GraphQLResponse.class, request.getResponseType());
         try {
             Gson responseGson = gson.newBuilder()
                 .registerTypeHierarchyAdapter(Iterable.class, new IterableDeserializer<>(request))

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -389,7 +389,7 @@ final class SubscriptionEndpoint {
 
         void dispatchNextMessage(String message) {
             try {
-                onNextItem.accept(responseFactory.buildResponse(request, message, responseType));
+                onNextItem.accept(responseFactory.buildResponse(request, message));
             } catch (ApiException exception) {
                 dispatchError(exception);
             }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
@@ -81,8 +81,9 @@ public final class GsonGraphQLResponseFactoryTest {
 
         // Act! Parse it into a model.
         Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Todo.class);
+        GraphQLRequest<PaginatedResult<Todo>> request = buildDummyRequest(responseType);
         final GraphQLResponse<PaginatedResult<Todo>> response =
-            responseFactory.buildResponse(null, nullResponseJson, responseType);
+            responseFactory.buildResponse(request, nullResponseJson);
 
         // Assert that the model is constructed without content
         assertNotNull(response);
@@ -107,7 +108,7 @@ public final class GsonGraphQLResponseFactoryTest {
         Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Todo.class);
         GraphQLRequest<PaginatedResult<Todo>> request = buildDummyRequest(responseType);
         final GraphQLResponse<PaginatedResult<Todo>> response =
-            responseFactory.buildResponse(request, partialResponseJson, responseType);
+            responseFactory.buildResponse(request, partialResponseJson);
 
         // Assert that the model contained things...
         assertNotNull(response);
@@ -222,7 +223,7 @@ public final class GsonGraphQLResponseFactoryTest {
 
         final GraphQLRequest<PaginatedResult<Todo>> request = buildDummyRequest(responseType);
         final GraphQLResponse<PaginatedResult<Todo>> response =
-                responseFactory.buildResponse(request, partialResponseJson, responseType);
+                responseFactory.buildResponse(request, partialResponseJson);
 
         // Assert
         assertEquals(expectedResponse, response);
@@ -248,8 +249,9 @@ public final class GsonGraphQLResponseFactoryTest {
 
         // Act! Parse it into a model.
         Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Todo.class);
+        GraphQLRequest<PaginatedResult<Todo>> request = buildDummyRequest(responseType);
         final GraphQLResponse<PaginatedResult<Todo>> response =
-                responseFactory.buildResponse(null, partialResponseJson, responseType);
+                responseFactory.buildResponse(request, partialResponseJson);
 
         // Build the expected response.
         String message = "Conflict resolver rejects mutation.";
@@ -298,8 +300,9 @@ public final class GsonGraphQLResponseFactoryTest {
 
         // Act! Parse it into a model.
         Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Todo.class);
+        GraphQLRequest<PaginatedResult<Todo>> request = buildDummyRequest(responseType);
         final GraphQLResponse<PaginatedResult<Todo>> response =
-                responseFactory.buildResponse(null, responseJson, responseType);
+                responseFactory.buildResponse(request, responseJson);
 
         // Build the expected response.
         Map<String, Object> extensions = new HashMap<>();
@@ -331,7 +334,7 @@ public final class GsonGraphQLResponseFactoryTest {
 
         // Act! Parse it into a String data type.
         final GraphQLResponse<String> response =
-                responseFactory.buildResponse(request, partialResponseJson.toString(), String.class);
+                responseFactory.buildResponse(request, partialResponseJson.toString());
 
         // Assert that the response data is just the data block as a JSON string
         assertEquals(
@@ -352,7 +355,7 @@ public final class GsonGraphQLResponseFactoryTest {
         Type responseType = TypeMaker.getParameterizedType(Iterable.class, String.class);
         GraphQLRequest<Iterable<String>> request = buildDummyRequest(responseType);
         GraphQLResponse<Iterable<String>> response =
-                responseFactory.buildResponse(request, baseQueryResponseJson.toString(), responseType);
+                responseFactory.buildResponse(request, baseQueryResponseJson.toString());
         final Iterable<String> queryResults = response.getData();
 
         final List<String> resultJsons = new ArrayList<>();
@@ -434,7 +437,7 @@ public final class GsonGraphQLResponseFactoryTest {
         Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Meeting.class);
         GraphQLRequest<PaginatedResult<Meeting>> request = buildDummyRequest(responseType);
         final GraphQLResponse<PaginatedResult<Meeting>> response =
-                responseFactory.buildResponse(request, responseString, responseType);
+                responseFactory.buildResponse(request, responseString);
         final Iterable<Meeting> actualMeetings = response.getData().getItems();
 
         // Assert

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLOperation.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLOperation.java
@@ -21,15 +21,12 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiOperation;
 
-import java.lang.reflect.Type;
-
 /**
  * A GraphQLOperation is an API operation which returns a GraphQLResponse.
  * @param <R> The type of data contained in the GraphQLResponse.
  */
 public abstract class GraphQLOperation<R> extends ApiOperation<GraphQLRequest<R>> {
     private final GraphQLResponse.Factory responseFactory;
-    private final Type responseType;
 
     /**
      * Constructs a new instance of a GraphQLOperation.
@@ -42,31 +39,21 @@ public abstract class GraphQLOperation<R> extends ApiOperation<GraphQLRequest<R>
     ) {
         super(graphQLRequest);
         this.responseFactory = responseFactory;
-        this.responseType = graphQLRequest.getResponseType();
     }
 
     /**
      * Converts a response json string containing a single object to a formatted
      * {@link GraphQLResponse} object that a response consumer can receive.
      * @param jsonResponse json response from API to be converted
-     * @param type Type of R, the data contained in the GraphQLResponse
      * @return wrapped response object
      * @throws ApiException If the class provided mismatches the data
      */
-    protected final GraphQLResponse<R> wrapResponse(String jsonResponse, Type type) throws ApiException {
+    protected final GraphQLResponse<R> wrapResponse(String jsonResponse) throws ApiException {
         try {
-            return responseFactory.buildResponse(getRequest(), jsonResponse, type);
+            return responseFactory.buildResponse(getRequest(), jsonResponse);
         } catch (ClassCastException cce) {
             throw new ApiException("Amplify encountered an error while deserializing an object",
                     AmplifyException.TODO_RECOVERY_SUGGESTION);
         }
-    }
-
-    /**
-     * Gets the Type to use for deserializing the response.
-     * @return response type
-     */
-    protected final Type getResponseType() {
-        return responseType;
     }
 }

--- a/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
+++ b/core/src/main/java/com/amplifyframework/api/graphql/GraphQLResponse.java
@@ -22,7 +22,6 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.util.Immutable;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -235,12 +234,11 @@ public final class GraphQLResponse<R> {
          * @param request The request which resulted in this GraphQLResponse
          * @param apiResponseJson Response from the endpoint, containing a string response
          *
-         * @param typeOfR The typeOfR to which the JSON string should be interpreted
          * @param <R> The typeOfR of the response object
          * @return An instance of provided typeOfR which models the data provided in the response JSON string
          * @throws ApiException If the class provided mismatches the data
          */
-        <R> GraphQLResponse<R> buildResponse(GraphQLRequest<R> request, String apiResponseJson, Type typeOfR)
+        <R> GraphQLResponse<R> buildResponse(GraphQLRequest<R> request, String apiResponseJson)
             throws ApiException;
     }
 }


### PR DESCRIPTION
No functional changes, just a small refactor to simplify the `GraphQLOperation`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
