### PR TITLE
fix(datastore) improve storage adapter performance

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java
@@ -131,6 +131,7 @@ public final class SerializedModel implements Model {
      * @return Name of the model in the hybrid platform.
      */
     @Nullable
+    @Override
     public String getModelName() {
         return modelSchema == null ? null : modelSchema.getName();
     }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.ModelSchemaRegistry;
+import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
+import com.amplifyframework.datastore.appsync.ModelConverter;
+import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.util.GsonFactory;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Asserts that the SQLCommandProcessor executes SqlCommand objects as expected.
+ */
+public class SQLCommandProcessorTest {
+    private SQLCommandFactory sqlCommandFactory;
+    private SQLCommandProcessor sqlCommandProcessor;
+    private SQLiteDatabase sqliteDatabase;
+    private ModelSchemaRegistry modelSchemaRegistry;
+
+    /**
+     * Sets up model registry and in-memory database.
+     * @throws AmplifyException if model fails to register.
+     */
+    @Before
+    public void setup() throws AmplifyException {
+        ModelProvider modelProvider = AmplifyModelProvider.getInstance();
+        modelSchemaRegistry = ModelSchemaRegistry.instance();
+        modelSchemaRegistry.register(modelProvider.models());
+        sqlCommandFactory = new SQLiteCommandFactory(modelSchemaRegistry, GsonFactory.instance());
+        sqliteDatabase = createDatabase(modelProvider, modelSchemaRegistry);
+        sqlCommandProcessor = new SQLCommandProcessor(sqliteDatabase);
+    }
+
+    private SQLiteDatabase createDatabase(ModelProvider modelProvider, ModelSchemaRegistry registry) {
+        SQLiteDatabase.OpenParams openParams = new SQLiteDatabase.OpenParams.Builder().build();
+        SQLiteDatabase db = SQLiteDatabase.createInMemory(openParams);
+        db.beginTransaction();
+        try {
+            for (String modelName : modelProvider.modelNames()) {
+                final ModelSchema modelSchema = registry.getModelSchemaForModelClass(modelName);
+                db.execSQL(sqlCommandFactory.createTableFor(modelSchema).sqlStatement());
+                for (SqlCommand command : sqlCommandFactory.createIndexesFor(modelSchema)) {
+                    db.execSQL(command.sqlStatement());
+                }
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+        return db;
+    }
+
+    /**
+     * Closes in-memory database.
+     */
+    @After
+    public void clear() {
+        sqliteDatabase.close();
+    }
+
+    /**
+     * Create and insert a BlogOwner, and then verify that a rawQuery returns a Cursor with one result, containing the
+     * previously inserted BlogOwner.
+     * @throws AmplifyException on failure to create ModelSchema from class
+     */
+    @Test
+    public void rawQueryReturnsResults() throws AmplifyException {
+        // Insert a BlogOwner
+        ModelSchema blogOwnerSchema = ModelSchema.fromModelClass(BlogOwner.class);
+        BlogOwner abigailMcGregor = BlogOwner.builder()
+                .name("Abigail McGregor")
+                .build();
+        sqlCommandProcessor.execute(sqlCommandFactory.insertFor(blogOwnerSchema, abigailMcGregor));
+
+        // Query for all BlogOwners, and verify that there is one result.
+        SqlCommand queryCommand = sqlCommandFactory.queryFor(blogOwnerSchema, Where.matchesAll());
+        Cursor cursor = sqlCommandProcessor.rawQuery(queryCommand);
+        List<BlogOwner> results = new ArrayList<>();
+
+        SQLiteModelFieldTypeConverter converter = new SQLiteModelFieldTypeConverter(blogOwnerSchema,
+                modelSchemaRegistry,
+                GsonFactory.instance());
+
+        if (cursor.moveToFirst()) {
+            do {
+                Map<String, Object> map = converter.buildMapForModel(cursor);
+                results.add(ModelConverter.fromMap(map, BlogOwner.class));
+            } while (cursor.moveToNext());
+        }
+        assertEquals(Arrays.asList(abigailMcGregor), results);
+    }
+
+    /**
+     * Create and insert a BlogOwner, and then verify that executeExists return true.
+     * @throws AmplifyException on failure to create ModelSchema from class.
+     */
+    @Test
+    public void executeExistsReturnsTrueWhenItemExists() throws AmplifyException {
+        // Insert a BlogOwner
+        ModelSchema blogOwnerSchema = ModelSchema.fromModelClass(BlogOwner.class);
+        BlogOwner abigailMcGregor = BlogOwner.builder()
+                .name("Abigail McGregor")
+                .build();
+        sqlCommandProcessor.execute(sqlCommandFactory.insertFor(blogOwnerSchema, abigailMcGregor));
+
+        // Check that the BlogOwner exists
+        QueryPredicate predicate = BlogOwner.ID.eq(abigailMcGregor.getId());
+        SqlCommand existsCommand = sqlCommandFactory.existsFor(blogOwnerSchema, predicate);
+        assertTrue(sqlCommandProcessor.executeExists(existsCommand));
+    }
+
+    /**
+     * Create a BlogOwner, but don't insert it.  Then verify that executeExists returns false.
+     * @throws AmplifyException on failure to create ModelSchema from class.
+     */
+    @Test
+    public void executeExistsReturnsFalseWhenItemDoesntExist() throws AmplifyException {
+        // Create a BlogOwner, but don't insert it
+        ModelSchema blogOwnerSchema = ModelSchema.fromModelClass(BlogOwner.class);
+        BlogOwner abigailMcGregor = BlogOwner.builder()
+                .name("Abigail McGregor")
+                .build();
+
+        QueryPredicate predicate = BlogOwner.ID.eq(abigailMcGregor.getId());
+        SqlCommand existsCommand = sqlCommandFactory.existsFor(blogOwnerSchema, predicate);
+        assertFalse(sqlCommandProcessor.executeExists(existsCommand));
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.storage.sqlite;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
@@ -59,6 +60,17 @@ interface SQLCommandFactory {
                         @NonNull QueryOptions options) throws DataStoreException;
 
     /**
+     * Generates the SELECT EXISTS command in a raw string representation from
+     * the {@link ModelSchema}.
+     *
+     * @param modelSchema schema of the model
+     * @return the QUERY SQL command
+     */
+    @NonNull
+    SqlCommand existsFor(@NonNull ModelSchema modelSchema,
+                         @NonNull QueryPredicate predicate) throws DataStoreException;
+
+    /**
      * Generates the INSERT INTO command in a raw string representation and a compiled
      * prepared statement that can be bound later with inputs.
      *
@@ -66,7 +78,7 @@ interface SQLCommandFactory {
      * @return the SQL command that encapsulates the INSERT INTO command
      */
     @NonNull
-    SqlCommand insertFor(@NonNull ModelSchema modelSchema);
+    <T extends Model> SqlCommand insertFor(@NonNull ModelSchema modelSchema, @NonNull T item) throws DataStoreException;
 
     /**
      * Generates the UPDATE command in a raw string representation and a compiled
@@ -76,8 +88,7 @@ interface SQLCommandFactory {
      * @return the SQL command that encapsulates the UPDATE command
      */
     @NonNull
-    SqlCommand updateFor(@NonNull ModelSchema modelSchema,
-                         @NonNull QueryPredicate predicate) throws DataStoreException;
+    <T extends Model> SqlCommand updateFor(@NonNull ModelSchema modelSchema, @NonNull T item) throws DataStoreException;
 
     /**
      * Generates the DELETE command in a raw string representation.
@@ -86,6 +97,5 @@ interface SQLCommandFactory {
      * @return the SQL command that encapsulates the DELETE command
      */
     @NonNull
-    SqlCommand deleteFor(@NonNull ModelSchema modelSchema,
-                         @NonNull QueryPredicate predicate) throws DataStoreException;
+    SqlCommand deleteFor(@NonNull ModelSchema modelSchema, @NonNull QueryPredicate predicate) throws DataStoreException;
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
@@ -53,6 +53,7 @@ interface SQLCommandFactory {
      * the {@link ModelSchema}.
      *
      * @param modelSchema schema of the model
+     * @param options options to apply to the query
      * @return the QUERY SQL command
      */
     @NonNull
@@ -64,6 +65,7 @@ interface SQLCommandFactory {
      * the {@link ModelSchema}.
      *
      * @param modelSchema schema of the model
+     * @param predicate predicate to filter by
      * @return the QUERY SQL command
      */
     @NonNull
@@ -75,6 +77,7 @@ interface SQLCommandFactory {
      * prepared statement that can be bound later with inputs.
      *
      * @param modelSchema schema of the model
+     * @param item the Model to insert
      * @return the SQL command that encapsulates the INSERT INTO command
      */
     @NonNull
@@ -85,6 +88,7 @@ interface SQLCommandFactory {
      * prepared statement that can be bound later with inputs.
      *
      * @param modelSchema schema of the model
+     * @param item the Model to update
      * @return the SQL command that encapsulates the UPDATE command
      */
     @NonNull

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessor.java
@@ -44,7 +44,6 @@ final class SQLCommandProcessor {
     }
 
     Cursor rawQuery(SqlCommand command) throws DataStoreException {
-        SQLiteStatement sqliteStatement = sqliteDatabase.compileStatement(command.sqlStatement());
         try {
             long startTime = System.currentTimeMillis();
             Cursor result = sqliteDatabase.rawQuery(command.sqlStatement(), command.getBindingsAsArray());
@@ -52,7 +51,7 @@ final class SQLCommandProcessor {
                     + " ms inTransaction: " + sqliteDatabase.inTransaction() + " SQL: " + command.sqlStatement());
             return result;
         } catch (SQLException sqlException) {
-            throw dataStoreException(sqlException, sqliteStatement);
+            throw dataStoreException(sqlException, command.sqlStatement());
         }
     }
 
@@ -66,7 +65,7 @@ final class SQLCommandProcessor {
                     + " ms inTransaction: " + sqliteDatabase.inTransaction() + " SQL: " + command.sqlStatement());
             return result;
         } catch (SQLException sqlException) {
-            throw dataStoreException(sqlException, sqliteStatement);
+            throw dataStoreException(sqlException, command.sqlStatement());
         }
     }
 
@@ -79,13 +78,13 @@ final class SQLCommandProcessor {
             LOG.verbose("SQLCommandProcessor execute in " + (System.currentTimeMillis() - startTime)
                     + " ms inTransaction: " + sqliteDatabase.inTransaction() + " SQL: " + command.sqlStatement());
         } catch (SQLException sqlException) {
-            throw dataStoreException(sqlException, sqliteStatement);
+            throw dataStoreException(sqlException, command.sqlStatement());
         }
     }
 
-    private DataStoreException dataStoreException(SQLException sqlException, SQLiteStatement sqliteStatement) {
+    private DataStoreException dataStoreException(SQLException sqlException, String sqlStatement) {
         return new DataStoreException(
-                "Invalid SQL statement: " + sqliteStatement,
+                "Invalid SQL statement: " + sqlStatement,
                 sqlException,
                 AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
         );

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessor.java
@@ -29,6 +29,11 @@ import com.amplifyframework.logging.Logger;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Responsible for compiling, binding values to, and executing SQLiteStatements.   Currently, each statement is run in
+ * its own transaction.  In the future, we can extend this class to support batching  multiple commands in the same
+ * transaction to improve performance.
+ */
 final class SQLCommandProcessor {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessor.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.logging.Logger;
+
+import java.util.List;
+import java.util.Objects;
+
+final class SQLCommandProcessor {
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
+
+    private final SQLiteDatabase sqliteDatabase;
+
+    SQLCommandProcessor(@NonNull SQLiteDatabase sqliteDatabase) {
+        this.sqliteDatabase = sqliteDatabase;
+    }
+
+    Cursor rawQuery(SqlCommand command) throws DataStoreException {
+        SQLiteStatement sqliteStatement = sqliteDatabase.compileStatement(command.sqlStatement());
+        try {
+            long startTime = System.currentTimeMillis();
+            Cursor result = sqliteDatabase.rawQuery(command.sqlStatement(), command.getBindingsAsArray());
+            LOG.verbose("SQLCommandProcessor rawQuery in " + (System.currentTimeMillis() - startTime)
+                    + " ms inTransaction: " + sqliteDatabase.inTransaction() + " SQL: " + command.sqlStatement());
+            return result;
+        } catch (SQLException sqlException) {
+            throw dataStoreException(sqlException, sqliteStatement);
+        }
+    }
+
+    boolean executeExists(SqlCommand command) throws DataStoreException {
+        SQLiteStatement sqliteStatement = sqliteDatabase.compileStatement(command.sqlStatement());
+        try {
+            long startTime = System.currentTimeMillis();
+            bindValuesToStatement(sqliteStatement, command.getBindings());
+            boolean result = sqliteStatement.simpleQueryForLong() > 0;
+            LOG.verbose("SQLCommandProcessor executeExists in " + (System.currentTimeMillis() - startTime)
+                    + " ms inTransaction: " + sqliteDatabase.inTransaction() + " SQL: " + command.sqlStatement());
+            return result;
+        } catch (SQLException sqlException) {
+            throw dataStoreException(sqlException, sqliteStatement);
+        }
+    }
+
+    void execute(SqlCommand command) throws DataStoreException {
+        SQLiteStatement sqliteStatement = sqliteDatabase.compileStatement(command.sqlStatement());
+        try {
+            long startTime = System.currentTimeMillis();
+            bindValuesToStatement(sqliteStatement, command.getBindings());
+            sqliteStatement.execute();
+            LOG.verbose("SQLCommandProcessor execute in " + (System.currentTimeMillis() - startTime)
+                    + " ms inTransaction: " + sqliteDatabase.inTransaction() + " SQL: " + command.sqlStatement());
+        } catch (SQLException sqlException) {
+            throw dataStoreException(sqlException, sqliteStatement);
+        }
+    }
+
+    private DataStoreException dataStoreException(SQLException sqlException, SQLiteStatement sqliteStatement) {
+        return new DataStoreException(
+                "Invalid SQL statement: " + sqliteStatement,
+                sqlException,
+                AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+        );
+    }
+
+    private void bindValuesToStatement(
+            SQLiteStatement statement,
+            List<Object> values
+    ) throws DataStoreException {
+        // remove any bindings if there is any
+        statement.clearBindings();
+
+        // 1-based index for columns
+        int columnIndex = 1;
+        // apply stored bindings after columns were bound
+        for (Object value : Objects.requireNonNull(values)) {
+            bindValueToStatement(statement, columnIndex++, value);
+        }
+    }
+
+    private void bindValueToStatement(
+            SQLiteStatement statement,
+            int columnIndex,
+            Object value
+    ) throws DataStoreException {
+        LOG.verbose("SQLCommandProcessor.bindValueToStatement(..., value = " + value);
+        if (value == null) {
+            statement.bindNull(columnIndex);
+        } else if (value instanceof String) {
+            statement.bindString(columnIndex, (String) value);
+        } else if (value instanceof Long) {
+            statement.bindLong(columnIndex, (Long) value);
+        } else if (value instanceof Integer) {
+            statement.bindLong(columnIndex, (Integer) value);
+        } else if (value instanceof Float) {
+            statement.bindDouble(columnIndex, (Float) value);
+        } else if (value instanceof Double) {
+            statement.bindDouble(columnIndex, (Double) value);
+        } else {
+            throw new DataStoreException(
+                    "Failed to bind " + value + " to SQL statement. " +
+                            value.getClass().getSimpleName() + " is an unsupported type.",
+                    AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+            );
+        }
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -15,13 +15,12 @@
 
 package com.amplifyframework.datastore.storage.sqlite;
 
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteStatement;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
+import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelIndex;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
@@ -29,22 +28,26 @@ import com.amplifyframework.core.model.PrimaryKey;
 import com.amplifyframework.core.model.query.QueryOptions;
 import com.amplifyframework.core.model.query.QueryPaginationInput;
 import com.amplifyframework.core.model.query.QuerySortBy;
+import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLPredicate;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteColumn;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteTable;
+import com.amplifyframework.logging.Logger;
 import com.amplifyframework.util.Empty;
 import com.amplifyframework.util.Immutable;
 import com.amplifyframework.util.Wrap;
 
+import com.google.gson.Gson;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -53,27 +56,19 @@ import java.util.Set;
  * {@link Model} and {@link ModelSchema}.
  */
 final class SQLiteCommandFactory implements SQLCommandFactory {
-    private final ModelSchemaRegistry modelSchemaRegistry;
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
-    // Connection handle to a SQLiteDatabase.
-    private final SQLiteDatabase databaseConnectionHandle;
+    private final ModelSchemaRegistry modelSchemaRegistry;
+    private final Gson gson;
 
     /**
      * Default constructor.
      */
-    SQLiteCommandFactory(ModelSchemaRegistry modelSchemaRegistry) {
-        this(modelSchemaRegistry, null);
-    }
-
-    /**
-     * Constructor with databaseConnectionHandle.
-     * @param databaseConnectionHandle connection to a SQLiteDatabase.
-     */
     SQLiteCommandFactory(
             @NonNull ModelSchemaRegistry modelSchemaRegistry,
-            @Nullable SQLiteDatabase databaseConnectionHandle) {
+            @NonNull Gson gson) {
         this.modelSchemaRegistry = Objects.requireNonNull(modelSchemaRegistry);
-        this.databaseConnectionHandle = databaseConnectionHandle;
+        this.gson = Objects.requireNonNull(gson);
     }
 
     /**
@@ -142,9 +137,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
 
     /**
      * {@inheritDoc}
-     *
-     * This method should be invoked from a worker thread and not from the main thread
-     * as this method calls {@link SQLiteDatabase#compileStatement(String)}.
      */
     @NonNull
     @WorkerThread
@@ -254,19 +246,57 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
 
         rawQuery.append(";");
         final String queryString = rawQuery.toString();
-        return new SqlCommand(table.getName(), queryString, columns, bindings);
+        return new SqlCommand(table.getName(), queryString, bindings);
     }
+
+    @NonNull
+    public SqlCommand existsFor(@NonNull ModelSchema modelSchema,
+                                @NonNull QueryPredicate predicate) throws DataStoreException {
+        final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
+        final String tableName = table.getName();
+        StringBuilder rawQuery = new StringBuilder();
+        final List<Object> bindings = new ArrayList<>();
+
+        // Start SELECT statement.
+        // SELECT EXISTS(SELECT 1 FROM tableName
+        rawQuery.append(SqlKeyword.SELECT)
+                .append(SqlKeyword.DELIMITER)
+                .append(SqlKeyword.EXISTS)
+                .append("(")
+                .append(SqlKeyword.SELECT)
+                .append(SqlKeyword.DELIMITER)
+                .append("1")
+                .append(SqlKeyword.DELIMITER)
+                .append(SqlKeyword.FROM)
+                .append(SqlKeyword.DELIMITER)
+                .append(Wrap.inBackticks(tableName));
+
+        // Append predicates.
+        // WHERE condition
+        if (!QueryPredicates.all().equals(predicate)) {
+            final SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+            bindings.addAll(sqlPredicate.getBindings());
+            rawQuery.append(SqlKeyword.DELIMITER)
+                    .append(SqlKeyword.WHERE)
+                    .append(SqlKeyword.DELIMITER)
+                    .append(sqlPredicate);
+        }
+
+        // Close the parentheses for EXISTS, and end with a semicolon.
+        rawQuery.append(");");
+        final String queryString = rawQuery.toString();
+        return new SqlCommand(table.getName(), queryString, bindings);
+    }
+
 
     /**
      * {@inheritDoc}
-     *
-     * This method should be invoked from a worker thread and not from the main thread
-     * as this method calls {@link SQLiteDatabase#compileStatement(String)}.
      */
     @NonNull
     @WorkerThread
     @Override
-    public SqlCommand insertFor(@NonNull ModelSchema modelSchema) {
+    public <T extends Model> SqlCommand insertFor(@NonNull ModelSchema modelSchema,
+                                                  @NonNull T item) throws DataStoreException {
         final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("INSERT INTO")
@@ -297,24 +327,21 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         }
         stringBuilder.append(")");
         final String preparedInsertStatement = stringBuilder.toString();
-        final SQLiteStatement compiledInsertStatement =
-                databaseConnectionHandle == null ?
-                null : databaseConnectionHandle.compileStatement(preparedInsertStatement);
-        return new SqlCommand(table.getName(), preparedInsertStatement, columns,
-                Collections.emptyList(), compiledInsertStatement);
+
+        return new SqlCommand(table.getName(),
+                preparedInsertStatement,
+                extractFieldValues(item) // VALUES clause
+        );
     }
 
     /**
      * {@inheritDoc}
-     *
-     * This method should be invoked from a worker thread and not from the main thread
-     * as this method calls {@link SQLiteDatabase#compileStatement(String)}.
      */
     @NonNull
     @WorkerThread
     @Override
-    public SqlCommand updateFor(@NonNull ModelSchema modelSchema,
-                                @NonNull QueryPredicate predicate) throws DataStoreException {
+    public <T extends Model> SqlCommand updateFor(@NonNull ModelSchema modelSchema,
+                                                  @NonNull T model) throws DataStoreException {
         final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("UPDATE")
@@ -342,7 +369,10 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         }
 
         // Append WHERE statement
-        SQLPredicate sqlPredicate = new SQLPredicate(predicate);
+        final SQLiteTable sqliteTable = SQLiteTable.fromSchema(modelSchema);
+        final String primaryKeyName = sqliteTable.getPrimaryKeyColumnName();
+        final QueryPredicate matchId = QueryField.field(primaryKeyName).eq(model.getId());
+        SQLPredicate sqlPredicate = new SQLPredicate(matchId);
         stringBuilder.append(SqlKeyword.DELIMITER)
                 .append(SqlKeyword.WHERE)
                 .append(SqlKeyword.DELIMITER)
@@ -350,15 +380,11 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                 .append(";");
 
         final String preparedUpdateStatement = stringBuilder.toString();
-        final SQLiteStatement compiledUpdateStatement =
-                databaseConnectionHandle == null ?
-                null : databaseConnectionHandle.compileStatement(preparedUpdateStatement);
+        List<Object> bindings = extractFieldValues(model); // SET clause
+        bindings.addAll(sqlPredicate.getBindings()); // WHERE clause
         return new SqlCommand(table.getName(),
                 preparedUpdateStatement,
-                columns,
-                sqlPredicate.getBindings(),
-                compiledUpdateStatement
-        );
+                bindings);
     }
 
     /**
@@ -380,15 +406,27 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                 SqlKeyword.DELIMITER +
                 sqlPredicate +
                 ";";
-        final SQLiteStatement compiledDeleteStatement =
-                databaseConnectionHandle == null ?
-                null : databaseConnectionHandle.compileStatement(preparedDeleteStatement);
         return new SqlCommand(table.getName(),
                 preparedDeleteStatement,
-                Collections.emptyList(),
-                sqlPredicate.getBindings(),
-                compiledDeleteStatement
+                sqlPredicate.getBindings() // WHERE clause
         );
+    }
+
+    // extract model field values to save in database
+    private List<Object> extractFieldValues(@NonNull Model model) throws DataStoreException {
+        final String modelName = model.getModelName();
+        final ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(modelName);
+        final SQLiteTable table = SQLiteTable.fromSchema(schema);
+        final SQLiteModelFieldTypeConverter converter =
+                new SQLiteModelFieldTypeConverter(schema, modelSchemaRegistry, gson);
+        final Map<String, ModelField> modelFields = schema.getFields();
+        final List<Object> bindings = new ArrayList<>();
+        for (SQLiteColumn column : table.getSortedColumns()) {
+            final ModelField modelField = Objects.requireNonNull(modelFields.get(column.getFieldName()));
+            final Object fieldValue = converter.convertValueFromTarget(model, modelField);
+            bindings.add(fieldValue);
+        }
+        return bindings;
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -71,9 +71,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         this.gson = Objects.requireNonNull(gson);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @NonNull
     @Override
     public SqlCommand createTableFor(@NonNull ModelSchema modelSchema) {
@@ -99,9 +96,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         return new SqlCommand(table.getName(), createSqlStatement);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @NonNull
     @Override
     public Set<SqlCommand> createIndexesFor(@NonNull ModelSchema modelSchema) {
@@ -135,9 +129,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         return Immutable.of(indexCommands);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @NonNull
     @Override
     public SqlCommand queryFor(@NonNull ModelSchema modelSchema,
@@ -288,10 +279,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         return new SqlCommand(table.getName(), queryString, bindings);
     }
 
-
-    /**
-     * {@inheritDoc}
-     */
     @NonNull
     @Override
     public <T extends Model> SqlCommand insertFor(@NonNull ModelSchema modelSchema,
@@ -333,9 +320,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         );
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @NonNull
     @Override
     public <T extends Model> SqlCommand updateFor(@NonNull ModelSchema modelSchema,
@@ -385,9 +369,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                 bindings);
     }
 
-    /**
-     * {@inheritDoc}.
-     */
+
     @NonNull
     @Override
     public SqlCommand deleteFor(@NonNull ModelSchema modelSchema,

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -139,7 +139,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
      * {@inheritDoc}
      */
     @NonNull
-    @WorkerThread
     @Override
     public SqlCommand queryFor(@NonNull ModelSchema modelSchema,
                                @NonNull QueryOptions options) throws DataStoreException {
@@ -250,6 +249,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
     }
 
     @NonNull
+    @Override
     public SqlCommand existsFor(@NonNull ModelSchema modelSchema,
                                 @NonNull QueryPredicate predicate) throws DataStoreException {
         final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
@@ -293,7 +293,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
      * {@inheritDoc}
      */
     @NonNull
-    @WorkerThread
     @Override
     public <T extends Model> SqlCommand insertFor(@NonNull ModelSchema modelSchema,
                                                   @NonNull T item) throws DataStoreException {
@@ -338,7 +337,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
      * {@inheritDoc}
      */
     @NonNull
-    @WorkerThread
     @Override
     public <T extends Model> SqlCommand updateFor(@NonNull ModelSchema modelSchema,
                                                   @NonNull T model) throws DataStoreException {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -16,7 +16,6 @@
 package com.amplifyframework.datastore.storage.sqlite;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
@@ -368,7 +367,6 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
                 preparedUpdateStatement,
                 bindings);
     }
-
 
     @NonNull
     @Override

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -80,6 +80,11 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
     // Database Version
     private static final int DATABASE_VERSION = 1;
 
+    // Thread pool size is determined as number of processors multiplied by this value.  We want to allow more threads
+    // than available processors to parallelize primarily IO bound work, but still provide a limit to avoid out of
+    // memory errors.
+    private static final int THREAD_POOL_SIZE_MULTIPLIER = 20;
+
     // Name of the database
     @VisibleForTesting @SuppressWarnings("checkstyle:all") // Keep logger first
     static final String DATABASE_NAME = "AmplifyDatastore.db";
@@ -174,7 +179,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         Objects.requireNonNull(onError);
         // Create a thread pool large enough to take advantage of parallelization, but small enough to avoid
         // OutOfMemoryError and CursorWindowAllocationException issues.
-        this.threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 20);
+        this.threadPool = Executors.newFixedThreadPool(
+                Runtime.getRuntime().availableProcessors() * THREAD_POOL_SIZE_MULTIPLIER);
         this.context = context;
         threadPool.submit(() -> {
             try {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -496,7 +496,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
 
                 // publish cascaded deletions
                 for (Model cascadedModel : cascadedModels) {
-                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(getModelName(cascadedModel));
+                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(cascadedModel.getModelName());
                     itemChangeSubject.onNext(StorageItemChange.builder()
                         .item(cascadedModel)
                         .patchItem(SerializedModel.create(cascadedModel, schema))
@@ -576,7 +576,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
 
                 // publish every deletion
                 for (Model model : modelsToDelete) {
-                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(getModelName(model));
+                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(model.getModelName());
                     itemChangeSubject.onNext(StorageItemChange.builder()
                             .item(model)
                             .patchItem(SerializedModel.create(model, schema))

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -172,7 +172,9 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
         Objects.requireNonNull(context);
         Objects.requireNonNull(onSuccess);
         Objects.requireNonNull(onError);
-        this.threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        // Create a thread pool large enough to take advantage of parallelization, but small enough to avoid
+        // OutOfMemoryError and CursorWindowAllocationException issues.
+        this.threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 20);
         this.context = context;
         threadPool.submit(() -> {
             try {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlCommand.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlCommand.java
@@ -15,12 +15,9 @@
 
 package com.amplifyframework.datastore.storage.sqlite;
 
-import android.database.sqlite.SQLiteStatement;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
-import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteColumn;
 import com.amplifyframework.util.Immutable;
 
 import java.util.Arrays;
@@ -39,14 +36,6 @@ final class SqlCommand {
     // A SQL command in string representation
     private final String sqlStatement;
 
-    // A pre-compiled Sql statement that can be bound with
-    // inputs later and executed. This object is not thread-safe. No two
-    // threads can operate on the same SQLiteStatement object.
-    private final SQLiteStatement compiledSqlStatement;
-
-    // The list of columns used to create the statement
-    private final List<SQLiteColumn> columns;
-
     // A list of arguments to be bound to the sqlStatement
     private final List<Object> bindings;
 
@@ -58,7 +47,7 @@ final class SqlCommand {
      */
     SqlCommand(@NonNull String tableName,
                @NonNull String sqlStatement) {
-        this(tableName, sqlStatement, Collections.emptyList(), Collections.emptyList());
+        this(tableName, sqlStatement, Collections.emptyList());
     }
 
     /**
@@ -66,36 +55,14 @@ final class SqlCommand {
      *
      * @param tableName name of the SQL table
      * @param sqlStatement create table command in string representation
-     * @param columns a list of columns used by the sqlStatement
      * @param bindings a list of arguments to be bound to the sqlStatement
      */
     SqlCommand(@NonNull String tableName,
                @NonNull String sqlStatement,
-               @NonNull List<SQLiteColumn> columns,
                @NonNull List<Object> bindings) {
-        this(tableName, sqlStatement, columns, bindings, null);
-    }
-
-    /**
-     * Construct a SqlCommand object.
-     *
-     * @param tableName name of the SQL table
-     * @param sqlStatement create table command in string representation
-     * @param columns a list of columns used by the sqlStatement
-     * @param bindings a list of arguments to be bound to the sqlStatement
-     * @param compiledSqlStatement a compiled Sql statement that can be bound with
-     *                             inputs later and executed.
-     */
-    SqlCommand(@NonNull String tableName,
-               @NonNull String sqlStatement,
-               @NonNull List<SQLiteColumn> columns,
-               @NonNull List<Object> bindings,
-               @Nullable SQLiteStatement compiledSqlStatement) {
         this.tableName = Objects.requireNonNull(tableName);
         this.sqlStatement = Objects.requireNonNull(sqlStatement);
-        this.columns = Objects.requireNonNull(columns);
         this.bindings = Objects.requireNonNull(bindings);
-        this.compiledSqlStatement = compiledSqlStatement;
     }
 
     /**
@@ -115,29 +82,11 @@ final class SqlCommand {
     }
 
     /**
-     * Return the compiled SQLite statement that can bound with inputs
-     * and executed later.
-     * @return the compiled SQLite statement that can bound with inputs
-     *         and executed later.
-     */
-    SQLiteStatement getCompiledSqlStatement() {
-        return compiledSqlStatement;
-    }
-
-    /**
      * Return the list of arguments to be bound to the sqlStatement.
      * @return the list of arguments to be bound to the sqlStatement
      */
     List<Object> getBindings() {
         return Immutable.of(bindings);
-    }
-
-    /**
-     * Return the list of columns used to create the statement.
-     * @return the list of columns used to create the statement
-     */
-    List<SQLiteColumn> getColumns() {
-        return Immutable.of(columns);
     }
 
     /**
@@ -166,16 +115,6 @@ final class SqlCommand {
     }
 
     /**
-     * Return true if compiledSqlStatement is not null
-     * and false otherwise.
-     * @return true if compiledSqlStatement is not null,
-     *         false otherwise.
-     */
-    boolean hasCompiledSqlStatement() {
-        return compiledSqlStatement != null;
-    }
-
-    /**
      * Return true if selectionArgs is not null and not empty.
      * @return true if selectionArgs is not null and not empty.
      */
@@ -200,12 +139,6 @@ final class SqlCommand {
         if (!ObjectsCompat.equals(sqlStatement, that.sqlStatement)) {
             return false;
         }
-        if (!ObjectsCompat.equals(compiledSqlStatement, that.compiledSqlStatement)) {
-            return false;
-        }
-        if (!ObjectsCompat.equals(columns, that.columns)) {
-            return false;
-        }
         return ObjectsCompat.equals(bindings, that.bindings);
     }
 
@@ -213,9 +146,7 @@ final class SqlCommand {
     public int hashCode() {
         int result = tableName != null ? tableName.hashCode() : 0;
         result = 31 * result + (sqlStatement != null ? sqlStatement.hashCode() : 0);
-        result = 31 * result + (compiledSqlStatement != null ? compiledSqlStatement.hashCode() : 0);
         result = 31 * result + (bindings != null ? bindings.hashCode() : 0);
-        result = 31 * result + (columns != null ? columns.hashCode() : 0);
         return result;
     }
 
@@ -224,9 +155,7 @@ final class SqlCommand {
         return "SqlCommand{" +
                 "tableName='" + tableName + '\'' +
                 ", sqlStatement='" + sqlStatement + '\'' +
-                ", columns=" + columns +
-                ", bindings=" + columns +
-                ", compiledSqlStatement=" + compiledSqlStatement +
+                ", bindings=" + bindings +
                 '}';
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
@@ -108,6 +108,11 @@ public enum SqlKeyword {
     LIKE("LIKE"),
 
     /**
+     * SQL keyword to check if an item EXISTS.
+     */
+    EXISTS("EXISTS"),
+
+    /**
      * SQL keyword to begin a SELECT statement.
      */
     SELECT("SELECT"),

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -267,7 +267,7 @@ final class MutationProcessor {
     private <T extends Model> Single<ModelWithMetadata<T>> update(PendingMutation<T> mutation) {
         final T updatedItem = mutation.getMutatedItem();
         final ModelSchema updatedItemSchema =
-            this.modelSchemaRegistry.getModelSchemaForModelClass(getModelName(updatedItem));
+            this.modelSchemaRegistry.getModelSchemaForModelClass(updatedItem.getModelName());
         return versionRepository.findModelVersion(updatedItem).flatMap(version ->
             publishWithStrategy(mutation, (model, onSuccess, onError) ->
                 appSync.update(model, updatedItemSchema, version, mutation.getPredicate(), onSuccess, onError)
@@ -279,7 +279,7 @@ final class MutationProcessor {
     private <T extends Model> Single<ModelWithMetadata<T>> create(PendingMutation<T> mutation) {
         final T createdItem = mutation.getMutatedItem();
         final ModelSchema createdItemSchema =
-            this.modelSchemaRegistry.getModelSchemaForModelClass(getModelName(createdItem));
+            this.modelSchemaRegistry.getModelSchemaForModelClass(createdItem.getModelName());
         return publishWithStrategy(mutation, (model, onSuccess, onError) ->
             appSync.create(model, createdItemSchema, onSuccess, onError));
     }
@@ -288,7 +288,7 @@ final class MutationProcessor {
     private <T extends Model> Single<ModelWithMetadata<T>> delete(PendingMutation<T> mutation) {
         final T deletedItem = mutation.getMutatedItem();
         final ModelSchema deletedItemSchema =
-            this.modelSchemaRegistry.getModelSchemaForModelClass(getModelName(deletedItem));
+            this.modelSchemaRegistry.getModelSchemaForModelClass(deletedItem.getModelName());
         return versionRepository.findModelVersion(deletedItem).flatMap(version ->
             publishWithStrategy(mutation, (model, onSuccess, onError) ->
                 appSync.delete(
@@ -353,14 +353,6 @@ final class MutationProcessor {
             "Mutation failed. Failed mutation = " + pendingMutation + ". " +
                 "AppSync response contained errors = " + errors, errors
         ));
-    }
-
-    private static String getModelName(@NonNull Model model) {
-        if (model.getClass() == SerializedModel.class) {
-            return ((SerializedModel) model).getModelName();
-        } else {
-            return model.getClass().getSimpleName();
-        }
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -52,8 +52,8 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
  */
 public final class Orchestrator {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
-    private static final long TIMEOUT_SECONDS_PER_MODEL = 2;
-    private static final long NETWORK_OP_TIMEOUT_SECONDS = 10;
+    private static final long TIMEOUT_SECONDS_PER_MODEL = 20;
+    private static final long NETWORK_OP_TIMEOUT_SECONDS = 60;
     private static final long LOCAL_OP_TIMEOUT_SECONDS = 2;
 
     private final SubscriptionProcessor subscriptionProcessor;
@@ -309,10 +309,12 @@ public final class Orchestrator {
                 subscriptionProcessor.startSubscriptions();
                 publishNetworkStatusEvent(true);
 
+                long startTime = System.currentTimeMillis();
                 LOG.debug("About to hydrate...");
                 try {
                     boolean subscribed = syncProcessor.hydrate()
                             .blockingAwait(adjustedTimeoutSeconds, TimeUnit.SECONDS);
+                    LOG.debug("Hydration complete in " + (System.currentTimeMillis() - startTime) + "ms");
                     if (!subscribed) {
                         throw new TimeoutException("Timed out while performing initial model sync.");
                     }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
@@ -32,6 +32,8 @@ import com.amplifyframework.util.GsonFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,6 +47,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Asserts that the SQLCommandProcessor executes SqlCommand objects as expected.
  */
+@RunWith(RobolectricTestRunner.class)
 public class SQLCommandProcessorTest {
     private SQLCommandFactory sqlCommandFactory;
     private SQLCommandProcessor sqlCommandProcessor;
@@ -89,6 +92,7 @@ public class SQLCommandProcessorTest {
      */
     @After
     public void clear() {
+        modelSchemaRegistry.clear();
         sqliteDatabase.close();
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -41,7 +41,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SqlCommandTest.java
@@ -260,7 +260,7 @@ public class SqlCommandTest {
         final SqlCommand sqlCommand = sqlCommandFactory.existsFor(personSchema, Person.ID.eq(personId));
         assertEquals("SELECT EXISTS(SELECT 1 FROM `Person` WHERE id = ?);",
             sqlCommand.sqlStatement());
-        assertEquals(Arrays.asList(personId), sqlCommand.getBindings());
+        assertEquals(Collections.singletonList(personId), sqlCommand.getBindings());
     }
 
     private static ModelSchema getPersonModelSchema() {

--- a/core/src/main/java/com/amplifyframework/core/model/Model.java
+++ b/core/src/main/java/com/amplifyframework/core/model/Model.java
@@ -30,4 +30,12 @@ public interface Model {
      */
     @NonNull
     String getId();
+
+    /**
+     * Returns the name of this model as a String.
+     * @return the name of this model as a String.
+     */
+    default String getModelName() {
+        return getClass().getSimpleName();
+    }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/Model.java
+++ b/core/src/main/java/com/amplifyframework/core/model/Model.java
@@ -35,6 +35,7 @@ public interface Model {
      * Returns the name of this model as a String.
      * @return the name of this model as a String.
      */
+    @NonNull
     default String getModelName() {
         return getClass().getSimpleName();
     }


### PR DESCRIPTION
Performance Improvements:
 - Querying pages of results from the API now happens in parallel with saving items to local storage.   This improves performance by about 0.5 seconds.  The benefit is small right now, only because SQL write performance is still pretty bad. 
 - For `save` and `delete` without a predicate (e.g. `QueryPredicates.all()`), I eliminated a redundant query to see if the model exists for a given predicate, by short circuiting if the provided predicate is `QueryPredicates.all()`
 - Use `SELECT EXISTS(SELECT 1 FROM tableName...` to check if a modelExists instead of doing a full query and checking if the Cursor has any results.   Improves performance from ~1.5ms to ~0.5ms for checking if a model exists.  

Other Improvements:
 - Reduced `SQLiteStorageAdapter` thread pool size to equal number of available processors.   Previously, syncing 1000 items resulted in creation of ~5000 threads.   This change doesn't have a measurable performance improvement, but should help prevent out of memory errors or errors due to too many SQLite cursors being open (https://github.com/aws-amplify/amplify-android/issues/944)
 - Increased orchestrator timeout from 10 seconds to 60 seconds.  We still have work to do to improve SQL transaction performance.  In the meantime, we should raise the timeout so that customers can at least use larger datasets.

Minor refactorings:
 - Added `default getModelName()` to `Model.java`, as a convenience so that `getModelName()` works not just on a `SerializedModel`, but also on any `Model`
 - Separated code for executing `SQLiteStatement` objects into a new `SQLiteCommandProcessor` class, since `SQLiteStorageAdapter` is getting quite large.
 - Moved responsibility for compiling `SQLiteStatement`s from `SQLCommandFactory` to `SQLiteCommandProcessor`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
