### PR TITLE
Throw AlreadyConfiguredException on reconfiguration attempt

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -114,7 +114,7 @@ public final class Amplify {
     /**
      * Read the configuration from amplifyconfiguration.json file.
      * @param context Android context required to read the contents of file
-     * @throws AmplifyException thrown when already configured or there is no plugin found for a configuration
+     * @throws AmplifyException Indicates one of numerous possible failures to configure the Framework
      */
     public static void configure(@NonNull Context context) throws AmplifyException {
         configure(AmplifyConfiguration.fromConfigFile(context), context);
@@ -124,7 +124,7 @@ public final class Amplify {
      * Configure Amplify with AmplifyConfiguration object.
      * @param configuration AmplifyConfiguration object for configuration via code
      * @param context An Android Context
-     * @throws AmplifyException thrown when already configured or there is no configuration found for a plugin
+     * @throws AmplifyException Indicates one of numerous possible failures to configure the Framework
      */
     public static void configure(@NonNull final AmplifyConfiguration configuration, @NonNull Context context)
             throws AmplifyException {
@@ -133,10 +133,7 @@ public final class Amplify {
 
         synchronized (CONFIGURATION_LOCK) {
             if (CONFIGURATION_LOCK.get()) {
-                throw new AmplifyException(
-                    "The client issued a subsequent call to `Amplify.configure` after the first had already succeeded.",
-                        "Be sure to only call Amplify.configure once"
-                );
+                throw new AlreadyConfiguredException();
             }
 
             // Configure User-Agent utility
@@ -233,4 +230,20 @@ public final class Amplify {
         REMOVE
     }
 
+    /**
+     * Amplify can only be configured once per process. This means that {@link #configure(Context)}
+     * and/or {@link #configure(AmplifyConfiguration, Context)} can only be called once per process.
+     * If the user tries to re-configure Amplify after it has already been configured, an
+     * AlreadyConfiguredException will be thrown.
+     */
+    public static final class AlreadyConfiguredException extends AmplifyException {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Constructs an AlreadyConfiguredException, indicating that Amplify has already been configured.
+         */
+        private AlreadyConfiguredException() {
+            super("Amplify has already been configured.", "Remove the duplicate call to `Amplify.configure()`");
+        }
+    }
 }

--- a/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
+++ b/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
@@ -15,22 +15,38 @@
 
 package com.amplifyframework.core;
 
+import android.content.Context;
 import android.os.Build;
 
 import com.amplifyframework.AmplifyException;
 
+import org.json.JSONObject;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 
 /**
  * Tests the top-level {@link Amplify} facade.
+ *
+ * NOTE:
+ *
+ * This test uses {@link FixMethodOrder}, which is an anti-pattern.
+ * Amplify is a static singleton and there is no simple way to reset its
+ * state, once the class' clinit has run.
+ *
+ * The reconfiguration test has to run after the plugin test, otherwise the
+ * plugin test will fail.
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @Config(sdk = Build.VERSION_CODES.P, manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class AmplifyTest {
@@ -50,5 +66,32 @@ public class AmplifyTest {
         // Remove it, make sure it's not there anymore.
         Amplify.removePlugin(loggingPlugin);
         assertTrue(Amplify.Logging.getPlugins().isEmpty());
+    }
+
+    /**
+     * It is an error to call {@link Amplify#configure(Context)} (or associated methods) more
+     * than once.
+     * @throws AmplifyException Not expected; this can be thrown from the first configuration
+     *                          attempt according to its signature, however this behavior
+     *                          would not be expected
+     */
+    @Test
+    public void reconfigurationAttemptRaisesException() throws AmplifyException {
+        AmplifyConfiguration config = AmplifyConfiguration.fromJson(new JSONObject());
+        Amplify.configure(config, getApplicationContext());
+        Amplify.AlreadyConfiguredException actuallyThrown =
+            assertThrows(
+                Amplify.AlreadyConfiguredException.class,
+                () -> Amplify.configure(config, getApplicationContext())
+            );
+
+        assertEquals(
+            "Amplify has already been configured.",
+            actuallyThrown.getMessage()
+        );
+        assertEquals(
+            "Remove the duplicate call to `Amplify.configure()`",
+            actuallyThrown.getRecoverySuggestion()
+        );
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/aws-amplify/amplify-android/issues/1108

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
