### PR TITLE
chore: fix transient syncCanHandle1000Pages test by increasing timeout

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -626,7 +626,10 @@ public final class SyncProcessorTest {
         // Act: Call hydrate, and await its completion - assert it completed without error
         TestObserver<ModelWithMetadata<? extends Model>> hydrationObserver = TestObserver.create();
         syncProcessor.hydrate().subscribe(hydrationObserver);
-        assertTrue(hydrationObserver.await(OP_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // Wait 2 seconds, or 1 second per 100 pages, whichever is greater
+        long timeoutMs = Math.max(OP_TIMEOUT_MS, TimeUnit.SECONDS.toMillis(numPages / 100));
+        assertTrue(hydrationObserver.await(timeoutMs, TimeUnit.MILLISECONDS));
         hydrationObserver.assertNoErrors();
         hydrationObserver.assertComplete();
 


### PR DESCRIPTION
Fixes transient unit tests.   Integration tests are still failing for an unrelated issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
