### PR TITLE
release: 1.16.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ dependencies section:
 ```groovy
 dependencies {
     // Only specify modules that provide functionality your app will use
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.16.13'
-    implementation 'com.amplifyframework:aws-api:1.16.13'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.16.13'
-    implementation 'com.amplifyframework:aws-datastore:1.16.13'
-    implementation 'com.amplifyframework:aws-predictions:1.16.13'
-    implementation 'com.amplifyframework:aws-storage-s3:1.16.13'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.16.14'
+    implementation 'com.amplifyframework:aws-api:1.16.14'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.16.14'
+    implementation 'com.amplifyframework:aws-datastore:1.16.14'
+    implementation 'com.amplifyframework:aws-predictions:1.16.14'
+    implementation 'com.amplifyframework:aws-storage-s3:1.16.14'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,8 @@ org.gradle.jvmargs=-Xmx4g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-VERSION_NAME=1.16.13
-VERSION_CODE=011613
+VERSION_NAME=1.16.14
+VERSION_CODE=011614
 
 POM_GROUP=com.amplifyframework
 POM_URL=https://github.com/aws-amplify/amplify-android

--- a/rxbindings/README.md
+++ b/rxbindings/README.md
@@ -24,7 +24,7 @@ library. In your module's `build.gradle`:
 ```gradle
 dependencies {
     // Add this line.
-    implementation 'com.amplifyframework:rxbindings:1.16.13'
+    implementation 'com.amplifyframework:rxbindings:1.16.14'
 }
 ```
 


### PR DESCRIPTION
This release contains the Kotlin extensions, which is definitely a feature big enough for a minor version bump, but since they are versioned separately (starting with `0.1.0`),  I don't think it makes sense to bump the minor, so I only bumped the patch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
