### PR TITLE
chore(datastore) remove overloaded query method in favor of just one

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -379,7 +379,8 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull Class<T> itemClass,
             @NonNull Consumer<Iterator<T>> onQueryResults,
             @NonNull Consumer<DataStoreException> onQueryFailure) {
-        start(() -> sqliteStorageAdapter.query(itemClass, onQueryResults, onQueryFailure), onQueryFailure);
+        start(() ->
+            sqliteStorageAdapter.query(itemClass, Where.matchesAll(), onQueryResults, onQueryFailure), onQueryFailure);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -85,19 +85,6 @@ public interface LocalStorageAdapter {
     );
 
     /**
-     * Query the storage for items of a given type.
-     * @param itemClass Items that have this class will be solicited
-     * @param onSuccess A callback that will be invoked if the query succeeds
-     * @param onError A callback that will be invoked if the query fails with an error
-     * @param <T> Type type of the items that are being queried
-     */
-    <T extends Model> void query(
-            @NonNull Class<T> itemClass,
-            @NonNull Consumer<Iterator<T>> onSuccess,
-            @NonNull Consumer<DataStoreException> onError
-    );
-
-    /**
      * Query the storage for items of a given type with specific conditions.
      * @param itemClass Items that have this class will be solicited
      * @param options options, such as predicates, pagination to apply to query

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/PersistentModelVersion.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/PersistentModelVersion.java
@@ -21,6 +21,7 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
@@ -71,6 +72,7 @@ public final class PersistentModelVersion implements Model {
         return Single.create(emitter ->
             localStorageAdapter.query(
                 PersistentModelVersion.class,
+                Where.matchesAll(),
                 emitter::onSuccess,
                 emitter::onError
             )

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -35,7 +35,6 @@ import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.query.QueryOptions;
-import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
@@ -342,20 +341,6 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 onError.accept(dataStoreException);
             }
         });
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T extends Model> void query(
-            @NonNull Class<T> itemClass,
-            @NonNull Consumer<Iterator<T>> onSuccess,
-            @NonNull Consumer<DataStoreException> onError) {
-        Objects.requireNonNull(itemClass);
-        Objects.requireNonNull(onSuccess);
-        Objects.requireNonNull(onError);
-        query(itemClass, Where.matchesAll(), onSuccess, onError);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -23,6 +23,7 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
@@ -181,7 +182,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
         return Completable.create(emitter -> {
             inFlightMutations.clear();
             mutationQueue.clear();
-            storage.query(PendingMutation.PersistentRecord.class,
+            storage.query(PendingMutation.PersistentRecord.class, Where.matchesAll(),
                 results -> {
                     while (results.hasNext()) {
                         try {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -25,7 +25,6 @@ import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.QueryOptions;
-import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
 
@@ -107,15 +106,6 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             .build();
         itemChangeStream.onNext(change);
         onSuccess.accept(change);
-    }
-
-    @Override
-    public <T extends Model> void query(
-            @NonNull final Class<T> itemClass,
-            @NonNull final Consumer<Iterator<T>> onSuccess,
-            @NonNull final Consumer<DataStoreException> onError
-    ) {
-        query(itemClass, Where.matchesAll(), onSuccess, onError);
     }
 
     @SuppressWarnings("unchecked") // (T) item *is* checked, via isAssignableFrom().


### PR DESCRIPTION
Small simplification to the `LocalStorageAdapter` and it's subclasses - this removes the `query` helper method which takes no predicate.  Code which previously used this method now just uses the `query` method that does take a predicate, and just passes `Where.matchesAll()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
