### PR TITLE
ci: fix maven publishing

### DIFF
--- a/configuration/publishing.gradle
+++ b/configuration/publishing.gradle
@@ -17,6 +17,9 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'maven-publish'
 
+version = project.ext.VERSION_NAME
+group = POM_GROUP
+
 def getReleaseRepositoryUrl() {
     return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL :
             "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/"


### PR DESCRIPTION
When trying to build an app that depends on `implementation 'com.amplifyframework:aws-datastore:1.16.14'`, the following build error occurs:

```
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not find amplify-android:core:unspecified.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/amplify-android/core/unspecified/core-unspecified.pom
       - https://jcenter.bintray.com/amplify-android/core/unspecified/core-unspecified.pom
     Required by:
         project :app > com.amplifyframework:aws-datastore:1.16.14
   > Could not find amplify-android:aws-api-appsync:unspecified.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/amplify-android/aws-api-appsync/unspecified/aws-api-appsync-unspecified.pom
       - https://jcenter.bintray.com/amplify-android/aws-api-appsync/unspecified/aws-api-appsync-unspecified.pom
     Required by:
         project :app > com.amplifyframework:aws-datastore:1.16.14
```

Taking a look at https://repo1.maven.org/maven2/com/amplifyframework/aws-datastore/1.16.14/aws-datastore-1.16.14.pom, we can see that `group` and `version` are incorrect.  group is `amplify-android`, but should be `com.amplifyframework`.  `version` is `unspecified`, but should be `1.16.14`.

This PR should fix the problem.  I've verified that the main branch is broken by publishing to `mavenLocal` and consuming in a sample app.  I've also verified that the change in this PR fixes the sample app, after updating `mavenLocal`.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
