### PR TITLE
chore: add explicit error for signin cancelation

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -937,7 +937,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                                 signOutLocally(options, onSuccess, onError);
                             } else if (error instanceof AuthNavigationException) {
                                 // User cancelled the sign-out screen.
-                                onError.accept(new AuthException.ActionCancelledException(
+                                onError.accept(new AuthException.UserCancelledException(
                                     "The user cancelled the sign-out attempt.", error,
                                     "To recover, catch this error, and retry sign-out."
                                 ));
@@ -998,7 +998,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                             ));
                         } else if (error instanceof AuthNavigationException) {
                             // User cancelled the sign-out screen.
-                            onError.accept(new AuthException.ActionCancelledException(
+                            onError.accept(new AuthException.UserCancelledException(
                                 "The user cancelled the sign-out attempt.", error,
                                 "To recover, catch this error, and retry sign-out."
                             ));
@@ -1075,7 +1075,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             @Override
             public void onError(Exception error) {
                 if (error instanceof AuthNavigationException) {
-                    onException.accept(new AuthException.ActionCancelledException(
+                    onException.accept(new AuthException.UserCancelledException(
                         "The user cancelled the sign-in attempt, so it did not complete.",
                         error, "To recover: catch this error, and show the sign-in screen again."
                     ));

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -452,16 +452,16 @@ public class AuthException extends AmplifyException {
     /**
      * Could not complete an action because it was cancelled by the user.
      */
-    public static class ActionCancelledException extends AuthException {
+    public static class UserCancelledException extends AuthException {
         private static final long serialVersionUID = 1L;
 
         /**
-         * Constructs an {@link ActionCancelledException}.
+         * Constructs an {@link UserCancelledException}.
          * @param message Describes why the error has occurred
          * @param cause An underlying cause of the error
          * @param recoverySuggestion How to remedy the error, if possible
          */
-        public ActionCancelledException(String message, Throwable cause, String recoverySuggestion) {
+        public UserCancelledException(String message, Throwable cause, String recoverySuggestion) {
             super(message, cause, recoverySuggestion);
         }
     }

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -450,6 +450,23 @@ public class AuthException extends AmplifyException {
     }
 
     /**
+     * Could not complete an action because it was cancelled by the user.
+     */
+    public static class ActionCancelledException extends AuthException {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Constructs an {@link ActionCancelledException}.
+         * @param message Describes why the error has occurred
+         * @param cause An underlying cause of the error
+         * @param recoverySuggestion How to remedy the error, if possible
+         */
+        public ActionCancelledException(String message, Throwable cause, String recoverySuggestion) {
+            super(message, cause, recoverySuggestion);
+        }
+    }
+
+    /**
      * Allows the user to specify whether guest access is enabled or not since this can affect which
      * recovery message should be included.
      */


### PR DESCRIPTION
During sign-in with the Cognito hosted web UI, a Chrome Custom tab will
pop up. The user may fill in their sign-in information. However, they
may also exit out of the tab, in which case the sign-in will be
cancelled.

The current behavior is to fire an exception on the onError callback
when this occurs. That exception looks like this:
```
AuthException{
  message=Sign in with web UI failed
  cause=[...mobile client...] AuthNavigationException{
    message=user cancelled
  }
  recoverySuggestion=See attached exception for more details
}
```

This commit updates the exception that gets returned, to something more
specific, that a user could catch explicitly:
```
ActionCancelledException{
  message=The user cancelled the sign-in attempt, so it did not complete.
  cause=[...mobile client...] AuthNavigationException {
    message=user cancelled
  }
  recoverySuggestion=To recover: catch this error, and show the sign-in screen again.
}
```

With this change, the caller may catch the cancellation exception in a
`when` block:
```kotlin
Amplify.Auth.signInWithWebUI(this, { /* result .. */ }, { error ->
    when (error) {
        is ActionCancelledException -> Log.w("TAG", "sign-in cancelled")
        else ->  Log.e("xx", "Login failed.", error)
    }
}
```

This commit also applies similar updates to the sign-out method.

Related: https://github.com/aws-amplify/amplify-ios/pull/982

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.