### PR TITLE
chore(datastore): fix integration test failure due to new timestamp fields

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
@@ -47,6 +47,7 @@ import com.amplifyframework.testutils.Resources;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -88,10 +89,12 @@ public final class AppSyncClientInstrumentationTest {
      * Tests the operations in AppSyncClient.
      * @throws DataStoreException If any call to AppSync endpoint fails to return a response
      * @throws AmplifyException On failure to obtain ModelSchema
+     * @throws NoSuchFieldException On failure to null out createdAt, updatedAt fields in response
+     * @throws IllegalAccessException On failure to null out createdAt, updatedAt fields in response
      */
     @Test
     @SuppressWarnings("MethodLength")
-    public void testAllOperations() throws AmplifyException {
+    public void testAllOperations() throws AmplifyException, NoSuchFieldException, IllegalAccessException {
         ModelSchema blogOwnerSchema = ModelSchema.fromModelClass(BlogOwner.class);
         ModelSchema postSchema = ModelSchema.fromModelClass(Post.class);
         ModelSchema blogSchema = ModelSchema.fromModelClass(Blog.class);
@@ -103,8 +106,14 @@ public final class AppSyncClientInstrumentationTest {
             .name("David")
             .build();
         ModelWithMetadata<BlogOwner> blogOwnerCreateResult = create(owner, blogOwnerSchema);
+        BlogOwner actual = blogOwnerCreateResult.getModel();
 
-        assertEquals(owner, blogOwnerCreateResult.getModel());
+        // The response from AppSync has createdAt and updatedAt fields.  We can't actually know what values to expect
+        // for these, so just null them out.
+        setField(actual, "createdAt", null);
+        setField(actual, "updatedAt", null);
+
+        assertEquals(owner, actual);
         assertEquals(new Integer(1), blogOwnerCreateResult.getSyncMetadata().getVersion());
         // TODO: BE AWARE THAT THE DELETED PROPERTY RETURNS NULL INSTEAD OF FALSE
         assertNull(blogOwnerCreateResult.getSyncMetadata().isDeleted());
@@ -351,5 +360,12 @@ public final class AppSyncClientInstrumentationTest {
                 emitter.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
             });
         });
+    }
+
+    private <T extends Model> void setField(T instance, String fieldName, Object value)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field privateField = instance.getClass().getDeclaredField(fieldName);
+        privateField.setAccessible(true);
+        privateField.set(instance, value);
     }
 }


### PR DESCRIPTION
The `AppSyncClientInstrumentationTest::testAllOperations` test was broke by https://github.com/aws-amplify/amplify-android/pull/1249, because `createdAt` and `updatedAt` fields were added to the `BlogOwner` model.    Those fields are now requested in the selection set, but we weren't expecting them in the response previously.  

There's not really a way we can know what to _expect_ for these fields, since they are set by the server, so instead, this PR sets them to null on the actual object returned from AppSync.  Then, when we compare it to the expected value, it succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
