### PR TITLE
fix(datastore): dont use where.id() function

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -852,11 +852,17 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
      * @return the Model instance from SQLite, if it exists, otherwise null.
      */
     private Model query(Model model) {
+        final String modelName = getModelName(model);
+        final ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(modelName);
+        final SQLiteTable table = SQLiteTable.fromSchema(schema);
+        final String primaryKeyName = table.getPrimaryKeyColumnName();
+        final QueryPredicate matchId = QueryField.field(primaryKeyName).eq(model.getId());
+
         Iterator<? extends Model> result = Single.<Iterator<? extends Model>>create(emitter -> {
             if (model instanceof SerializedModel) {
-                query(getModelName(model), Where.id(model.getId()), emitter::onSuccess, emitter::onError);
+                query(modelName, Where.matches(matchId), emitter::onSuccess, emitter::onError);
             } else {
-                query(model.getClass(), Where.id(model.getId()), emitter::onSuccess, emitter::onError);
+                query(model.getClass(), Where.matches(matchId), emitter::onSuccess, emitter::onError);
             }
         }).blockingGet();
         return result.hasNext() ? result.next() : null;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/908#issuecomment-766284487

*Description of changes:*
Using `Where.id()` internally to match model ID broke query function for models that had `@BelongsTo` relationship with another model. This PR reverts that change and adds a test case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
