### PR TITLE
chore: enable per-module versioning by override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,14 @@ subprojects { project ->
 }
 
 private void configureAndroidLibrary(Project project) {
+    project.ext.VERSION_NAME = project.hasProperty('VERSION_NAME') ?
+        project.findProperty('VERSION_NAME') :
+        rootProject.findProperty('VERSION_NAME')
+
+    project.ext.VERSION_CODE = project.hasProperty('VERSION_CODE') ?
+        project.findProperty('VERSION_CODE').toInteger() :
+        rootProject.findProperty('VERSION_CODE').toInteger()
+
     project.android {
         buildToolsVersion rootProject.ext.buildToolsVersion
         compileSdkVersion rootProject.ext.compileSdkVersion
@@ -137,8 +145,8 @@ private void configureAndroidLibrary(Project project) {
             multiDexEnabled true
             minSdkVersion rootProject.ext.minSdkVersion
             targetSdkVersion rootProject.ext.targetSdkVersion
-            versionCode rootProject.findProperty('VERSION_CODE').toInteger()
-            versionName rootProject.findProperty('VERSION_NAME')
+            versionName project.ext.VERSION_NAME
+            versionCode project.ext.VERSION_CODE
             testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
             consumerProguardFiles rootProject.file('configuration/consumer-rules.pro')
 

--- a/configuration/publishing.gradle
+++ b/configuration/publishing.gradle
@@ -17,13 +17,6 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'maven-publish'
 
-version = VERSION_NAME
-group = GROUP
-
-def isReleaseBuild() {
-    return VERSION_NAME.contains("SNAPSHOT") == false
-}
-
 def getReleaseRepositoryUrl() {
     return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL :
             "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/"
@@ -42,8 +35,6 @@ def getRepositoryPassword() {
     return hasProperty('SONATYPE_NEXUS_PASSWORD') ? SONATYPE_NEXUS_PASSWORD : ""
 }
 
-archivesBaseName = POM_ARTIFACT_ID
-
 afterEvaluate { project ->
     uploadArchives {
         repositories {
@@ -51,9 +42,9 @@ afterEvaluate { project ->
                 mavenDeployer {
                     beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-                    pom.groupId = GROUP
+                    pom.groupId = POM_GROUP
                     pom.artifactId = POM_ARTIFACT_ID
-                    pom.version = VERSION_NAME
+                    pom.version = project.ext.VERSION_NAME
 
                     repository(url: getReleaseRepositoryUrl()) {
                         authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
@@ -95,16 +86,19 @@ afterEvaluate { project ->
                 }
             } else {
                 mavenInstaller {
-                    pom.groupId = GROUP
+                    pom.groupId = POM_GROUP
                     pom.artifactId = POM_ARTIFACT_ID
-                    pom.version = VERSION_NAME
+                    pom.version = project.ext.VERSION_NAME
                 }
             }
         }
     }
 
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        required {
+            project.ext.VERSION_NAME.contains("SNAPSHOT") == false &&
+                gradle.taskGraph.hasTask("uploadArchives")
+        }
         sign configurations.archives
     }
 
@@ -114,9 +108,9 @@ afterEvaluate { project ->
             repositories.mavenInstaller {
                 configuration = configurations.archives
 
-                pom.groupId = GROUP
+                pom.groupId = POM_GROUP
                 pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
+                pom.version = project.ext.VERSION_NAME
 
                 pom.project {
                     name POM_NAME
@@ -166,9 +160,9 @@ afterEvaluate { project ->
     } else {
         install {
             repositories.mavenInstaller {
-                pom.groupId = GROUP
+                pom.groupId = POM_GROUP
                 pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
+                pom.version = project.ext.VERSION_NAME
 
                 pom.project {
                     name POM_NAME
@@ -219,9 +213,9 @@ afterEvaluate { project ->
     publishing {
         publications {
             library(MavenPublication) {
-                groupId GROUP
+                groupId POM_GROUP
                 artifactId POM_ARTIFACT_ID
-                version VERSION_NAME
+                version project.ext.VERSION_NAME
                 artifact("${buildDir}/outputs/aar/${artifactId}-release.aar")
                 pom.withXml {
                     def dependenciesNode = asNode().appendNode('dependencies')

--- a/core-kotlin/gradle.properties
+++ b/core-kotlin/gradle.properties
@@ -2,3 +2,6 @@ POM_ARTIFACT_ID=core-kotlin
 POM_NAME=Amplify Framework for Android - Kotlin facade for Core library
 POM_DESCRIPTION=Amplify Framework for Android - Kotlin facade for Core library
 POM_PACKAGING=aar
+
+VERSION_CODE=000100
+VERSION_NAME=0.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,10 +12,10 @@ org.gradle.jvmargs=-Xmx4g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-GROUP=com.amplifyframework
 VERSION_NAME=1.16.13
 VERSION_CODE=011613
 
+POM_GROUP=com.amplifyframework
 POM_URL=https://github.com/aws-amplify/amplify-android
 POM_SCM_URL=https://github.com/aws-amplify/amplify-android
 POM_SCM_CONNECTION=scm:git:git://github.com/aws-amplify/amplify-android.git


### PR DESCRIPTION
By default, modules will use the `VERSION_CODE` and `VERSION_NAME` in `amplify-android/gradle.properties`.

Individual modules may override this value, if they use their own versioning. Such modules must populate `VERSION_CODE` and `VERSION_NAME` in _their own_ `gradle.properties`, e.g. `core-kotlin/gradle.properties`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
