### PR TITLE
fix: export proguard rules for consumers

### DIFF
--- a/configuration/consumer-rules.pro
+++ b/configuration/consumer-rules.pro
@@ -1,0 +1,4 @@
+-keepclassmembers enum * { *; }
+
+-keep class com.amazonaws.** { *; }
+-keep class com.amplifyframework.** { *; }


### PR DESCRIPTION
Numerous consumers report missing symbols when using the library in a
release build (where R8 shrinking is enabled.)

Customers have reported success by keeping the com.amazonaws.** and
com.amplfyframework.** classes, as well as enums.

Resolves: https://github.com/aws-amplify/amplify-flutter/issues/156
Resolves: https://github.com/aws-amplify/amplify-flutter/issues/286
Resolves: https://github.com/aws-amplify/amplify-flutter/issues/188

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
