### PR TITLE
fix: add a small initial delay to failing rxbinding test

### DIFF
--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxStorageBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxStorageBindingTest.java
@@ -120,7 +120,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
             Consumer<StorageDownloadFileResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
 
-            Observable.interval(100, TimeUnit.MILLISECONDS)
+            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
                       .take(5)
                       .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                       .doOnComplete(() -> resultConsumer.accept(result))
@@ -186,7 +186,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageUploadFileResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
 
-            Observable.interval(100, TimeUnit.MILLISECONDS)
+            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
                       .take(5)
                       .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                       .doOnComplete(() -> resultConsumer.accept(result))
@@ -225,7 +225,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageUploadInputStreamResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
 
-            Observable.interval(100, TimeUnit.MILLISECONDS)
+            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
                     .take(5)
                     .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                     .doOnComplete(() -> resultConsumer.accept(result))


### PR DESCRIPTION
The Rx storage upload and download operations are "hot" operations,
which emit progress events as soon as the operations are started.

There is a short period of time wherein it is possible that no one is
listening to the progress updates yet, until a subscription is formed.

Therefore, it's possible to "miss" an update.

To improve the resilience of our tests, we add a short (100ms) delay
before the first emission, which allows time to setup the subscriber, so
that it can be sure to receive all of the progress values in a
repeatable way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
