### PR TITLE
feat(aws-api): Support Custom OkHttp Configurations

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/TestApiCategory.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/TestApiCategory.java
@@ -15,12 +15,12 @@
 
 package com.amplifyframework.api.aws;
 
-import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.RawRes;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiCategory;
+import com.amplifyframework.api.aws.sigv4.CognitoUserPoolsAuthProvider;
 import com.amplifyframework.api.aws.sigv4.DefaultCognitoUserPoolsAuthProvider;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.AmplifyConfiguration;
@@ -47,24 +47,23 @@ final class TestApiCategory {
      */
     @NonNull
     static ApiCategory fromConfiguration(@RawRes int resourceId) throws AmplifyException {
-        Context context = getApplicationContext();
+        CognitoUserPoolsAuthProvider cognitoUserPoolsAuthProvider =
+            new DefaultCognitoUserPoolsAuthProvider(AWSMobileClient.getInstance());
+        ApiAuthProviders providers = ApiAuthProviders.builder()
+            .awsCredentialsProvider(AWSMobileClient.getInstance())
+            .cognitoUserPoolsAuthProvider(cognitoUserPoolsAuthProvider)
+            .build();
+        AWSApiPlugin plugin = AWSApiPlugin.builder()
+            .apiAuthProviders(providers)
+            .build();
         ApiCategory apiCategory = new ApiCategory();
-        apiCategory.addPlugin(
-                new AWSApiPlugin(
-                        ApiAuthProviders
-                                .builder()
-                                .awsCredentialsProvider(AWSMobileClient.getInstance())
-                                .cognitoUserPoolsAuthProvider(
-                                        new DefaultCognitoUserPoolsAuthProvider(AWSMobileClient.getInstance())
-                                )
-                                .build()
-                )
-        );
+        apiCategory.addPlugin(plugin);
+
         CategoryConfiguration apiConfiguration =
-            AmplifyConfiguration.fromConfigFile(context, resourceId)
+            AmplifyConfiguration.fromConfigFile(getApplicationContext(), resourceId)
                 .forCategoryType(CategoryType.API);
-        apiCategory.configure(apiConfiguration, context);
-        // apiCategory.initialize(context); Doesn't currently contain any logic, so, skip it.
+        apiCategory.configure(apiConfiguration, getApplicationContext());
+        // apiCategory.initialize(...); Doesn't currently contain any logic, so, skip it.
         return apiCategory;
     }
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -781,7 +781,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         /**
          * Apply customizations to an underlying OkHttpClient that will be used
          * for a particular API.
-         * @param forApiName The name of the API for which these customizations should apply
+         * @param forApiName The name of the API for which these customizations should apply.  This can be found in your `amplifyconfiguration.json` file.
          * @param byConfigurator A lambda that hands the user an OkHttpClient.Builder,
          *                       and enables the user to set come configurations on it.
          * @return A builder instance, to continue chaining configurations

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -781,7 +781,8 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         /**
          * Apply customizations to an underlying OkHttpClient that will be used
          * for a particular API.
-         * @param forApiName The name of the API for which these customizations should apply.  This can be found in your `amplifyconfiguration.json` file.
+         * @param forApiName The name of the API for which these customizations should apply.
+                             This can be found in your `amplifyconfiguration.json` file.
          * @param byConfigurator A lambda that hands the user an OkHttpClient.Builder,
          *                       and enables the user to set come configurations on it.
          * @return A builder instance, to continue chaining configurations

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -39,6 +39,7 @@ import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.util.Immutable;
 import com.amplifyframework.util.UserAgent;
 
 import org.json.JSONObject;
@@ -69,6 +70,7 @@ import okhttp3.Protocol;
 @SuppressWarnings("TypeParameterHidesVisibleType") // <R> shadows >com.amplifyframework.api.aws.R
 public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     private final Map<String, ClientDetails> apiDetails;
+    private final Map<String, OkHttpConfigurator> apiConfigurators;
     private final GraphQLResponse.Factory gqlResponseFactory;
     private final ApiAuthProviders authProvider;
     private final ExecutorService executorService;
@@ -78,30 +80,39 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
     private final Set<String> gqlApis;
 
     /**
-     * Default constructor for this plugin without any override.
+     * Default constructor for this plugin without any overrides.
      */
     public AWSApiPlugin() {
-        this(ApiAuthProviders.noProviderOverrides());
+        this(builder());
     }
 
     /**
-     * Constructs an instance of AWSApiPlugin with
-     * configured auth providers to override default modes
-     * of authorization.
-     * If no Auth provider implementation is provided, then
-     * the plugin will assume default behavior for that specific
-     * mode of authorization.
-     *
-     * @param apiAuthProvider configured instance of {@link ApiAuthProviders}
+     * Deprecated. Use {@link #builder()} instead.
+     * @param apiAuthProvider Don't use this
+     * @deprecated Use the fluent {@link #builder()}, instead.
      */
+    @Deprecated
     public AWSApiPlugin(@NonNull ApiAuthProviders apiAuthProvider) {
+        this(builder().apiAuthProviders(apiAuthProvider));
+    }
+
+    private AWSApiPlugin(@NonNull Builder builder) {
         this.apiDetails = new HashMap<>();
         this.gqlResponseFactory = new GsonGraphQLResponseFactory();
-        this.authProvider = Objects.requireNonNull(apiAuthProvider);
+        this.authProvider = builder.apiAuthProviders;
         this.restApis = new HashSet<>();
         this.gqlApis = new HashSet<>();
         this.executorService = Executors.newCachedThreadPool();
         this.requestDecorator = new AuthRuleRequestDecorator(authProvider);
+        this.apiConfigurators = Immutable.of(builder.apiConfigurators);
+    }
+
+    /**
+     * Begins construction of a new AWSApiPlugin instance by using a fluent builder.
+     * @return A builder to help construct an AWSApiPlugin
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     @NonNull
@@ -132,7 +143,13 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             if (apiConfiguration.getAuthorizationType() != AuthorizationType.NONE) {
                 builder.addInterceptor(interceptorFactory.create(apiConfiguration));
             }
+
+            OkHttpConfigurator configurator = apiConfigurators.get(apiName);
+            if (configurator != null) {
+                configurator.applyConfiguration(builder);
+            }
             final OkHttpClient okHttpClient = builder.build();
+
             final SubscriptionAuthorizer subscriptionAuthorizer =
                     new SubscriptionAuthorizer(apiConfiguration, authProvider);
             final SubscriptionEndpoint subscriptionEndpoint =
@@ -734,6 +751,55 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
                 ApiEndpointStatusChangeEvent apiEndpointStatusChangeEvent = previousStatus.transitionTo(newStatus);
                 Amplify.Hub.publish(HubChannel.API, apiEndpointStatusChangeEvent.toHubEvent());
             }
+        }
+    }
+
+    /**
+     * Builds an {@link AWSApiPlugin}.
+     */
+    public static final class Builder {
+        private ApiAuthProviders apiAuthProviders;
+        private final Map<String, OkHttpConfigurator> apiConfigurators;
+
+        private Builder() {
+            this.apiAuthProviders = ApiAuthProviders.noProviderOverrides();
+            this.apiConfigurators = new HashMap<>();
+        }
+
+        /**
+         * Specify authentication providers.
+         * @param apiAuthProviders A set of authentication providers to use for API calls
+         * @return Current builder instance, for fluent construction of plugin
+         */
+        @NonNull
+        public Builder apiAuthProviders(@NonNull ApiAuthProviders apiAuthProviders) {
+            Objects.requireNonNull(apiAuthProviders);
+            Builder.this.apiAuthProviders = apiAuthProviders;
+            return Builder.this;
+        }
+
+        /**
+         * Apply customizations to an underlying OkHttpClient that will be used
+         * for a particular API.
+         * @param forApiName The name of the API for which these customizations should apply
+         * @param byConfigurator A lambda that hands the user an OkHttpClient.Builder,
+         *                       and enables the user to set come configurations on it.
+         * @return A builder instance, to continue chaining configurations
+         */
+        @NonNull
+        public Builder configureClient(
+                @NonNull String forApiName, @NonNull OkHttpConfigurator byConfigurator) {
+            this.apiConfigurators.put(forApiName, byConfigurator);
+            return this;
+        }
+
+        /**
+         * Builds an {@link AWSApiPlugin}.
+         * @return An AWSApiPlugin
+         */
+        @NonNull
+        public AWSApiPlugin build() {
+            return new AWSApiPlugin(Builder.this);
         }
     }
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/OkHttpConfigurator.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/OkHttpConfigurator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Amplify;
+
+import okhttp3.OkHttpClient;
+
+/**
+ * An OkHttpConfigurator is a hook provided to a customer, enabling them to customize
+ * the way an API client is setup while the AWS API plugin is being instantiated.
+ *
+ * This hook is for advanced use cases, such as where a user may want to append some of
+ * their own request headers, or otherwise manipulate an outgoing request.
+ *
+ * See {@link AWSApiPlugin.Builder#configureClient(String, OkHttpConfigurator)}
+ * for more details.
+ */
+@FunctionalInterface
+public interface OkHttpConfigurator {
+    /**
+     * A customer can implement this hook to apply additional configurations
+     * for a particular API. The user supplies an implementation of this function
+     * when the AWSApiPlugin is being constructed:
+     * <pre>
+     *     AWSApiPlugin plugin = AWSApiPlugin.builder()
+     *         .configureClient("someApi", okHttpBuilder -> {
+     *             okHttpBuilder.connectTimeout(10, TimeUnit.SECONDS);
+     *         })
+     *         .build();
+     * </pre>
+     * The hook itself is applied later, when {@link Amplify#configure(Context)} is invoked.
+     *
+     * @param okHttpClientBuilder An {@link OkHttpClient.Builder} instance
+     */
+    void applyConfiguration(@NonNull OkHttpClient.Builder okHttpClientBuilder);
+}

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/auth/OwnerBasedAuthTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/auth/OwnerBasedAuthTest.java
@@ -127,7 +127,9 @@ public final class OwnerBasedAuthTest {
             // This shouldn't happen...
         }
 
-        plugin = new AWSApiPlugin(providers);
+        plugin = AWSApiPlugin.builder()
+            .apiAuthProviders(providers)
+            .build();
         plugin.configure(configuration, ApplicationProvider.getApplicationContext());
     }
 


### PR DESCRIPTION
While constructing the AWSApiPlugin, the customer may now apply
additional configurations to the OkHttpClient instance that is used
internally.

For example, a user may like to add custom headers to outgoing requests:

```java
AWSApiPlugin plugin = AWSApiPlugin.builder()
    .customizeClient("apiName", okHttpClientBuilder -> {
        okHttpClientBuilder.addInterceptor(chain -> {
            return chain.proceed(chain.request()
                .newBuilder()
                .addHeader("specialKey", "specialValue")
                .build();
            );
        });
    })
    .build();
```

The same facility may be used to set custom timeouts, e.g.:
```java
AWSApiPlugin plugin = AWSApiPlugin.builder()
    .customizeClient("apiName", okHttpClientBuilder -> {
        okHttpClientBuilder.connectTimeout(10, TimeUnit.SECONDS);
    })
    .build();
```

Resolves: https://github.com/aws-amplify/amplify-android/issues/1178
Resolves: https://github.com/aws-amplify/amplify-android/issues/913

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
