### PR TITLE
chore: Wrap labels with spaces in quotes

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,13 +4,13 @@ daysUntilStale: 30
 daysUntilClose: 7
 # Label to use when marking an issue as stale
 exemptLabels:
-  - Feature Request
-  - Good First Issue
+  - "Feature Request"
+  - "Good First Issue"
   - Improvement
   - Infrastructure
-  - Pending Release
+  - "Pending Release"
   - RFC
-staleLabel: Closing Soon
+staleLabel: "Closing Soon"
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
The stale bot has not been auto closing issues, even after we add the "Closing Soon" label.  This may be because the label name has a space in it.  

This PR wraps the label name in quotes, in an attempt to fix the problem.  Here's a random other stale.yml setup, where the label name has a space in it, and it is wrapped in double quotes: https://github.com/shineware/KOMORAN/blob/4f764cd83eafc0f584ec0ab1dd0cfdf8c8513dbb/.github/stale.yml 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
