### PR TITLE
chore(api): Fix integration tests

### DIFF
--- a/aws-api/src/androidTest/assets/create-comment.graphql
+++ b/aws-api/src/androidTest/assets/create-comment.graphql
@@ -1,5 +1,5 @@
-mutation CommentOnEvent($eventId: ID!, $content: String!, $createdAt: String!) {
-  commentOnEvent(eventId: $eventId, content: $content, createdAt: $createdAt) {
+mutation CommentOnEvent($eventId: ID!, $commentId:String!, $content: String!, $createdAt: String!) {
+   createComment(input: {commentId: $commentId, eventId: $eventId, content: $content, createdAt: $createdAt}) {
       eventId
       content
       createdAt

--- a/aws-api/src/androidTest/assets/create-comment.graphql
+++ b/aws-api/src/androidTest/assets/create-comment.graphql
@@ -1,8 +1,7 @@
-mutation CommentOnEvent($eventId: ID!, $commentId:String!, $content: String!, $createdAt: String!) {
+mutation CreateComment($eventId: ID!, $commentId:String!, $content: String!, $createdAt: String!) {
    createComment(input: {commentId: $commentId, eventId: $eventId, content: $content, createdAt: $createdAt}) {
       eventId
       content
       createdAt
   }
 }
-

--- a/aws-api/src/androidTest/assets/create-event.graphql
+++ b/aws-api/src/androidTest/assets/create-event.graphql
@@ -1,5 +1,5 @@
 mutation CreateEvent($name: String!, $when: String!, $where: String!, $description: String!) {
-  createEvent(name: $name, when: $when, where: $where, description: $description) {
+  createEvent(input: {name: $name, when: $when, where: $where, description: $description}) {
     id
     name
     where

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
@@ -15,12 +15,15 @@
 
 package com.amplifyframework.api.aws;
 
+import androidx.annotation.NonNull;
+
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategory;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.aws.test.R;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.SimpleGraphQLRequest;
+import com.amplifyframework.core.model.Model;
 import com.amplifyframework.testutils.Assets;
 import com.amplifyframework.testutils.Resources;
 import com.amplifyframework.testutils.sync.SynchronousApi;
@@ -244,15 +247,23 @@ public final class GraphQLInstrumentationTest {
      * for the purposes of our tests, we just model a Comment as a thing containing
      * a String content message. This is enough for a simple assertion: "yup, same one".
      */
-    static final class Comment {
+    static final class Comment implements Model {
         private final String content;
+        private final String id;
 
-        Comment(final String content) {
+        Comment(final String id, final String content) {
+            this.id = id;
             this.content = content;
         }
 
         String content() {
             return content;
+        }
+
+        @NonNull
+        @Override
+        public String getId() {
+            return id;
         }
     }
 
@@ -260,7 +271,7 @@ public final class GraphQLInstrumentationTest {
      * Model of an Event, which we create as part of this test, so that we can
      * associate comments to the event.
      */
-    static final class Event {
+    static final class Event implements Model {
         private final String id;
         private final String name;
         private final String when;
@@ -299,6 +310,12 @@ public final class GraphQLInstrumentationTest {
 
         String description() {
             return description;
+        }
+
+        @NonNull
+        @Override
+        public String getId() {
+            return id;
         }
     }
 }

--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLInstrumentationTest.java
@@ -251,6 +251,7 @@ public final class GraphQLInstrumentationTest {
         private final String content;
         private final String id;
 
+        @SuppressWarnings("checkstyle:ParameterName")
         Comment(final String id, final String content) {
             this.id = id;
             this.content = content;

--- a/configuration/instrumentation-tests.gradle
+++ b/configuration/instrumentation-tests.gradle
@@ -3,7 +3,7 @@
 Need to create backends for s3, pinpoint, predictions, core
  */
 def module_backends = [
-    'aws-datastore':'InstrumentedTests',
+    'aws-datastore':'DataStoreInstrumentedTests',
     'aws-api': 'ApiInstrumentedTests',
     'aws-storage-s3': 'NONE',
     'aws-analytics-pinpoint': 'NONE',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A few tweaks related to get the `subscriptionReceivesMutationOverApiKey` test passing again. The previous backend being used was created using the console and relied on some custom resolvers (Events app sample from the AppSync console). These changes allow the test to work with the resolvers generated by the CLI. 

Updated the name of the Amplify app used by the DataStore tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
