### PR TITLE
fix: remove MultiDexApplication from DataStore manifest

### DIFF
--- a/aws-datastore/src/main/AndroidManifest.xml
+++ b/aws-datastore/src/main/AndroidManifest.xml
@@ -15,6 +15,5 @@
 -->
 
 <manifest package="com.amplifyframework.datastore"
-        xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:name="androidx.multidex.MultiDexApplication" />
-</manifest>
+    xmlns:android="http://schemas.android.com/apk/res/android" />
+


### PR DESCRIPTION
When running the DataStore on versions of Android prior to API level 21,
it will be necessary for the customer to add MultiDex support to their
project, explicitly.

This is a platform limitation covered in depth in the Android
documentation:

https://developer.android.com/studio/build/multidex#mdex-pre-l

The DataStore's AndroidManifest.xml selected one of the three documented
approaches. However, applications which set their own application class
name will get a build error:

> Manifest merger failed : Attribute application@name [...] is also
> present at [com.amplifyframework:aws-datastore ...

This is easy to resolve by adding:
> 'tools:replace="android:name"'

However, newcomers may not understand what is causing this error. It
would be better for us to step out of the way and let users follow the
platform documentation, making their own choices about MultiDex.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
