### PR TITLE
fix(rxbindings): don't emit errors to disposed subscriber

### DIFF
--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAdapters.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAdapters.java
@@ -41,14 +41,14 @@ final class RxAdapters {
 
         static <E extends Throwable> Completable toCompletable(ActionEmitter<E> behavior) {
             return Completable.create(subscriber -> {
-                Cancelable cancelable = behavior.emitTo(subscriber::onComplete, subscriber::onError);
+                Cancelable cancelable = behavior.emitTo(subscriber::onComplete, subscriber::tryOnError);
                 subscriber.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
             });
         }
 
         static <T, E extends Throwable> Single<T> toSingle(ResultEmitter<T, E> behavior) {
             return Single.create(subscriber -> {
-                Cancelable cancelable = behavior.emitTo(subscriber::onSuccess, subscriber::onError);
+                Cancelable cancelable = behavior.emitTo(subscriber::onSuccess, subscriber::tryOnError);
                 subscriber.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
             });
         }
@@ -58,7 +58,7 @@ final class RxAdapters {
                 Cancelable cancelable = behavior.streamTo(
                     NoOpConsumer.create(),
                     subscriber::onNext,
-                    subscriber::onError,
+                    subscriber::tryOnError,
                     subscriber::onComplete
                 );
                 subscriber.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
@@ -114,11 +114,11 @@ final class RxAdapters {
         private VoidBehaviors() {}
 
         static <E extends Throwable> Completable toCompletable(ActionEmitter<E> behavior) {
-            return Completable.create(subscriber -> behavior.emitTo(subscriber::onComplete, subscriber::onError));
+            return Completable.create(subscriber -> behavior.emitTo(subscriber::onComplete, subscriber::tryOnError));
         }
 
         static <T, E extends Throwable> Single<T> toSingle(ResultEmitter<T, E> behavior) {
-            return Single.create(subscriber -> behavior.emitTo(subscriber::onSuccess, subscriber::onError));
+            return Single.create(subscriber -> behavior.emitTo(subscriber::onSuccess, subscriber::tryOnError));
         }
 
         static <S, T, E extends Throwable> Observable<T> toObservable(StreamEmitter<S, T, E> behavior) {
@@ -126,7 +126,7 @@ final class RxAdapters {
                 behavior.streamTo(
                     NoOpConsumer.create(),
                     subscriber::onNext,
-                    subscriber::onError,
+                    subscriber::tryOnError,
                     subscriber::onComplete
                 );
             });

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
@@ -53,10 +53,9 @@ public final class RxOperations {
             onConnected = new OnConnectedConsumer();
             connectionStateSubject = BehaviorSubject.create();
             subscriptionData = Observable.create(emitter -> {
-                amplifyOperation = callbacks.streamTo(onConnected::accept,
-                                                      emitter::onNext,
-                                                      emitter::onError,
-                                                      emitter::onComplete);
+                amplifyOperation = callbacks.streamTo(
+                    onConnected, emitter::onNext, emitter::tryOnError, emitter::onComplete
+                );
             });
         }
 

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxStorageBinding.java
@@ -202,7 +202,9 @@ public final class RxStorageBinding implements RxStorageCategoryBehavior {
         @Override
         public Single<T> observeResult() {
             return Single.create(emitter -> {
-                resultSubject.subscribe(emitter::onSuccess, emitter::onError);
+                emitter.setDisposable(
+                    resultSubject.subscribe(emitter::onSuccess, emitter::tryOnError)
+                );
             });
         }
 


### PR DESCRIPTION
Resolves: https://github.com/aws-amplify/amplify-android/issues/1119

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
