### PR TITLE
fix(api) serialize nulls on requests to support setting fields to null

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/util/GsonFactory.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/util/GsonFactory.java
@@ -53,6 +53,7 @@ public final class GsonFactory {
         GsonResponseAdapters.register(builder);
         ModelWithMetadataAdapter.register(builder);
         SerializedModelAdapter.register(builder);
+        builder.serializeNulls();
         return builder.create();
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncClientTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncClientTest.java
@@ -165,7 +165,7 @@ public final class AppSyncClientTest {
                 .time(new Temporal.Time("01:22:33"))
                 .timestamp(new Temporal.Timestamp(1234567890000L, TimeUnit.MILLISECONDS))
                 .build();
-        endpoint.update(meeting, ModelSchema.fromModelClass(Meeting.class), null, response -> { }, error -> { });
+        endpoint.update(meeting, ModelSchema.fromModelClass(Meeting.class), 1, response -> { }, error -> { });
 
         // Now, capture the request argument on API, so we can see what was passed.
         ArgumentCaptor<GraphQLRequest<ModelWithMetadata<Meeting>>> requestCaptor =

--- a/aws-datastore/src/test/resources/update-blog-owner-with-predicate.txt
+++ b/aws-datastore/src/test/resources/update-blog-owner-with-predicate.txt
@@ -22,7 +22,8 @@
     "input": {
       "_version" : 42,
       "id" : "926d7ee8-4ea5-40c0-8e62-3fb80b2a2edd",
-      "name" : "John Doe"
+      "name" : "John Doe",
+      "wea" : null
     }
   }
 }

--- a/aws-datastore/src/test/resources/update-meeting.txt
+++ b/aws-datastore/src/test/resources/update-meeting.txt
@@ -11,4 +11,16 @@
     timestamp
   }
 }
-","variables":{"input":{"date":"2001-02-03","dateTime":"2001-02-03T01:30:15Z","name":"meeting1","id":"45a5f600-8aa8-41ac-a529-aed75036f5be","time":"01:22:33","timestamp":1234567890}}}
+",
+"variables": {
+    "input": {
+      "date": "2001-02-03",
+      "dateTime": "2001-02-03T01:30:15Z",
+      "name": "meeting1",
+      "id": "45a5f600-8aa8-41ac-a529-aed75036f5be",
+      "time": "01:22:33",
+      "timestamp": 1234567890,
+      "_version": 1
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-android/issues/1054

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
