### PR TITLE
chore(datastore): ignore OperationDisabled subscription errors

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncExtensions.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncExtensions.java
@@ -145,6 +145,13 @@ public final class AppSyncExtensions {
         CONFLICT_UNHANDLED("ConflictUnhandled"),
 
         /**
+         * This error is not for general use unless you have consulted directly with AWS.  When DataStore encounters
+         * this error, it will ignore the error and allow DataStore to continue running.  This error is subject to be
+         * deprecated/removed in the future.
+         */
+        OPERATION_DISABLED("OperationDisabled"),
+
+        /**
          * An Unauthorized error will occur if the provided credentials are not authorized for the requested operation.
          */
         UNAUTHORIZED("Unauthorized");


### PR DESCRIPTION
### Use Case

AppSync doesn't support runtime filtering for subscriptions today.  This means there's no way to limit the network traffic transmitted via subscriptions, and for some applications, the amount of traffic could overwhelm a client.   Some customers wish to disable subscriptions on the backend, but allow DataStore to proceed with sync queries, and continue working, just without real-time updates.

### Solution

Customers can throw an `OperationDisabled` error in their VTL response mapping template which will be ignored by the DataStore `SubscriptionProcessor`.    Note: This is subject to be removed in the future, and should not be used without prior consultation with AWS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
