### PR TITLE
chore(datastore): fix unit tests by adding createdAt updatedAt

### DIFF
--- a/aws-datastore/src/test/resources/base-sync-request-with-predicate-group.txt
+++ b/aws-datastore/src/test/resources/base-sync-request-with-predicate-group.txt
@@ -8,8 +8,10 @@
       blog {
         id
       }
+      createdAt
       id
       name
+      updatedAt
       wea
     }
     nextToken

--- a/aws-datastore/src/test/resources/base-sync-request-with-predicate-operation.txt
+++ b/aws-datastore/src/test/resources/base-sync-request-with-predicate-operation.txt
@@ -8,8 +8,10 @@
       blog {
         id
       }
+      createdAt
       id
       name
+      updatedAt
       wea
     }
     nextToken


### PR DESCRIPTION
When https://github.com/aws-amplify/amplify-android/pull/1225 was merged, the associated unit tests started failing, because they hadn't been updated to include the createdAt and updatedAt timestamps yet, introduced by https://github.com/aws-amplify/amplify-android/pull/1249.

This PR fixes those tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
