### PR TITLE
fix(datastore) Make PendingMutationConverter work for SerializedModel

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelConverter.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelConverter.java
@@ -15,13 +15,13 @@
 
 package com.amplifyframework.datastore.appsync;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.Model;
-import com.amplifyframework.util.GsonFactory;
-import com.amplifyframework.util.GsonObjectConverter;
+import com.amplifyframework.core.model.ModelAssociation;
+import com.amplifyframework.core.model.ModelField;
+import com.amplifyframework.core.model.ModelSchema;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,33 +34,64 @@ public final class ModelConverter {
 
     /**
      * Convert a Model to a Map&lt;String, Object&gt;.
-     * @param model a Model instance.
+     * @param instance a Model instance.
+     * @param schema a Model schema for the instance.
      * @param <T> type of the Model instance.
      * @return a Map&lt;String, Object&gt; representation of the provided Model instance.
+     * @throws AmplifyException if schema doesn't match instance
      */
-    public static <T extends Model> Map<String, Object> toMap(T model) {
-        if (model == null) {
-            return new HashMap<>();
+    public static <T extends Model> Map<String, Object> toMap(T instance, ModelSchema schema) throws AmplifyException {
+        final Map<String, Object> result = new HashMap<>();
+        for (ModelField modelField : schema.getFields().values()) {
+            String fieldName = modelField.getName();
+            try {
+                final ModelAssociation association = schema.getAssociations().get(fieldName);
+                if (association == null) {
+                    if (instance instanceof SerializedModel) {
+                        Map<String, Object> serializedData = ((SerializedModel) instance).getSerializedData();
+                        if (serializedData.containsKey(modelField.getName())) {
+                            result.put(fieldName, serializedData.get(modelField.getName()));
+                        }
+                    } else {
+                        result.put(fieldName, extractFieldValue(modelField, instance));
+                    }
+                } else if (association.isOwner()) {
+                    result.put(association.getTargetName(), extractAssociateId(modelField, instance));
+                }
+                // Ignore if field is associated, but is not a "belongsTo" relationship
+            } catch (Exception exception) {
+                throw new AmplifyException(
+                        "An invalid field was provided. " + fieldName + " is not present in " + schema.getName(),
+                        exception,
+                        "Check if this model schema is a correct representation of the fields in the provided Object");
+            }
         }
-        if (model instanceof SerializedModel) {
-            return ((SerializedModel) model).getSerializedData();
+        return result;
+    }
+
+    private static Object extractAssociateId(ModelField modelField, Model instance)
+            throws NoSuchFieldException, IllegalAccessException {
+        final Object fieldValue = extractFieldValue(modelField, instance);
+        if (modelField.isModel() && fieldValue instanceof Model) {
+            return ((Model) fieldValue).getId();
+        } else if (modelField.isModel() && fieldValue instanceof Map) {
+            return ((Map<?, ?>) fieldValue).get("id");
+        } else if (modelField.isModel() && fieldValue == null) {
+            return null;
         } else {
-            Gson gson = GsonFactory.instance();
-            JsonElement jsonElement = gson.toJsonTree(model);
-            return GsonObjectConverter.toMap(jsonElement.getAsJsonObject());
+            throw new IllegalStateException("Associated data is not a Model or Map.");
         }
     }
 
-    /**
-     * Convert a Map&lt;String, Object&gt; to a Model.
-     * @param map a Map&lt;String, Object&gt;.
-     * @param modelClass Class of Model to convert the Map to.
-     * @param <T> type of the Model instance to convert to.
-     * @return a Model instance created from the provided Map.
-     */
-    public static <T extends Model> T fromMap(Map<String, Object> map, Class<T> modelClass) {
-        Gson gson = GsonFactory.instance();
-        String jsonString = gson.toJson(map);
-        return gson.fromJson(jsonString, modelClass);
+    private static Object extractFieldValue(ModelField modelField, Model instance)
+            throws NoSuchFieldException, IllegalAccessException {
+        if (instance instanceof SerializedModel) {
+            SerializedModel serializedModel = (SerializedModel) instance;
+            Map<String, Object> serializedData = serializedModel.getSerializedData();
+            return serializedData.get(modelField.getName());
+        }
+        Field privateField = instance.getClass().getDeclaredField(modelField.getName());
+        privateField.setAccessible(true);
+        return privateField.get(instance);
     }
 }

--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
+import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelSchema;
@@ -50,10 +51,11 @@ public final class SerializedModel implements Model {
      * @param modelSchema schema for the Model object
      * @param <T> type of the Model object.
      * @return SerializedModel equivalent of the Model object.
+     * @throws AmplifyException ModelConverter.toMap
      */
-    public static <T extends Model> SerializedModel create(T model, ModelSchema modelSchema) {
+    public static <T extends Model> SerializedModel create(T model, ModelSchema modelSchema) throws AmplifyException {
         return SerializedModel.builder()
-                .serializedData(ModelConverter.toMap(model))
+                .serializedData(ModelConverter.toMap(model, modelSchema))
                 .modelSchema(modelSchema)
                 .build();
     }
@@ -67,10 +69,15 @@ public final class SerializedModel implements Model {
      * @param <T> type of the Models being compared.
      * @return a SerializedModel, containing only the values from the updated Model that are different from the
      *         corresponding values in original.
+     * @throws AmplifyException ModelConverter.toMap
      */
-    public static <T extends Model> SerializedModel difference(T updated, T original, ModelSchema modelSchema) {
-        Map<String, Object> updatedMap = ModelConverter.toMap(updated);
-        Map<String, Object> originalMap = ModelConverter.toMap(original);
+    public static <T extends Model> SerializedModel difference(T updated, T original, ModelSchema modelSchema)
+            throws AmplifyException {
+        if (original == null) {
+            return SerializedModel.create(updated, modelSchema);
+        }
+        Map<String, Object> updatedMap = ModelConverter.toMap(updated, modelSchema);
+        Map<String, Object> originalMap = ModelConverter.toMap(original, modelSchema);
         Map<String, Object> patchMap = new HashMap<>();
         for (String key : updatedMap.keySet()) {
             if ("id".equals(key) || !ObjectsCompat.equals(originalMap.get(key), updatedMap.get(key))) {

--- a/aws-api-appsync/src/test/java/com/amplifyframework/datastore/appsync/ModelConverterTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/datastore/appsync/ModelConverterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.appsync;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.testmodels.commentsblog.Blog;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ModelConverterTest {
+
+    /**
+     * Verify that a Java model converted to a Map returns the expected value.
+     * @throws AmplifyException On failure to derive ModelSchema
+     */
+    @Test
+    public void toMapForModelReturnsExpectedMap() throws AmplifyException {
+        BlogOwner blogOwner = BlogOwner.builder()
+            .name("Joe Swanson")
+            .build();
+        ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
+        Map<String, Object> actual = ModelConverter.toMap(blogOwner, schema);
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("id", blogOwner.getId());
+        expected.put("createdAt", null);
+        expected.put("name", "Joe Swanson");
+        expected.put("updatedAt", null);
+        expected.put("wea", null);
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Verify that a Java model with children converted to a Map returns the expected value.
+     * @throws AmplifyException On failure to derive ModelSchema
+     */
+    @Test public void toMapForModelWithChildrenReturnsExpectedMap() throws AmplifyException {
+        Blog blog = Blog.builder()
+                .name("A neat blog")
+                .owner(BlogOwner.builder()
+                        .name("Joe Swanson")
+                        .build())
+                .build();
+        ModelSchema schema = ModelSchema.fromModelClass(Blog.class);
+        Map<String, Object> actual = ModelConverter.toMap(blog, schema);
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("id", blog.getId());
+        expected.put("name", "A neat blog");
+        expected.put("blogOwnerId", blog.getOwner().getId());
+        assertEquals(expected, actual);
+    }
+}

--- a/aws-api-appsync/src/test/java/com/amplifyframework/datastore/appsync/ModelConverterTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/datastore/appsync/ModelConverterTest.java
@@ -22,6 +22,7 @@ import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -67,7 +68,10 @@ public class ModelConverterTest {
         Map<String, Object> expected = new HashMap<>();
         expected.put("id", blog.getId());
         expected.put("name", "A neat blog");
-        expected.put("blogOwnerId", blog.getOwner().getId());
+        expected.put("owner", SerializedModel.builder()
+                .serializedData(Collections.singletonMap("id", blog.getOwner().getId()))
+                .modelSchema(null)
+                .build());
         assertEquals(expected, actual);
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -38,7 +38,6 @@ import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
-import com.amplifyframework.datastore.appsync.ModelConverter;
 import com.amplifyframework.datastore.appsync.SerializedModel;
 import com.amplifyframework.datastore.model.CompoundModelProvider;
 import com.amplifyframework.datastore.model.SystemModelsProviderFactory;
@@ -369,7 +368,8 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 if (cursor.moveToFirst()) {
                     do {
                         Map<String, Object> map = converter.buildMapForModel(cursor);
-                        models.add(ModelConverter.fromMap(map, itemClass));
+                        String jsonString = gson.toJson(map);
+                        models.add(gson.fromJson(jsonString, itemClass));
                     } while (cursor.moveToNext());
                 }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverter.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.appsync.SerializedModel;
 import com.amplifyframework.util.GsonFactory;
 
 import com.google.gson.Gson;
@@ -45,9 +46,13 @@ final class GsonPendingMutationConverter implements PendingMutation.Converter {
     @NonNull
     @Override
     public <T extends Model> PendingMutation.PersistentRecord toRecord(@NonNull PendingMutation<T> mutation) {
+        String containedModelClassName = mutation.getModelSchema().getModelClass().getName();
+        if (mutation.getMutatedItem() instanceof SerializedModel) {
+            containedModelClassName = SerializedModel.class.getName();
+        }
         return PendingMutation.PersistentRecord.builder()
             .containedModelId(mutation.getMutatedItem().getId())
-            .containedModelClassName(mutation.getModelSchema().getModelClass().getName())
+            .containedModelClassName(containedModelClassName)
             .serializedMutationData(gson.toJson(mutation))
             .mutationId(mutation.getMutationId())
             .build();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverter.java
@@ -19,7 +19,6 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.datastore.DataStoreException;
-import com.amplifyframework.datastore.appsync.SerializedModel;
 import com.amplifyframework.util.GsonFactory;
 
 import com.google.gson.Gson;
@@ -46,13 +45,9 @@ final class GsonPendingMutationConverter implements PendingMutation.Converter {
     @NonNull
     @Override
     public <T extends Model> PendingMutation.PersistentRecord toRecord(@NonNull PendingMutation<T> mutation) {
-        String containedModelClassName = mutation.getModelSchema().getModelClass().getName();
-        if (mutation.getMutatedItem() instanceof SerializedModel) {
-            containedModelClassName = SerializedModel.class.getName();
-        }
         return PendingMutation.PersistentRecord.builder()
             .containedModelId(mutation.getMutatedItem().getId())
-            .containedModelClassName(containedModelClassName)
+            .containedModelClassName(mutation.getMutatedItem().getClass().getName())
             .serializedMutationData(gson.toJson(mutation))
             .mutationId(mutation.getMutationId())
             .build();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/InMemoryStorageAdapter.java
@@ -90,8 +90,10 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
             }
         }
         final ModelSchema schema;
+        final SerializedModel patchItem;
         try {
             schema = ModelSchema.fromModelClass(item.getClass());
+            patchItem = SerializedModel.difference(item, savedItem, schema);
         } catch (AmplifyException schemaBuildFailure) {
             onError.accept(new DataStoreException(
                 "Failed to build model schema.", schemaBuildFailure, "Verify your model."
@@ -101,7 +103,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
         items.add(item);
         StorageItemChange<T> change = StorageItemChange.<T>builder()
             .item(item)
-            .patchItem(SerializedModel.difference(item, savedItem, schema))
+            .patchItem(patchItem)
             .modelSchema(schema)
             .type(type)
             .predicate(predicate)
@@ -165,8 +167,10 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
         Model savedItem = items.remove(index);
 
         final ModelSchema schema;
+        final SerializedModel patchItem;
         try {
             schema = ModelSchema.fromModelClass(item.getClass());
+            patchItem = SerializedModel.create(savedItem, schema);
         } catch (AmplifyException schemaBuildFailure) {
             onError.accept(new DataStoreException(
                 "Failed to build model schema.", schemaBuildFailure, "Verify your model."
@@ -181,7 +185,7 @@ public final class InMemoryStorageAdapter implements LocalStorageAdapter {
         }
         StorageItemChange<T> deletion = StorageItemChange.<T>builder()
             .item((T) savedItem)
-            .patchItem(SerializedModel.create(savedItem, schema))
+            .patchItem(patchItem)
             .modelSchema(schema)
             .type(StorageItemChange.Type.DELETE)
             .predicate(predicate)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
@@ -24,11 +24,11 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.ModelSchemaRegistry;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
-import com.amplifyframework.datastore.appsync.ModelConverter;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.util.GsonFactory;
 
+import com.google.gson.Gson;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +53,7 @@ public class SQLCommandProcessorTest {
     private SQLCommandProcessor sqlCommandProcessor;
     private SQLiteDatabase sqliteDatabase;
     private ModelSchemaRegistry modelSchemaRegistry;
+    private Gson gson;
 
     /**
      * Sets up model registry and in-memory database.
@@ -66,6 +67,7 @@ public class SQLCommandProcessorTest {
         sqlCommandFactory = new SQLiteCommandFactory(modelSchemaRegistry, GsonFactory.instance());
         sqliteDatabase = createDatabase(modelProvider, modelSchemaRegistry);
         sqlCommandProcessor = new SQLCommandProcessor(sqliteDatabase);
+        gson = GsonFactory.instance();
     }
 
     private SQLiteDatabase createDatabase(ModelProvider modelProvider, ModelSchemaRegistry registry) {
@@ -122,7 +124,8 @@ public class SQLCommandProcessorTest {
         if (cursor.moveToFirst()) {
             do {
                 Map<String, Object> map = converter.buildMapForModel(cursor);
-                results.add(ModelConverter.fromMap(map, BlogOwner.class));
+                String jsonString = gson.toJson(map);
+                results.add(gson.fromJson(jsonString, BlogOwner.class));
             } while (cursor.moveToNext());
         }
         assertEquals(Arrays.asList(abigailMcGregor), results);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverterTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverterTest.java
@@ -103,7 +103,7 @@ public final class GsonPendingMutationConverterTest {
      * @throws AmplifyException On failure to arrange model schema
      */
     @Test
-    public void convertPendingMutationWithSerializedModelWithChildrenToRecordAndBack() throws AmplifyException {
+    public void convertPendingMutationWithSerializedModelWithChildToRecordAndBack() throws AmplifyException {
         // Arrange a PendingMutation<SerializedModel>
         Blog blog = Blog.builder()
                 .name("A neat blog")

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Blog.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/commentsblog/Blog.java
@@ -73,8 +73,18 @@ public final class Blog implements Model {
       .toString()
       .hashCode();
   }
-  
-  public static NameStep builder() {
+
+    @Override
+    public String toString() {
+        return "Blog{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", posts=" + posts +
+                ", owner=" + owner +
+                '}';
+    }
+
+    public static NameStep builder() {
       return new Builder();
   }
   


### PR DESCRIPTION
There were two bugs introduced by https://github.com/aws-amplify/amplify-android/pull/1110, which changed the update mutation behavior to only send fields that had _changed_.  To do that, we convert the Java models to `SerializedModel` objects, because it allows us to represent the absence of a field, since the field is stored as a `Map`:

1. Items saved while offline (and thus persisted into the `PendingRecord` SQLite table) were not persisted correctly, and the mutations ended up getting sent to AppSync with all of the fields set to null, except for "id". (https://github.com/aws-amplify/amplify-android/issues/1199).  I've fixed this by updating the `PendingMutationConverter` to actually work for `SerializedModel` objects.

2. Mutations for models with children weren't created properly.    `ModelConverter.toMap` (added in the previously mentioned PR) just used Gson to convert a Java model to a Map.  This is not sufficient for serializing models with children, because the association fields just the child's ID needs to be serialized, not the whole child object.  

Fixes #1199

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
