### PR TITLE
chore: publicize 1.16.11 in the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ dependencies section:
 ```groovy
 dependencies {
     // Only specify modules that provide functionality your app will use
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.6.11'
-    implementation 'com.amplifyframework:aws-api:1.6.11'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.6.11'
-    implementation 'com.amplifyframework:aws-datastore:1.6.11'
-    implementation 'com.amplifyframework:aws-predictions:1.6.11'
-    implementation 'com.amplifyframework:aws-storage-s3:1.6.11'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.16.11'
+    implementation 'com.amplifyframework:aws-api:1.16.11'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.16.11'
+    implementation 'com.amplifyframework:aws-datastore:1.16.11'
+    implementation 'com.amplifyframework:aws-predictions:1.16.11'
+    implementation 'com.amplifyframework:aws-storage-s3:1.16.11'
 }
 ```
 

--- a/rxbindings/README.md
+++ b/rxbindings/README.md
@@ -24,7 +24,7 @@ library. In your module's `build.gradle`:
 ```gradle
 dependencies {
     // Add this line.
-    implementation 'com.amplifyframework:rxbindings:1.6.11'
+    implementation 'com.amplifyframework:rxbindings:1.16.11'
 }
 ```
 


### PR DESCRIPTION
Amplify Android has moved from 1.6.11 to 1.16.11.

See [the Amplify Android 1.16.11 release notes](https://github.com/aws-amplify/amplify-android/releases/tag/release_v1.16.11) for more details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
