### PR TITLE
chore(devmenu) set dev menu disabled by default

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
+++ b/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
@@ -64,7 +64,7 @@ public final class AmplifyConfiguration {
     @VisibleForTesting
     @SuppressWarnings("WeakerAccess") // These are created and accessed as public API
     public AmplifyConfiguration(@NonNull Map<String, CategoryConfiguration> configs) {
-        // Dev menu is enabled by default in debug mode
+        // Dev menu is disabled by default
         this(configs, new LinkedHashMap<>(), false);
     }
 

--- a/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
+++ b/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
@@ -65,7 +65,7 @@ public final class AmplifyConfiguration {
     @SuppressWarnings("WeakerAccess") // These are created and accessed as public API
     public AmplifyConfiguration(@NonNull Map<String, CategoryConfiguration> configs) {
         // Dev menu is enabled by default in debug mode
-        this(configs, new LinkedHashMap<>(), true);
+        this(configs, new LinkedHashMap<>(), false);
     }
 
     /**
@@ -261,7 +261,7 @@ public final class AmplifyConfiguration {
     public static final class Builder {
         private final Map<String, CategoryConfiguration> categoryConfiguration;
         private final Map<UserAgent.Platform, String> platformVersions;
-        private boolean devMenuEnabled = true; // Dev menu is enabled by default in debug mode
+        private boolean devMenuEnabled = false; // Dev menu is disabled by default
 
         private Builder(Map<String, CategoryConfiguration> categoryConfiguration) {
             this.categoryConfiguration = categoryConfiguration;


### PR DESCRIPTION
Disable the dev menu by default.

Customers can still enable and use the dev menu with the follow code:
```
val config = AmplifyConfiguration.builder(ctx)
    .devMenuEnabled(true)
    .build()
Amplify.configure(config, ctx)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
