### PR TITLE
feat(datastore) only include changed fields in update mutations

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelConverter.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelConverter.java
@@ -53,7 +53,7 @@ public final class ModelConverter {
 
     /**
      * Convert a Map&lt;String, Object&gt; to a Model.
-     * @param map a a Map&lt;String, Object&gt;
+     * @param map a Map&lt;String, Object&gt;.
      * @param modelClass Class of Model to convert the Map to.
      * @param <T> type of the Model instance to convert to.
      * @return a Model instance created from the provided Map.
@@ -64,4 +64,3 @@ public final class ModelConverter {
         return gson.fromJson(jsonString, modelClass);
     }
 }
-

--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelConverter.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelConverter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.appsync;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.util.GsonFactory;
+import com.amplifyframework.util.GsonObjectConverter;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility for converting a Model to/from a Map&lt;String, Object&gt;.
+ */
+public final class ModelConverter {
+
+    private ModelConverter() { }
+
+    /**
+     * Convert a Model to a Map&lt;String, Object&gt;.
+     * @param model a Model instance.
+     * @param <T> type of the Model instance.
+     * @return a Map&lt;String, Object&gt; representation of the provided Model instance.
+     */
+    public static <T extends Model> Map<String, Object> toMap(T model) {
+        if (model == null) {
+            return new HashMap<>();
+        }
+        if (model instanceof SerializedModel) {
+            return ((SerializedModel) model).getSerializedData();
+        } else {
+            Gson gson = GsonFactory.instance();
+            JsonElement jsonElement = gson.toJsonTree(model);
+            return GsonObjectConverter.toMap(jsonElement.getAsJsonObject());
+        }
+    }
+
+    /**
+     * Convert a Map&lt;String, Object&gt; to a Model.
+     * @param map a a Map&lt;String, Object&gt;
+     * @param modelClass Class of Model to convert the Map to.
+     * @param <T> type of the Model instance to convert to.
+     * @return a Model instance created from the provided Map.
+     */
+    public static <T extends Model> T fromMap(Map<String, Object> map, Class<T> modelClass) {
+        Gson gson = GsonFactory.instance();
+        String jsonString = gson.toJson(map);
+        return gson.fromJson(jsonString, modelClass);
+    }
+}
+

--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelConverter.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelConverter.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 public final class ModelConverter {
 
-    private ModelConverter() { }
+    private ModelConverter() {}
 
     /**
      * Convert a Model to a Map&lt;String, Object&gt;.

--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java
@@ -45,6 +45,45 @@ public final class SerializedModel implements Model {
     }
 
     /**
+     * Creates a SerializedModel from a generated Java Model object.
+     * @param model Model object
+     * @param modelSchema schema for the Model object
+     * @param <T> type of the Model object.
+     * @return SerializedModel equivalent of the Model object.
+     */
+    public static <T extends Model> SerializedModel create(T model, ModelSchema modelSchema) {
+        return SerializedModel.builder()
+                .serializedData(ModelConverter.toMap(model))
+                .modelSchema(modelSchema)
+                .build();
+    }
+
+    /**
+     * Computes the difference between two Models, comparing equality of each field value for each Model, and returns
+     * the difference as a SerializedModel.
+     * @param updated the updated Model, whose values will be used to build the resulting SerializedModel.
+     * @param original the original Model to compare against.
+     * @param modelSchema ModelSchema for the Models between compared.
+     * @param <T> type of the Models being compared.
+     * @return a SerializedModel, containing only the values from the updated Model that are different from the
+     *         corresponding values in original.
+     */
+    public static <T extends Model> SerializedModel difference(T updated, T original, ModelSchema modelSchema) {
+        Map<String, Object> updatedMap = ModelConverter.toMap(updated);
+        Map<String, Object> originalMap = ModelConverter.toMap(original);
+        Map<String, Object> patchMap = new HashMap<>();
+        for (String key : updatedMap.keySet()) {
+            if ("id".equals(key) || !ObjectsCompat.equals(originalMap.get(key), updatedMap.get(key))) {
+                patchMap.put(key, updatedMap.get(key));
+            }
+        }
+        return SerializedModel.builder()
+                .serializedData(patchMap)
+                .modelSchema(modelSchema)
+                .build();
+    }
+
+    /**
      * Return a builder of {@link SerializedModel}.
      * @return A serialized model builder
      */

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -341,7 +341,14 @@ final class AppSyncRequestFactory {
             try {
                 final ModelAssociation association = schema.getAssociations().get(fieldName);
                 if (association == null) {
-                    result.put(fieldName, extractFieldValue(modelField, instance));
+                    if (instance instanceof SerializedModel) {
+                        Map<String, Object> serializedData = ((SerializedModel) instance).getSerializedData();
+                        if (serializedData.containsKey(modelField.getName())) {
+                            result.put(fieldName, serializedData.get(modelField.getName()));
+                        }
+                    } else {
+                        result.put(fieldName, extractFieldValue(modelField, instance));
+                    }
                 } else if (association.isOwner()) {
                     result.put(association.getTargetName(), extractAssociateId(modelField, instance));
                 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/StorageItemChange.java
@@ -21,6 +21,7 @@ import androidx.annotation.Nullable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.datastore.appsync.SerializedModel;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -37,6 +38,7 @@ public final class StorageItemChange<T extends Model> {
     private final Type type;
     private final QueryPredicate predicate;
     private final T item;
+    private final SerializedModel patchItem;
     private final ModelSchema modelSchema;
 
     private StorageItemChange(
@@ -45,12 +47,14 @@ public final class StorageItemChange<T extends Model> {
             Type type,
             QueryPredicate predicate,
             T item,
+            SerializedModel patchItem,
             ModelSchema modelSchema) {
         this.changeId = changeId;
         this.initiator = initiator;
         this.type = type;
         this.predicate = predicate;
         this.item = item;
+        this.patchItem = patchItem;
         this.modelSchema = modelSchema;
     }
 
@@ -99,6 +103,15 @@ public final class StorageItemChange<T extends Model> {
     @NonNull
     public T item() {
         return item;
+    }
+
+    /**
+     * Gets a SerializedModel containing only the fields that have changed.
+     * @return a SerializedModel containing only the fields that have changed.
+     */
+    @NonNull
+    public SerializedModel patchItem() {
+        return patchItem;
     }
 
     /**
@@ -183,6 +196,7 @@ public final class StorageItemChange<T extends Model> {
         private Type type;
         private QueryPredicate predicate;
         private T item;
+        private SerializedModel patchItem;
         private ModelSchema modelSchema;
 
         /**
@@ -257,6 +271,16 @@ public final class StorageItemChange<T extends Model> {
         }
 
         /**
+         * Configures the patchItem, a SerializedModel containing only the fields that changed.
+         * @param patchItem Representation of the changes that occurred.
+         * @return Current Builder instance for fluent configuration chaining.
+         */
+        public Builder<T> patchItem(@NonNull SerializedModel patchItem) {
+            this.patchItem = Objects.requireNonNull(patchItem);
+            return this;
+        }
+
+        /**
          * Configures the schema of the item that changed.
          * @param modelSchema Schema of the item that changed
          * @return Current Builder instance for fluent configuration chaining
@@ -281,6 +305,7 @@ public final class StorageItemChange<T extends Model> {
                 Objects.requireNonNull(type),
                 Objects.requireNonNull(predicate),
                 Objects.requireNonNull(item),
+                Objects.requireNonNull(patchItem),
                 Objects.requireNonNull(modelSchema)
             );
         }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -773,7 +773,11 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         final QueryPredicate condition = matchId.and(predicate);
 
         Iterator<? extends Model> result = Single.<Iterator<? extends Model>>create(emitter -> {
-            query(schema.getModelClass(), Where.matches(condition), emitter::onSuccess, emitter::onError);
+            if (model instanceof SerializedModel) {
+                query(modelName, Where.matches(condition), emitter::onSuccess, emitter::onError);
+            } else {
+                query(model.getClass(), Where.matches(condition), emitter::onSuccess, emitter::onError);
+            }
         }).blockingGet();
         return result.hasNext() ? result.next() : null;
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.datastore.appsync.SerializedModel;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.logging.Logger;
@@ -78,14 +79,14 @@ final class StorageObserver {
         );
     }
 
-    private <T extends Model> PendingMutation<T> toPendingMutation(StorageItemChange<T> change) {
+    private PendingMutation<SerializedModel> toPendingMutation(StorageItemChange<? extends Model> change) {
         switch (change.type()) {
             case CREATE:
-                return PendingMutation.creation(change.item(), change.modelSchema());
+                return PendingMutation.creation(change.patchItem(), change.modelSchema());
             case UPDATE:
-                return PendingMutation.update(change.item(), change.modelSchema(), change.predicate());
+                return PendingMutation.update(change.patchItem(), change.modelSchema(), change.predicate());
             case DELETE:
-                return PendingMutation.deletion(change.item(), change.modelSchema(), change.predicate());
+                return PendingMutation.deletion(change.patchItem(), change.modelSchema(), change.predicate());
             default:
                 throw new IllegalStateException("Unknown mutation type = " + change.type());
         }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
@@ -21,7 +21,6 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.aws.AppSyncGraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.SubscriptionType;
-import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.AuthStrategy;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
@@ -33,7 +32,6 @@ import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testmodels.commentsblog.Comment;
 import com.amplifyframework.testmodels.commentsblog.Post;
-import com.amplifyframework.testmodels.meeting.Meeting;
 import com.amplifyframework.testmodels.parenting.Address;
 import com.amplifyframework.testmodels.parenting.Child;
 import com.amplifyframework.testmodels.parenting.City;
@@ -45,7 +43,6 @@ import com.amplifyframework.testutils.Resources;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -54,8 +51,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests the {@link AppSyncRequestFactory}.

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -27,6 +27,7 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.appsync.SerializedModel;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -74,10 +75,12 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull final Consumer<DataStoreException> onError) {
         StorageItemChange.Type type = StorageItemChange.Type.CREATE;
         final int index = indexOf(item);
+        Model savedItem = null;
         if (index > -1) {
             // There is an existing record with that ID; this is an update.
             type = StorageItemChange.Type.UPDATE;
-            Model savedItem = items.get(index);
+            savedItem = items.get(index);
+
             if (!predicate.evaluate(savedItem)) {
                 onError.accept(new DataStoreException(
                     "Conditional check failed.",
@@ -99,6 +102,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
         items.add(item);
         StorageItemChange<T> change = StorageItemChange.<T>builder()
             .item(item)
+            .patchItem(SerializedModel.difference(item, savedItem, schema))
             .modelSchema(schema)
             .type(type)
             .predicate(predicate)
@@ -178,6 +182,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
         }
         StorageItemChange<T> deletion = StorageItemChange.<T>builder()
             .item((T) savedItem)
+            .patchItem(SerializedModel.create(savedItem, schema))
             .modelSchema(schema)
             .type(StorageItemChange.Type.DELETE)
             .predicate(predicate)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/ItemChangeMapperTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/ItemChangeMapperTest.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreCategoryBehavior;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.DataStoreItemChange;
+import com.amplifyframework.datastore.appsync.SerializedModel;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 
 import org.junit.Before;
@@ -73,6 +74,7 @@ public final class ItemChangeMapperTest {
                 .changeId(changeId)
                 .initiator(StorageItemChange.Initiator.DATA_STORE_API)
                 .item(joe)
+                .patchItem(SerializedModel.create(joe, ModelSchema.fromModelClass(BlogOwner.class)))
                 .modelSchema(ModelSchema.fromModelClass(BlogOwner.class))
                 .predicate(QueryPredicates.all())
                 .type(StorageItemChange.Type.UPDATE)
@@ -101,6 +103,7 @@ public final class ItemChangeMapperTest {
                 .changeId(changeId)
                 .initiator(StorageItemChange.Initiator.SYNC_ENGINE)
                 .item(joe)
+                .patchItem(SerializedModel.create(joe, ModelSchema.fromModelClass(BlogOwner.class)))
                 .modelSchema(ModelSchema.fromModelClass(BlogOwner.class))
                 .predicate(QueryPredicates.all())
                 .type(StorageItemChange.Type.DELETE)

--- a/aws-datastore/src/test/resources/update-blog-owner-only-changed-fields.txt
+++ b/aws-datastore/src/test/resources/update-blog-owner-only-changed-fields.txt
@@ -1,0 +1,22 @@
+{"query": "mutation UpdateBlogOwner($input: UpdateBlogOwnerInput!) {
+  updateBlogOwner(input: $input) {
+    _deleted
+    _lastChangedAt
+    _version
+    blog {
+      id
+    }
+    id
+    name
+    wea
+  }
+}
+",
+"variables": {
+    "input":{
+       "name":"John Smith",
+       "id":"5aef1282-64d6-4fa8-ba2c-290f9d9c6973",
+       "_version":1
+    }
+  }
+}


### PR DESCRIPTION
### Problem
Currently when performing an update mutation, all fields are sent in the request to AppSync.  This prevents customers from being able to benefit from the AutoMerge conflict resolution strategy.  If AppSync receives a mutation with an outdated version, it attempt to intelligently merge the update, if the fields that have changed do not overlap with the fields that changed in the conflicting mutation.  However, since the client sends all fields, the benefits of AutoMerge will never occur.   Instead, all mutations with outdated versions will silently fail.  The update will not occur, and the original model is returned back to the client.

### Solution
This PR updates DataStore so that only the fields that have _changed_ will be sent to the server.   A comparison is done with the current version of the model in SQLite to determine which fields are different.   
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
