### PR TITLE
fix: Use ObjectsCompat since Objects is API 19+

### DIFF
--- a/rxbindings/build.gradle
+++ b/rxbindings/build.gradle
@@ -20,6 +20,7 @@ apply from: rootProject.file("configuration/publishing.gradle")
 dependencies {
     implementation project(path: ':core')
     implementation dependency.androidx.annotation
+    implementation dependency.androidx.appcompat
     implementation dependency.rxjava
 
     testImplementation project(path: ':testutils')

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
@@ -17,6 +17,7 @@ package com.amplifyframework.rx;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.core.Consumer;
@@ -144,8 +145,8 @@ public final class RxOperations {
                     return false;
                 } else {
                     ConnectionStateEvent privateNote = (ConnectionStateEvent) obj;
-                    return Objects.equals(getConnectionState(), privateNote.getConnectionState()) &&
-                        Objects.equals(getSubscriptionId(), privateNote.getSubscriptionId());
+                    return ObjectsCompat.equals(getConnectionState(), privateNote.getConnectionState()) &&
+                        ObjectsCompat.equals(getSubscriptionId(), privateNote.getSubscriptionId());
                 }
             }
 

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
@@ -24,8 +24,6 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.rx.RxAdapters.CancelableBehaviors.StreamEmitter;
 
-import java.util.Objects;
-
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.BehaviorSubject;
 

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxOperations.java
@@ -142,9 +142,9 @@ public final class RxOperations {
                 } else if (obj == null || getClass() != obj.getClass()) {
                     return false;
                 } else {
-                    ConnectionStateEvent privateNote = (ConnectionStateEvent) obj;
-                    return ObjectsCompat.equals(getConnectionState(), privateNote.getConnectionState()) &&
-                        ObjectsCompat.equals(getSubscriptionId(), privateNote.getSubscriptionId());
+                    ConnectionStateEvent event = (ConnectionStateEvent) obj;
+                    return ObjectsCompat.equals(getConnectionState(), event.getConnectionState()) &&
+                        ObjectsCompat.equals(getSubscriptionId(), event.getSubscriptionId());
                 }
             }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
