### PR TITLE
fix(datastore): optimize sync queries with predicates by wrapping in an AND group

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -115,7 +115,7 @@ final class AppSyncRequestFactory {
                     // provided syncPredicate is already a QueryPredicateGroup, this is not needed.  If the provided
                     // group is of type AND, the optimization will occur.  If the top level group is OR or NOT, the
                     // optimization is not possible anyway.
-                    syncPredicate = new QueryPredicateGroup(QueryPredicateGroup.Type.AND, Arrays.asList(syncPredicate));
+                    syncPredicate = QueryPredicateGroup.andOf(syncPredicate);
                 }
                 builder.variable("filter", filterType, parsePredicate(syncPredicate));
             }

--- a/aws-datastore/src/test/resources/base-sync-request-with-predicate-group.txt
+++ b/aws-datastore/src/test/resources/base-sync-request-with-predicate-group.txt
@@ -1,0 +1,36 @@
+{
+  "query": "query SyncBlogOwners($filter: ModelBlogOwnerFilterInput) {
+  syncBlogOwners(filter: $filter) {
+    items {
+      _deleted
+      _lastChangedAt
+      _version
+      blog {
+        id
+      }
+      id
+      name
+      wea
+    }
+    nextToken
+    startedAt
+  }
+}
+",
+  "variables": {
+    "filter": {
+        "and": [
+            {
+                "id": {
+                    "eq" : "426f8e8d-ea0f-4839-a73f-6a2a38565ba1"
+                }
+            },
+            {
+                "name": {
+                    "eq" : "Spaghetti"
+                }
+            }
+        ]
+    }
+  }
+}

--- a/aws-datastore/src/test/resources/base-sync-request-with-predicate-operation.txt
+++ b/aws-datastore/src/test/resources/base-sync-request-with-predicate-operation.txt
@@ -1,0 +1,31 @@
+{
+  "query": "query SyncBlogOwners($filter: ModelBlogOwnerFilterInput) {
+  syncBlogOwners(filter: $filter) {
+    items {
+      _deleted
+      _lastChangedAt
+      _version
+      blog {
+        id
+      }
+      id
+      name
+      wea
+    }
+    nextToken
+    startedAt
+  }
+}
+",
+  "variables": {
+    "filter": {
+        "and": [
+            {
+                "id": {
+                    "eq" : "426f8e8d-ea0f-4839-a73f-6a2a38565ba1"
+                }
+            }
+        ]
+    }
+  }
+}

--- a/aws-datastore/src/test/resources/sync-request-with-predicate.txt
+++ b/aws-datastore/src/test/resources/sync-request-with-predicate.txt
@@ -19,9 +19,13 @@
 ",
   "variables": {
     "filter": {
-      "name": {
-        "beginsWith": "J"
-      }
+      "and" : [
+        {
+          "name": {
+             "beginsWith": "J"
+          }
+        }
+      ]
     },
     "limit": 342,
     "lastSync": 123412341

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateGroup.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateGroup.java
@@ -37,8 +37,8 @@ public final class QueryPredicateGroup implements QueryPredicate {
      * @param predicates the operations and/or groups of operations to group together here
      * @throws IllegalArgumentException when the group does not contain any predicate element
      */
-    public QueryPredicateGroup(@NonNull Type type,
-                               @NonNull List<QueryPredicate> predicates) {
+    QueryPredicateGroup(@NonNull Type type,
+                        @NonNull List<QueryPredicate> predicates) {
         this.type = type;
         this.predicates = new ArrayList<>(predicates);
         if (predicates.isEmpty()) {
@@ -61,6 +61,15 @@ public final class QueryPredicateGroup implements QueryPredicate {
      */
     public List<QueryPredicate> predicates() {
         return predicates;
+    }
+
+    /**
+     * Returns a group with an AND type, containing only the provided predicate.
+     * @param predicate the query predicate operation to wrap
+     * @return a group with an AND type, containing only the provided predicate.
+     */
+    public static QueryPredicate andOf(QueryPredicate predicate) {
+        return new QueryPredicateGroup(Type.AND, Arrays.asList(predicate));
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateGroup.java
+++ b/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateGroup.java
@@ -37,8 +37,8 @@ public final class QueryPredicateGroup implements QueryPredicate {
      * @param predicates the operations and/or groups of operations to group together here
      * @throws IllegalArgumentException when the group does not contain any predicate element
      */
-    QueryPredicateGroup(@NonNull Type type,
-                        @NonNull List<QueryPredicate> predicates) {
+    public QueryPredicateGroup(@NonNull Type type,
+                               @NonNull List<QueryPredicate> predicates) {
         this.type = type;
         this.predicates = new ArrayList<>(predicates);
         if (predicates.isEmpty()) {


### PR DESCRIPTION
When a filter is provided on a sync operation, AppSync will attempt to optimize the request by performing a DynamoDB query, rather than a scan.  A query is only possible if the filter contains the hash key, or the hash key and the sort key.     To perform this optimization, the [AppSync resolver requires the presence of a top level "and"](https://github.com/aws-amplify/amplify-cli/blob/018548a772cab14a1f99fb3d2413eb720142a562/packages/graphql-key-transformer/src/KeyTransformer.ts#L1105) group.   

This PR wraps the sync expression filter with an AND group if the predicate provided by the customer is just a predicate operation, rather than a group.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
