### PR TITLE
chore: add workflow to sync release branch

### DIFF
--- a/.github/workflows/sync_release_branch.yml
+++ b/.github/workflows/sync_release_branch.yml
@@ -1,0 +1,27 @@
+name: Commits pushed to main
+on:
+  push:
+    branches:
+      - main
+jobs:
+  update_release_branch:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Update git # Apparently ubuntu-latest has an older version of git that causes some issues with scripts.
+        run: |
+          sudo add-apt-repository -y ppa:git-core/ppa
+          sudo apt-get update
+          sudo apt-get install git -y
+      - uses: actions/checkout@v2
+        with:
+          ref: releases/next
+          token: ${{ github.token }} # This will need to change to a token belonging to a service account.
+          fetch-depth: 0
+      - name: Merge changes from main
+        run: |
+          cd $GITHUB_WORKSPACE
+          git fetch --tags
+          git status
+          git merge origin/main
+          git push origin releases/next


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a Github workflow triggered on pushes to the main branch. This workflow simply merges the changes from main into releases/next and pushes. This ensures the release branch always has all the changes from main. 

This is important because we will have another workflow that will be triggered when commits are pushed to releases/next. That will be in a separate PR.

Note on the token being used: I haven't setup the secret for the repo yet, so I'm using the auto-generated Github token. That token has limited permissions. It should allow us to do the merge and push, but won't trigger other workflows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
