### PR TITLE
fix(datastore): save root instance instead of creating multiple iterators

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
@@ -30,6 +30,7 @@ import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.appsync.SerializedModel;
 import com.amplifyframework.datastore.storage.sqlite.adapter.SQLiteTable;
 import com.amplifyframework.logging.Logger;
 import com.amplifyframework.util.Empty;
@@ -84,7 +85,7 @@ final class SQLiteModelTree {
             return new ArrayList<>();
         }
         Map<ModelSchema, Set<String>> modelMap = new LinkedHashMap<>();
-        ModelSchema rootSchema = registry.getModelSchemaForModelInstance(root.iterator().next());
+        ModelSchema rootSchema = registry.getModelSchemaForModelClass(getModelName(root.iterator().next()));
         Set<String> rootIds = new HashSet<>();
         for (T model : root) {
             rootIds.add(model.getId());
@@ -171,5 +172,13 @@ final class SQLiteModelTree {
         final String rawQuery = sqlCommand.sqlStatement();
         final String[] bindings = sqlCommand.getBindingsAsArray();
         return database.rawQuery(rawQuery, bindings);
+    }
+
+    private String getModelName(@NonNull Model model) {
+        if (model.getClass() == SerializedModel.class) {
+            return ((SerializedModel) model).getModelName();
+        } else {
+            return model.getClass().getSimpleName();
+        }
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
@@ -96,10 +96,18 @@ final class SQLiteModelTree {
         for (Map.Entry<ModelSchema, Set<String>> entry : modelMap.entrySet()) {
             ModelSchema schema = entry.getKey();
             for (String id : entry.getValue()) {
-                // Create dummy model instance using just the ID and model type
-                String dummyJson = gson.toJson(Collections.singletonMap("id", id));
-                Model dummyItem = gson.fromJson(dummyJson, schema.getModelClass());
-                descendants.add(dummyItem);
+                if (root.iterator().next().getClass() == SerializedModel.class) {
+                    SerializedModel dummyItem = SerializedModel.builder()
+                            .serializedData(Collections.singletonMap("id", id))
+                            .modelSchema(schema)
+                            .build();
+                    descendants.add(dummyItem);
+                } else {
+                    // Create dummy model instance using just the ID and model type
+                    String dummyJson = gson.toJson(Collections.singletonMap("id", id));
+                    Model dummyItem = gson.fromJson(dummyJson, schema.getModelClass());
+                    descendants.add(dummyItem);
+                }
             }
         }
         return descendants;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
@@ -85,7 +85,8 @@ final class SQLiteModelTree {
             return new ArrayList<>();
         }
         Map<ModelSchema, Set<String>> modelMap = new LinkedHashMap<>();
-        ModelSchema rootSchema = registry.getModelSchemaForModelClass(getModelName(root.iterator().next()));
+        Model rootModel = root.iterator().next();
+        ModelSchema rootSchema = registry.getModelSchemaForModelClass(getModelName(rootModel));
         Set<String> rootIds = new HashSet<>();
         for (T model : root) {
             rootIds.add(model.getId());
@@ -96,7 +97,7 @@ final class SQLiteModelTree {
         for (Map.Entry<ModelSchema, Set<String>> entry : modelMap.entrySet()) {
             ModelSchema schema = entry.getKey();
             for (String id : entry.getValue()) {
-                if (root.iterator().next().getClass() == SerializedModel.class) {
+                if (rootModel.getClass() == SerializedModel.class) {
                     SerializedModel dummyItem = SerializedModel.builder()
                             .serializedData(Collections.singletonMap("id", id))
                             .modelSchema(schema)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -495,7 +495,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
 
                 // publish cascaded deletions
                 for (Model cascadedModel : cascadedModels) {
-                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelInstance(cascadedModel);
+                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(getModelName(cascadedModel));
                     itemChangeSubject.onNext(StorageItemChange.builder()
                         .item(cascadedModel)
                         .patchItem(SerializedModel.create(cascadedModel, schema))
@@ -575,7 +575,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
 
                 // publish every deletion
                 for (Model model : modelsToDelete) {
-                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelInstance(model);
+                    ModelSchema schema = modelSchemaRegistry.getModelSchemaForModelClass(getModelName(model));
                     itemChangeSubject.onNext(StorageItemChange.builder()
                             .item(model)
                             .patchItem(SerializedModel.create(model, schema))


### PR DESCRIPTION
*Issue #, if available:* Followup https://github.com/aws-amplify/amplify-android/pull/1168

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
