### PR TITLE
chore: update dependencies

### DIFF
--- a/aws-analytics-pinpoint/build.gradle
+++ b/aws-analytics-pinpoint/build.gradle
@@ -25,10 +25,7 @@ dependencies {
 
     testImplementation dependency.junit
     testImplementation dependency.mockito
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
 
     androidTestImplementation project(path: ':testutils')
     androidTestImplementation dependency.androidx.test.core

--- a/aws-api-appsync/build.gradle
+++ b/aws-api-appsync/build.gradle
@@ -25,10 +25,7 @@ dependencies {
     implementation dependency.gson
 
     testImplementation dependency.junit
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
     testImplementation dependency.jsonassert
     testImplementation project(path: ':testmodels')
     testImplementation project(path: ':testutils')

--- a/aws-api/build.gradle
+++ b/aws-api/build.gradle
@@ -35,10 +35,7 @@ dependencies {
     testImplementation dependency.mockito
     testImplementation dependency.mockwebserver
     testImplementation dependency.rxjava
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
 
     androidTestImplementation project(path: ':testutils')
     androidTestImplementation project(path: ':testmodels')

--- a/aws-auth-cognito/build.gradle
+++ b/aws-auth-cognito/build.gradle
@@ -26,9 +26,6 @@ dependencies {
     testImplementation project(path: ':testutils')
     testImplementation dependency.junit
     testImplementation dependency.mockito
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
     testImplementation dependency.androidx.test.core
 }

--- a/aws-datastore/build.gradle
+++ b/aws-datastore/build.gradle
@@ -33,10 +33,7 @@ dependencies {
     testImplementation dependency.jsonassert
     testImplementation dependency.junit
     testImplementation dependency.mockito
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
     testImplementation dependency.androidx.test.core
 
     androidTestImplementation project(path: ':testmodels')

--- a/aws-predictions/build.gradle
+++ b/aws-predictions/build.gradle
@@ -29,10 +29,7 @@ dependencies {
 
     testImplementation project(path: ':testutils')
     testImplementation dependency.junit
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
     testImplementation dependency.rxjava
 
     androidTestImplementation project(path: ':testutils')

--- a/aws-storage-s3/build.gradle
+++ b/aws-storage-s3/build.gradle
@@ -26,10 +26,7 @@ dependencies {
     testImplementation project(path: ':testutils')
     testImplementation dependency.junit
     testImplementation dependency.mockito
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
     testImplementation dependency.androidx.test.core
 
     androidTestImplementation project(path: ':testutils')

--- a/build.gradle
+++ b/build.gradle
@@ -51,9 +51,9 @@ ext {
     minSdkVersion = 16
     targetSdkVersion = 30
 
-    awsSdkVersion = '2.19.3'
+    awsSdkVersion = '2.20.1'
     fragmentVersion = '1.2.5'
-    navigationVersion = '2.3.1'
+    navigationVersion = '2.3.2'
     dependency = [
         android: [
             desugartools: 'com.android.tools:desugar_jdk_libs:1.0.9',

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,10 +33,7 @@ dependencies {
     }
     testImplementation dependency.junit
     testImplementation dependency.mockito
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
     testImplementation dependency.rxjava
     testImplementation dependency.androidx.test.core
     testImplementation dependency.jsonassert

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/rxbindings/build.gradle
+++ b/rxbindings/build.gradle
@@ -26,8 +26,5 @@ dependencies {
     testImplementation dependency.junit
     testImplementation dependency.mockito
     testImplementation dependency.androidx.test.core
-    testImplementation (dependency.robolectric) {
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation dependency.robolectric
 }


### PR DESCRIPTION
AWS SDK => 2.20.1.
AndroidX Navigation 2.3.2.
Gradle => 6.7.1.

Robolectric was already upgraded to 4.4. However, the AutoValue
annotations workaround is no longer needed for Robolectric as of 4.4.
So, we are able to remove that from the dependencies blocks, too.

AGP is being held at 4.0.1. We are going to skip 4.1.x and move directly
to 4.2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
