### PR TITLE
chore(build): add buildspec for publishing to maven

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,24 +11,26 @@ all information necessary to effectively respond to your bug report or
 contribution.
 
 - [Contributing Guidelines](#contributing-guidelines)
-  * [Getting Started](#getting-started)
-    + [Consuming Development Versions of the Framework](#consuming-development-versions-of-the-framework)
-  * [Tools](#tools)
-  * [Workflows](#workflows)
-    + [Adding Code to Support a New Feature](#adding-code-to-support-a-new-feature)
-    + [Build and Validate Your Work](#build-and-validate-your-work)
-    + [Run Instrumentation Tests](#run-instrumentation-tests)
-  * [Reporting Bugs/Feature Requests](#reporting-bugs-feature-requests)
-  * [Contributing via Pull Requests](#contributing-via-pull-requests)
-  * [Troubleshooting](#troubleshooting)
-    + [Environment Debugging](#environment-debugging)
-    + [Problems with the Build](#problems-with-the-build)
-    + [Failing Instrumentation Tests](#failing-instrumentation-tests)
-  * [Related Repositories](#related-repositories)
-  * [Finding Contributions to Make](#finding-contributions-to-make)
-  * [Code of Conduct](#code-of-conduct)
-  * [Security Issue Notifications](#security-issue-notifications)
-  * [Licensing](#licensing)
+  - [Getting Started](#getting-started)
+    - [Consuming Development Versions of the Framework](#consuming-development-versions-of-the-framework)
+  - [Tools](#tools)
+  - [Workflows](#workflows)
+    - [Adding Code to Support a New Feature](#adding-code-to-support-a-new-feature)
+    - [Build and Validate Your Work](#build-and-validate-your-work)
+    - [Run Instrumentation Tests](#run-instrumentation-tests)
+    - [Test changes to CodeBuild build definitions](#test-changes-to-codebuild-build-definitions)
+  - [Reporting Bugs/Feature Requests](#reporting-bugsfeature-requests)
+  - [Contributing via Pull Requests](#contributing-via-pull-requests)
+  - [Troubleshooting](#troubleshooting)
+    - [Environment Debugging](#environment-debugging)
+    - [Problems with the Build](#problems-with-the-build)
+    - [Getting More Output](#getting-more-output)
+    - [Failing Instrumentation Tests](#failing-instrumentation-tests)
+  - [Related Repositories](#related-repositories)
+  - [Finding Contributions to Make](#finding-contributions-to-make)
+  - [Code of Conduct](#code-of-conduct)
+  - [Security Issue Notifications](#security-issue-notifications)
+  - [Licensing](#licensing)
 
 ## Getting Started
 
@@ -346,6 +348,18 @@ To run __all__ tests:
 ```shell
 ./gradlew cAT
 ```
+
+### Test changes to CodeBuild build definitions
+
+Changes made to one of the buildspec files under the `./scripts` folder can be tested locally inside a docker container (See [setup instructions](https://docs.aws.amazon.com/codebuild/latest/userguide/use-codebuild-agent.html) in the CodeBuild docs).
+
+The following command will spin up a docker container locally and run through the build definition in the buildspec file.
+
+```bash
+./scripts/codebuild_build.sh -i aws/codebuild/standard:4.0  -a build/codebuild-out -s . -d -m -c -b "scripts/<build_spec_file>.yml"
+```
+
+Note that the `-c` option pulls in AWS configuration from your local environment into the docker container. That means any `AWS_*` environment variables will be set inside the container. This is useful when the build process needs to access AWS resources from an AWS account. **Be sure to check which AWS account your current credentials belong to and which permissions are granted**. Typically, the target account should be a development account.
 
 ## Reporting Bugs/Feature Requests
 

--- a/build.gradle
+++ b/build.gradle
@@ -132,8 +132,8 @@ private void configureAndroidLibrary(Project project) {
 
     if (project.hasProperty('signingKeyId')) {
         System.out.println("Getting signing info from protected source.")
-        project.ext.'signing.keyId' = findProperty('signingKeyId').trim()   
-        project.ext.'signing.password' = findProperty('signingPassword').trim()
+        project.ext.'signing.keyId' = findProperty('signingKeyId') 
+        project.ext.'signing.password' = findProperty('signingPassword')
         project.ext.'signing.secretKeyRingFile' = findProperty('signingSecretKeyRingFile')
         project.ext.'signing.inMemoryKey' = findProperty('signingInMemoryKey')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,14 @@ private void configureAndroidLibrary(Project project) {
         project.findProperty('VERSION_NAME') :
         rootProject.findProperty('VERSION_NAME')
 
+    if (project.hasProperty('signingKeyId')) {
+        System.out.println("Getting signing info from protected source.")
+        project.ext.'signing.keyId' = findProperty('signingKeyId').trim()   
+        project.ext.'signing.password' = findProperty('signingPassword').trim()
+        project.ext.'signing.secretKeyRingFile' = findProperty('signingSecretKeyRingFile')
+        project.ext.'signing.inMemoryKey' = findProperty('signingInMemoryKey')
+    }
+
     project.android {
         buildToolsVersion rootProject.ext.buildToolsVersion
         compileSdkVersion rootProject.ext.compileSdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,6 @@ private void configureAndroidLibrary(Project project) {
         System.out.println("Getting signing info from protected source.")
         project.ext.'signing.keyId' = findProperty('signingKeyId') 
         project.ext.'signing.password' = findProperty('signingPassword')
-        project.ext.'signing.secretKeyRingFile' = findProperty('signingSecretKeyRingFile')
         project.ext.'signing.inMemoryKey' = findProperty('signingInMemoryKey')
     }
 

--- a/configuration/publishing.gradle
+++ b/configuration/publishing.gradle
@@ -102,6 +102,12 @@ afterEvaluate { project ->
             project.ext.VERSION_NAME.contains("SNAPSHOT") == false &&
                 gradle.taskGraph.hasTask("uploadArchives")
         }
+        if (project.hasProperty('signing.inMemoryKey')) {
+            def signingKey = findProperty("signing.inMemoryKey").replace("\\n","\n")
+            def signingPassword = findProperty("signing.password")
+            def keyId = findProperty("signing.keyId")
+            useInMemoryPgpKeys(keyId, signingKey, signingPassword)
+        }
         sign configurations.archives
     }
 

--- a/scripts/codebuild_build.sh
+++ b/scripts/codebuild_build.sh
@@ -124,7 +124,7 @@ fi
 
 if [ -n "$buildspec" ]
 then
-    docker_command+=" -e \"BUILDSPEC=$(allOSRealPath "$buildspec")\""
+    docker_command+=" -e \"BUILDSPEC=$buildspec\""
 fi
 
 if [ -n "$environment_variable_file" ]

--- a/scripts/maven-release-publisher.yml
+++ b/scripts/maven-release-publisher.yml
@@ -25,9 +25,10 @@ phases:
       - |
         # List all available gradle tasks, grep for the uploadArchive tasks, and then use cut to strip the
         # task description and just return the name of the task, one for each module (e.g. aws-api:uploadArchives)
+        JAVA_HOME=$JDK_8_HOME ./gradlew clean build
         for task_name in $(./gradlew tasks --all | grep uploadArchives | cut -d " " -f 1); do
           echo "Gradle task $task_name"
-          JAVA_HOME=$JDK_8_HOME ./gradlew clean build $task_name;
+          JAVA_HOME=$JDK_8_HOME ./gradlew $task_name;
         done
     finally:
       - echo 'Build phase completed.'

--- a/scripts/maven-release-publisher.yml
+++ b/scripts/maven-release-publisher.yml
@@ -7,7 +7,6 @@ env:
     ORG_GRADLE_PROJECT_signingPassword:  awsmobilesdk/android/signing:password
     ORG_GRADLE_PROJECT_signingKeyId:  awsmobilesdk/android/signing:keyId
     ORG_GRADLE_PROJECT_signingInMemoryKey: awsmobilesdk/android/signing:inMemoryKey
-    ORG_GRADLE_PROJECT_signingSecretKeyRingFile:  awsmobilesdk/android/signing:secretKeyRingFile
 phases:
   install:
     commands:

--- a/scripts/maven-release-publisher.yml
+++ b/scripts/maven-release-publisher.yml
@@ -27,7 +27,7 @@ phases:
         # task description and just return the name of the task, one for each module (e.g. aws-api:uploadArchives)
         for task_name in $(./gradlew tasks --all | grep uploadArchives | cut -d " " -f 1); do
           echo "Gradle task $task_name"
-          JAVA_HOME=$JDK_8_HOME ./gradlew $task_name;
+          JAVA_HOME=$JDK_8_HOME ./gradlew clean build $task_name;
         done
     finally:
       - echo 'Build phase completed.'

--- a/scripts/maven-release-publisher.yml
+++ b/scripts/maven-release-publisher.yml
@@ -2,12 +2,12 @@ version: 0.2
 env:
   shell: /bin/sh
   secrets-manager:
-    ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: amplify/android/sonatype:username
-    ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: amplify/android/sonatype:password
-    ORG_GRADLE_PROJECT_signingPassword:  amplify/android/signing:password
-    ORG_GRADLE_PROJECT_signingKeyId:  amplify/android/signing:keyId
-    ORG_GRADLE_PROJECT_signingInMemoryKey: amplify/android/signing:inMemoryKey
-    ORG_GRADLE_PROJECT_signingSecretKeyRingFile:  amplify/android/signing:secretKeyRingFile
+    ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: awsmobilesdk/android/sonatype:username
+    ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: awsmobilesdk/android/sonatype:password
+    ORG_GRADLE_PROJECT_signingPassword:  awsmobilesdk/android/signing:password
+    ORG_GRADLE_PROJECT_signingKeyId:  awsmobilesdk/android/signing:keyId
+    ORG_GRADLE_PROJECT_signingInMemoryKey: awsmobilesdk/android/signing:inMemoryKey
+    ORG_GRADLE_PROJECT_signingSecretKeyRingFile:  awsmobilesdk/android/signing:secretKeyRingFile
 phases:
   install:
     commands:

--- a/scripts/maven-release-publisher.yml
+++ b/scripts/maven-release-publisher.yml
@@ -1,0 +1,37 @@
+version: 0.2
+env:
+  shell: /bin/sh
+  secrets-manager:
+    ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: amplify/android/sonatype:username
+    ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: amplify/android/sonatype:password
+    ORG_GRADLE_PROJECT_signingPassword:  amplify/android/signing:password
+    ORG_GRADLE_PROJECT_signingKeyId:  amplify/android/signing:keyId
+    ORG_GRADLE_PROJECT_signingInMemoryKey: amplify/android/signing:inMemoryKey
+    ORG_GRADLE_PROJECT_signingSecretKeyRingFile:  amplify/android/signing:secretKeyRingFile
+phases:
+  install:
+    commands:
+      - echo 'Install phase starting'
+    finally:
+      - echo 'Install phase completed.'
+  pre_build:
+    commands:
+      - echo 'Pre-build phase starting'
+    finally:
+      - echo 'Pre-build phase completed.'
+  build:
+    commands:
+      - echo 'Build phase starting.'
+      - |
+        for item in aws-* core core-kotlin rxbindings; do 
+          task_name=":$item:uploadArchives"
+          echo "Gradle task $task_name"
+          JAVA_HOME=$JDK_8_HOME ./gradlew $task_name;
+        done
+    finally:
+      - echo 'Build phase completed.'
+  post_build:
+    commands:
+      - echo 'Post-build phase starting'
+    finally:
+      - echo 'Post-build phase completed.'

--- a/scripts/maven-release-publisher.yml
+++ b/scripts/maven-release-publisher.yml
@@ -23,8 +23,9 @@ phases:
     commands:
       - echo 'Build phase starting.'
       - |
-        for item in aws-* core core-kotlin rxbindings; do 
-          task_name=":$item:uploadArchives"
+        # List all available gradle tasks, grep for the uploadArchive tasks, and then use cut to strip the
+        # task description and just return the name of the task, one for each module (e.g. aws-api:uploadArchives)
+        for task_name in $(./gradlew tasks --all | grep uploadArchives | cut -d " " -f 1); do
           echo "Gradle task $task_name"
           JAVA_HOME=$JDK_8_HOME ./gradlew $task_name;
         done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Create a CodeBuild definition (buildspec file) that executes the `uploadArchives` gradle task. This build definition will run inside a CodeBuild project, which will be defined in the `amplify-ci-support` repo in a separate PR.

The buildspec is fairly straightforward. The one callout is that it pulls in any sensitive information from Secrets Manager by using the `secrets-manager` section and makes them available via environment variables. These environment variables are prefixed with `ORG_GRADLE_PROJECT_` which automatically sets gradle project properties. This ensures that at no point, that information is passed in via the command line. 

See [CodeBuild docs](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec.env.secrets-manager) for more information on secret handling inside the build. 

The trigger for this build will be setup as part of the `amplify-ci-support` PR. The intent is to trigger it every time there is a a merge into `main` from `release` whose commit message starts with `chore(release)`. We'll also be able to trigger it manually via the console or CLI by specifying the commit ID of the merge.

The change in `build.gradle` is due to the fact that the `signing` project settings have a period in them (`signing.keyId` for example) and cannot be represented directly as an environment variable. If a project variable with the name `signingKeyId` exists, it sets the `signing.*` project variables from the `signing*` variables read from secrets manager. For example, `signingKeyId` becomes `signing.keyId`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
