### PR TITLE
feat(datastore) add support for notContains query operator

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/query/predicate/GsonPredicateAdapters.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/query/predicate/GsonPredicateAdapters.java
@@ -64,6 +64,8 @@ public final class GsonPredicateAdapters {
             switch (QueryOperator.Type.valueOf(operatorType)) {
                 case CONTAINS:
                     return context.deserialize(json, ContainsQueryOperator.class);
+                case NOT_CONTAINS:
+                    return context.deserialize(json, NotContainsQueryOperator.class);
                 case GREATER_OR_EQUAL:
                     return context.deserialize(json, GreaterOrEqualQueryOperator.class);
                 case LESS_OR_EQUAL:
@@ -93,6 +95,8 @@ public final class GsonPredicateAdapters {
         public JsonElement serialize(QueryOperator<?> operator, Type type, JsonSerializationContext context) {
             if (operator instanceof ContainsQueryOperator) {
                 return context.serialize(operator, ContainsQueryOperator.class);
+            } else if (operator instanceof NotContainsQueryOperator) {
+                return context.serialize(operator, NotContainsQueryOperator.class);
             } else if (operator instanceof GreaterOrEqualQueryOperator) {
                 return context.serialize(operator, GreaterOrEqualQueryOperator.class);
             } else if (operator instanceof LessOrEqualQueryOperator) {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -37,6 +37,7 @@ import com.amplifyframework.core.model.query.predicate.GreaterOrEqualQueryOperat
 import com.amplifyframework.core.model.query.predicate.GreaterThanQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessOrEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessThanQueryOperator;
+import com.amplifyframework.core.model.query.predicate.NotContainsQueryOperator;
 import com.amplifyframework.core.model.query.predicate.NotEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
@@ -336,6 +337,8 @@ public final class AppSyncGraphQLRequestFactory {
                 return ((GreaterThanQueryOperator<?>) qOp).value();
             case CONTAINS:
                 return ((ContainsQueryOperator) qOp).value();
+            case NOT_CONTAINS:
+                return ((NotContainsQueryOperator) qOp).value();
             case BETWEEN:
                 BetweenQueryOperator<?> betweenOp = (BetweenQueryOperator<?>) qOp;
                 return Arrays.asList(betweenOp.start(), betweenOp.end());

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -38,6 +38,7 @@ import com.amplifyframework.core.model.query.predicate.GreaterOrEqualQueryOperat
 import com.amplifyframework.core.model.query.predicate.GreaterThanQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessOrEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessThanQueryOperator;
+import com.amplifyframework.core.model.query.predicate.NotContainsQueryOperator;
 import com.amplifyframework.core.model.query.predicate.NotEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
@@ -248,6 +249,8 @@ final class AppSyncRequestFactory {
                 return ((GreaterThanQueryOperator<?>) qOp).value();
             case CONTAINS:
                 return ((ContainsQueryOperator) qOp).value();
+            case NOT_CONTAINS:
+                return ((NotContainsQueryOperator) qOp).value();
             case BETWEEN:
                 BetweenQueryOperator<?> betweenOp = (BetweenQueryOperator<?>) qOp;
                 return Arrays.asList(betweenOp.start(), betweenOp.end());

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -23,6 +23,7 @@ import com.amplifyframework.core.model.query.predicate.GreaterOrEqualQueryOperat
 import com.amplifyframework.core.model.query.predicate.GreaterThanQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessOrEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.LessThanQueryOperator;
+import com.amplifyframework.core.model.query.predicate.NotContainsQueryOperator;
 import com.amplifyframework.core.model.query.predicate.NotEqualQueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryOperator;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
@@ -161,6 +162,19 @@ public final class SQLPredicate {
                         .append(")")
                         .append(SqlKeyword.DELIMITER)
                         .append(SqlKeyword.fromQueryOperator(QueryOperator.Type.GREATER_THAN))
+                        .append(SqlKeyword.DELIMITER)
+                        .append("0");
+
+            case NOT_CONTAINS:
+                NotContainsQueryOperator notContainsOp = (NotContainsQueryOperator) op;
+                addBinding(notContainsOp.value());
+                return builder.append("instr(")
+                        .append(column)
+                        .append(",")
+                        .append("?")
+                        .append(")")
+                        .append(SqlKeyword.DELIMITER)
+                        .append(SqlKeyword.fromQueryOperator(QueryOperator.Type.EQUAL))
                         .append(SqlKeyword.DELIMITER)
                         .append("0");
             case BEGINS_WITH:

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
@@ -81,9 +81,37 @@ public class SQLPredicateTest {
         validateSQLExpressionForContains(sqlPredicate, "tags");
     }
 
+    /**
+     * Test notContains in the context of a String field.
+     * @throws DataStoreException Not thrown.
+     */
+    @Test
+    public void testNotContainsForStringField() throws DataStoreException {
+        QueryPredicate predicate = Where.matches(Blog.NAME.notContains("something")).getQueryPredicate();
+        SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+        validateSQLExpressionForNotContains(sqlPredicate, "name");
+    }
+
+    /**
+     * Test notContains in the context of a list.
+     * @throws DataStoreException Not thrown.
+     */
+    @Test
+    public void testNotContainsForStringList() throws DataStoreException {
+        QueryPredicateOperation<String> predicate = Blog.TAGS.notContains("something");
+        SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+        validateSQLExpressionForNotContains(sqlPredicate, "tags");
+    }
+
     private void validateSQLExpressionForContains(SQLPredicate sqlPredicate, String fieldName) {
         assertEquals(1, sqlPredicate.getBindings().size());
         assertEquals("something", sqlPredicate.getBindings().get(0));
         assertEquals("instr(" + fieldName + ",?) > 0", sqlPredicate.toString());
+    }
+
+    private void validateSQLExpressionForNotContains(SQLPredicate sqlPredicate, String fieldName) {
+        assertEquals(1, sqlPredicate.getBindings().size());
+        assertEquals("something", sqlPredicate.getBindings().get(0));
+        assertEquals("instr(" + fieldName + ",?) = 0", sqlPredicate.toString());
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/NotContainsQueryOperator.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/NotContainsQueryOperator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model.query.predicate;
+
+import androidx.core.util.ObjectsCompat;
+
+/**
+ * Represents a notContains condition with a target value for comparison.
+ */
+public final class NotContainsQueryOperator extends QueryOperator<String> {
+    private final String value;
+
+    /**
+     * Constructs a notContains condition.
+     * @param value the value to be used in the comparison
+     */
+    NotContainsQueryOperator(String value) {
+        super(Type.NOT_CONTAINS);
+        this.value = value;
+    }
+
+    /**
+     * Returns the value to be used in the comparison.
+     * @return the value to be used in the comparison
+     */
+    public Object value() {
+        return value;
+    }
+
+    /**
+     * Returns true if the provided field value does not contain
+     * the value associated with this operator.
+     * @param field the field value to operate on
+     * @return evaluated result of the operator
+     */
+    @Override
+    public boolean evaluate(String field) {
+        return !field.contains(value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            NotContainsQueryOperator op = (NotContainsQueryOperator) obj;
+
+            return ObjectsCompat.equals(type(), op.type()) &&
+                    ObjectsCompat.equals(value(), op.value());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                type(),
+                value()
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "NotContainsQueryOperator { " +
+                "type: " + type() +
+                ", value: " + value() +
+                " }";
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryField.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryField.java
@@ -144,6 +144,15 @@ public final class QueryField {
     }
 
     /**
+     * Generates a new notContains comparison object to compare this field to the specified value.
+     * @param value the value to be compared
+     * @return an operation object representing the contains condition
+     */
+    public QueryPredicateOperation<String> notContains(String value) {
+        return new QueryPredicateOperation<>(modelName, fieldName, new NotContainsQueryOperator(value));
+    }
+
+    /**
      * Generates a new sort object specifying a field that should be sorted in ascending order for a query.
      *
      * @return a QuerySortBy object, representing a field that should be sorted in ascending order for a query.

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryOperator.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryOperator.java
@@ -72,6 +72,10 @@ public abstract class QueryOperator<T> implements Evaluable<T> {
          */
         CONTAINS,
         /**
+         * Does not contain some value comparison.
+         */
+        NOT_CONTAINS,
+        /**
          * Between two values comparison.
          */
         BETWEEN,

--- a/core/src/test/java/com/amplifyframework/core/model/query/predicate/OperatorTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/query/predicate/OperatorTest.java
@@ -203,5 +203,18 @@ public final class OperatorTest {
         assertFalse(operator.evaluate("World"));
         assertFalse(operator.evaluate(""));
     }
+
+    /**
+     * Test the accuracy of notContains operator evaluation.
+     */
+    @Test
+    public void testNotContainsOperator() {
+        final NotContainsQueryOperator operator = new NotContainsQueryOperator("e");
+
+        assertFalse(operator.evaluate("Hello"));
+        assertFalse(operator.evaluate("e"));
+        assertTrue(operator.evaluate("World"));
+        assertTrue(operator.evaluate(""));
+    }
 }
 

--- a/core/src/test/java/com/amplifyframework/core/model/query/predicate/PredicateTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/query/predicate/PredicateTest.java
@@ -78,6 +78,8 @@ public final class PredicateTest {
         assertTrue(Person.FIRST_NAME.eq("Jane").evaluate(jane));
         assertTrue(Person.FIRST_NAME.beginsWith("J").evaluate(jane));
         assertTrue(Person.FIRST_NAME.contains("Jan").evaluate(jane));
+        assertTrue(Person.FIRST_NAME.notContains("D").evaluate(jane));
+        assertFalse(Person.FIRST_NAME.notContains("Jan").evaluate(jane));
         assertFalse(Person.LAST_NAME.eq("Jane").evaluate(jane));
     }
 


### PR DESCRIPTION
Adds support for `notContains` query operator.  [Our documentation](https://docs.amplify.aws/start/getting-started/integrate/q/integration/android#query-todos) indicates that we do support this, but it looks like it was missed during the initial implementation.   This PR adds support for it.

On amplify-ios, it is also [not supported](https://github.com/aws-amplify/amplify-ios/blob/e2f7f64e2a501f3b2807481ca921e71710c82b22/Amplify/Categories/DataStore/Query/QueryField.swift#L34-L44), so I opened https://github.com/aws-amplify/amplify-ios/issues/1049.
On amplify-js, it [is supported](https://github.com/aws-amplify/amplify-js/blob/6e28eaf37525ce231d7793bf82a960046fc7f8f4/packages/datastore/src/types.ts#L295-L299).  

Note: I also discovered there are 3 other AppSync operators not supported by Amplify: `attributeExists`, `attributeType`, and `size`, though I don't think we need to add support for them unless there is a specific customer use case or request.

Resolves https://github.com/aws-amplify/amplify-android/issues/1142


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
