### PR TITLE
fix(ci): try older ubuntu image since newer one removes lots of older Android build tools.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
`ubuntu-latest` recently migrated to Ubuntu 20.04 (https://github.com/actions/virtual-environments/issues/1816), which removed lots of older Android build tools and SDKs.    This PR is to try ubuntu-18.04, and see if the unit tests are more reliable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
