### PR TITLE
[DO NOT MERGE] Multi-auth POC

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthProviderChainRepository.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthProviderChainRepository.java
@@ -24,6 +24,8 @@ import com.amplifyframework.core.model.ModelOperation;
 import com.amplifyframework.core.model.ModelSchema;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +35,16 @@ import java.util.Map;
  */
 public class AuthProviderChainRepository {
     private static final String TAG = "AuthProviderChainRepository";
+    //TODO: Use enums for keys. Right now we have a couple different enums, so we may need to consolidate.
     private Map<String, Map<String, AuthProviderChain>> authProviderChains;
+
+    /**
+     * Convenience constructor if the caller want to pass in a map.
+     * @param modelSchemas
+     */
+    public AuthProviderChainRepository(Map<String, ModelSchema> modelSchemas) {
+        this(new ArrayList<ModelSchema>(modelSchemas.values()));
+    }
 
     /**
      * Default constructor.

--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthProviderChainRepository.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthProviderChainRepository.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+import android.util.Log;
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.model.AuthRule;
+import com.amplifyframework.core.model.AuthRuleProvider;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.ModelSchema;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cache of auth provider chains by model/operation.
+ */
+public class AuthProviderChainRepository {
+    private static final String TAG = "AuthProviderChainRepository";
+    private Map<String, Map<String, AuthProviderChain>> authProviderChains;
+
+    /**
+     * Default constructor.
+     * TODO: better comments.
+     * @param modelSchemas The list of model schemas to use when building the auth chain.
+     */
+    public AuthProviderChainRepository(List<ModelSchema> modelSchemas) {
+        authProviderChains = new HashMap<>();
+        for (ModelSchema modelSchema : modelSchemas) {
+            Map<String, AuthProviderChain> modelAuthProviderChain = new HashMap<>();
+            authProviderChains.put(modelSchema.getName(), modelAuthProviderChain);
+            for (ModelOperation operation : ModelOperation.values()) {
+                List<AuthRule> applicableRules = modelSchema.getApplicableRules(operation);
+                AuthProviderChain modelOpChain = new AuthProviderChain(modelSchema.getName(), operation.name());
+                for (AuthRule rule : applicableRules) {
+                    for (AuthRuleProvider provider : rule.getAuthStrategy().getCompatibleProviders()) {
+                        modelOpChain.addProvider(provider);
+                    }
+                }
+                modelAuthProviderChain.put(operation.name(), modelOpChain);
+            }
+        }
+    }
+
+    /**
+     * Get the provider chain by model and operation type.
+     * @param modelName The name of the model (name field from ModelSchema type).
+     * @param operation The operation type (READ, CREATE, UPDATE, DELETE).
+     * @return The auth provider chain for the given parameters.
+     */
+    public final AuthProviderChain getChain(String modelName, String operation) {
+        //TODO: Check for missing item
+        return authProviderChains != null ? authProviderChains.get(modelName).get(operation) : null;
+    }
+
+    /**
+     * Resets the active auth mode for all model/operation combinations currently in the cache.
+     */
+    public final void reset() {
+        for (Map<String, AuthProviderChain> modelChain : authProviderChains.values()) {
+            modelChain.values().forEach(AuthProviderChain::reset);
+        }
+    }
+
+    static class AuthProviderChain {
+        private final String modelName;
+        private final String operation;
+        private final List<AuthRuleProvider> providers;
+        private AuthProviderChainNode head;
+        private AuthProviderChainNode tail;
+        private AuthProviderChainNode current;
+
+        AuthProviderChain(String modelname,
+                          String operation) {
+            this.providers = new ArrayList<>();
+            this.modelName = modelname;
+            this.operation = operation;
+        }
+
+        public void addProvider(AuthRuleProvider provider) {
+            if (!providers.contains(provider)) {
+                Log.i(TAG, "Before adding " + provider.name() + " to " + this.toString());
+                if (head == null) { // chain is empty
+                    head = new AuthProviderChainNode(provider, null);
+                    tail = head;
+                } else {
+                    tail.next = new AuthProviderChainNode(provider, null);
+                    tail = tail.next;
+                }
+                providers.add(provider);
+                Log.i(TAG, "After adding " + provider.name() + " to " + this.toString());
+            }
+        }
+
+        public AuthRuleProvider getCurrent() {
+            if (current == null) {
+                current = head;
+            }
+            return current.provider;
+        }
+
+        public boolean nextProvider() {
+            Log.i(TAG, "Before moving next " + this.toString());
+            if (current == null) { // Set current to be the first provider
+                if (head != null) {
+                    current = head;
+                    return true;
+                } else {
+                    return false;
+                }
+            } else if (current.next != null) { // Advance
+                this.current = current.next;
+                return true;
+            } else {
+                this.current = null;
+                return false;
+            }
+        }
+
+        public void reset() {
+            this.current = null;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return modelName + "(" + operation + ")" +
+                    " Head = " + head +
+                    " Tail = " + tail +
+                    " Current = " + current;
+        }
+    }
+
+    static class AuthProviderChainNode {
+        private AuthRuleProvider provider;
+        private AuthProviderChainNode next;
+
+        /**
+         * Construct a node for the given auth provider.
+         * @param provider The auth provider for the node.
+         * @param next The next provider in the chain (if any).
+         */
+        AuthProviderChainNode(AuthRuleProvider provider,
+                              AuthProviderChainNode next) {
+            this.provider = provider;
+            this.next = next;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return provider.name() + " Has Next = " + (next != null);
+        }
+    }
+}

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -16,8 +16,6 @@
 package com.amplifyframework.api.aws;
 
 import android.content.Context;
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -50,6 +48,7 @@ import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubSubscriber;
+import com.amplifyframework.logging.Logger;
 import com.amplifyframework.util.UserAgent;
 
 import org.json.JSONObject;
@@ -79,7 +78,7 @@ import okhttp3.Protocol;
  */
 @SuppressWarnings("TypeParameterHidesVisibleType") // <R> shadows >com.amplifyframework.api.aws.R
 public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
-    public static final String TAG = "AWSApiPlugin";
+    private static final Logger LOG = Amplify.Logging.forNamespace("ampify:aws-api");
     private final Map<String, ClientDetails> apiDetails;
     private final GraphQLResponse.Factory gqlResponseFactory;
     private final ApiAuthProviders authProvider;
@@ -128,7 +127,6 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
      * the plugin will assume default behavior for that specific
      * mode of authorization.
      *
-     * @param apiAuthProvider configured instance of {@link ApiAuthProviders}.
      * @param modelProvider an instance of a class that implements the {@link ModelProvider} interface.
      */
     public AWSApiPlugin(ModelProvider modelProvider) {
@@ -172,14 +170,14 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             //TODO: Need a better way to allow for easier injection of providers
             // on a per-api basis
             ApiAuthProviders apiAuthProvider = ApiAuthProviders.builder()
-                                                               .cognitoUserPoolsAuthProvider(defaultCognitoUserPoolsAuthProvider)
-                                                               .apiKeyAuthProvider(new ApiKeyAuthProvider() {
-                                                                   @Override
-                                                                   public String getAPIKey() {
-                                                                       return apiConfiguration.getApiKey();
-                                                                   }
-                                                               })
-                                                               .build();
+                                                   .cognitoUserPoolsAuthProvider(defaultCognitoUserPoolsAuthProvider)
+                                                   .apiKeyAuthProvider(new ApiKeyAuthProvider() {
+                                                       @Override
+                                                       public String getAPIKey() {
+                                                           return apiConfiguration.getApiKey();
+                                                       }
+                                                   })
+                                                   .build();
             final SubscriptionAuthorizer subscriptionAuthorizer =
                     new SubscriptionAuthorizer(apiConfiguration, apiAuthProvider, authProviderChains);
 
@@ -204,7 +202,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         }
 
         Amplify.Hub.subscribe(HubChannel.AUTH, HubSubscriber.create(event -> {
-            Log.i(TAG, "Received auth event: " + event + ". Resetting auth provider chains.");
+            LOG.info("Received auth event: " + event + ". Resetting auth provider chains.");
             authProviderChains.reset();
         }));
     }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReader.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReader.java
@@ -87,9 +87,7 @@ final class AWSApiPluginConfigurationReader {
                         .region(apiSpec.getString(ConfigKey.REGION.key()))
                         .authorizationType(authorizationType);
 
-                if (AuthorizationType.API_KEY.equals(authorizationType)) {
-                    apiConfigBuilder.apiKey(apiSpec.getString(ConfigKey.API_KEY.key()));
-                }
+                apiConfigBuilder.apiKey(apiSpec.getString(ConfigKey.API_KEY.key()));
 
                 configBuilder.addApi(apiName, apiConfigBuilder.build());
             }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionAuthorizer.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionAuthorizer.java
@@ -53,7 +53,8 @@ final class SubscriptionAuthorizer {
         this(configuration, ApiAuthProviders.noProviderOverrides(), null);
     }
 
-    SubscriptionAuthorizer(ApiConfiguration configuration, ApiAuthProviders authProviders,
+    SubscriptionAuthorizer(ApiConfiguration configuration,
+                           ApiAuthProviders authProviders,
                            AuthProviderChainRepository authProviderChains) {
         this.configuration = configuration;
         this.authProviders = authProviders;

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -107,7 +107,7 @@ final class SubscriptionEndpoint {
             webSocketListener = new AmplifyWebSocketListener();
             try {
                 webSocket = okHttpClient.newWebSocket(new Request.Builder()
-                    .url(buildConnectionRequestUrl())
+                    .url(buildConnectionRequestUrl(request))
                     .addHeader("Sec-WebSocket-Protocol", "graphql-ws")
                     .build(), webSocketListener);
             } catch (ApiException apiException) {
@@ -273,9 +273,9 @@ final class SubscriptionEndpoint {
      * AppSync endpoint : https://xxxxxxxxxxxx.appsync-api.ap-southeast-2.amazonaws.com/graphql
      * Discovered WebSocket endpoint : wss:// xxxxxxxxxxxx.appsync-realtime-api.ap-southeast-2.amazonaws.com/graphql
      */
-    private String buildConnectionRequestUrl() throws ApiException {
+    private String buildConnectionRequestUrl(GraphQLRequest<?> request) throws ApiException {
         // Construct the authorization header for connection request
-        final byte[] rawHeader = authorizer.createHeadersForConnection()
+        final byte[] rawHeader = authorizer.createHeadersForConnection(request)
             .toString()
             .getBytes();
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AWSRequestSigner.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AWSRequestSigner.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws.sigv4;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.aws.AuthorizationType;
+
+import okhttp3.Request;
+
+/**
+ * Implementations of this interface should be used to sign
+ * HTTP requests sent to AppSync.
+ */
+public interface AWSRequestSigner {
+
+    /**
+     * Implementations of this method should take in an instance of the OkHttp Request
+     * object and return a new request with the necessary signature information.
+     * @param httpRequest The unsigned HTTP request.
+     * @param authMode The authorizatioon mode to use when signing the request.
+     * @return The signed request.
+     * @throws ApiException If an issue occurs while signing the request.
+     */
+    Request sign(Request httpRequest, AuthorizationType authMode) throws ApiException;
+}

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncRequestSigner.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/AppSyncRequestSigner.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws.sigv4;
+
+import com.amplifyframework.api.ApiException;
+import com.amplifyframework.api.aws.ApiAuthProviders;
+import com.amplifyframework.api.aws.AuthorizationType;
+import com.amplifyframework.util.Empty;
+
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.http.HttpMethodName;
+import com.amazonaws.util.IOUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okio.Buffer;
+
+/**
+ * HTTP request signer for AppSync that signs the request using the auth mode set in the constructor.
+ */
+public final class AppSyncRequestSigner implements AWSRequestSigner {
+    private static final String CONTENT_TYPE = "application/json";
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.parse(CONTENT_TYPE);
+    private static final String APP_SYNC_SERVICE_NAME = "appsync";
+    private static final String X_API_KEY = "x-api-key";
+    private static final String AUTHORIZATION = "authorization";
+
+    private final ApiAuthProviders providers;
+    private final String awsRegion;
+    private final String apiKey;
+
+    /**
+     * Constructor that allows consumers to pass the desired auth mode along with
+     * other necessary parameters needed to sign HTTP requests to be sent to AppSync.
+     * @param providers The provider types that produce the token to be added to the request.
+     * @param apiKey The API key to be used when signing requests.
+     * @param awsRegion The region where the AppSync API resides.
+     */
+    public AppSyncRequestSigner(ApiAuthProviders providers,
+                                String apiKey, //HACK: Each API can have a different key
+                                String awsRegion) {
+        this.apiKey = apiKey;
+        this.providers = providers;
+        this.awsRegion = awsRegion;
+    }
+
+    @Override
+    public Request sign(Request req, AuthorizationType authMode) throws ApiException {
+        //Clone the request into a new DefaultRequest object and populate it with credentials
+        final DefaultRequest<?> dr;
+        dr = new DefaultRequest<>(APP_SYNC_SERVICE_NAME);
+        //set the endpoint
+        dr.setEndpoint(req.url().uri());
+        //copy all the headers
+        for (String headerName : req.headers().names()) {
+            dr.addHeader(headerName, req.header(headerName));
+        }
+        //set the http method
+        dr.setHttpMethod(HttpMethodName.valueOf(req.method()));
+
+        //set the request body
+        final byte[] bodyBytes = getBodyBytes(req);
+        dr.setContent(new ByteArrayInputStream(bodyBytes));
+
+        //set the query string parameters
+        dr.setParameters(splitQuery(req.url().url()));
+
+        //Sign or Decorate request with the required headers
+        if (AuthorizationType.AWS_IAM.equals(authMode) && providers.getAWSCredentialsProvider() != null) {
+            AWSCredentials credentials = providers.getAWSCredentialsProvider().getCredentials();
+            new AppSyncV4Signer(this.awsRegion).sign(dr, credentials);
+        } else if (AuthorizationType.API_KEY.equals(authMode) && apiKey != null) {
+            dr.addHeader(X_API_KEY, apiKey);
+        } else if (AuthorizationType.AMAZON_COGNITO_USER_POOLS.equals(authMode) &&
+                    providers.getCognitoUserPoolsAuthProvider() != null) {
+            dr.addHeader(AUTHORIZATION, providers.getCognitoUserPoolsAuthProvider().getLatestAuthToken());
+        } else if (AuthorizationType.OPENID_CONNECT.equals(authMode) && providers.getOidcAuthProvider() != null) {
+            dr.addHeader(AUTHORIZATION, providers.getOidcAuthProvider().getLatestAuthToken());
+        } else {
+            throw new ApiException("No provider for the requested auth mode:" + authMode.name(), "TODO");
+        }
+        //Copy the signed/credentialed request back into an OKHTTP Request object.
+        Request.Builder okReqBuilder = new Request.Builder();
+        //set the headers from default request, since it contains the signed headers as well.
+        for (Map.Entry<String, String> e : dr.getHeaders().entrySet()) {
+            okReqBuilder.addHeader(e.getKey(), e.getValue());
+        }
+        //Set the URL and Method
+        okReqBuilder.url(req.url());
+        final RequestBody requestBody;
+        if (bodyBytes != null && bodyBytes.length > 0) {
+            requestBody = RequestBody.create(bodyBytes, JSON_MEDIA_TYPE);
+        } else {
+            requestBody = null;
+        }
+        okReqBuilder.method(req.method(), requestBody);
+        return okReqBuilder.build();
+    }
+
+    private static byte[] getBodyBytes(Request req) throws ApiException {
+        final byte[] bodyBytes;
+        RequestBody body = req.body();
+        if (body != null) {
+            //write the body to a byte array.
+            final Buffer buffer = new Buffer();
+            try {
+                body.writeTo(buffer);
+                bodyBytes = IOUtils.toByteArray(buffer.inputStream());
+            } catch (IOException ioException) {
+                //TODO: suggestions
+                throw new ApiException("Unable to build HTTP request body.", ioException, "");
+            }
+        } else {
+            bodyBytes = "".getBytes();
+        }
+        return bodyBytes;
+    }
+
+    private static Map<String, String> splitQuery(URL url) throws ApiException {
+        Map<String, String> queryPairs = new LinkedHashMap<>();
+        String query = url.getQuery();
+        if (Empty.check(query)) {
+            return Collections.emptyMap();
+        }
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            int index = pair.indexOf("=");
+            if (index < 0) {
+                throw new ApiException("Failed to construct the request URL.",
+                                       new MalformedURLException("URL query parameters are malformed."),
+                                       "TODO");
+            }
+            try {
+                queryPairs.put(
+                    URLDecoder.decode(pair.substring(0, index), "UTF-8"),
+                    URLDecoder.decode(pair.substring(index + 1), "UTF-8")
+                );
+            } catch (IOException ioException) {
+                //TODO: Suggestion
+                throw new ApiException("Failed to construct the request URL.",
+                                       ioException,
+                                       "");
+            }
+        }
+        return queryPairs;
+    }
+}

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
@@ -27,8 +27,10 @@ import com.amplifyframework.api.graphql.model.ModelMutation;
 import com.amplifyframework.api.graphql.model.ModelPagination;
 import com.amplifyframework.api.graphql.model.ModelQuery;
 import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.model.AuthRuleProvider;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
+import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testutils.Await;
 import com.amplifyframework.testutils.HubAccumulator;
@@ -59,6 +61,9 @@ import okhttp3.mockwebserver.MockWebServer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests the {@link AWSApiPlugin}.
@@ -89,7 +94,21 @@ public final class AWSApiPluginTest {
                 .put("authorizationType", "API_KEY")
                 .put("apiKey", "FAKE-API-KEY"));
 
-        this.plugin = new AWSApiPlugin();
+        AuthProviderChainRepository chainRepository = mock(AuthProviderChainRepository.class);
+//        when(chainRepository.get(anyString(),anyString())).thenReturn(chain);
+        this.plugin = new AWSApiPlugin(AmplifyModelProvider.getInstance());
+        AuthProviderChainRepository.AuthProviderChain chain = mock(AuthProviderChainRepository.AuthProviderChain.class);
+
+        doAnswer(invocation -> {
+
+            return AuthRuleProvider.API_KEY;
+        }).when(chain).getCurrent();
+
+        doAnswer(invocation -> {
+            System.out.println("Inside mock");
+            return chain;
+        }).when(chainRepository).getChain(anyString(), anyString());
+
         this.plugin.configure(configuration, ApplicationProvider.getApplicationContext());
     }
 

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/SubscriptionAuthorizerTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/SubscriptionAuthorizerTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test that Subscription authorizer can correctly generate appropriate
@@ -74,7 +75,7 @@ public final class SubscriptionAuthorizerTest {
                 .region(RandomString.string())
                 .authorizationType(AuthorizationType.API_KEY)
                 .build();
-        SubscriptionAuthorizer authorizer = new SubscriptionAuthorizer(config, apiAuthProviders);
+        SubscriptionAuthorizer authorizer = new SubscriptionAuthorizer(config, apiAuthProviders, null);
         JSONObject header = authorizer.createHeadersForConnection();
         assertEquals(authenticationSecret, header.getString("x-api-key"));
     }
@@ -92,7 +93,9 @@ public final class SubscriptionAuthorizerTest {
                 .region(RandomString.string())
                 .authorizationType(AuthorizationType.AMAZON_COGNITO_USER_POOLS)
                 .build();
-        SubscriptionAuthorizer authorizer = new SubscriptionAuthorizer(config, apiAuthProviders);
+        SubscriptionAuthorizer authorizer = new SubscriptionAuthorizer(config,
+                                                                       apiAuthProviders,
+                                                                       mock(AuthProviderChainRepository.class));
         JSONObject header = authorizer.createHeadersForConnection();
         assertEquals(authenticationSecret, header.getString("Authorization"));
     }
@@ -110,7 +113,9 @@ public final class SubscriptionAuthorizerTest {
                 .region(RandomString.string())
                 .authorizationType(AuthorizationType.OPENID_CONNECT)
                 .build();
-        SubscriptionAuthorizer authorizer = new SubscriptionAuthorizer(config, apiAuthProviders);
+        SubscriptionAuthorizer authorizer = new SubscriptionAuthorizer(config,
+                                                                       apiAuthProviders,
+                                                                       mock(AuthProviderChainRepository.class));
         JSONObject header = authorizer.createHeadersForConnection();
         assertEquals(authenticationSecret, header.getString("Authorization"));
     }

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRuleProvider.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRuleProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model;
+
+/**
+ * Enum representing auth rule providers. Shadow of AuthorizationType from aws-api :(
+ */
+public enum AuthRuleProvider {
+    /**
+     * A hardcoded key which can provide throttling for an
+     * unauthenticated API.
+     * @see <a href="https://docs.aws.amazon.com/appsync/latest/devguide/security.html#api-key-authorization">
+     *     API Key Authorization</a>
+     */
+    API_KEY,
+
+    /**
+     * Use an IAM access/secret key credential pair to authorize access
+     * to an API.
+     * @see <a href="https://docs.aws.amazon.com/appsync/latest/devguide/security.html#aws-iam-authorization">
+     *     IAM Authorization</a>
+     * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html">IAM Introduction</a>
+     */
+    AWS_IAM,
+
+    /**
+     * OpenID Connect is a simple identity layer on top of OAuth2.0.
+     * @see <a href="https://docs.aws.amazon.com/appsync/latest/devguide/security.html#openid-connect-authorization">
+     *     OpenID Connect Authorization</a>
+     * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Specification</a>
+     */
+    OPENID_CONNECT,
+
+    /**
+     * Control access to date by putting users into different
+     * permissions pools.
+     * @see <a
+     * href="https://docs.aws.amazon.com/appsync/latest/devguide/security.html#amazon-cognito-user-pools-authorization">
+     *     Amazon Cognito User Pools</a>
+     */
+    @SuppressWarnings("LineLength")
+    AMAZON_COGNITO_USER_POOLS
+}

--- a/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.core.model;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -27,29 +28,45 @@ public enum AuthStrategy {
      * Owner authorization specifies whether a user can access or operate against an object.  To use OWNER, the API
      * must have Cognito User Pool configured.
      */
-    OWNER(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS, List.of(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
-                                                              AuthRuleProvider.OPENID_CONNECT)),
+    OWNER(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+        Arrays.asList(new AuthRuleProvider[] {
+            AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+            AuthRuleProvider.OPENID_CONNECT
+        })
+    ),
 
     /**
      * Group authorization specifies whether a group can access or operate against an object.  To use GROUPS, the API
      * must have Cognito User Pool configured.
      */
-    GROUPS(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS, List.of(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
-                                                               AuthRuleProvider.OPENID_CONNECT)),
+    GROUPS(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+       Arrays.asList(new AuthRuleProvider[] {
+           AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+           AuthRuleProvider.OPENID_CONNECT
+       })
+    ),
 
     /**
      * The private authorization specifies that everyone will be allowed to access the API with a valid JWT token from
      * the configured Cognito User Pool. To use PRIVATE, the API must have Cognito User Pool configured.
      */
-    PRIVATE(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS, List.of(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
-                                                                AuthRuleProvider.AWS_IAM)),
+    PRIVATE(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+        Arrays.asList(new AuthRuleProvider[] {
+            AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+            AuthRuleProvider.AWS_IAM
+        })
+    ),
 
     /**
      * The public authorization specifies that everyone will be allowed to access the API, behind the scenes the API
      * will be protected with an API Key. To use PUBLIC, the API must have API Key configured.
      */
-    PUBLIC(AuthRuleProvider.API_KEY, List.of(AuthRuleProvider.API_KEY,
-                                             AuthRuleProvider.AMAZON_COGNITO_USER_POOLS));
+    PUBLIC(AuthRuleProvider.API_KEY,
+       Arrays.asList(new AuthRuleProvider[] {
+           AuthRuleProvider.API_KEY,
+           AuthRuleProvider.AMAZON_COGNITO_USER_POOLS
+       })
+    );
 
     private AuthRuleProvider defaultProvider;
     private List<AuthRuleProvider> compatibleProviders;

--- a/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.core.model;
 
+import java.util.List;
+
 /**
  *  The type of strategy for an @auth directive rule.
  * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth">GraphQL Transformer @auth directive
@@ -25,23 +27,51 @@ public enum AuthStrategy {
      * Owner authorization specifies whether a user can access or operate against an object.  To use OWNER, the API
      * must have Cognito User Pool configured.
      */
-    OWNER,
+    OWNER(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS, List.of(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+                                                              AuthRuleProvider.OPENID_CONNECT)),
 
     /**
      * Group authorization specifies whether a group can access or operate against an object.  To use GROUPS, the API
      * must have Cognito User Pool configured.
      */
-    GROUPS,
+    GROUPS(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS, List.of(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+                                                               AuthRuleProvider.OPENID_CONNECT)),
 
     /**
      * The private authorization specifies that everyone will be allowed to access the API with a valid JWT token from
      * the configured Cognito User Pool. To use PRIVATE, the API must have Cognito User Pool configured.
      */
-    PRIVATE,
+    PRIVATE(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS, List.of(AuthRuleProvider.AMAZON_COGNITO_USER_POOLS,
+                                                                AuthRuleProvider.AWS_IAM)),
 
     /**
      * The public authorization specifies that everyone will be allowed to access the API, behind the scenes the API
      * will be protected with an API Key. To use PUBLIC, the API must have API Key configured.
      */
-    PUBLIC,
+    PUBLIC(AuthRuleProvider.API_KEY, List.of(AuthRuleProvider.API_KEY,
+                                             AuthRuleProvider.AMAZON_COGNITO_USER_POOLS));
+
+    private AuthRuleProvider defaultProvider;
+    private List<AuthRuleProvider> compatibleProviders;
+    AuthStrategy(AuthRuleProvider defaultProvider,
+                 List<AuthRuleProvider> compatibleProviders) {
+        this.defaultProvider = defaultProvider;
+        this.compatibleProviders = compatibleProviders;
+    }
+
+    /**
+     * Returns the default provider for this strategy.
+     * @return the default auth provider.
+     */
+    public AuthRuleProvider getDefaultProvider() {
+        return defaultProvider;
+    }
+
+    /**
+     * Gets a list of the auth providers that can be used for this strategy.
+     * @return A list of compatible auth providers.
+     */
+    public List<AuthRuleProvider> getCompatibleProviders() {
+        return compatibleProviders;
+    }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * Schema of a Model that implements the {@link Model} interface.
@@ -152,6 +153,18 @@ public final class ModelSchema {
                     AmplifyException.TODO_RECOVERY_SUGGESTION
             );
         }
+    }
+
+    /**
+     * Returns the applicable auth rules for a given operation.
+     * @param operationType The desired operation type (read, create, update, delete).
+     * @return A list of {@link AuthRule}s for the given operation.
+     */
+    public List<AuthRule> getApplicableRules(ModelOperation operationType) {
+        return authRules
+            .stream()
+            .filter(rule -> rule.getOperationsOrDefault().contains(operationType))
+            .collect(Collectors.toList());
     }
 
     // Utility method to extract field metadata

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 /**
  * Schema of a Model that implements the {@link Model} interface.
@@ -161,10 +160,13 @@ public final class ModelSchema {
      * @return A list of {@link AuthRule}s for the given operation.
      */
     public List<AuthRule> getApplicableRules(ModelOperation operationType) {
-        return authRules
-            .stream()
-            .filter(rule -> rule.getOperationsOrDefault().contains(operationType))
-            .collect(Collectors.toList());
+        List<AuthRule> result = new ArrayList<>();
+        for (AuthRule rule : authRules) {
+            if (rule.getOperationsOrDefault().contains(operationType)) {
+                result.add(rule);
+            }
+        }
+        return result;
     }
 
     // Utility method to extract field metadata


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This POC introduces the concept of an auth mode chain to the API plugin. An auth mode chain is essentially a linked list of auth modes (user pools, oidc, api key, iam). An auth chain is constructed from the `@auth` rules specified in the graphql schema.

Given the following schema:
```
type Post 
@model 
@auth(rules: [
    { allow: owner },
    { allow: public operations:[read] }
  ]
)
{
  id: ID!
  name: String!
  description: String
  status: String 
}
```

The auth mode chain for the `Post` model would look like:

```
+-------------------------------------------------------+                                        
| Model name: Post                                      |                                        
|    +-------------------------------------------------+|                                        
|    |Operation:READ                                   ||                                        
|    |+------------+       +------------+              ||                                        
|    || User pools |------>|  API Key   |              ||                                        
|    |+------------+       +------------+              ||                                        
|    +-------------------------------------------------+|                                        
|    +-------------------------------------------------+|                                        
|    |Operation:CREATE                                 ||                                        
|    |+------------+                                   ||                                        
|    ||User pools  |                                   ||                                        
|    |+------------+                                   ||                                        
|    +-------------------------------------------------+|                                        
|    +-------------------------------------------------+|                                        
|    |Operation:UPDATE                                 ||                                        
|    |+------------+                                   ||                                        
|    ||User pools  |                                   ||                                        
|    |+------------+                                   ||                                        
|    +-------------------------------------------------+|                                        
|    +-------------------------------------------------+|                                        
|    |Operation:DELETE                                 ||                                        
|    |+------------+                                   ||                                        
|    ||User pools  |                                   ||                                        
|    |+------------+                                   ||                                        
|    +-------------------------------------------------+|                                        
+-------------------------------------------------------+                                        
                                                            
```
The order of auth modes, follows some basic rules for this POC:
- If a model has a rule with owner or group strategy, the associated provider (user pools or OIDC) is added to the list
- If a model has a rule with private strategy, the associated provider (user pools or IAM) is added to the end of the list (if not already present)
- If a model has a rule with public strategy, the associated provider (API Key or user pools) is added to the end of the list (if not already present)

As with any linked list, it has the following properties:
- A current pointer, which is initially set to the first item in the list
- A `next()` method which advances the current pointer to the next mode (if available)
- A `reset()` method which sets the current pointer to be the first element in the list.

When the API plugin receives a GraphQL request, it retrieves the chain using the model name and the operation associated with the request. The request is then signed using the current auth mode of the chain. If an auth failure occurs, the `next()` method is called and the request is retried with the next mode. If it's the end of the list, an authorization failure bubbles up.

An optimization should also be made to this in order to avoid requests that have no chance of succeeding. For example, if user is not signed in, there's no sense in trying to fulfill an owner or group rule. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
