### PR TITLE
chore: remove versionCode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,10 +133,6 @@ private void configureAndroidLibrary(Project project) {
         project.findProperty('VERSION_NAME') :
         rootProject.findProperty('VERSION_NAME')
 
-    project.ext.VERSION_CODE = project.hasProperty('VERSION_CODE') ?
-        project.findProperty('VERSION_CODE').toInteger() :
-        rootProject.findProperty('VERSION_CODE').toInteger()
-
     project.android {
         buildToolsVersion rootProject.ext.buildToolsVersion
         compileSdkVersion rootProject.ext.compileSdkVersion
@@ -146,7 +142,6 @@ private void configureAndroidLibrary(Project project) {
             minSdkVersion rootProject.ext.minSdkVersion
             targetSdkVersion rootProject.ext.targetSdkVersion
             versionName project.ext.VERSION_NAME
-            versionCode project.ext.VERSION_CODE
             testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
             consumerProguardFiles rootProject.file('configuration/consumer-rules.pro')
 

--- a/core-kotlin/gradle.properties
+++ b/core-kotlin/gradle.properties
@@ -3,5 +3,4 @@ POM_NAME=Amplify Framework for Android - Kotlin facade for Core library
 POM_DESCRIPTION=Amplify Framework for Android - Kotlin facade for Core library
 POM_PACKAGING=aar
 
-VERSION_CODE=000101
 VERSION_NAME=0.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@ org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
 
 VERSION_NAME=1.17.0
-VERSION_CODE=011700
 
 POM_GROUP=com.amplifyframework
 POM_URL=https://github.com/aws-amplify/amplify-android


### PR DESCRIPTION
Per the [documentation for `versionCode`](https://developer.android.com/studio/publish/versioning), it's only use is to prevent users from downgrading to an APK with a lower `versionCode` than the version currently installed.  Since `amplify-android` is a library, and not an app, this doesn't apply.

I believe we can remove `versionCode` to simplify our release process.  Let's give this a try during our next release and see if it works. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
