### PR TITLE
fix(datastore) fix crash caused by null patchItem

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -578,6 +578,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelInstance(model);
                     itemChangeSubject.onNext(StorageItemChange.builder()
                             .item(model)
+                            .patchItem(SerializedModel.create(model, schema))
                             .modelSchema(schema)
                             .type(StorageItemChange.Type.DELETE)
                             .predicate(QueryPredicates.all())


### PR DESCRIPTION
The `deleteModelTypeWithPredicateCascades` and `deleteModelTypeWithPredicateDeletesData` integration tests are currently failing on the `main` branch due to `patchItem` being null in one scenario.  This PR fixes the issue.   I believe it was broken when https://github.com/aws-amplify/amplify-android/pull/1110 was merged.   Even though the tests passed on the PR, they failed after the changes were squashed and merged to `main`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
