### PR TITLE
Make MatchAll/NoneQueryPredicate classes private

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -23,13 +23,12 @@ import com.amplifyframework.core.model.query.predicate.GreaterOrEqualQueryOperat
 import com.amplifyframework.core.model.query.predicate.GreaterThanQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessOrEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessThanQueryOperator;
-import com.amplifyframework.core.model.query.predicate.MatchAllQueryPredicate;
-import com.amplifyframework.core.model.query.predicate.MatchNoneQueryPredicate;
 import com.amplifyframework.core.model.query.predicate.NotEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
+import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.core.model.types.JavaFieldType;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.sqlite.SQLiteModelFieldTypeConverter;
@@ -108,10 +107,10 @@ public final class SQLPredicate {
 
     // Utility method to recursively parse a given predicate.
     private StringBuilder parsePredicate(QueryPredicate queryPredicate) throws DataStoreException {
-        if (queryPredicate instanceof MatchAllQueryPredicate) {
+        if (QueryPredicates.all().equals(queryPredicate)) {
             return new StringBuilder("1 = 1");
         }
-        if (queryPredicate instanceof MatchNoneQueryPredicate) {
+        if (QueryPredicates.none().equals(queryPredicate)) {
             return new StringBuilder("1 = 0");
         }
         if (queryPredicate instanceof QueryPredicateOperation) {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMockingTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMockingTest.java
@@ -23,7 +23,6 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.NoOpAction;
 import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.core.model.ModelSchema;
-import com.amplifyframework.core.model.query.predicate.MatchAllQueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.datastore.DataStoreException;
@@ -230,7 +229,7 @@ public final class AppSyncMockingTest {
                     schema,
                     StrawMen.TONY_MODEL.getId(),
                     1,
-                    MatchAllQueryPredicate.instance(),
+                    QueryPredicates.all(),
                     emitter::onSuccess,
                     emitter::onError
                 )
@@ -257,7 +256,7 @@ public final class AppSyncMockingTest {
                 schema,
                 StrawMen.JOE_MODEL.getId(),
                 1,
-                MatchAllQueryPredicate.instance(),
+                QueryPredicates.all(),
                 emitter::onSuccess,
                 emitter::onError
             ))

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/MatchAllQueryPredicate.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/MatchAllQueryPredicate.java
@@ -21,7 +21,7 @@ import androidx.annotation.Nullable;
 /**
  * A {@link QueryPredicate} that matches any/all objects passed to it.
  */
-public final class MatchAllQueryPredicate implements QueryPredicate {
+final class MatchAllQueryPredicate implements QueryPredicate {
     private MatchAllQueryPredicate() {}
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/MatchNoneQueryPredicate.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/MatchNoneQueryPredicate.java
@@ -21,7 +21,7 @@ import androidx.annotation.Nullable;
 /**
  * A {@link QueryPredicate} that matches none of the objects passed to it.
  */
-public final class MatchNoneQueryPredicate implements QueryPredicate {
+final class MatchNoneQueryPredicate implements QueryPredicate {
     private MatchNoneQueryPredicate() {}
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicates.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicates.java
@@ -25,7 +25,7 @@ public final class QueryPredicates {
      * Creates a {@link QueryPredicate} which matches any object it is asked to evaluate.
      * @return A query predicate that matches everything.
      */
-    public static MatchAllQueryPredicate all() {
+    public static QueryPredicate all() {
         return MatchAllQueryPredicate.instance();
     }
 
@@ -33,7 +33,7 @@ public final class QueryPredicates {
      * Creates a {@link QueryPredicate} which matches nothing.
      * @return A query predicate that matches nothing.
      */
-    public static MatchNoneQueryPredicate none() {
+    public static QueryPredicate none() {
         return MatchNoneQueryPredicate.instance();
     }
 }


### PR DESCRIPTION
Clients should use the `QueryPredicates.all()` and `QueryPredicates.none()`.  The underlying `MatchAllQueryPredicate` and `MatchNoneQueryPredicate` classes should be package-private.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
