### PR TITLE
fix(kotlin): getCurrentUser return type should be nullable

### DIFF
--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -256,7 +256,7 @@ interface Auth {
      * @return the currently logged in user with basic info and methods for fetching/updating user attributes
      * @return Information about the current user
      */
-    fun getCurrentUser(): AuthUser
+    fun getCurrentUser(): AuthUser?
 
     /**
      * Sign out with advanced options.

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -274,7 +274,7 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
         }
     }
 
-    override fun getCurrentUser(): AuthUser {
+    override fun getCurrentUser(): AuthUser? {
         return delegate.currentUser
     }
 

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -778,6 +778,18 @@ class KotlinAuthFacadeTest {
     }
 
     /**
+     * When the getCurrentUser() delegate return null, the proxy API in the
+     * Kotlin facade should, too.  Essentially, the AuthUser returned is nullable.
+     */
+    @Test
+    fun getCurrentUserSucceedsWhenSignedOut() {
+        val expectedAuthUser = null
+        every { delegate.currentUser } returns expectedAuthUser
+        assertEquals(expectedAuthUser, auth.getCurrentUser())
+
+    }
+
+    /**
      * When the getCurrentUser() delegate throws an error, the proxy
      * API in the Kotlin facade should, too. Note that this API doesn't
      * have any suspending functions, this is a straight pass through verification.

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -786,7 +786,6 @@ class KotlinAuthFacadeTest {
         val expectedAuthUser = null
         every { delegate.currentUser } returns expectedAuthUser
         assertEquals(expectedAuthUser, auth.getCurrentUser())
-
     }
 
     /**


### PR DESCRIPTION
Calling `Amplify.Auth.getCurrentUser` while using the core-kotlin facade will crash if signed out with this error:

```
java.lang.NullPointerException: delegate.currentUser must not be null
	at com.amplifyframework.kotlin.auth.KotlinAuthFacade.getCurrentUser(KotlinAuthFacade.kt:278)
	at com.amplifyframework.kotlin.auth.KotlinAuthFacadeTest.getCurrentUserSucceedsWhenSignedOut(KotlinAuthFacadeTest.kt:788)
```

This PR eliminates the crash by making the return type nullable.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
