### PR TITLE
chore(ci): create test report dir before execution

### DIFF
--- a/scripts/devicefarm-test-runner-buildspec.yml
+++ b/scripts/devicefarm-test-runner-buildspec.yml
@@ -28,6 +28,7 @@ phases:
   pre_build:
     commands:
       - echo 'Pre-build phase starting'
+      - mkdir -p build/allTests
       - |
         if [[ -z "${CONFIG_SOURCE_BUCKET}" ]]; then
           echo 'Pulling config files from Amplify'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To troubleshoot integration tests, we need to ensure that the reports are exported correctly after execution. In certain instances, tests are failing and the reports are not getting generated. It's not clear why this is happening, but by creating the report output directory before running the build, we can at least allow the post-build event to run successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
