### PR TITLE
chore(devmenu) use java.util.Date instead of java.time for dev menu logging

### DIFF
--- a/core/src/main/java/com/amplifyframework/devmenu/LogEntry.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/LogEntry.java
@@ -22,8 +22,8 @@ import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.logging.LogLevel;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -33,7 +33,7 @@ import java.util.Objects;
 public final class LogEntry implements Comparable<LogEntry> {
     // The format for the log's date and time.
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
-    private final LocalDateTime dateTime;
+    private final Date date;
     private final String namespace;
     private final String message;
     private final Throwable throwable;
@@ -42,15 +42,15 @@ public final class LogEntry implements Comparable<LogEntry> {
     /**
      * Creates a new LogEntry representing a log with the given time, tag, message,
      * and throwable that was logged at the given level.
-     * @param dateTime the date and time of the log.
+     * @param date the date of the log.
      * @param namespace the namespace of the logger that emitted the log.
      * @param message the message for the log.
      * @param throwable the Throwable associated with the log.
      * @param logLevel the level the log was logged at.
      */
-    public LogEntry(@NonNull LocalDateTime dateTime, @Nullable String namespace, @Nullable String message,
+    public LogEntry(@NonNull Date date, @Nullable String namespace, @Nullable String message,
                     @Nullable Throwable throwable, @NonNull LogLevel logLevel) {
-        this.dateTime = Objects.requireNonNull(dateTime);
+        this.date = Objects.requireNonNull(date);
         this.logLevel = Objects.requireNonNull(logLevel);
         this.namespace = namespace;
         this.message = message;
@@ -61,8 +61,8 @@ public final class LogEntry implements Comparable<LogEntry> {
      * Gets the date and time of the log.
      * @return the date and time of the log.
      */
-    public LocalDateTime getDateTime() {
-        return dateTime;
+    public Date getDate() {
+        return date;
     }
 
     /**
@@ -99,7 +99,7 @@ public final class LogEntry implements Comparable<LogEntry> {
 
     @Override
     public int compareTo(LogEntry logEntry) {
-        return getDateTime().compareTo(logEntry.getDateTime());
+        return getDate().compareTo(logEntry.getDate());
     }
 
     @Override
@@ -111,14 +111,14 @@ public final class LogEntry implements Comparable<LogEntry> {
             return false;
         }
         LogEntry logEntry = (LogEntry) object;
-        return dateTime.equals(logEntry.getDateTime()) && ObjectsCompat.equals(namespace, logEntry.getNamespace())
+        return date.equals(logEntry.getDate()) && ObjectsCompat.equals(namespace, logEntry.getNamespace())
                 && ObjectsCompat.equals(message, logEntry.getMessage()) && logLevel == logEntry.getLogLevel()
                 && ObjectsCompat.equals(throwable, logEntry.getThrowable());
     }
 
     @Override
     public int hashCode() {
-        int result = getDateTime().hashCode();
+        int result = getDate().hashCode();
         result = 31 * result + (getNamespace() != null ? getNamespace().hashCode() : 0);
         result = 31 * result + (getMessage() != null ? getMessage().hashCode() : 0);
         result = 31 * result + (getThrowable() != null ? getThrowable().hashCode() : 0);
@@ -131,7 +131,8 @@ public final class LogEntry implements Comparable<LogEntry> {
      * @return a String representing this log.
      */
     public String toString() {
-        String dateString = dateTime.format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT));
+        SimpleDateFormat df = new SimpleDateFormat(DATE_TIME_FORMAT, Locale.US);
+        String dateString = df.format(date);
         String exceptionTrace = throwable == null ? "" : Log.getStackTraceString(throwable);
         if (!exceptionTrace.isEmpty() && !exceptionTrace.endsWith("\n")) {
             exceptionTrace += "\n";

--- a/core/src/main/java/com/amplifyframework/devmenu/PersistentLogger.java
+++ b/core/src/main/java/com/amplifyframework/devmenu/PersistentLogger.java
@@ -23,7 +23,7 @@ import com.amplifyframework.logging.LogLevel;
 import com.amplifyframework.logging.Logger;
 import com.amplifyframework.util.Immutable;
 
-import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -113,6 +113,6 @@ final class PersistentLogger implements Logger {
         if (logs.size() == MAX_NUM_LOGS) {
             logs.remove(0);
         }
-        logs.add(new LogEntry(LocalDateTime.now(), namespace, message, throwable, logLevel));
+        logs.add(new LogEntry(new Date(), namespace, message, throwable, logLevel));
     }
 }

--- a/core/src/test/java/com/amplifyframework/devmenu/PersistentLogStoragePluginTest.java
+++ b/core/src/test/java/com/amplifyframework/devmenu/PersistentLogStoragePluginTest.java
@@ -44,7 +44,8 @@ public final class PersistentLogStoragePluginTest {
         logger.error(message, throwable);
         List<LogEntry> logs = plugin.getLogs();
         assertEquals(1, logs.size());
-        LogEntry expectedLog = new LogEntry(logs.get(0).getDateTime(), logger.getNamespace(), message,
+
+        LogEntry expectedLog = new LogEntry(logs.get(0).getDate(), logger.getNamespace(), message,
                 throwable, LogLevel.ERROR);
         assertEquals(expectedLog, logs.get(0));
     }


### PR DESCRIPTION
The developer menu logging functionality used `java.time.LocalDateTime` to store time of log messages.  The `java.time` library either requires API 26 or above, or requires customers to be on Android Studio 4.0 and above, and make changes in their `build.gradle` to enable desugaring.  There no particular reason to use `java.time.*` over `java.util.Date` in this case, so this PR changes the dev menu to use `java.util.Date`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
