### PR TITLE
chore: remove DataStoreException from catch since try body never throws

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
@@ -133,7 +133,7 @@ final class SQLiteModelTree {
                                 childrenIds.add(cursor.getString(index));
                             } while (cursor.moveToNext());
                         }
-                    } catch (DataStoreException | SQLiteException exception) {
+                    } catch (SQLiteException exception) {
                         // Don't cut the search short. Populate rest of the tree.
                         LOG.warn("Failed to query children of deleted model(s).", exception);
                     }


### PR DESCRIPTION
This PR fixes the issue causing our build to fail on the `main` branch.  It broke after https://github.com/aws-amplify/amplify-android/pull/1149/ was merged, which is strange, because the build on that PR passed.    The reason for this though, is because https://github.com/aws-amplify/amplify-android/pull/1121/ was merged in between, which refactored part of `SQLiteModelTree` such that the body of the try block was no longer ever throwing a `DataStoreException`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
