### PR TITLE
fix(core): query field now stores model name

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
@@ -110,6 +110,8 @@ final class SQLiteModelTree {
             Collection<String> parentIds
     ) {
         SQLiteTable parentTable = SQLiteTable.fromSchema(modelSchema);
+        final String parentTableName = parentTable.getName();
+        final String parentPrimaryKeyName = parentTable.getPrimaryKey().getName();
         for (ModelAssociation association : modelSchema.getAssociations().values()) {
             switch (association.getName()) {
                 case "HasOne":
@@ -118,7 +120,7 @@ final class SQLiteModelTree {
                     ModelSchema childSchema = registry.getModelSchemaForModelClass(childModel);
                     SQLiteTable childTable = SQLiteTable.fromSchema(childSchema);
                     String childPrimaryKey = childTable.getPrimaryKey().getAliasedName();
-                    QueryField queryField = QueryField.field(parentTable.getPrimaryKeyColumnName());
+                    QueryField queryField = QueryField.field(parentTableName, parentPrimaryKeyName);
 
                     // Chain predicates with OR operator.
                     QueryPredicate predicate = QueryPredicates.none();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -729,8 +729,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         final ModelSchema modelSchema =
                 modelSchemaRegistry.getModelSchemaForModelClass(modelName);
         final SQLiteTable sqliteTable = SQLiteTable.fromSchema(modelSchema);
-        final String primaryKeyName = sqliteTable.getPrimaryKeyColumnName();
-        final QueryPredicate matchId = QueryField.field(primaryKeyName).eq(item.getId());
+        final String primaryKeyName = sqliteTable.getPrimaryKey().getName();
+        final QueryPredicate matchId = QueryField.field(modelName, primaryKeyName).eq(item.getId());
 
         // Generate SQL command for given action
         final SqlCommand sqlCommand;
@@ -836,9 +836,9 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         final ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(modelName);
         final SQLiteTable table = SQLiteTable.fromSchema(schema);
         final String tableName = table.getName();
-        final String primaryKeyName = table.getPrimaryKeyColumnName();
+        final String primaryKeyName = table.getPrimaryKey().getName();
 
-        final QueryPredicate matchId = QueryField.field(primaryKeyName).eq(model.getId());
+        final QueryPredicate matchId = QueryField.field(tableName, primaryKeyName).eq(model.getId());
         final QueryPredicate condition = matchId.and(predicate);
         try (Cursor cursor = getQueryAllCursor(tableName, Where.matches(condition))) {
             return cursor.moveToFirst();
@@ -855,8 +855,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         final String modelName = getModelName(model);
         final ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(modelName);
         final SQLiteTable table = SQLiteTable.fromSchema(schema);
-        final String primaryKeyName = table.getPrimaryKeyColumnName();
-        final QueryPredicate matchId = QueryField.field(primaryKeyName).eq(model.getId());
+        final String primaryKeyName = table.getPrimaryKey().getName();
+        final QueryPredicate matchId = QueryField.field(modelName, primaryKeyName).eq(model.getId());
 
         Iterator<? extends Model> result = Single.<Iterator<? extends Model>>create(emitter -> {
             if (model instanceof SerializedModel) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -133,7 +133,7 @@ public final class SQLPredicate {
     // Utility method to recursively parse a given predicate operation.
     private StringBuilder parsePredicateOperation(QueryPredicateOperation<?> operation) throws DataStoreException {
         final StringBuilder builder = new StringBuilder();
-        final String model = Wrap.inBackticks(operation.model());
+        final String model = Wrap.inBackticks(operation.modelName());
         final String field = Wrap.inBackticks(operation.field());
         final String column = model == null ? operation.field() : model + "." + field;
         final QueryOperator<?> op = operation.operator();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -114,7 +114,7 @@ public final class SQLPredicate {
             return new StringBuilder("1 = 0");
         }
         if (queryPredicate instanceof QueryPredicateOperation) {
-            QueryPredicateOperation<?> qpo = (QueryPredicateOperation) queryPredicate;
+            QueryPredicateOperation<?> qpo = (QueryPredicateOperation<?>) queryPredicate;
             return parsePredicateOperation(qpo);
         }
         if (queryPredicate instanceof QueryPredicateGroup) {
@@ -132,14 +132,16 @@ public final class SQLPredicate {
     // Utility method to recursively parse a given predicate operation.
     private StringBuilder parsePredicateOperation(QueryPredicateOperation<?> operation) throws DataStoreException {
         final StringBuilder builder = new StringBuilder();
+        final String model = operation.model();
         final String field = operation.field();
+        final String column = model == null ? field : model + "." + field;
         final QueryOperator<?> op = operation.operator();
         switch (op.type()) {
             case BETWEEN:
                 BetweenQueryOperator<?> betweenOp = (BetweenQueryOperator<?>) op;
                 addBinding(betweenOp.start());
                 addBinding(betweenOp.end());
-                return builder.append(field)
+                return builder.append(column)
                         .append(SqlKeyword.DELIMITER)
                         .append(SqlKeyword.BETWEEN)
                         .append(SqlKeyword.DELIMITER)
@@ -152,7 +154,7 @@ public final class SQLPredicate {
                 ContainsQueryOperator containsOp = (ContainsQueryOperator) op;
                 addBinding(containsOp.value());
                 return builder.append("instr(")
-                        .append(field)
+                        .append(column)
                         .append(",")
                         .append("?")
                         .append(")")
@@ -163,7 +165,7 @@ public final class SQLPredicate {
             case BEGINS_WITH:
                 BeginsWithQueryOperator beginsWithOp = (BeginsWithQueryOperator) op;
                 addBinding(beginsWithOp.value() + "%");
-                return builder.append(field)
+                return builder.append(column)
                         .append(SqlKeyword.DELIMITER)
                         .append(SqlKeyword.LIKE)
                         .append(SqlKeyword.DELIMITER)
@@ -175,7 +177,7 @@ public final class SQLPredicate {
             case LESS_OR_EQUAL:
             case GREATER_OR_EQUAL:
                 addBinding(getOperatorValue(op));
-                return builder.append(field)
+                return builder.append(column)
                         .append(SqlKeyword.DELIMITER)
                         .append(SqlKeyword.fromQueryOperator(op.type()))
                         .append(SqlKeyword.DELIMITER)
@@ -227,13 +229,13 @@ public final class SQLPredicate {
             case EQUAL:
                 return ((EqualQueryOperator) qOp).value();
             case LESS_OR_EQUAL:
-                return ((LessOrEqualQueryOperator) qOp).value();
+                return ((LessOrEqualQueryOperator<?>) qOp).value();
             case LESS_THAN:
-                return ((LessThanQueryOperator) qOp).value();
+                return ((LessThanQueryOperator<?>) qOp).value();
             case GREATER_OR_EQUAL:
-                return ((GreaterOrEqualQueryOperator) qOp).value();
+                return ((GreaterOrEqualQueryOperator<?>) qOp).value();
             case GREATER_THAN:
-                return ((GreaterThanQueryOperator) qOp).value();
+                return ((GreaterThanQueryOperator<?>) qOp).value();
             default:
                 throw new DataStoreException(
                         "Tried to parse an unsupported QueryOperator type",

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -36,6 +36,7 @@ import com.amplifyframework.datastore.storage.sqlite.SqlKeyword;
 import com.amplifyframework.datastore.storage.sqlite.TypeConverter;
 import com.amplifyframework.util.GsonFactory;
 import com.amplifyframework.util.Immutable;
+import com.amplifyframework.util.Wrap;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -132,9 +133,9 @@ public final class SQLPredicate {
     // Utility method to recursively parse a given predicate operation.
     private StringBuilder parsePredicateOperation(QueryPredicateOperation<?> operation) throws DataStoreException {
         final StringBuilder builder = new StringBuilder();
-        final String model = operation.model();
-        final String field = operation.field();
-        final String column = model == null ? field : model + "." + field;
+        final String model = Wrap.inBackticks(operation.model());
+        final String field = Wrap.inBackticks(operation.field());
+        final String column = model == null ? operation.field() : model + "." + field;
         final QueryOperator<?> op = operation.operator();
         switch (op.type()) {
             case BETWEEN:

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.java
@@ -19,8 +19,6 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.query.Where;
-import com.amplifyframework.core.model.query.predicate.QueryField;
-import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
@@ -55,10 +53,9 @@ final class VersionRepository {
      * @return Current version known locally
      */
     <T extends Model> Single<Integer> findModelVersion(T model) {
-        // The ModelMetadata for the model uses the same ID as an identifier.
-        final QueryPredicate hasMatchingId = QueryField.field("id").eq(model.getId());
         return Single.create(emitter -> {
-            localStorageAdapter.query(ModelMetadata.class, Where.matches(hasMatchingId), iterableResults -> {
+            // The ModelMetadata for the model uses the same ID as an identifier.
+            localStorageAdapter.query(ModelMetadata.class, Where.id(model.getId()), iterableResults -> {
                 try {
                     emitter.onSuccess(extractVersion(model, iterableResults));
                 } catch (DataStoreException badVersionFailure) {

--- a/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  * {@link QueryField#descending()} helper methods (e.g. Todo.DESCRIPTION.ascending() or Todo.DESCRIPTION.descending())
  */
 public final class QuerySortBy {
-    private final String model;
+    private final String modelName;
     private final String field;
     private final QuerySortOrder sortOrder;
 
@@ -51,12 +51,12 @@ public final class QuerySortBy {
     /**
      * Constructor for {@code QuerySortBy}.
      *
-     * @param model name of the model being sorted.
+     * @param modelName name of the model being sorted.
      * @param field name of field to sort by.
      * @param sortOrder order to sort by, either ASCENDING or DESCENDING.
      */
-    public QuerySortBy(@Nullable String model, @NonNull String field, @NonNull QuerySortOrder sortOrder) {
-        this.model = model;
+    public QuerySortBy(@Nullable String modelName, @NonNull String field, @NonNull QuerySortOrder sortOrder) {
+        this.modelName = modelName;
         this.field = Objects.requireNonNull(field);
         this.sortOrder = Objects.requireNonNull(sortOrder);
     }
@@ -66,8 +66,8 @@ public final class QuerySortBy {
      * @return the model being sorted.
      */
     @Nullable
-    public String getModel() {
-        return model;
+    public String getModelName() {
+        return modelName;
     }
 
     /**
@@ -99,21 +99,21 @@ public final class QuerySortBy {
         }
 
         QuerySortBy that = (QuerySortBy) object;
-        return ObjectsCompat.equals(model, that.model) &&
+        return ObjectsCompat.equals(modelName, that.modelName) &&
                 ObjectsCompat.equals(field, that.field) &&
                 ObjectsCompat.equals(sortOrder, that.sortOrder);
     }
 
     @Override
     public int hashCode() {
-        return ObjectsCompat.hash(model, field, sortOrder);
+        return ObjectsCompat.hash(modelName, field, sortOrder);
     }
 
     @Override
     public String toString() {
         return "QuerySortBy{" +
-                "model=" + (model == null ? null : Wrap.inSingleQuotes(model)) +
-                ", field='" + field + '\'' +
+                "model=" + (modelName == null ? null : Wrap.inSingleQuotes(modelName)) +
+                ", field=" + Wrap.inSingleQuotes(field) +
                 ", sortOrder=" + sortOrder +
                 '}';
     }

--- a/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/QuerySortBy.java
@@ -16,11 +16,13 @@
 package com.amplifyframework.core.model.query;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.datastore.DataStoreCategoryBehavior;
+import com.amplifyframework.util.Wrap;
 
 import java.util.Objects;
 
@@ -32,6 +34,7 @@ import java.util.Objects;
  * {@link QueryField#descending()} helper methods (e.g. Todo.DESCRIPTION.ascending() or Todo.DESCRIPTION.descending())
  */
 public final class QuerySortBy {
+    private final String model;
     private final String field;
     private final QuerySortOrder sortOrder;
 
@@ -42,14 +45,36 @@ public final class QuerySortBy {
      * @param sortOrder order to sort by, either ASCENDING or DESCENDING.
      */
     public QuerySortBy(@NonNull String field, @NonNull QuerySortOrder sortOrder) {
+        this(null, field, sortOrder);
+    }
+
+    /**
+     * Constructor for {@code QuerySortBy}.
+     *
+     * @param model name of the model being sorted.
+     * @param field name of field to sort by.
+     * @param sortOrder order to sort by, either ASCENDING or DESCENDING.
+     */
+    public QuerySortBy(@Nullable String model, @NonNull String field, @NonNull QuerySortOrder sortOrder) {
+        this.model = model;
         this.field = Objects.requireNonNull(field);
         this.sortOrder = Objects.requireNonNull(sortOrder);
+    }
+
+    /**
+     * Returns the model being sorted.
+     * @return the model being sorted.
+     */
+    @Nullable
+    public String getModel() {
+        return model;
     }
 
     /**
      * Returns the field to sort by.
      * @return the field to sort by.
      */
+    @NonNull
     public String getField() {
         return field;
     }
@@ -58,6 +83,7 @@ public final class QuerySortBy {
      * Returns the order to sort by, either ASCENDING or DESCENDING.
      * @return the order to sort by, either ASCENDING or DESCENDING.
      */
+    @NonNull
     public QuerySortOrder getSortOrder() {
         return sortOrder;
     }
@@ -73,19 +99,21 @@ public final class QuerySortBy {
         }
 
         QuerySortBy that = (QuerySortBy) object;
-        return ObjectsCompat.equals(field, that.field) &&
+        return ObjectsCompat.equals(model, that.model) &&
+                ObjectsCompat.equals(field, that.field) &&
                 ObjectsCompat.equals(sortOrder, that.sortOrder);
     }
 
     @Override
     public int hashCode() {
-        return ObjectsCompat.hash(field, sortOrder);
+        return ObjectsCompat.hash(model, field, sortOrder);
     }
 
     @Override
     public String toString() {
         return "QuerySortBy{" +
-                "field='" + field + '\'' +
+                "model=" + (model == null ? null : Wrap.inSingleQuotes(model)) +
+                ", field='" + field + '\'' +
                 ", sortOrder=" + sortOrder +
                 '}';
     }

--- a/core/src/main/java/com/amplifyframework/core/model/query/Where.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/Where.java
@@ -17,6 +17,7 @@ package com.amplifyframework.core.model.query;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.core.model.PrimaryKey;
 import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 
@@ -56,7 +57,9 @@ public final class Where {
      * @return options with proper predicate and pagination to match a model by its id.
      */
     public static QueryOptions id(@NonNull final String modelId) {
-        return matches(QueryField.field("id").eq(Objects.requireNonNull(modelId))).paginated(Page.firstResult());
+        final QueryField idField = QueryField.field(PrimaryKey.fieldName());
+        return matches(idField.eq(Objects.requireNonNull(modelId)))
+                .paginated(Page.firstResult());
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryField.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryField.java
@@ -22,24 +22,38 @@ import com.amplifyframework.core.model.query.QuerySortOrder;
  * Represents a property in a model with methods for chaining conditions.
  */
 public final class QueryField {
+    private final String modelName;
     private final String fieldName;
 
     /**
      * Constructs a new QueryField for a given model property.
      * This would not be used by the developer but rather is called from the static factory method.
+     * @param modelName the name of the model owning this field
      * @param fieldName the model property this QueryField represents
      */
-    private QueryField(String fieldName) {
+    private QueryField(String modelName, String fieldName) {
+        this.modelName = modelName;
         this.fieldName = fieldName;
     }
 
     /**
      * Public factory method to create a new QueryField from the name of the property in the model.
+     * This factory method ignores model name
      * @param fieldName the model property this QueryField represents
      * @return a new QueryField which represents the given model property
      */
     public static QueryField field(String fieldName) {
-        return new QueryField(fieldName);
+        return field(null, fieldName);
+    }
+
+    /**
+     * Public factory method to create a new QueryField from the name of the property in the model.
+     * @param modelName the name of the model owning this field
+     * @param fieldName the model property this QueryField represents
+     * @return a new QueryField which represents the given model property
+     */
+    public static QueryField field(String modelName, String fieldName) {
+        return new QueryField(modelName, fieldName);
     }
 
     /**
@@ -48,7 +62,7 @@ public final class QueryField {
      * @return an operation object representing the equality condition
      */
     public QueryPredicateOperation<Object> eq(Object value) {
-        return new QueryPredicateOperation<>(fieldName, new EqualQueryOperator(value));
+        return new QueryPredicateOperation<>(modelName, fieldName, new EqualQueryOperator(value));
     }
 
     /**
@@ -57,7 +71,7 @@ public final class QueryField {
      * @return an operation object representing the not equal condition
      */
     public QueryPredicateOperation<Object> ne(Object value) {
-        return new QueryPredicateOperation<>(fieldName, new NotEqualQueryOperator(value));
+        return new QueryPredicateOperation<>(modelName, fieldName, new NotEqualQueryOperator(value));
     }
 
     /**
@@ -67,7 +81,7 @@ public final class QueryField {
      * @return an operation object representing the greater or equal condition
      */
     public <T extends Comparable<T>> QueryPredicateOperation<T> ge(T value) {
-        return new QueryPredicateOperation<>(fieldName, new GreaterOrEqualQueryOperator<>(value));
+        return new QueryPredicateOperation<>(modelName, fieldName, new GreaterOrEqualQueryOperator<>(value));
     }
 
     /**
@@ -77,7 +91,7 @@ public final class QueryField {
      * @return an operation object representing the greater than condition
      */
     public <T extends Comparable<T>> QueryPredicateOperation<T> gt(T value) {
-        return new QueryPredicateOperation<>(fieldName, new GreaterThanQueryOperator<>(value));
+        return new QueryPredicateOperation<>(modelName, fieldName, new GreaterThanQueryOperator<>(value));
     }
 
     /**
@@ -87,7 +101,7 @@ public final class QueryField {
      * @return an operation object representing the less or equal condition
      */
     public <T extends Comparable<T>> QueryPredicateOperation<T> le(T value) {
-        return new QueryPredicateOperation<>(fieldName, new LessOrEqualQueryOperator<>(value));
+        return new QueryPredicateOperation<>(modelName, fieldName, new LessOrEqualQueryOperator<>(value));
     }
 
     /**
@@ -97,7 +111,7 @@ public final class QueryField {
      * @return an operation object representing the less than condition
      */
     public <T extends Comparable<T>> QueryPredicateOperation<T> lt(T value) {
-        return new QueryPredicateOperation<>(fieldName, new LessThanQueryOperator<>(value));
+        return new QueryPredicateOperation<>(modelName, fieldName, new LessThanQueryOperator<>(value));
     }
 
     /**
@@ -108,7 +122,7 @@ public final class QueryField {
      * @return an operation object representing the between condition
      */
     public <T extends Comparable<T>> QueryPredicateOperation<T> between(T start, T end) {
-        return new QueryPredicateOperation<>(fieldName, new BetweenQueryOperator<>(start, end));
+        return new QueryPredicateOperation<>(modelName, fieldName, new BetweenQueryOperator<>(start, end));
     }
 
     /**
@@ -117,7 +131,7 @@ public final class QueryField {
      * @return an operation object representing the beginsWith condition
      */
     public QueryPredicateOperation<String> beginsWith(String value) {
-        return new QueryPredicateOperation<>(fieldName, new BeginsWithQueryOperator(value));
+        return new QueryPredicateOperation<>(modelName, fieldName, new BeginsWithQueryOperator(value));
     }
 
     /**
@@ -126,7 +140,7 @@ public final class QueryField {
      * @return an operation object representing the contains condition
      */
     public QueryPredicateOperation<String> contains(String value) {
-        return new QueryPredicateOperation<>(fieldName, new ContainsQueryOperator(value));
+        return new QueryPredicateOperation<>(modelName, fieldName, new ContainsQueryOperator(value));
     }
 
     /**
@@ -135,7 +149,7 @@ public final class QueryField {
      * @return a QuerySortBy object, representing a field that should be sorted in ascending order for a query.
      */
     public QuerySortBy ascending() {
-        return new QuerySortBy(fieldName, QuerySortOrder.ASCENDING);
+        return new QuerySortBy(modelName, fieldName, QuerySortOrder.ASCENDING);
     }
 
     /**
@@ -144,6 +158,6 @@ public final class QueryField {
      * @return a QuerySortBy object, representing a field that should be sorted in descending order for a query.
      */
     public QuerySortBy descending() {
-        return new QuerySortBy(fieldName, QuerySortOrder.DESCENDING);
+        return new QuerySortBy(modelName, fieldName, QuerySortOrder.DESCENDING);
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateOperation.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateOperation.java
@@ -16,18 +16,21 @@
 package com.amplifyframework.core.model.query.predicate;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.util.FieldFinder;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 
 /**
  * Represents an individual comparison operation on a model field.
  * @param <T> Data type of the field being evaluated
  */
 public final class QueryPredicateOperation<T> implements QueryPredicate {
+    private final String model;
     private final String field;
     private final QueryOperator<T> operator;
 
@@ -36,16 +39,43 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
      * @param field the name of the Java property in the model representing the field to perform this comparison on
      * @param operator the comparison to perform on it
      */
-    QueryPredicateOperation(@NonNull String field,
-                            @NonNull QueryOperator<T> operator) {
-        this.field = field;
-        this.operator = operator;
+    QueryPredicateOperation(
+            @NonNull String field,
+            @NonNull QueryOperator<T> operator
+    ) {
+        this(null, field, operator);
+    }
+
+    /**
+     * Create a new comparison operation with the field to examine and the comparison to perform on it.
+     * @param model the name of the Java model whose field is being compared
+     * @param field the name of the Java property in the model representing the field to perform this comparison on
+     * @param operator the comparison to perform on it
+     */
+    QueryPredicateOperation(
+            @Nullable String model,
+            @NonNull String field,
+            @NonNull QueryOperator<T> operator
+    ) {
+        this.model = model;
+        this.field = Objects.requireNonNull(field);
+        this.operator = Objects.requireNonNull(operator);
+    }
+
+    /**
+     * Get the name of the Java model to perform this comparison on.
+     * @return the name of the Java model to perform this comparison on
+     */
+    @Nullable
+    public String model() {
+        return model;
     }
 
     /**
      * Get the name of the field in the Java model to perform this comparison on.
      * @return the name of the field in the Java model to perform this comparison on
      */
+    @NonNull
     public String field() {
         return field;
     }
@@ -55,6 +85,7 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
      * This includes both the type (e.g. EQUAL) and the value to compare the field to (e.g. "ABC")
      * @return the comparison operation to perform on this field
      */
+    @NonNull
     public QueryOperator<T> operator() {
         return operator;
     }
@@ -64,6 +95,7 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
      * @param predicate the predicate to connect to
      * @return a group connecting this operation with another predicate with an AND type
      */
+    @NonNull
     public QueryPredicateGroup and(QueryPredicate predicate) {
         return new QueryPredicateGroup(QueryPredicateGroup.Type.AND, Arrays.asList(this, predicate));
     }
@@ -73,6 +105,7 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
      * @param predicate the group/operation to connect to
      * @return a group connecting this operation with another group/operation with an OR type
      */
+    @NonNull
     public QueryPredicateGroup or(QueryPredicate predicate) {
         return new QueryPredicateGroup(QueryPredicateGroup.Type.OR, Arrays.asList(this, predicate));
     }
@@ -82,6 +115,7 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
      * @param predicate the operation to negate
      * @return a group negating the given operation
      */
+    @NonNull
     public static QueryPredicateGroup not(QueryPredicateOperation<?> predicate) {
         return new QueryPredicateGroup(QueryPredicateGroup.Type.NOT, Collections.singletonList(predicate));
     }
@@ -118,9 +152,10 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
         } else if (obj == null || getClass() != obj.getClass()) {
             return false;
         } else {
-            QueryPredicateOperation<?> op = (QueryPredicateOperation) obj;
+            QueryPredicateOperation<?> op = (QueryPredicateOperation<?>) obj;
 
-            return ObjectsCompat.equals(field(), op.field()) &&
+            return ObjectsCompat.equals(model(), op.model()) &&
+                    ObjectsCompat.equals(field(), op.field()) &&
                     ObjectsCompat.equals(operator(), op.operator());
         }
     }
@@ -128,6 +163,7 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
     @Override
     public int hashCode() {
         return ObjectsCompat.hash(
+                model(),
                 field(),
                 operator()
         );
@@ -136,7 +172,8 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
     @Override
     public String toString() {
         return "QueryPredicateOperation { " +
-            "field: " + field() +
+            "model: " + model() +
+            ", field: " + field() +
             ", operator: " + operator() +
             " }";
     }

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateOperation.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateOperation.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * @param <T> Data type of the field being evaluated
  */
 public final class QueryPredicateOperation<T> implements QueryPredicate {
-    private final String model;
+    private final String modelName;
     private final String field;
     private final QueryOperator<T> operator;
 
@@ -48,16 +48,16 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
 
     /**
      * Create a new comparison operation with the field to examine and the comparison to perform on it.
-     * @param model the name of the Java model whose field is being compared
+     * @param modelName the name of the Java model whose field is being compared
      * @param field the name of the Java property in the model representing the field to perform this comparison on
      * @param operator the comparison to perform on it
      */
     QueryPredicateOperation(
-            @Nullable String model,
+            @Nullable String modelName,
             @NonNull String field,
             @NonNull QueryOperator<T> operator
     ) {
-        this.model = model;
+        this.modelName = modelName;
         this.field = Objects.requireNonNull(field);
         this.operator = Objects.requireNonNull(operator);
     }
@@ -67,8 +67,8 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
      * @return the name of the Java model to perform this comparison on
      */
     @Nullable
-    public String model() {
-        return model;
+    public String modelName() {
+        return modelName;
     }
 
     /**
@@ -154,7 +154,7 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
         } else {
             QueryPredicateOperation<?> op = (QueryPredicateOperation<?>) obj;
 
-            return ObjectsCompat.equals(model(), op.model()) &&
+            return ObjectsCompat.equals(modelName(), op.modelName()) &&
                     ObjectsCompat.equals(field(), op.field()) &&
                     ObjectsCompat.equals(operator(), op.operator());
         }
@@ -163,7 +163,7 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
     @Override
     public int hashCode() {
         return ObjectsCompat.hash(
-                model(),
+                modelName(),
                 field(),
                 operator()
         );
@@ -172,7 +172,7 @@ public final class QueryPredicateOperation<T> implements QueryPredicate {
     @Override
     public String toString() {
         return "QueryPredicateOperation { " +
-            "model: " + model() +
+            "model: " + modelName() +
             ", field: " + field() +
             ", operator: " + operator() +
             " }";


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add an additional parameter to `QueryField` instance called `modelName` so that SQL queries can be constructed without ambiguous column names.

This PR aims to address #908 without introducing breaking changes for existing customers. While this PR itself does not yet fix the issue, it allows for model codegen to be enhanced to support better usage of built-in query fields from code-generated models. This way, the enhanced codegen will fix the issue and allow all customers to rely directly on the built-in query fields instead of needing to construct their own.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
