### PR TITLE
fix(rest-api) Expose HTTP headers in RestResponse

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.api.aws.operation;
 
 import android.annotation.SuppressLint;
+import android.text.TextUtils;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
@@ -28,6 +29,9 @@ import com.amplifyframework.core.Consumer;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import okhttp3.Call;
@@ -113,13 +117,20 @@ public final class AWSRestOperation extends RestOperation {
                                @NonNull Response response) throws IOException {
             final ResponseBody responseBody = response.body();
             final int statusCode = response.code();
-
+            final Map<String, String> headersMap = new HashMap<>();
+            final Map<String, List<String>> headersMultiMap = response.headers().toMultimap();
+            for (String key : headersMultiMap.keySet()) {
+                List<String> value = headersMultiMap.get(key);
+                if (value.size() > 0) {
+                    headersMap.put(key, TextUtils.join(",", value));
+                }
+            }
             RestResponse restResponse;
             if (responseBody != null) {
                 final byte[] data = responseBody.bytes();
-                restResponse = new RestResponse(statusCode, data);
+                restResponse = new RestResponse(statusCode, headersMap, data);
             } else {
-                restResponse = new RestResponse(statusCode);
+                restResponse = new RestResponse(statusCode, headersMap);
             }
 
             onResponse.accept(restResponse);

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
@@ -26,8 +26,12 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import okhttp3.HttpUrl;
@@ -36,16 +40,19 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
 import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the {@link AWSRestOperation}.
  */
+@RunWith(RobolectricTestRunner.class)
 public final class AWSRestOperationTest {
     private MockWebServer server;
     private HttpUrl baseUrl;
     private OkHttpClient client;
+    private Map<String, String> responseHeaders;
 
     /**
      * Sets up a mock web server to serve fake responses.
@@ -63,7 +70,10 @@ public final class AWSRestOperationTest {
             .setBody(new JSONObject()
                 .put("message", "thanks!")
                 .toString()
-            );
+            )
+            .addHeader("foo", "bar")
+            .addHeader("foo", "baz")
+            .addHeader("qux", "quux");
         server.enqueue(response);
 
         client = new OkHttpClient();
@@ -96,6 +106,11 @@ public final class AWSRestOperationTest {
             operation.start();
         });
         assertTrue(response.getCode().isSuccessful());
+        Map<String, String> expected = new HashMap<>();
+        expected.put("foo", "bar,baz");
+        expected.put("qux", "quux");
+        expected.put("content-length", "21");
+        assertEquals(expected, response.getHeaders());
     }
 
     /**

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/api/KotlinApiFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/api/KotlinApiFacadeTest.kt
@@ -181,7 +181,7 @@ class KotlinApiFacadeTest {
     @Test
     fun getSucceeds() = runBlocking {
         val request = RestOptions.builder().build()
-        val expectedResponse = RestResponse(200, "Nice one, bruf!".toByteArray())
+        val expectedResponse = RestResponse(200, emptyMap(), "Nice one, bruf!".toByteArray())
         every {
             delegate.get(eq(request), any(), any())
         } answers {
@@ -219,7 +219,7 @@ class KotlinApiFacadeTest {
     @Test
     fun putSucceeds() = runBlocking {
         val request = RestOptions.builder().build()
-        val expectedResponse = RestResponse(200, "Nice one, bruf!".toByteArray())
+        val expectedResponse = RestResponse(200, emptyMap(), "Nice one, bruf!".toByteArray())
         every {
             delegate.put(eq(request), any(), any())
         } answers {
@@ -257,7 +257,7 @@ class KotlinApiFacadeTest {
     @Test
     fun postSucceeds() = runBlocking {
         val request = RestOptions.builder().build()
-        val expectedResponse = RestResponse(200, "Nice one, bruf!".toByteArray())
+        val expectedResponse = RestResponse(200, emptyMap(), "Nice one, bruf!".toByteArray())
         every {
             delegate.post(eq(request), any(), any())
         } answers {
@@ -295,7 +295,7 @@ class KotlinApiFacadeTest {
     @Test
     fun deleteSucceeds() = runBlocking {
         val request = RestOptions.builder().build()
-        val expectedResponse = RestResponse(200, "Nice one, bruf!".toByteArray())
+        val expectedResponse = RestResponse(200, emptyMap(), "Nice one, bruf!".toByteArray())
         every {
             delegate.delete(eq(request), any(), any())
         } answers {
@@ -329,7 +329,7 @@ class KotlinApiFacadeTest {
     @Test
     fun headSucceeds() = runBlocking {
         val request = RestOptions.builder().build()
-        val expectedResponse = RestResponse(200, "Nice one, bruf!".toByteArray())
+        val expectedResponse = RestResponse(200, emptyMap(), "Nice one, bruf!".toByteArray())
         every {
             delegate.head(eq(request), any(), any())
         } answers {
@@ -367,7 +367,7 @@ class KotlinApiFacadeTest {
     @Test
     fun patchSucceeds() = runBlocking {
         val request = RestOptions.builder().build()
-        val expectedResponse = RestResponse(200, "Nice one, bruf!".toByteArray())
+        val expectedResponse = RestResponse(200, emptyMap(), "Nice one, bruf!".toByteArray())
         every {
             delegate.patch(eq(request), any(), any())
         } answers {

--- a/core/src/main/java/com/amplifyframework/api/rest/RestResponse.java
+++ b/core/src/main/java/com/amplifyframework/api/rest/RestResponse.java
@@ -19,12 +19,14 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
+import com.amplifyframework.util.Immutable;
 import com.amplifyframework.util.Range;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Response from rest request.
@@ -32,22 +34,26 @@ import java.util.Arrays;
 public final class RestResponse {
     private final Data data;
     private final Code code;
+    private final Map<String, String> headers;
 
     /**
      * Constructs a response for the rest operation with empty data.
      * @param statusCode Status code of the response
+     * @param headers Map of HTTP headers of the response
      */
-    public RestResponse(int statusCode) {
-        this(statusCode, null);
+    public RestResponse(int statusCode, Map<String, String> headers) {
+        this(statusCode, headers, null);
     }
 
     /**
      * Constructs a response for the rest operation.
      * @param statusCode Status code of the response
      * @param data Data returned by the operation
+     * @param headers Map of HTTP headers of the response
      */
-    public RestResponse(int statusCode, byte[] data) {
+    public RestResponse(int statusCode, Map<String, String> headers, byte[] data) {
         this.data = new Data(data);
+        this.headers = headers;
         this.code = new Code(statusCode);
     }
 
@@ -65,6 +71,14 @@ public final class RestResponse {
      */
     public Code getCode() {
         return code;
+    }
+
+    /**
+     * Get the HTTP request headers of the response.
+     * @return Map of HTTP request headers of the response.
+     */
+    public Map<String, String> getHeaders() {
+        return Immutable.of(headers);
     }
 
     @Override

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxApiBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxApiBindingTest.java
@@ -382,7 +382,7 @@ public final class RxApiBindingTest {
             .build();
         byte[] data = "{\"movies\":[\"Spider Man\"]}".getBytes(); // JSONObject would need to bring in Robolectric
         final int httpOkStatus = 200;
-        RestResponse response = new RestResponse(httpOkStatus, data);
+        RestResponse response = new RestResponse(httpOkStatus, Collections.emptyMap(), data);
         doAnswer(invocation -> {
             final int positionOfResponseConsumer = 1;
             Consumer<RestResponse> onResponse = invocation.getArgument(positionOfResponseConsumer);
@@ -446,7 +446,7 @@ public final class RxApiBindingTest {
             .addBody(body)
             .build();
         final int httpOkStatus = 200;
-        RestResponse response = new RestResponse(httpOkStatus, body); // Re-use body
+        RestResponse response = new RestResponse(httpOkStatus, Collections.emptyMap(), body); // Re-use body
         doAnswer(invocation -> {
             final int positionOfResponseConsumer = 1; // 0 = options, 1 = onResponse, 2 = onFailure
             Consumer<RestResponse> onResponse = invocation.getArgument(positionOfResponseConsumer);


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.