### PR TITLE
fix(aws-api): dont fire error if rest op canceled

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
@@ -128,6 +128,14 @@ public final class AWSRestOperation extends RestOperation {
         @Override
         public void onFailure(@NonNull Call call,
                               @NonNull IOException ioe) {
+            // Don't emit a failure if the user has canceled the operation.
+            // This behavior is consistent with how iOS' REST API category works
+            // Rx streams similarly do not report cancellation via
+            // onError or onComplete.
+            if (ongoingCall != null && ongoingCall.isCanceled()) {
+                return;
+            }
+
             onFailure.accept(new ApiException(
                 "Received an IO exception while making the request.",
                 ioe, "Retry the request."

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
@@ -60,6 +60,10 @@ public final class RestRequestFactory {
             .host(url.getHost())
             .addPathSegment(stripLeadingSlashes(url.getPath()));
 
+        if (url.getPort() != -1) {
+            builder.port(url.getPort());
+        }
+
         if (path != null) {
             builder.addPathSegments(stripLeadingSlashes(path));
         }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
@@ -87,7 +87,7 @@ public final class AWSRestOperationTest {
      *         expected, and would constitute a test failure.
      */
     @Test
-    public void responseEmittedIfOperationWhenOperationSucceeds() throws ApiException {
+    public void responseEmittedWhenOperationSucceeds() throws ApiException {
         RestOperationRequest request =
             new RestOperationRequest(HttpMethod.GET, baseUrl.uri().getPath(), emptyMap(), emptyMap());
         RestResponse response = Await.<RestResponse, ApiException>result((onResult, onError) -> {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws.operation;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.rest.HttpMethod;
+import com.amplifyframework.api.rest.RestOperationRequest;
+import com.amplifyframework.api.rest.RestResponse;
+import com.amplifyframework.testutils.Await;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link AWSRestOperation}.
+ */
+public final class AWSRestOperationTest {
+    private MockWebServer server;
+    private HttpUrl baseUrl;
+    private OkHttpClient client;
+
+    /**
+     * Sets up a mock web server to serve fake responses.
+     * @throws IOException while starting the mock web server
+     * @throws JSONException on failure to arrange response JSON
+     */
+    @Before
+    public void setup() throws IOException, JSONException {
+        server = new MockWebServer();
+        server.start(8080);
+        baseUrl = server.url("/");
+
+        MockResponse response = new MockResponse()
+            .setResponseCode(200)
+            .setBody(new JSONObject()
+                .put("message", "thanks!")
+                .toString()
+            );
+        server.enqueue(response);
+
+        client = new OkHttpClient();
+    }
+
+    /**
+     * Stop the {@link MockWebServer} that was started in {@link #setup()}.
+     * @throws IOException On failure to shutdown the MockWebServer
+     */
+    @After
+    public void cleanup() throws IOException {
+        server.shutdown();
+    }
+
+    /**
+     * Tests the happy path, wherein the server returns a response, the
+     * operation hasn't been canceled, and we get a {@link RestResponse}
+     * at the end of it.
+     * @throws ApiException
+     *         A possible outcome of the operation. This is not
+     *         expected, and would constitute a test failure.
+     */
+    @Test
+    public void responseEmittedIfOperationWhenOperationSucceeds() throws ApiException {
+        RestOperationRequest request =
+            new RestOperationRequest(HttpMethod.GET, baseUrl.uri().getPath(), emptyMap(), emptyMap());
+        RestResponse response = Await.<RestResponse, ApiException>result((onResult, onError) -> {
+            AWSRestOperation operation =
+                new AWSRestOperation(request, baseUrl.url().toString(), client, onResult, onError);
+            operation.start();
+        });
+        assertTrue(response.getCode().isSuccessful());
+    }
+
+    /**
+     * If the user calls {@link AWSRestOperation#cancel()}, then the operation
+     * will not fire any callback. This behavior is consistent with iOS's REST operation.
+     */
+    @Test
+    public void noErrorEmittedIfOperationIsCancelled() {
+        long timeToWaitForResponse = 300L;
+        RestOperationRequest request =
+            new RestOperationRequest(HttpMethod.GET, baseUrl.uri().getPath(), emptyMap(), emptyMap());
+        assertTimedOut(() ->
+            Await.<RestResponse, ApiException>result(timeToWaitForResponse, (onResult, onError) -> {
+                AWSRestOperation operation =
+                    new AWSRestOperation(request, baseUrl.url().toString(), client, onResult, onError);
+                operation.start();
+                operation.cancel();
+            })
+        );
+    }
+
+    private void assertTimedOut(Callable<RestResponse> action) {
+        RuntimeException exception = assertThrows(RuntimeException.class, action::call);
+        assertTrue(exception.getMessage().startsWith("Failed to count down latch"));
+    }
+}


### PR DESCRIPTION
iOS doesn't fire any terminal event when a REST operation is canceled.

When an Rx subscription is disposed, neither onError nor onComplete is
called.

In those cases, there is no notification of cancelation/disposal.

This commit aligns Android's behavior, so that an operation will
terminate silently, when canceled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
