### PR TITLE
fix: throws AlreadyConfiguredException when configured == true

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -37,7 +37,6 @@ import com.amplifyframework.util.Immutable;
 import com.amplifyframework.util.UserAgent;
 
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
@@ -192,11 +191,7 @@ public final class Amplify {
 
         synchronized (CONFIGURATION_LOCK) {
             if (CONFIGURATION_LOCK.get()) {
-                final String updateString = registryUpdateType.name().toLowerCase(Locale.US);
-                throw new AmplifyException(
-                    "The client tried to " + updateString + " a plugin after calling configure().",
-                        "Plugins may not be added or removed after configure(...) is called."
-                );
+                throw new AlreadyConfiguredException();
             }
 
             if (Empty.check(plugin.getPluginKey())) {

--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -136,7 +136,7 @@ public final class Amplify {
 
         synchronized (CONFIGURATION_LOCK) {
             if (CONFIGURATION_LOCK.get()) {
-                throw new AlreadyConfiguredException();
+                throw new AlreadyConfiguredException("Remove the duplicate call to `Amplify.configure()`.");
             }
 
             // Configure User-Agent utility
@@ -191,7 +191,7 @@ public final class Amplify {
 
         synchronized (CONFIGURATION_LOCK) {
             if (CONFIGURATION_LOCK.get()) {
-                throw new AlreadyConfiguredException();
+                throw new AlreadyConfiguredException("Do not add plugins after calling `Amplify.configure()`.");
             }
 
             if (Empty.check(plugin.getPluginKey())) {
@@ -241,8 +241,8 @@ public final class Amplify {
         /**
          * Constructs an AlreadyConfiguredException, indicating that Amplify has already been configured.
          */
-        private AlreadyConfiguredException() {
-            super("Amplify has already been configured.", "Remove the duplicate call to `Amplify.configure()`");
+        private AlreadyConfiguredException(@NonNull String recoverySuggestion) {
+            super("Amplify has already been configured.", recoverySuggestion);
         }
     }
 }

--- a/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
+++ b/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
@@ -102,14 +102,13 @@ public class AmplifyTest {
      *  NOTE: The name of this method must result in it running last, according to {@link FixMethodOrder}
      */
     @Test
-    public void secondaryAddPluginAfterConfigurationRaisesException() throws AmplifyException {
+    public void secondaryAddPluginAfterConfigurationRaisesException() throws Amplify.AlreadyConfiguredException {
         final SimpleLoggingPlugin loggingPlugin = SimpleLoggingPlugin.instance();
         Amplify.AlreadyConfiguredException actuallyThrown =
-                assertThrows(
-                        Amplify.AlreadyConfiguredException.class,
-                        () -> Amplify.addPlugin(loggingPlugin)
-
-                );
+            assertThrows(
+                Amplify.AlreadyConfiguredException.class,
+                () -> Amplify.addPlugin(loggingPlugin)
+            );
 
         assertEquals(
                 "Amplify has already been configured.",

--- a/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
+++ b/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.os.Build;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.core.plugin.Plugin;
 
 import org.json.JSONObject;
 import org.junit.FixMethodOrder;
@@ -92,6 +93,33 @@ public class AmplifyTest {
         assertEquals(
             "Remove the duplicate call to `Amplify.configure()`",
             actuallyThrown.getRecoverySuggestion()
+        );
+    }
+
+    /**
+     * It is an error to call {@link Amplify#addPlugin(Plugin)}} after configuration.
+     * @throws Amplify.AlreadyConfiguredException
+     *  NOTE: The name of this method must result in it running last, according to {@link FixMethodOrder}
+     *
+     */
+
+    @Test
+    public void secondaryAddPluginAfterConfigurationRaisesException() throws AmplifyException {
+        final SimpleLoggingPlugin loggingPlugin = SimpleLoggingPlugin.instance();
+        Amplify.AlreadyConfiguredException actuallyThrown =
+                assertThrows(
+                        Amplify.AlreadyConfiguredException.class,
+                        () -> Amplify.addPlugin(loggingPlugin)
+
+                );
+
+        assertEquals(
+                "Amplify has already been configured.",
+                actuallyThrown.getMessage()
+        );
+        assertEquals(
+                "Remove the duplicate call to `Amplify.configure()`",
+                actuallyThrown.getRecoverySuggestion()
         );
     }
 }

--- a/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
+++ b/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
@@ -91,7 +91,7 @@ public class AmplifyTest {
             actuallyThrown.getMessage()
         );
         assertEquals(
-            "Remove the duplicate call to `Amplify.configure()`",
+            "Remove the duplicate call to `Amplify.configure()`.",
             actuallyThrown.getRecoverySuggestion()
         );
     }
@@ -118,7 +118,7 @@ public class AmplifyTest {
                 actuallyThrown.getMessage()
         );
         assertEquals(
-                "Remove the duplicate call to `Amplify.configure()`",
+                "Do not add plugins after calling `Amplify.configure()`.",
                 actuallyThrown.getRecoverySuggestion()
         );
     }

--- a/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
+++ b/core/src/test/java/com/amplifyframework/core/AmplifyTest.java
@@ -100,9 +100,7 @@ public class AmplifyTest {
      * It is an error to call {@link Amplify#addPlugin(Plugin)}} after configuration.
      * @throws Amplify.AlreadyConfiguredException
      *  NOTE: The name of this method must result in it running last, according to {@link FixMethodOrder}
-     *
      */
-
     @Test
     public void secondaryAddPluginAfterConfigurationRaisesException() throws AmplifyException {
         final SimpleLoggingPlugin loggingPlugin = SimpleLoggingPlugin.instance();


### PR DESCRIPTION
*Description of changes:*
fix: throws AlreadyConfiguredException when addPlugin called after configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
