### PR TITLE
datastore(feat): support delete by model type with predicate

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore.storage;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
@@ -27,6 +28,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testutils.Await;
+import com.amplifyframework.testutils.VoidResult;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -234,6 +236,28 @@ public final class SynchronousStorageAdapter {
                     onResult,
                     onError
                 )
+        );
+    }
+
+    /**
+     * Delete every model of given type that matches predicate.
+     * @param modelType Model type to delete
+     * @param predicate Filter to apply for deletion
+     * @param <T> Type of model being deleted
+     * @throws DataStoreException On any failure to delete the models
+     */
+    public <T extends Model> void delete(@NonNull Class<T> modelType, @NonNull QueryPredicate predicate)
+            throws DataStoreException {
+        Await.result(
+                operationTimeoutMs,
+                (Consumer<Object> onResult, Consumer<DataStoreException> onError) ->
+                    asyncDelegate.delete(
+                            modelType,
+                            StorageItemChange.Initiator.DATA_STORE_API,
+                            predicate,
+                            () -> onResult.accept(VoidResult.instance()),
+                            onError
+                    )
         );
     }
 

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -18,7 +18,6 @@ package com.amplifyframework.datastore.storage;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
@@ -249,15 +248,15 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> void delete(@NonNull Class<T> modelType, @NonNull QueryPredicate predicate)
             throws DataStoreException {
         Await.result(
-                operationTimeoutMs,
-                (Consumer<Object> onResult, Consumer<DataStoreException> onError) ->
-                    asyncDelegate.delete(
-                            modelType,
-                            StorageItemChange.Initiator.DATA_STORE_API,
-                            predicate,
-                            () -> onResult.accept(VoidResult.instance()),
-                            onError
-                    )
+            operationTimeoutMs,
+            (Consumer<Object> onResult, Consumer<DataStoreException> onError) ->
+                asyncDelegate.delete(
+                    modelType,
+                    StorageItemChange.Initiator.DATA_STORE_API,
+                    predicate,
+                    () -> onResult.accept(VoidResult.instance()),
+                    onError
+                )
         );
     }
 

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -201,6 +202,35 @@ public final class SQLiteStorageAdapterDeleteTest {
         adapter.delete(jane, predicate);
         //noinspection ThrowableNotThrown This is the point of this method.
         adapter.deleteExpectingError(mark, predicate); // Should not be deleted
+
+        List<BlogOwner> blogOwners = adapter.query(BlogOwner.class);
+        assertEquals(1, blogOwners.size());
+        assertTrue(blogOwners.contains(mark));
+    }
+
+
+    /**
+     * Test delete type with predicate.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void deleteModelTypeWithPredicateDeletesData() throws DataStoreException {
+        final BlogOwner john = BlogOwner.builder()
+                .name("John")
+                .build();
+        final BlogOwner jane = BlogOwner.builder()
+                .name("Jane")
+                .build();
+        final BlogOwner mark = BlogOwner.builder()
+                .name("Mark")
+                .build();
+        adapter.save(john);
+        adapter.save(jane);
+        adapter.save(mark);
+
+        // Delete everybody whose names start with "J" (i.e. John & Jane)
+        final QueryPredicate predicate = BlogOwner.NAME.beginsWith("J");
+        adapter.delete(BlogOwner.class, predicate);
 
         List<BlogOwner> blogOwners = adapter.query(BlogOwner.class);
         assertEquals(1, blogOwners.size());

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterDeleteTest.java
@@ -15,7 +15,6 @@
 
 package com.amplifyframework.datastore.storage.sqlite;
 
-import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
@@ -33,7 +32,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -371,6 +371,21 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         ), onFailureToDelete);
     }
 
+    @Override
+    public <T extends Model> void delete(
+            @NonNull Class<T> itemClass,
+            @NonNull QueryPredicate predicate,
+            @NonNull Action onItemsDeleted,
+            @NonNull Consumer<DataStoreException> onFailureToDelete) {
+        start(() -> sqliteStorageAdapter.delete(
+                itemClass,
+                StorageItemChange.Initiator.DATA_STORE_API,
+                predicate,
+                onItemsDeleted,
+                onFailureToDelete
+        ), onFailureToDelete);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -147,7 +147,7 @@ public interface LocalStorageAdapter {
             @NonNull Class<T> itemClass,
             @NonNull StorageItemChange.Initiator initiator,
             @NonNull QueryPredicate predicate,
-            @NonNull Consumer<Iterator<StorageItemChange<T>>> onSuccess,
+            @NonNull Action onSuccess,
             @NonNull Consumer<DataStoreException> onError
     );
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/LocalStorageAdapter.java
@@ -133,6 +133,25 @@ public interface LocalStorageAdapter {
     );
 
     /**
+     * Deletes all items of a given type from storage that meet the
+     * specific conditions. A {@link Consumer} will be invoked when the
+     * save operation is completed, to notify the caller of success or failure.
+     * @param <T> The type of item being deleted
+     * @param itemClass Item to delete
+     * @param initiator An identification of the actor who initiated this deletion
+     * @param predicate Predicate condition for conditional delete
+     * @param onSuccess A callback that will be invoked when deletion succeeds
+     * @param onError A callback that will be invoked when deletion fails with an error
+     */
+    <T extends Model> void delete(
+            @NonNull Class<T> itemClass,
+            @NonNull StorageItemChange.Initiator initiator,
+            @NonNull QueryPredicate predicate,
+            @NonNull Consumer<Iterator<StorageItemChange<T>>> onSuccess,
+            @NonNull Consumer<DataStoreException> onError
+    );
+
+    /**
      * Observe all changes to that occur to any/all objects in the storage.
      * @param onItemChange
      *        Receives a {@link StorageItemChange} notification every time

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
@@ -81,7 +81,7 @@ final class SQLiteModelTree {
      */
     <T extends Model> List<Model> descendantsOf(Collection<T> root) {
         if (Empty.check(root)) {
-            throw new IllegalArgumentException("Cannot traverse tree from an empty root.");
+            return new ArrayList<>();
         }
         Map<ModelSchema, Set<String>> modelMap = new LinkedHashMap<>();
         ModelSchema rootSchema = registry.getModelSchemaForModelInstance(root.iterator().next());

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -521,6 +521,70 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         });
     }
 
+    public <T extends Model> void delete(
+            @NonNull Class<T> itemClass,
+            @NonNull StorageItemChange.Initiator initiator,
+            @NonNull QueryPredicate predicate,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<DataStoreException> onError
+    ) {
+        Objects.requireNonNull(itemClass);
+        Objects.requireNonNull(initiator);
+        Objects.requireNonNull(predicate);
+        Objects.requireNonNull(onSuccess);
+        Objects.requireNonNull(onError);
+
+        threadPool.submit(() -> {
+            try (Cursor cursor = getQueryAllCursor(itemClass.getSimpleName(), Where.matches(predicate))) {
+                final ModelSchema modelSchema = modelSchemaRegistry.getModelSchemaForModelClass(itemClass);
+                final SQLiteTable sqliteTable = SQLiteTable.fromSchema(modelSchema);
+                final String primaryKeyName = sqliteTable.getPrimaryKeyColumnName();
+
+                // identify items that meet the predicate
+                List<T> items = new ArrayList<>();
+                if (cursor != null && cursor.moveToFirst()) {
+                    int index = cursor.getColumnIndexOrThrow(primaryKeyName);
+                    do {
+                        String id = cursor.getString(index);
+                        String dummyJson = gson.toJson(Collections.singletonMap("id", id));
+                        T dummyItem = gson.fromJson(dummyJson, itemClass);
+                        items.add(dummyItem);
+                    } while (cursor.moveToNext());
+                }
+
+                // identify every model to delete as a result of this operation
+                List<Model> modelsToDelete = new ArrayList<>(items);
+                List<Model> cascadedModels = sqliteModelTree.descendantsOf(items);
+                modelsToDelete.addAll(cascadedModels);
+
+                // execute local deletions
+                SqlCommand sqlCommand = sqlCommandFactory.deleteFor(modelSchema, predicate);
+                executeStatement(sqlCommand.getCompiledSqlStatement(), sqlCommand.getBindings());
+
+                // publish every deletion
+                for (Model model : modelsToDelete) {
+                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelInstance(model);
+                    itemChangeSubject.onNext(StorageItemChange.builder()
+                            .item(model)
+                            .modelSchema(schema)
+                            .type(StorageItemChange.Type.DELETE)
+                            .predicate(QueryPredicates.all())
+                            .initiator(initiator)
+                            .build());
+                }
+                onSuccess.call();
+            } catch (DataStoreException dataStoreException) {
+                onError.accept(dataStoreException);
+            } catch (Exception someOtherTypeOfException) {
+                DataStoreException dataStoreException = new DataStoreException(
+                        "Error in deleting models.", someOtherTypeOfException,
+                        "See attached exception for details."
+                );
+                onError.accept(dataStoreException);
+            }
+        });
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -521,6 +521,10 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         });
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public <T extends Model> void delete(
             @NonNull Class<T> itemClass,
             @NonNull StorageItemChange.Initiator initiator,

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -538,7 +538,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
             try (Cursor cursor = getQueryAllCursor(itemClass.getSimpleName(), Where.matches(predicate))) {
                 final ModelSchema modelSchema = modelSchemaRegistry.getModelSchemaForModelClass(itemClass);
                 final SQLiteTable sqliteTable = SQLiteTable.fromSchema(modelSchema);
-                final String primaryKeyName = sqliteTable.getPrimaryKeyColumnName();
+                final String primaryKeyName = sqliteTable.getPrimaryKey().getAliasedName();
 
                 // identify items that meet the predicate
                 List<T> items = new ArrayList<>();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -26,10 +26,14 @@ import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
+
+import com.google.common.base.Predicates;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -185,6 +189,46 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             .build();
         itemChangeStream.onNext(deletion);
         onSuccess.accept(deletion);
+    }
+
+    @SuppressWarnings("unchecked") // item.getClass() -> Class<?>, but type is T. So cast as Class<T> is OK.
+    @Override
+    public <T extends Model> void delete(
+            @NonNull Class<T> itemClass,
+            @NonNull StorageItemChange.Initiator initiator,
+            @NonNull QueryPredicate predicate,
+            @NonNull Consumer<Iterator<StorageItemChange<T>>> onSuccess,
+            @NonNull Consumer<DataStoreException> onError
+    ) {
+        final ModelSchema schema;
+        try {
+            schema = ModelSchema.fromModelClass(itemClass);
+        } catch (AmplifyException schemaBuildFailure) {
+            onError.accept(new DataStoreException(
+                    "Failed to build model schema.", schemaBuildFailure, "Verify your model."
+            ));
+            return;
+        }
+
+        List<StorageItemChange<T>> changes = new LinkedList<>();
+        for (Model savedItem : items) {
+            if (!itemClass.isInstance(savedItem) || !predicate.evaluate(savedItem)) {
+                continue;
+            }
+            items.remove(savedItem);
+
+            StorageItemChange<T> deletion = StorageItemChange.<T>builder()
+                    .item((T) savedItem)
+                    .modelSchema(schema)
+                    .type(StorageItemChange.Type.DELETE)
+                    .predicate(predicate)
+                    .initiator(initiator)
+                    .build();
+            itemChangeStream.onNext(deletion);
+            changes.add(deletion);
+        }
+
+        onSuccess.accept(changes.iterator());
     }
 
     @NonNull

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -26,14 +26,10 @@ import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
-import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
-
-import com.google.common.base.Predicates;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 import io.reactivex.rxjava3.disposables.Disposable;

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -197,7 +197,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull Class<T> itemClass,
             @NonNull StorageItemChange.Initiator initiator,
             @NonNull QueryPredicate predicate,
-            @NonNull Consumer<Iterator<StorageItemChange<T>>> onSuccess,
+            @NonNull Action onSuccess,
             @NonNull Consumer<DataStoreException> onError
     ) {
         final ModelSchema schema;
@@ -210,7 +210,6 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             return;
         }
 
-        List<StorageItemChange<T>> changes = new LinkedList<>();
         for (Model savedItem : items) {
             if (!itemClass.isInstance(savedItem) || !predicate.evaluate(savedItem)) {
                 continue;
@@ -225,10 +224,8 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
                     .initiator(initiator)
                     .build();
             itemChangeStream.onNext(deletion);
-            changes.add(deletion);
         }
-
-        onSuccess.accept(changes.iterator());
+        onSuccess.call();
     }
 
     @NonNull

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore.storage.sqlite;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLPredicate;
 import com.amplifyframework.testmodels.ratingsblog.Blog;
@@ -27,9 +28,36 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class SQLPredicateTest {
+
+    /**
+     * Test that MATCH ALL predicate is correctly parsed to an
+     * expression that is always true.
+     * @throws DataStoreException if parsing fails
+     */
+    @Test
+    public void testMatchAllPredicate() throws DataStoreException {
+        QueryPredicate predicate = QueryPredicates.all();
+        SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+        assertEquals("1 = 1", sqlPredicate.toString());
+        assertTrue(sqlPredicate.getBindings().isEmpty());
+    }
+
+    /**
+     * Test that MATCH NONE predicate is correctly parsed to an
+     * expression that is always false.
+     * @throws DataStoreException if parsing fails
+     */
+    @Test
+    public void testMatchNonePredicate() throws DataStoreException {
+        QueryPredicate predicate = QueryPredicates.none();
+        SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+        assertEquals("1 = 0", sqlPredicate.toString());
+        assertTrue(sqlPredicate.getBindings().isEmpty());
+    }
 
     /**
      * Test contains in the context of a String field.

--- a/core/src/main/java/com/amplifyframework/core/NoOpAction.java
+++ b/core/src/main/java/com/amplifyframework/core/NoOpAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * An {@link Action} that does nothing when called.
+ */
+public final class NoOpAction implements Action {
+    private NoOpAction() {}
+
+    /**
+     * Creates an instance of an {@link Consumer} which does nothing
+     * when called.
+     * @return A No-operation action
+     */
+    @NonNull
+    public static NoOpAction create() {
+        return new NoOpAction();
+    }
+
+    @Override
+    public void call() {}
+
+    @Override
+    public int hashCode() {
+        return NoOpAction.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        return obj instanceof NoOpAction;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "NoOpAction {}";
+    }
+}

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategory.java
@@ -94,6 +94,15 @@ public final class DataStoreCategory
         getSelectedPlugin().delete(object, predicate, onItemDeleted, onFailureToDelete);
     }
 
+    @Override
+    public <T extends Model> void delete(
+            @NonNull Class<T> objectClass,
+            @NonNull QueryPredicate predicate,
+            @NonNull Action onItemsDeleted,
+            @NonNull Consumer<DataStoreException> onFailureToDelete) {
+        getSelectedPlugin().delete(objectClass, predicate, onItemsDeleted, onFailureToDelete);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -98,6 +98,22 @@ public interface DataStoreCategoryBehavior {
     );
 
     /**
+     * Deletes every item of given type from the DataStore that meets the provided
+     * conditions.
+     * @param itemClass Item type to delete from the DataStore
+     * @param predicate Predicate condition to filter items to delete
+     * @param onItemDeleted Called upon successful deletion of item
+     * @param onFailureToDelete Called upon failure to delete item
+     * @param <T> The type of item being deleted
+     */
+    <T extends Model> void delete(
+            @NonNull Class<T> itemClass,
+            @NonNull QueryPredicate predicate,
+            @NonNull Action onItemDeleted,
+            @NonNull Consumer<DataStoreException> onFailureToDelete
+    );
+
+    /**
      * Query the DataStore to find all items of the requested Java class.
      * @param itemClass Items of this class will be targeted by this query
      * @param onQueryResults Called when a query successfully returns 0 or more results

--- a/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStoreCategoryBehavior.java
@@ -68,7 +68,8 @@ public interface DataStoreCategoryBehavior {
     );
 
     /**
-     * Deletes an item from the DataStore.
+     * Deletes an item from the DataStore. If item doesn't exist, then
+     * operation succeeds with no-op.
      * @param item An item to delete from the DataStore
      * @param onItemDeleted Called upon successful deletion of item
      * @param onFailureToDelete Called upon failure to delete item
@@ -83,7 +84,8 @@ public interface DataStoreCategoryBehavior {
     /**
      * Deletes an item from the DataStore if the data being deleted meets the
      * provided conditions. This is useful for making sure that no data is being
-     * deleted with an outdated/incorrect assumption.
+     * deleted with an outdated/incorrect assumption. If item doesn't exist,
+     * then operation succeeds with no-op.
      * @param item An item to delete from the DataStore
      * @param predicate Predicate condition to apply for conditional write
      * @param onItemDeleted Called upon successful deletion of item
@@ -99,7 +101,8 @@ public interface DataStoreCategoryBehavior {
 
     /**
      * Deletes every item of given type from the DataStore that meets the provided
-     * conditions.
+     * conditions. If there is no match, then nothing is deleted and operation
+     * succeeds.
      * @param itemClass Item type to delete from the DataStore
      * @param predicate Predicate condition to filter items to delete
      * @param onItemDeleted Called upon successful deletion of item

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.NoOpAction;
 import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.QueryOptions;
@@ -76,7 +77,7 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
     @Override
     public <T extends Model> Completable delete(@NonNull Class<T> itemClass, @NonNull QueryPredicate predicate) {
         return toCompletable((onResult, onError) ->
-                dataStore.delete(itemClass, predicate, () -> { }, onError));
+                dataStore.delete(itemClass, predicate, NoOpAction.create(), onError));
     }
 
     @NonNull

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
@@ -76,7 +76,7 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
     @Override
     public <T extends Model> Completable delete(@NonNull Class<T> itemClass, @NonNull QueryPredicate predicate) {
         return toCompletable((onResult, onError) ->
-                dataStore.delete(itemClass, predicate, () -> {}, onError));
+                dataStore.delete(itemClass, predicate, () -> { }, onError));
     }
 
     @NonNull

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreBinding.java
@@ -74,6 +74,13 @@ final class RxDataStoreBinding implements RxDataStoreCategoryBehavior {
 
     @NonNull
     @Override
+    public <T extends Model> Completable delete(@NonNull Class<T> itemClass, @NonNull QueryPredicate predicate) {
+        return toCompletable((onResult, onError) ->
+                dataStore.delete(itemClass, predicate, () -> {}, onError));
+    }
+
+    @NonNull
+    @Override
     public <T extends Model> Observable<T> query(@NonNull Class<T> itemClass) {
         return toObservable((onResult, onError) -> dataStore.query(itemClass, onResult, onError));
     }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxDataStoreCategoryBehavior.java
@@ -80,6 +80,19 @@ public interface RxDataStoreCategoryBehavior {
     );
 
     /**
+     * Deletes item from the DataStore, filtered by a predicate.
+     * @param <T> The type of item being deleted
+     * @param itemClass Item type to delete from the DataStore
+     * @param predicate Predicate condition to filter items
+     * @return A {@link Completable} which completes on success, emits error on error
+     */
+    @NonNull
+    <T extends Model> Completable delete(
+            @NonNull Class<T> itemClass,
+            @NonNull QueryPredicate predicate
+    );
+
+    /**
      * Query the DataStore to find all items of the requested Java class.
      * @param itemClass Items of this class will be targeted by this query
      * @param <T> The type of items being queried


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added method to `DataStoreCategoryBehavior` interface for deleting models by type & predicate
* Implemented it on DataStore plugin and local storage engine
* Added tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
