### PR TITLE
chore: allow empty methods in checkstyle

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
@@ -39,8 +39,7 @@ public final class Temporal {
     /**
      * This class acts as a namespace and should not be directly instantiated.
      */
-    private Temporal() {
-    }
+    private Temporal() {}
 
     /**
      * Represents a valid extended ISO-8601 Date string, with an optional timezone offset.

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageReservedWordTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageReservedWordTest.java
@@ -515,9 +515,7 @@ public final class SQLiteStorageReservedWordTest {
         private static final String AMPLIFY_MODEL_VERSION = "305719dace2b972243b439fbd551fe1a";
         private static AmplifyModelProvider amplifyGeneratedModelInstance;
 
-        private AmplifyModelProvider() {
-
-        }
+        private AmplifyModelProvider() {}
 
         /**
          * Instance of AmplifyModelProvider.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreErrorHandler.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreErrorHandler.java
@@ -20,5 +20,4 @@ import com.amplifyframework.core.Consumer;
 /**
  * Just a ~type-alias for a consumer of DataStoreException.
  */
-public interface DataStoreErrorHandler extends Consumer<DataStoreException> {
-}
+public interface DataStoreErrorHandler extends Consumer<DataStoreException> {}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/TypeConverter.java
@@ -34,8 +34,7 @@ public final class TypeConverter {
     /**
      * Dis-allows instantiation of the static utility.
      */
-    private TypeConverter() {
-    }
+    private TypeConverter() {}
 
     static {
         JAVA_TO_SQL.put(JavaFieldType.BOOLEAN, SQLiteDataType.INTEGER);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RetryStrategy.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RetryStrategy.java
@@ -36,9 +36,7 @@ public final class RetryStrategy {
 
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
-    private RetryStrategy() {
-
-    }
+    private RetryStrategy() {}
 
     /**
      * Simple implementation of an exponential backoff startegy that can be used with RxCompletables.

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -62,8 +62,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             @NonNull Context context,
             @NonNull Consumer<List<ModelSchema>> onSuccess,
             @NonNull Consumer<DataStoreException> onError
-    ) {
-    }
+    ) {}
 
     @Override
     public <T extends Model> void save(

--- a/configuration/checkstyle-rules.xml
+++ b/configuration/checkstyle-rules.xml
@@ -93,10 +93,16 @@
             <!--
                 Utility class constructors should be private. This
                 happens widely in the code base, and is the desirable
-                default. These should also have empty construtors, which
-                might as well be consisely written.
+                default. These should also have empty constructors, which
+                might as well be concisely written.
             -->
             <property name="allowEmptyConstructors" value="true" />
+            <!--
+                Some no-op operations must be defined to satisfy the
+                interface requirements. These will be more concisely
+                written by allowing this property.
+            -->
+            <property name="allowEmptyMethods" value="true" />
             <!--
                  false is already the default value for
                  WhitespaceAround.  This documents that we have this

--- a/core/src/main/java/com/amplifyframework/analytics/AnalyticsPlugin.java
+++ b/core/src/main/java/com/amplifyframework/analytics/AnalyticsPlugin.java
@@ -38,7 +38,6 @@ public abstract class AnalyticsPlugin<E> implements AnalyticsCategoryBehavior, P
 
     @WorkerThread
     @Override
-    public void initialize(@NonNull Context context) throws AmplifyException {
-    }
+    public void initialize(@NonNull Context context) throws AmplifyException {}
 }
 

--- a/core/src/main/java/com/amplifyframework/api/ApiPlugin.java
+++ b/core/src/main/java/com/amplifyframework/api/ApiPlugin.java
@@ -40,7 +40,6 @@ public abstract class ApiPlugin<E> implements ApiCategoryBehavior, Plugin<E> {
 
     @WorkerThread
     @Override
-    public void initialize(@NonNull Context context) throws AmplifyException {
-    }
+    public void initialize(@NonNull Context context) throws AmplifyException {}
 }
 

--- a/core/src/main/java/com/amplifyframework/auth/AuthPlugin.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthPlugin.java
@@ -38,6 +38,5 @@ public abstract class AuthPlugin<E> implements AuthCategoryBehavior, Plugin<E> {
 
     @WorkerThread
     @Override
-    public void initialize(@NonNull Context context) throws AmplifyException {
-    }
+    public void initialize(@NonNull Context context) throws AmplifyException {}
 }

--- a/core/src/main/java/com/amplifyframework/core/NoOpConsumer.java
+++ b/core/src/main/java/com/amplifyframework/core/NoOpConsumer.java
@@ -37,8 +37,7 @@ public final class NoOpConsumer<T> implements Consumer<T> {
     }
 
     @Override
-    public void accept(@NonNull T value) {
-    }
+    public void accept(@NonNull T value) {}
 
     @Override
     public int hashCode() {

--- a/core/src/main/java/com/amplifyframework/core/async/NoOpCancelable.java
+++ b/core/src/main/java/com/amplifyframework/core/async/NoOpCancelable.java
@@ -20,6 +20,5 @@ package com.amplifyframework.core.async;
  */
 public final class NoOpCancelable implements Cancelable {
     @Override
-    public void cancel() {
-    }
+    public void cancel() {}
 }

--- a/core/src/main/java/com/amplifyframework/datastore/DataStorePlugin.java
+++ b/core/src/main/java/com/amplifyframework/datastore/DataStorePlugin.java
@@ -37,6 +37,5 @@ public abstract class DataStorePlugin<E> implements DataStoreCategoryBehavior, P
 
     @WorkerThread
     @Override
-    public void initialize(@NonNull Context context) throws AmplifyException {
-    }
+    public void initialize(@NonNull Context context) throws AmplifyException {}
 }

--- a/core/src/main/java/com/amplifyframework/devmenu/PersistentLogStoragePlugin.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/PersistentLogStoragePlugin.java
@@ -69,8 +69,7 @@ public final class PersistentLogStoragePlugin extends LoggingPlugin<Void> {
     }
 
     @Override
-    public void configure(JSONObject pluginConfiguration, @NonNull Context context) {
-    }
+    public void configure(JSONObject pluginConfiguration, @NonNull Context context) {}
 
     @Nullable
     @Override

--- a/core/src/main/java/com/amplifyframework/hub/AWSHubPlugin.java
+++ b/core/src/main/java/com/amplifyframework/hub/AWSHubPlugin.java
@@ -107,8 +107,7 @@ public final class AWSHubPlugin extends HubPlugin<Void> {
     }
 
     @Override
-    public void configure(JSONObject pluginConfiguration, @NonNull Context context) {
-    }
+    public void configure(JSONObject pluginConfiguration, @NonNull Context context) {}
 
     @Nullable
     @Override

--- a/core/src/main/java/com/amplifyframework/hub/HubPlugin.java
+++ b/core/src/main/java/com/amplifyframework/hub/HubPlugin.java
@@ -39,6 +39,5 @@ public abstract class HubPlugin<E> implements HubCategoryBehavior, Plugin<E> {
 
     @WorkerThread
     @Override
-    public void initialize(@NonNull Context context) throws AmplifyException {
-    }
+    public void initialize(@NonNull Context context) throws AmplifyException {}
 }

--- a/core/src/main/java/com/amplifyframework/logging/LoggingPlugin.java
+++ b/core/src/main/java/com/amplifyframework/logging/LoggingPlugin.java
@@ -39,8 +39,7 @@ public abstract class LoggingPlugin<E> implements LoggingCategoryBehavior, Plugi
 
     @WorkerThread
     @Override
-    public void initialize(@NonNull Context context) throws AmplifyException {
-    }
+    public void initialize(@NonNull Context context) throws AmplifyException {}
 
     @Override
     public final boolean equals(Object object) {

--- a/core/src/main/java/com/amplifyframework/predictions/PredictionsPlugin.java
+++ b/core/src/main/java/com/amplifyframework/predictions/PredictionsPlugin.java
@@ -38,6 +38,5 @@ public abstract class PredictionsPlugin<E> implements PredictionsCategoryBehavio
 
     @WorkerThread
     @Override
-    public void initialize(@NonNull Context context) throws AmplifyException {
-    }
+    public void initialize(@NonNull Context context) throws AmplifyException {}
 }

--- a/core/src/main/java/com/amplifyframework/predictions/result/IdentifyResult.java
+++ b/core/src/main/java/com/amplifyframework/predictions/result/IdentifyResult.java
@@ -19,5 +19,4 @@ package com.amplifyframework.predictions.result;
  * Interface to group different types of results from
  * identify operation in Predictions category.
  */
-public interface IdentifyResult {
-}
+public interface IdentifyResult {}

--- a/core/src/main/java/com/amplifyframework/storage/StoragePlugin.java
+++ b/core/src/main/java/com/amplifyframework/storage/StoragePlugin.java
@@ -38,6 +38,5 @@ public abstract class StoragePlugin<E> implements StorageCategoryBehavior, Plugi
 
     @WorkerThread
     @Override
-    public void initialize(@NonNull Context context) throws AmplifyException {
-    }
+    public void initialize(@NonNull Context context) throws AmplifyException {}
 }

--- a/core/src/main/java/com/amplifyframework/util/FieldFinder.java
+++ b/core/src/main/java/com/amplifyframework/util/FieldFinder.java
@@ -36,8 +36,7 @@ public final class FieldFinder {
     /**
      * Dis-allows instantiation of this utility.
      */
-    private FieldFinder() {
-    }
+    private FieldFinder() {}
 
     /**
      * Get a set of all the fields of a class that are

--- a/core/src/main/java/com/amplifyframework/util/Immutable.java
+++ b/core/src/main/java/com/amplifyframework/util/Immutable.java
@@ -29,8 +29,7 @@ import java.util.Set;
  * Contains methods for immutability.
  */
 public final class Immutable {
-    private Immutable() {
-    }
+    private Immutable() {}
 
     /**
      * Create an immutable copy of the map passed in.

--- a/core/src/test/java/com/amplifyframework/core/BadInitLoggingPlugin.java
+++ b/core/src/test/java/com/amplifyframework/core/BadInitLoggingPlugin.java
@@ -48,8 +48,7 @@ public final class BadInitLoggingPlugin extends LoggingPlugin<Void> {
     }
 
     @Override
-    public void configure(@NonNull JSONObject pluginConfiguration, @NonNull Context context) {
-    }
+    public void configure(@NonNull JSONObject pluginConfiguration, @NonNull Context context) {}
 
     @Override
     public void initialize(@NonNull Context context) throws AmplifyException {

--- a/core/src/test/java/com/amplifyframework/logging/FakeLoggingPlugin.java
+++ b/core/src/test/java/com/amplifyframework/logging/FakeLoggingPlugin.java
@@ -51,8 +51,7 @@ final class FakeLoggingPlugin<E> extends LoggingPlugin<E> {
     }
 
     @Override
-    public void configure(@NonNull JSONObject pluginConfiguration, @NonNull Context context) {
-    }
+    public void configure(@NonNull JSONObject pluginConfiguration, @NonNull Context context) {}
 
     @Nullable
     @Override

--- a/core/src/test/resources/logging-config.json
+++ b/core/src/test/resources/logging-config.json
@@ -3,10 +3,8 @@
   "version": "1.0",
   "logging": {
     "plugins": {
-      "SimpleLoggingPlugin": {
-      },
-      "BadInitLoggingPlugin": {
-      }
+      "SimpleLoggingPlugin": {},
+      "BadInitLoggingPlugin": {}
     }
   }
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxApiCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxApiCategoryBehavior.java
@@ -21,5 +21,4 @@ import com.amplifyframework.api.ApiCategoryBehavior;
  * An Rx-idiomatic expression of Amplify's {@link ApiCategoryBehavior}s.
  */
 @SuppressWarnings("WeakerAccess") // This is a public API.
-public interface RxApiCategoryBehavior extends RxRestBehavior, RxGraphQlBehavior {
-}
+public interface RxApiCategoryBehavior extends RxRestBehavior, RxGraphQlBehavior {}

--- a/testutils/src/main/java/com/amplifyframework/testutils/EmptyAction.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/EmptyAction.java
@@ -26,8 +26,7 @@ public final class EmptyAction implements Action {
     private EmptyAction() {}
 
     @Override
-    public void call() {
-    }
+    public void call() {}
 
     /**
      * Creates a new instance of an {@link EmptyAction}.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Allow empty methods to be concisely written as `{}` without triggering `WhitespaceAround` check.
* Make empty classes, empty methods, and empty constructors use more concise pattern.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
