### PR TITLE
fix(datastore) Defer merger.merge to avoid failure if outbox has mutation

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -140,7 +140,7 @@ final class MutationProcessor {
                     // This is done before merging, because the merger will refuse to merge
                     // if there are outstanding mutations in the outbox.
                     mutationOutbox.remove(mutationOutboxItem.getMutationId())
-                        .andThen(Completable.defer(() -> merger.merge(modelWithMetadata)))
+                        .andThen(merger.merge(modelWithMetadata))
                         .doOnComplete(() -> {
                             String modelName = mutationOutboxItem.getModelSchema().getName();
                             announceMutationProcessed(modelName, modelWithMetadata);


### PR DESCRIPTION
Previously, there was an issue where mutation responses were not merged because the merge was attempted before the item was removed from the queue.  This was fixed in #1051 by wrapping the merge in `Completable.defer()`.   Thanks @kjones!

This PR moves the `Completable.defer()` into the merge method itself.  This ensures that the fix will be effective for any calls to the `merge` method, such as calls from the `SyncProcessor`.  This PR also adds a test that fails without this fix, or the fix from #1051.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
