### PR TITLE
feat(datastore): support sorting by related models

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -17,7 +17,6 @@ package com.amplifyframework.datastore.storage.sqlite;
 
 import com.amplifyframework.core.model.query.Page;
 import com.amplifyframework.core.model.query.Where;
-import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.StrictMode;
@@ -40,7 +39,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.reactivex.rxjava3.core.Observable;
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -220,8 +220,13 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
             Iterator<QuerySortBy> sortByIterator = sortByList.iterator();
             while (sortByIterator.hasNext()) {
                 final QuerySortBy sortBy = sortByIterator.next();
-                SQLiteColumn column = table.getColumn(sortBy.getField());
-                rawQuery.append(Wrap.inBackticks(column.getAliasedName()))
+                String modelName = Wrap.inBackticks(sortBy.getModelName());
+                String fieldName = Wrap.inBackticks(sortBy.getField());
+                if (modelName == null) {
+                    modelName = Wrap.inBackticks(tableName);
+                }
+                final String columnName = modelName + "." + fieldName;
+                rawQuery.append(columnName)
                         .append(SqlKeyword.DELIMITER)
                         .append(SqlKeyword.fromQuerySortOrder(sortBy.getSortOrder()));
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -238,7 +238,7 @@ public class SqlCommandTest {
         );
         assertNotNull(sqlCommand);
         assertEquals(
-                PERSON_BASE_QUERY + " ORDER BY `Person_lastName` ASC, `Person_firstName` DESC;",
+                PERSON_BASE_QUERY + " ORDER BY `Person`.`lastName` ASC, `Person`.`firstName` DESC;",
                 sqlCommand.sqlStatement()
         );
         assertEquals(0, sqlCommand.getBindings().size());

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Author.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Author.java
@@ -20,8 +20,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "Authors")
 public final class Author implements Model {
-  public static final QueryField ID = field("id");
-  public static final QueryField NAME = field("name");
+  public static final QueryField ID = field("Author", "id");
+  public static final QueryField NAME = field("Author", "name");
   private final @ModelField(targetType="ID", isRequired = true) String id;
   private final @ModelField(targetType="String", isRequired = true) String name;
   private final @ModelField(targetType="PostAuthorJoin") @HasMany(associatedWith = "author", type = PostAuthorJoin.class) List<PostAuthorJoin> posts = null;

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Blog.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Blog.java
@@ -21,9 +21,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "Blogs")
 public final class Blog implements Model {
-  public static final QueryField ID = field("id");
-  public static final QueryField NAME = field("name");
-  public static final QueryField OWNER = field("blogOwnerId");
+  public static final QueryField ID = field("Blog", "id");
+  public static final QueryField NAME = field("Blog", "name");
+  public static final QueryField OWNER = field("Blog", "blogOwnerId");
   private final @ModelField(targetType="ID", isRequired = true) String id;
   private final @ModelField(targetType="String", isRequired = true) String name;
   private final @ModelField(targetType="Post") @HasMany(associatedWith = "blog", type = Post.class) List<Post> posts = null;

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/BlogOwner.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/BlogOwner.java
@@ -17,9 +17,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "BlogOwners")
 public final class BlogOwner implements Model {
-  public static final QueryField NAME = field("name");
-  public static final QueryField ID = field("id");
-  public static final QueryField WEA = field("wea");
+  public static final QueryField NAME = field("BlogOwner", "name");
+  public static final QueryField ID = field("BlogOwner", "id");
+  public static final QueryField WEA = field("BlogOwner", "wea");
   private final @ModelField(targetType="String", isRequired = true) String name;
   private final @ModelField(targetType="ID", isRequired = true) String id;
   private final @ModelField(targetType="Blog") @HasOne(associatedWith = "owner", type = Blog.class) Blog blog = null;

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Comment.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Comment.java
@@ -20,9 +20,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "Comments")
 public final class Comment implements Model {
-  public static final QueryField ID = field("id");
-  public static final QueryField CONTENT = field("content");
-  public static final QueryField POST = field("commentPostId");
+  public static final QueryField ID = field("Comment", "id");
+  public static final QueryField CONTENT = field("Comment", "content");
+  public static final QueryField POST = field("Comment", "commentPostId");
   private final @ModelField(targetType="ID", isRequired = true) String id;
   private final @ModelField(targetType="String") String content;
   private final @ModelField(targetType="Post") @BelongsTo(targetName = "commentPostId", type = Post.class) Post post;

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Post.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Post.java
@@ -21,11 +21,11 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "Posts")
 public final class Post implements Model {
-  public static final QueryField ID = field("id");
-  public static final QueryField TITLE = field("title");
-  public static final QueryField BLOG = field("postBlogId");
-  public static final QueryField STATUS = field("status");
-  public static final QueryField RATING = field("rating");
+  public static final QueryField ID = field("Post", "id");
+  public static final QueryField TITLE = field("Post", "title");
+  public static final QueryField BLOG = field("Post", "postBlogId");
+  public static final QueryField STATUS = field("Post", "status");
+  public static final QueryField RATING = field("Post", "rating");
   private final @ModelField(targetType="ID", isRequired = true) String id;
   private final @ModelField(targetType="String", isRequired = true) String title;
   private final @ModelField(targetType="Blog") @BelongsTo(targetName = "postBlogId", type = Blog.class) Blog blog;

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/PostAuthorJoin.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/PostAuthorJoin.java
@@ -22,9 +22,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @Index(name = "byAuthor", fields = {"authorId"})
 @Index(name = "byPost", fields = {"postId"})
 public final class PostAuthorJoin implements Model {
-  public static final QueryField ID = field("id");
-  public static final QueryField AUTHOR = field("authorId");
-  public static final QueryField POST = field("postId");
+  public static final QueryField ID = field("PostAuthorJoin", "id");
+  public static final QueryField AUTHOR = field("PostAuthorJoin", "authorId");
+  public static final QueryField POST = field("PostAuthorJoin", "postId");
   private final @ModelField(targetType="ID", isRequired = true) String id;
   private final @ModelField(targetType="Author") @BelongsTo(targetName = "authorId", type = Author.class) Author author;
   private final @ModelField(targetType="Post") @BelongsTo(targetName = "postId", type = Post.class) Post post;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
DataStore's `query` supports filtering by field of a related model (e.g. "Filter `Blog` by `BlogOwner`'s name"). However, we don't currently support sorting queried result by related model (e.g. "Sort `Blog` by `Blog`'s name" is *supported* but "Sort `Blog` by `BlogOwner`'s name" is *not*). This PR uses new `QueryField` property to allow this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
