### PR TITLE
chore(datastore) verbose log instead of warn when deleting a non existent item

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -490,7 +490,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 final String primaryKeyName = sqliteTable.getPrimaryKeyColumnName();
 
                 if (!dataExistsInSQLiteTable(sqliteTable.getName(), primaryKeyName, item.getId())) {
-                    LOG.warn(modelName + " model with id = " + item.getId() + " does not exist.");
+                    LOG.verbose(modelName + " model with id = " + item.getId() + " does not exist.");
                     // Pass back item change instance without publishing it.
                     onSuccess.accept(StorageItemChange.<T>builder()
                         .changeId(item.getId())


### PR DESCRIPTION
When DataStore is started, the sync downloads all items, even deleted ones.   An attempt is made to delete these from the local store.   If it's a fresh install, or the app is already in sync, a warning is logged that the item is already deleted.  This isn't really a warning or anything to be concerned about, so this PR raises the log level to verbose.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
