### PR TITLE
chore(release) Add script for generating javadoc

### DIFF
--- a/scripts/javadoc/ReleaseConfiguration.json
+++ b/scripts/javadoc/ReleaseConfiguration.json
@@ -1,0 +1,104 @@
+{
+	JavaDoc : {
+		variables:	{
+			"javadoc.doctitle" : "AWS Amplify for Android - $sdkVersion"
+		},
+		modules:[
+			"aws-analytics-pinpoint",
+			"aws-api",
+			"aws-api-appsync",
+			"aws-auth-cognito",
+			"aws-datastore",
+			"aws-predictions",
+			"aws-predictions-tensorflow",
+			"aws-storage-s3",
+			"core",
+			"rxbindings"
+		],
+		packages : [
+			"com.amplifyframework"
+		],
+
+		subpackages : [
+			"com.amplifyframework"
+		],
+
+		sourcefiles: [
+		],
+
+		excludes: [
+		],
+		groups : [
+			{
+				title : "Analytics",
+				packages : [
+					"com.amplifyframework.analytics*"
+				]			
+			},
+			{
+				title : "API",
+				packages : [
+					"com.amplifyframework.api*"
+				]
+			},
+			{
+				title : "Authentication",
+				packages : [
+					"com.amplifyframework.auth*"
+				]
+			},
+			{ 
+				title : "DataStore" , 
+				packages : [ 
+					"com.amplifyframework.datastore*"
+				] 
+			},
+			{ 
+				title : "Predictions" , 
+				packages : [ 
+					"com.amplifyframework.predictions*"
+				]  
+			},
+			{ 
+				title : "Storage" , 
+				packages : [ 
+					"com.amplifyframework.storage*"
+				]  
+			},
+			{ 
+				title : "Core" , 
+				packages : [ 
+					"com.amplifyframework",
+					"com.amplifyframework.core*",
+					"com.amplifyframework.util",
+					"com.amplifyframework.logging",
+					"com.amplifyframework.devmenu",
+					"com.amplifyframework.hub"
+				]
+			},
+			{ 
+				title : "Rx Bindings" , 
+				packages : [ 
+					"com.amplifyframework.rx"
+				]
+			}
+		],
+		otheroptions :	{
+			"link" :"http://java.sun.com/j2se/1.5.0/docs/api/" ,
+			"windowtitle" : "${javadoc.doctitle}" ,
+			"doctitle" : "${javadoc.doctitle}",
+			"bottom": "Copyright &#169; 2020 Amazon Web Services, Inc. All Rights Reserved.",
+			"encoding" : "UTF-8",
+			"docencoding" : "UTF-8",
+			"stylesheetfile" : "scripts/javadoc/style.css"
+		},
+		otherargs : [
+			"Xdoclint:none",
+			"public",
+			"version",
+			"notree",
+			"nodeprecatedlist"
+		]
+	}
+
+}

--- a/scripts/javadoc/ReleaseConfiguration.json
+++ b/scripts/javadoc/ReleaseConfiguration.json
@@ -87,7 +87,7 @@
 			"link" :"http://java.sun.com/j2se/1.5.0/docs/api/" ,
 			"windowtitle" : "${javadoc.doctitle}" ,
 			"doctitle" : "${javadoc.doctitle}",
-			"bottom": "Copyright &#169; 2020 Amazon Web Services, Inc. All Rights Reserved.",
+			"bottom": "Copyright &#169; 2021 Amazon Web Services, Inc. All Rights Reserved.",
 			"encoding" : "UTF-8",
 			"docencoding" : "UTF-8",
 			"stylesheetfile" : "scripts/javadoc/style.css"

--- a/scripts/javadoc/generate.py
+++ b/scripts/javadoc/generate.py
@@ -102,7 +102,7 @@ def resolveList(list):
 
 def resolveDict(dict):
     for k in dict:
-        dict[k] = resolveVaraibles(dict[k])      
+        dict[k] = resolveVariables(dict[k])      
     return dict
 
 def printset(s):

--- a/scripts/javadoc/generate.py
+++ b/scripts/javadoc/generate.py
@@ -96,7 +96,7 @@ def resolveVariables(str):
 def resolveList(list):
     newlist = []
     for e in list:
-        newlist.append(resolveVaraibles(e))
+        newlist.append(resolveVariables(e))
     return newlist
 
 

--- a/scripts/javadoc/generate.py
+++ b/scripts/javadoc/generate.py
@@ -1,0 +1,194 @@
+
+import os
+import sys
+import demjson
+import glob
+from utils import runcommand
+
+def getCommandline(dest, root, modules, packages, sourcefiles, subpackages,excludes, groups, otheroptions, otherargs):
+
+
+    commandline = "javadoc " + \
+                " -d '{0}'".format(dest) + \
+                " -sourcepath  '{0}'".format(':'.join(map(lambda module: (root + "/" + module + "/src/main/java/"), modules)))  + \
+                " " + ' '.join(packages)  +  \
+                " " + ' '.join(map(lambda sourcefile:("'{0}'".format(sourcefile)), sourcefiles))  +  \
+                " -subpackages '{0}' ".format(':'.join(subpackages)) + \
+                " -exclude '{0}' ".format(':'.join(excludes)) + \
+                " ".join(map(lambda group:(" -group '{0}' '{1}' ".format(group['title'], ':'.join(group['packages']))), groups)) +  \
+                " ".join(map(lambda otheroption:(' -{0} "{1}" '.format(otheroption[0], otheroption[1])), otheroptions.items()))  + \
+                " ".join(map(lambda otherarg: ('-' + otherarg), otherargs))
+    return commandline 
+
+def  getWords(pattern):
+    firstPos = pattern.find(".")
+    if firstPos == -1 :
+        firstWord = pattern
+    else:
+        firstWord = pattern[0:firstPos]
+    if firstPos == -1 :
+        secondWord = ""
+        leftWord = ""
+    else:
+        leftWord = pattern[firstPos+1 : len(pattern)]
+        secondPos = pattern.find(".",firstPos + 1)
+        if secondPos == -1 :
+            secondWord = leftWord
+        else:
+            secondWord = pattern[firstPos+1 : secondPos]
+
+    return (firstWord, secondWord, leftWord)
+
+def getPackagesWithPattern(root, pattern):
+    # ipdb.set_trace()  ######### Break Point ###########
+    packages = set()
+    (firstWord, secondWord, leftWord) = getWords(pattern)
+    for folder in os.listdir(root):
+        folderpath = os.path.join(root,folder)
+        if os.path.isdir(folderpath):
+            if firstWord == "**" :
+                if leftWord == "" :
+                    packages.add(folder)
+                elif secondWord == folder:
+                    (firstWord1, secondWord1, leftWord1) = getWords(leftWord)
+                    if leftWord1 == "" :
+                        packages.add(folder)
+                    else :
+                        subpackages = getPackagesWithPattern(folderpath, leftWord1)
+                        for subpackage in subpackages:
+                            packages.add(folder + "." + subpackage)
+                else:
+                    subpackages = getPackagesWithPattern(folderpath, pattern)
+                    for subpackage in subpackages:
+                        packages.add(folder + "." + subpackage)
+            elif firstWord == folder  or firstWord == "*":
+                if leftWord == "" :
+                    packages.add(folder)
+                else :
+                    subpackages = getPackagesWithPattern(folderpath, leftWord)
+                    for subpackage in subpackages:
+                        packages.add(folder + "." + subpackage)
+    return packages
+
+def getAllPackagesWithPattern(root, modules, pattern):
+    packages = set()
+    sourcepaths = ""
+    for module in modules:
+        sourcepath = os.path.join(root, module ,  "src/main/java/")
+        p = getPackagesWithPattern(sourcepath, pattern);
+        packages.update(p);
+    return packages
+def getsourceFilesWithPattern(root, module, patterns):
+    files = []
+    sourcepaths = ""
+    for module in modules:
+        for pattern in patterns:
+            sourcepath =os.path.join(root , module , "src/main/java/", pattern)
+            files.extend(list(filter(lambda x:x.endswith('.html') or x.endswith('.java'), glob.glob(sourcepath))))
+
+    return files
+
+variableDict = {}
+def resolveVaraibles(str):
+    for k,v in variableDict.items():
+        str = str.replace("${" + k + "}" , v)
+    return str
+def resolveList(list):
+    newlist = []
+    for e in list:
+        newlist.append(resolveVaraibles(e))
+    return newlist
+
+
+def resolveDict(dict):
+    for k in dict:
+        dict[k] = resolveVaraibles(dict[k])      
+    return dict
+
+def printset(s):
+    for e in s:
+        print(e)
+
+def getJARs(root, libs):
+    jars=[]
+    for path, subdirs, files in os.walk(os.path.join(root, libs)):
+        for name in files:
+            if (name.endswith(".jar")):
+                jars.append(os.path.join(path, name))    
+    return jars
+
+
+def copylib(root, modules, target):
+    for module in modules:
+        sourcepath = os.path.join(root, module, "build/libs")
+        if os.path.isdir(sourcepath):
+            runcommand('cp {0}/*.jar "{1}"'.format(sourcepath, target))
+
+
+
+####################
+if (len(sys.argv) < 6  or sys.argv[1] == '-h' or sys.argv[1] == '--help') : 
+    print("Usage: \r\n {0} <configuration json file path> <project root path> <destination path> <dependency libarary path> <sdkVersion>".format(sys.argv[0])) ;
+    exit(1)
+
+jsonfilename=sys.argv[1]
+root = sys.argv[2]
+dest = sys.argv[3]
+libs = sys.argv[4]
+sdkVersion = sys.argv[5] 
+print("jsonfilename={0};root={1};dest={2};libs={3};sdkVersion={4}".format(jsonfilename,root,dest,libs,sdkVersion))
+
+with open(jsonfilename, 'r') as jsonfile:
+    jsonstring = jsonfile.read()
+rootelement =  demjson.decode(jsonstring)
+docConfigure =  rootelement["JavaDoc"]
+variableDict = docConfigure["variables"] 
+
+
+
+modules = resolveList(docConfigure["modules"])
+packages = set()
+# packagess = docConfigure["packages"]
+# print(packagess)
+for package in resolveList(docConfigure["packages"]):
+    if package.find("*") == -1 :
+        packages.add(package);
+    else:
+        packageset = getAllPackagesWithPattern(root, modules, package);
+        packages.update(packageset) 
+
+subpackages = set()
+for subpackage in resolveList(docConfigure["subpackages"]):
+    if subpackage.find("*") == -1 :
+        subpackages.add(subpackage);
+    else:
+        subpackageset = getAllPackagesWithPattern(root, modules, subpackage);
+        subpackages.update(subpackageset)
+
+excludes = set()
+for exclude in resolveList(docConfigure["excludes"]):
+    if exclude.find("*") == -1 :
+        excludes.add(exclude);
+    else:
+        excludepackageset = getAllPackagesWithPattern(root, modules, exclude);
+        excludes.update(excludepackageset)
+
+sourcefiles = getsourceFilesWithPattern(root, modules, docConfigure["sourcefiles"])
+print("sourcefiles: ", sourcefiles)
+groups = docConfigure["groups"]
+for group in groups:
+    group['packages'] = resolveList(group['packages'])
+
+otheroptions = resolveDict(docConfigure["otheroptions"])
+otherargs = resolveList(docConfigure["otherargs"])
+
+jarlist = getJARs(root, libs)
+if "CLASSPATH" in os.environ:
+    jarlist.append(os.environ["CLASSPATH"])
+os.environ["CLASSPATH"]=':'.join(jarlist)
+os.environ["sdkVersion"]=sdkVersion
+commandline = getCommandline(dest, root, modules, packages,sourcefiles, subpackages,excludes, groups, otheroptions, otherargs)
+returncode = runcommand(commandline)
+print("return code:" , returncode)
+exit(returncode)
+#print(commandline)

--- a/scripts/javadoc/generate.py
+++ b/scripts/javadoc/generate.py
@@ -89,7 +89,7 @@ def getsourceFilesWithPattern(root, module, patterns):
     return files
 
 variableDict = {}
-def resolveVaraibles(str):
+def resolveVariables(str):
     for k,v in variableDict.items():
         str = str.replace("${" + k + "}" , v)
     return str

--- a/scripts/javadoc/preserve_olddocument.sh
+++ b/scripts/javadoc/preserve_olddocument.sh
@@ -1,0 +1,37 @@
+echo "release_version=$release_version"
+previousversion=$(grep -o "AWS SDK for Android - [0-9]\+.[0-9]\+.[0-9]\+" docs/reference/allclasses-frame.html | grep -o "[0-9]\+.[0-9]\+.[0-9]\+")
+echo "previousversion=$previousversion"
+previousminorversion=$(echo  "$previousversion" | sed  -e 's|[0-9]*\.\([0-9]*\)\.[0-9]*$|\1|')
+echo "previousminorversion=$previousminorversion"
+if [ "$previousversion" == "$previousminorversion" ]
+then
+    previousminorversion=""
+fi
+echo "after verification previousminorversion=$previousminorversion"
+currentminorversion=$(echo  "$release_version" | sed  -e 's|[0-9]*\.\([0-9]*\)\.[0-9]*$|\1|')
+echo "currentminorversion=$currentminorversion"
+if [ "$release_version" == "$currentminorversion" ]
+then
+    currentminorversion=""
+fi
+echo "after verification currentminorversion=$currentminorversion"
+if  [ -z "$currentminorversion" ] 
+then 
+    echo "currentminorversion is empty"
+    exit 1
+fi
+if  [ -z "$previousminorversion" ] 
+then 
+    echo "previousminorversion is empty"
+    exit 1
+fi
+if [ "$previousminorversion" != "$currentminorversion" ] 
+then
+  echo "preserve current document to docs/$previousversion/reference"
+  mkdir -p  "docs/$previousversion"
+  mkdir -p "docs/$previousversion/reference"
+  cp -R  docs/reference/* docs/$previousversion/reference
+  git add "docs/$previousversion/reference"
+else 
+    echo "don't preserve old document"
+fi

--- a/scripts/javadoc/preserve_olddocument.sh
+++ b/scripts/javadoc/preserve_olddocument.sh
@@ -1,5 +1,5 @@
 echo "release_version=$release_version"
-previousversion=$(grep -o "AWS SDK for Android - [0-9]\+.[0-9]\+.[0-9]\+" docs/reference/allclasses-frame.html | grep -o "[0-9]\+.[0-9]\+.[0-9]\+")
+previousversion=$(grep -o "Amplify Android - [0-9]\+.[0-9]\+.[0-9]\+" docs/reference/allclasses-frame.html | grep -o "[0-9]\+.[0-9]\+.[0-9]\+")
 echo "previousversion=$previousversion"
 previousminorversion=$(echo  "$previousversion" | sed  -e 's|[0-9]*\.\([0-9]*\)\.[0-9]*$|\1|')
 echo "previousminorversion=$previousminorversion"

--- a/scripts/javadoc/release.sh
+++ b/scripts/javadoc/release.sh
@@ -49,7 +49,7 @@ cp -R build/javadoc/* docs/reference/
 # check in documents
 git add docs/reference
 git rm --cached  preserve_olddocument.sh
-git commit -m "AWS SDK for Android $release_version"
+git commit -m "Amplify Android $release_version"
 git push
 
 # Add documentation tags to gh-pages

--- a/scripts/javadoc/release.sh
+++ b/scripts/javadoc/release.sh
@@ -1,0 +1,60 @@
+# Make sure the release_version was passed as an argument
+if [ $# -eq 0 ]; then
+    echo "Missing release_version argument."
+    echo "Usage: scripts/javadoc/release.sh major.minor.patch"
+    exit 1
+fi
+
+release_version=$1
+
+# Make sure the git repo is not dirty, since this script switches branches and commits changes.
+if [ "$(git status --porcelain)" ]; then
+    echo "Your git repo is dirty.  Commit or revert all changes before running this script."
+    exit 1
+fi
+
+# Make sure this script is run from the project root.
+if [[ ! -d "scripts" ]]
+then
+    echo "No scripts folder found.  This script must be run from the project root."
+    exit 1
+fi  
+
+# generate documents
+projectRoot=$(pwd)
+configFile="scripts/javadoc/ReleaseConfiguration.json"
+destinationPath="build/javadoc"
+sdkPath="$HOME/Library/Android/sdk/platforms/android-29/"
+
+## Make sure the Android SDK is installed at the expected place
+if [[ ! -f "${sdkPath}android.jar" ]]
+then
+    echo "Failed to find Android library at ${sdkPath}android.jar."
+    exit 1
+fi  
+
+python3 scripts/javadoc/generate.py "$configFile" "$projectRoot" "$destinationPath" "$sdkPath" "$release_version"
+
+# check out gh-pages and preserve old document
+git fetch
+git checkout gh-pages
+git checkout main scripts/javadoc/preserve_olddocument.sh
+release_version=$release_version bash scripts/javadoc/preserve_olddocument.sh
+
+# copy new document
+rm -rf docs/reference
+mkdir -p docs/reference
+cp -R build/javadoc/* docs/reference/
+
+# check in documents
+git add docs/reference
+git rm --cached  preserve_olddocument.sh
+git commit -m "AWS SDK for Android $release_version"
+git push
+
+# Add documentation tags to gh-pages
+git tag -a "docs_v$release_version"  -m "Add documentation tags to version $release_version"
+git push --tags
+
+# Switch back to the main branch
+git checkout main

--- a/scripts/javadoc/style.css
+++ b/scripts/javadoc/style.css
@@ -1,0 +1,591 @@
+/* Javadoc style sheet */
+/*
+Overall document style
+*/
+body {
+    background-color:#ffffff;
+    color:#353833;
+    font-family:Arial, Helvetica, sans-serif;
+    font-size:76%;
+    margin:0;
+}
+a:link, a:visited {
+    text-decoration:none;
+    color:#4c6b87;
+}
+a:hover, a:focus {
+    text-decoration:none;
+    color:#bb7a2a;
+}
+a:active {
+    text-decoration:none;
+    color:#4c6b87;
+}
+a[name] {
+    color:#353833;
+}
+a[name]:hover {
+    text-decoration:none;
+    color:#353833;
+}
+pre {
+    font-size:1.3em;
+}
+h1 {
+    font-size:1.8em;
+}
+h2 {
+    font-size:1.5em;
+}
+h3 {
+    font-size:1.4em;
+}
+h4 {
+    font-size:1.3em;
+}
+h5 {
+    font-size:1.2em;
+}
+h6 {
+    font-size:1.1em;
+}
+ul {
+    list-style-type:disc;
+}
+code, tt {
+    font-size:1.2em;
+}
+dt code {
+    font-size:1.2em;
+}
+table tr td dt code {
+    font-size:1.2em;
+    vertical-align:top;
+}
+sup {
+    font-size:.6em;
+}
+/*
+Document title and Copyright styles
+*/
+.clear {
+    clear:both;
+    height:0px;
+    overflow:hidden;
+}
+.aboutLanguage {
+    float:right;
+    padding:0px 10px;
+    font-size:1em;
+    z-index:200;
+    margin-top:-5px;
+}
+.legalCopy {
+    margin-left:.5em;
+}
+.bar a, .bar a:link, .bar a:visited, .bar a:active {
+    color:#FFFFFF;
+    text-decoration:none;
+}
+.bar a:hover, .bar a:focus {
+    color:#bb7a2a;
+}
+.tab {
+    background-color:#0066FF;
+    background-image:url(resources/titlebar.gif);
+    background-position:left top;
+    background-repeat:no-repeat;
+    color:#ffffff;
+    padding:8px;
+    width:5em;
+    font-weight:bold;
+}
+/*
+Navigation bar styles
+*/
+.bar {
+    background-image:url(resources/background.gif);
+    background-repeat:repeat-x;
+    padding:.8em .5em .4em .8em;
+    height:auto;/*height:1.8em;*/
+    font-size:1em;
+    margin:0;
+}
+.topNav {
+    background-image:url(resources/background.gif);
+    background-repeat:repeat-x;
+    float:left;
+    padding:0;
+    width:100%;
+    clear:right;
+    height:2.8em;
+    padding-top:10px;
+    overflow:hidden;
+}
+.bottomNav {
+    margin-top:10px;
+    background-image:url(resources/background.gif);
+    background-repeat:repeat-x;
+    float:left;
+    padding:0;
+    width:100%;
+    clear:right;
+    height:2.8em;
+    padding-top:10px;
+    overflow:hidden;
+}
+.subNav {
+    background-color:#dee3e9;
+    border-bottom:1px solid #9eadc0;
+    float:left;
+    width:100%;
+    overflow:hidden;
+}
+.subNav div {
+    clear:left;
+    float:left;
+    padding:0 0 5px 6px;
+}
+ul.navList, ul.subNavList {
+    float:left;
+    margin:0 25px 0 0;
+    padding:0;
+}
+ul.navList li{
+    list-style:none;
+    float:left;
+    padding:3px 6px;
+    border-color: black;
+    border-style: solid;
+    border-width: 1px 1px 0px 1px;
+    margin-right: 1em;
+    color: lightgrey;
+}
+ul.navList li.a{
+    color: black;
+}
+ul.subNavList li{
+    list-style:none;
+    float:left;
+    font-size:90%;
+}
+.topNav a:link, .topNav a:active, .topNav a:visited, .bottomNav a:link, .bottomNav a:active, .bottomNav a:visited {
+    text-decoration:none;
+}
+.topNav a:hover, .bottomNav a:hover {
+    text-decoration:none;
+    color:#bb7a2a;
+}
+.navBarCell1Rev {
+    background-image:url(resources/tab.gif);
+    background-color:lightsalmon;
+    color:#FFFFFF;
+    margin: auto 5px;
+    border:1px solid #c9aa44;
+}
+ul.navList .navBarCell1Rev {
+    color:white;
+}
+/*
+Page header and footer styles
+*/
+.header, .footer {
+    clear:both;
+    margin:0 20px;
+    padding:5px 0 0 0;
+}
+.indexHeader {
+    margin:10px;
+    position:relative;
+}
+.indexHeader h1 {
+    font-size:1.3em;
+}
+.title {
+    color:#2c4557;
+    margin:10px 0;
+}
+.subTitle {
+    margin:5px 0 0 0;
+}
+.header ul {
+    margin:0 0 25px 0;
+    padding:0;
+}
+.footer ul {
+    margin:20px 0 5px 0;
+}
+.header ul li, .footer ul li {
+    list-style:none;
+    font-size:1.2em;
+}
+/*
+Heading styles
+*/
+div.details ul.blockList ul.blockList ul.blockList li.blockList h4, div.details ul.blockList ul.blockList ul.blockListLast li.blockList h4 {
+    background-color:#dee3e9;
+    border-top:1px solid #9eadc0;
+    border-bottom:1px solid #9eadc0;
+    margin:0 0 6px -8px;
+    padding:2px 5px;
+}
+ul.blockList ul.blockList ul.blockList li.blockList h3 {
+    background-color:#dee3e9;
+    border-top:1px solid #9eadc0;
+    border-bottom:1px solid #9eadc0;
+    margin:0 0 6px -8px;
+    padding:2px 5px;
+}
+ul.blockList ul.blockList li.blockList h3 {
+    padding:0;
+    margin:15px 0;
+}
+ul.blockList li.blockList h2 {
+    padding:0px 0 20px 0;
+}
+/*
+Page layout container styles
+*/
+.contentContainer, .sourceContainer, .classUseContainer, .serializedFormContainer, .constantValuesContainer {
+    clear:both;
+    padding:10px 20px;
+    position:relative;
+}
+.indexContainer {
+    margin:10px;
+    position:relative;
+    font-size:1.0em;
+}
+.indexContainer h2 {
+    font-size:1.1em;
+    padding:0 0 3px 0;
+}
+.indexContainer ul {
+    margin:0;
+    padding:0;
+}
+.indexContainer ul li {
+    list-style:none;
+}
+.contentContainer .description dl dt, .contentContainer .details dl dt, .serializedFormContainer dl dt {
+    font-size:1.1em;
+    font-weight:bold;
+    margin:10px 0 0 0;
+    color:#4E4E4E;
+}
+.contentContainer .description dl dd, .contentContainer .details dl dd, .serializedFormContainer dl dd {
+    margin:10px 0 10px 20px;
+}
+.serializedFormContainer dl.nameValue dt {
+    margin-left:1px;
+    font-size:1.1em;
+    display:inline;
+    font-weight:bold;
+}
+.serializedFormContainer dl.nameValue dd {
+    margin:0 0 0 1px;
+    font-size:1.1em;
+    display:inline;
+}
+div#regionDisclaimer {
+    padding-top:4px;
+    padding-bottom: 4px;    
+    border-top: 1px solid #CCCCCC;
+    border-bottom: 1px solid #CCCCCC;
+    font-weight: bold;
+    margin-top: 6px;
+    margin-bottom: 6px;
+}
+div#regionDisclaimer p {
+    padding-bottom: 0 !important;
+    color: #CC6600 !important;
+}
+/*
+List styles
+*/
+ul.horizontal li {
+    display:inline;
+    font-size:0.9em;
+}
+ul.inheritance {
+    margin:0;
+    padding:0;
+}
+ul.inheritance li {
+    display:inline;
+    list-style:none;
+}
+ul.inheritance li ul.inheritance {
+    margin-left:15px;
+    padding-left:15px;
+    padding-top:1px;
+}
+ul.blockList, ul.blockListLast {
+    margin:10px 0 10px 0;
+    padding:0;
+}
+ul.blockList li.blockList, ul.blockListLast li.blockList {
+    list-style:none;
+    margin-bottom:25px;
+}
+ul.blockList ul.blockList li.blockList, ul.blockList ul.blockListLast li.blockList {
+    padding:0px 20px 5px 10px;
+    border:1px solid #9eadc0;
+    background-color:#f9f9f9;
+}
+ul.blockList ul.blockList ul.blockList li.blockList, ul.blockList ul.blockList ul.blockListLast li.blockList {
+    padding:0 0 5px 8px;
+    background-color:#ffffff;
+    border:1px solid #9eadc0;
+    border-top:none;
+}
+ul.blockList ul.blockList ul.blockList ul.blockList li.blockList {
+    margin-left:0;
+    padding-left:0;
+    padding-bottom:15px;
+    border:none;
+    border-bottom:1px solid #9eadc0;
+}
+ul.blockList ul.blockList ul.blockList ul.blockList li.blockListLast {
+    list-style:none;
+    border-bottom:none;
+    padding-bottom:0;
+}
+table tr td dl, table tr td dl dt, table tr td dl dd {
+    margin-top:0;
+    margin-bottom:1px;
+}
+/*
+Table styles
+*/
+.contentContainer table, .classUseContainer table, .constantValuesContainer table {
+    border-bottom:1px solid #9eadc0;
+    width:100%;
+}
+.contentContainer ul li table, .classUseContainer ul li table, .constantValuesContainer ul li table {
+    width:100%;
+}
+.contentContainer .description table, .contentContainer .details table {
+    border-bottom:none;
+}
+.contentContainer ul li table th.colOne, .contentContainer ul li table th.colFirst, .contentContainer ul li table th.colLast, .classUseContainer ul li table th, .constantValuesContainer ul li table th, .contentContainer ul li table td.colOne, .contentContainer ul li table td.colFirst, .contentContainer ul li table td.colLast, .classUseContainer ul li table td, .constantValuesContainer ul li table td{
+    vertical-align:top;
+    padding-right:20px;
+}
+.contentContainer ul li table th.colLast, .classUseContainer ul li table th.colLast,.constantValuesContainer ul li table th.colLast,
+.contentContainer ul li table td.colLast, .classUseContainer ul li table td.colLast,.constantValuesContainer ul li table td.colLast,
+.contentContainer ul li table th.colOne, .classUseContainer ul li table th.colOne,
+.contentContainer ul li table td.colOne, .classUseContainer ul li table td.colOne {
+    padding-right:3px;
+}
+.overviewSummary caption, .packageSummary caption, .contentContainer ul.blockList li.blockList caption, .summary caption, .classUseContainer caption, .constantValuesContainer caption {
+    position:relative;
+    text-align:left;
+    background-repeat:no-repeat;
+    font-weight:bold;
+    clear:none;
+    overflow:hidden;
+    padding:0px;
+    margin:0px;
+}
+.tableTab {
+    border-color: black;
+    border-style: solid;
+    border-width: 1px 1px 0px 1px;
+    margin-right: 1em;
+}
+.activeTableTab {
+    background-color: lightsalmon;
+    color: white;
+    border-color: black;
+    border-style: solid;
+    border-width: 1px 1px 0px 1px;
+    margin-right: 1em;
+}
+.overviewSummary caption span, .packageSummary caption span, .contentContainer ul.blockList li.blockList caption span, .summary caption span, .classUseContainer caption span, .constantValuesContainer caption span {
+    white-space:nowrap;
+    padding-top:0.25em;
+    padding-left:8px;
+    display:block;
+    float:left;
+    background-image:url(resources/titlebar.gif);
+}
+.overviewSummary .tabEnd, .packageSummary .tabEnd, .contentContainer ul.blockList li.blockList .tabEnd, .summary .tabEnd, .classUseContainer .tabEnd, .constantValuesContainer .tabEnd {
+    width:10px;
+    background-image:url(resources/titlebar_end.gif);
+    background-repeat:no-repeat;
+    background-position:top right;
+    position:relative;
+    float:left;
+}
+ul.blockList ul.blockList li.blockList table {
+    margin:0 0 12px 0px;
+    width:100%;
+}
+.tableSubHeadingColor {
+    background-color: #EEEEFF;
+}
+.altColor {
+    background-color:#eeeeef;
+}
+.rowColor {
+    background-color:#ffffff;
+}
+.overviewSummary td, .packageSummary td, .contentContainer ul.blockList li.blockList td, .summary td, .classUseContainer td, .constantValuesContainer td {
+    text-align:left;
+    padding:3px 3px 3px 7px;
+}
+th.colFirst, th.colLast, th.colOne, .constantValuesContainer th {
+    background:#dee3e9;
+    border-top:1px solid #9eadc0;
+    border-bottom:1px solid #9eadc0;
+    text-align:left;
+    padding:3px 3px 3px 7px;
+}
+td.colOne a:link, td.colOne a:active, td.colOne a:visited, td.colOne a:hover, td.colFirst a:link, td.colFirst a:active, td.colFirst a:visited, td.colFirst a:hover, td.colLast a:link, td.colLast a:active, td.colLast a:visited, td.colLast a:hover, .constantValuesContainer td a:link, .constantValuesContainer td a:active, .constantValuesContainer td a:visited, .constantValuesContainer td a:hover {
+    font-weight:bold;
+}
+td.colFirst, th.colFirst {
+    border-left:1px solid #9eadc0;
+    white-space:nowrap;
+}
+td.colLast, th.colLast {
+    border-right:1px solid #9eadc0;
+}
+td.colOne, th.colOne {
+    border-right:1px solid #9eadc0;
+    border-left:1px solid #9eadc0;
+}
+table.overviewSummary  {
+    padding:0px;
+    margin-left:0px;
+}
+table.overviewSummary td.colFirst, table.overviewSummary th.colFirst,
+table.overviewSummary td.colOne, table.overviewSummary th.colOne {
+    width:25%;
+    vertical-align:middle;
+}
+table.packageSummary td.colFirst, table.overviewSummary th.colFirst {
+    width:25%;
+    vertical-align:middle;
+}
+/*
+Content styles
+*/
+.description pre {
+    margin-top:0;
+}
+.deprecatedContent {
+    margin:0;
+    padding:10px 0;
+}
+.docSummary {
+    padding:0;
+}
+/*
+Formatting effect styles
+*/
+.sourceLineNo {
+    color:green;
+    padding:0 30px 0 0;
+}
+h1.hidden {
+    visibility:hidden;
+    overflow:hidden;
+    font-size:.9em;
+}
+.block {
+    display:block;
+    margin:3px 0 0 0;
+}
+.strong {
+    font-weight:bold;
+}
+/*
+Styles for the search box
+*/
+#divsearch {
+    width: 342px;
+    height: 33px;
+    background-color: transparent;
+    padding-top: 0px;
+    margin-top: 0px;
+    padding-right: 20px;
+}
+#lblsearch {
+    font-weight: bold;
+    color: rgb(255, 255, 255);
+    display: inline-block;
+    float: left;
+    line-height: 34px;
+    margin-right: 8px;
+    font-family: "arial","sans-serif";
+    font-size: 1.2em
+}
+#nav-search-form {
+    position: relative;
+    display: block;
+    float: left;
+    height: 34px;
+    padding: 0px;
+    width: 280px;
+}
+.nav-sprite {
+    background-image: url("javadoc-resources/nav_main_sprite.png");
+}
+#nav-searchfield-outer {
+    background-position: -156px -65px;
+    background-repeat: no-repeat;
+    height: 34px;
+    padding-left: 6px;
+    padding-right: 37px;
+}
+.nav-searchfield-inner {
+    height: 34px;
+    background-color: white;
+    background-position: 0px -101px;
+    background-repeat: repeat-x;
+}
+#nav-searchfield-width {
+    padding: 0px 2px 0px 2px;
+}
+#nav-searchfield {
+    background: none repeat scroll 0% 0% transparent;
+    border: 0px none;
+    color: rgb(0, 0, 0);
+    font-size: 13px;
+    height: 23px;
+    line-height: 15px;
+    margin-top: 6px;
+    outline: 0px none;
+    padding: 0px;
+    width: 100%;
+}
+#nav-search-button {
+    position: absolute;
+    right: 0px;
+    top: 0px;
+    height: 34px;
+    overflow: hidden;
+    background-position: -117px -65px;
+    padding: 0px;
+    margin: 0px;
+}
+#nav-search-button-inner {
+    display: block;
+    width: 37px;
+    height: 34px;
+    padding: 0px;
+    margin: 0px;
+}
+/*
+Styles for feedback links
+*/
+#feedback-section {
+    float: left;
+    margin-top: -18px
+}
+#feedback-link-sectioin {
+    float: right;
+    margin-top: -15px;
+}

--- a/scripts/javadoc/utils.py
+++ b/scripts/javadoc/utils.py
@@ -1,0 +1,180 @@
+import sys
+from subprocess import Popen, PIPE
+import subprocess
+import xml.etree.ElementTree as ET
+import os
+from datetime import datetime
+from enum import Enum
+from collections import namedtuple
+import re
+import platform
+import time 
+
+TestType  = namedtuple('TestType', ['value', 'testAction', 'displayString'])
+class TestTypes(Enum):
+    UnitTest = TestType(1, 'test -PexcludeTests=**/*IntegrationTest.class', 'unit test')
+    IntegrationTest = TestType(2, 'connectedAndroidTest', 'integration test')   
+    @property
+    def displayString(self):
+        return self.value.displayString
+
+    @property
+    def testAction(self):
+        return self.value.testAction
+        
+
+def runcommand(command, timeout=0,pipein=None, pipeout =  None, logcommandline = True,  workingdirectory=None):
+    if logcommandline:
+        print("running command: ", command, "......")
+    process = Popen(command, shell=True, stdin=pipein, stdout = pipeout, cwd = workingdirectory)
+    wait_times = 0 
+    while True:
+        try:
+            process.communicate(timeout = 10)
+        except subprocess.TimeoutExpired:        
+            #tell circleci I am still alive, don't kill me
+            if wait_times % 30 == 0 :
+                print(str(datetime.now())+ ": I am still alive")
+            # if time costed exceed timeout, quit
+            if timeout >0 and wait_times > timeout * 6 :
+                print(str(datetime.now())+ ": time out")
+                return 1
+            wait_times+=1 
+
+            continue
+        break
+    exit_code = process.wait()    
+    return exit_code
+
+def getFailedTestcases(indexHtml):
+    content = open(indexHtml, 'r').read() 
+    #Notice  it seems andriod integration test runner has a bug. </html> is missing from index.html 
+    if not content.endswith("</html>"):
+        content += "</html>"
+    root = ET.XML(content) 
+    # root = tree.getroot() 
+
+    failedtests = set()
+    print("failed test list")
+    for failure in root.findall(".//td[@class='failures']"):  
+        a = failure.find('a')
+        if a is None:
+            continue
+        failedhref = a.get('href')
+        index = failedhref.find(".html#")
+        if index > 0 :
+            classname = failedhref[:index]
+            methodname = failedhref[index+6:]
+            if methodname == "null" or methodname == "No tests found.":
+                continue
+            failedtest = classname + "#" + methodname
+            print("["+classname+"]", "["+methodname+"]")
+            failedtests.add(failedtest)        
+    return failedtests     
+
+
+def runtest(module, testtype, results, ignoreFailures = None):
+    testcommand = "bash gradlew {0}:{1} ".format(module, testtype.testAction)
+    print("Running {0} for {1} .......".format(testtype.displayString, module))   
+    exit_code = runcommand(testcommand)   
+    dest = "{0}/{1}".format(results, module)
+    runcommand('mkdir -p "{0}"'.format(dest))
+    source = "{0}/build/reports/*".format(module)             
+    if runcommand("cp -rf {0} {1}".format(source,dest)) != 0 :
+        print("Failed to copy test result")
+        return 1
+    if exit_code != 0 :    
+        print("test failed for {0}".format(module))
+
+        if testtype == TestTypes.IntegrationTest:
+            retrytimes = 3 
+            indexHtml = os.path.join(module , "build/reports/androidTests/connected/index.html")
+            failedtests = getFailedTestcases(indexHtml)   
+            #if test failed but we cannot get the failed test list, we need to run the whole test
+            if not failedtests:
+                for retry in range(retrytimes): 
+                    time.sleep(10)
+                    print("retry running test for whole module for {0} times".format(retry + 1)) 
+                    exit_code = runcommand(testcommand)  
+                    if exit_code == 0 :
+                        break;
+                    failedtests = getFailedTestcases(indexHtml) 
+                    if failedtests:
+                        break;
+
+            if exit_code != 0:
+                if failedtests: 
+                    failedretrytests = set()
+                    for failedtest in failedtests:  
+                        time.sleep(10)
+                        single_exit_code = 1               
+                        for retry in range(retrytimes):        
+                            print("retry running failed test {0}  for {1} times".format(failedtest, retry + 1))      
+                            testcommand = "bash gradlew {0}:{1} -Pandroid.testInstrumentationRunnerArguments.class={2}".format(module, testtype.testAction, failedtest)
+                            single_exit_code = runcommand(testcommand)   
+                            if single_exit_code == 0 : 
+                                break
+                        if single_exit_code != 0 :
+                            print("retry cannot resolve failed test {0}".format(failedtest))
+                            failedretrytests.add(failedtest)
+
+                    if failedretrytests :   
+                        print("Failed tests that cannot be resolved by retry: ", failedretrytests)         
+                        if ignoreFailures is not None:
+                            ignoreFailures = set(ignoreFailures)
+                            if failedretrytests.issubset(ignoreFailures):
+                                print("All failed test cases can be ignored")
+                                exit_code = 0 
+                            else :
+                                print("Unable ignore failures: ", failedretrytests - ignoreFailures)  
+                    else:  
+                        print("All failed test cases can be resolved by retry")
+                        exit_code = 0 
+                else:
+                    print("exit_code is not 0, but cannot get failed test cases from index.html")
+
+    print("exit_code:", exit_code)
+    if exit_code != 0:
+        runcommand('echo "export testresult=1" >> $BASH_ENV')  
+
+    return 0
+
+def getmodules(root):
+    with open(os.path.join(root, "settings.gradle")) as f:
+        lines = f.readlines()
+    modules = []
+    for line in lines:
+        m = re.match(".*':(aws-android-sdk-.*).*'", line)
+        if m is not None:
+            modules.append(m.group(1))
+        else:
+            print("{0} is not a sdk module ".format(line)) 
+    return modules ;
+ #replace is a dictionary. it has a format 
+ #{
+ # "exclude:string"
+ # "match":string,
+ # "replace":string 
+ # "files" : [
+ # string,
+ # ]
+ # match and replace will be used by sed command like  sed -E 's/{match}/{replace}/'
+ # please check with sed document to see how to handle escape characaters in match and replace
+ #}
+def replacefiles(root, replaces):
+    for replaceaction in replaces:
+        match = replaceaction["match"]
+        replace = replaceaction["replace"]
+        files = replaceaction["files"]
+        paramters = "-r -i''"
+        if platform.system() == "Darwin":
+            paramters = "-E -i ''"
+        exclude=""
+        if 'exclude' in replaceaction:
+            exclude = "/{0}/ ! ".format(replaceaction['exclude'])       
+        for file in files:
+            targetfile = os.path.join(root, file)           
+            runcommand(command = "sed {4}   '{3}s/{0}/{1}/'  '{2}'".format(match, replace, targetfile, exclude, paramters), logcommandline = True) 
+
+
+


### PR DESCRIPTION
Adds script for generating javadoc in the same way it is done for https://github.com/aws-amplify/aws-sdk-android/

Usage:
```
scripts/javadoc/release.sh
```

Generated docs can be found here: https://github.com/aws-amplify/amplify-android/tree/gh-pages

This isn't published to a gh-pages site yet, but if we want to do that, it should just require someone with admin privileges to click a few buttons to make it live.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
