### PR TITLE
fix: adds ConfirmSignInOptions for confirmSignIn API method

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -33,6 +33,7 @@ import com.amplifyframework.auth.AuthSession;
 import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignOutOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignUpOptions;
@@ -40,6 +41,7 @@ import com.amplifyframework.auth.cognito.options.AWSCognitoAuthWebUISignInOption
 import com.amplifyframework.auth.cognito.util.AuthProviderConverter;
 import com.amplifyframework.auth.cognito.util.CognitoAuthExceptionConverter;
 import com.amplifyframework.auth.cognito.util.SignInStateConverter;
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -389,10 +391,16 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     @Override
     public void confirmSignIn(
             @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignInOptions options,
             @NonNull Consumer<AuthSignInResult> onSuccess,
             @NonNull Consumer<AuthException> onException
     ) {
-        awsMobileClient.confirmSignIn(confirmationCode, new Callback<SignInResult>() {
+        final Map<String, String> metadata = new HashMap<>();
+        if (options instanceof AWSCognitoAuthConfirmSignInOptions) {
+            metadata.putAll(((AWSCognitoAuthConfirmSignInOptions) options).getMetadata());
+        }
+
+        awsMobileClient.confirmSignIn(confirmationCode, metadata, new Callback<SignInResult>() {
             @Override
             public void onResult(SignInResult result) {
                 try {
@@ -411,6 +419,15 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                 );
             }
         });
+    }
+
+    @Override
+    public void confirmSignIn(
+            @NonNull String confirmationCode,
+            @NonNull Consumer<AuthSignInResult> onSuccess,
+            @NonNull Consumer<AuthException> onException
+    ) {
+        confirmSignIn(confirmationCode, AuthConfirmSignInOptions.defaults(), onSuccess, onException);
     }
 
     @Override

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.options;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
+import com.amplifyframework.util.Immutable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Cognito extension of confirm sign in options to add the platform specific fields.
+ */
+public final class AWSCognitoAuthConfirmSignInOptions extends AuthConfirmSignInOptions {
+    private final Map<String, String> metadata;
+
+    /**
+     * Advanced options for confirming sign in.
+     * @param metadata Additional custom attributes to be sent to the service such as information about the client
+     */
+    protected AWSCognitoAuthConfirmSignInOptions(
+            Map<String, String> metadata
+    ) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Get custom attributes to be sent to the service such as information about the client.
+     * @return custom attributes to be sent to the service such as information about the client
+     */
+    @NonNull
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Get a builder object.
+     * @return a builder object.
+     */
+    @NonNull
+    public static CognitoBuilder builder() {
+        return new CognitoBuilder();
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getMetadata()
+        );
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            AWSCognitoAuthConfirmSignInOptions authConfirmSignInOptions = (AWSCognitoAuthConfirmSignInOptions) obj;
+            return ObjectsCompat.equals(getMetadata(), authConfirmSignInOptions.getMetadata());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AWSCognitoAuthConfirmSignInOptions{" +
+                "metadata=" + metadata +
+                '}';
+    }
+
+    /**
+     * The builder for this class.
+     */
+    public static final class CognitoBuilder extends Builder<CognitoBuilder> {
+        private Map<String, String> metadata;
+
+        /**
+         * Constructor for the builder.
+         */
+        public CognitoBuilder() {
+            super();
+            this.metadata = new HashMap<>();
+        }
+
+        /**
+         * Returns the type of builder this is to support proper flow with it being an extended class.
+         * @return the type of builder this is to support proper flow with it being an extended class.
+         */
+        @Override
+        public CognitoBuilder getThis() {
+            return this;
+        }
+
+        /**
+         * Set the metadata field for the object being built.
+         * @param metadata Custom user metadata to be sent with the sign in request.
+         * @return The builder object to continue building.
+         */
+        @NonNull
+        public CognitoBuilder metadata(@NonNull Map<String, String> metadata) {
+            Objects.requireNonNull(metadata);
+            this.metadata.clear();
+            this.metadata.putAll(metadata);
+            return getThis();
+        }
+
+        /**
+         * Construct and return the object with the values set in the builder.
+         * @return a new instance of AWSCognitoAuthConfirmSignInOptions with the values specified in the builder.
+         */
+        @NonNull
+        public AWSCognitoAuthConfirmSignInOptions build() {
+            return new AWSCognitoAuthConfirmSignInOptions(
+                    Immutable.of(metadata));
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -336,7 +336,7 @@ public final class AuthComponentTest {
      */
     @Test
     @SuppressWarnings("unchecked") // Casts final parameter to Callback to differentiate methods
-    public void confirmSign() throws AuthException {
+    public void confirmSignIn() throws AuthException {
         SignInResult amcResult = new SignInResult(
                 SignInState.DONE,
                 new UserCodeDeliveryDetails(

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -382,8 +382,8 @@ public final class AuthComponentTest {
         );
 
         Tokens tokensResult = new Tokens(ACCESS_TOKEN, ID_TOKEN, REFRESH_TOKEN);
-        AWSCognitoAuthConfirmSignInOptions.CognitoBuilder options =  AWSCognitoAuthConfirmSignInOptions.builder();
-        Map <String, String> metadata = new HashMap<String, String>();
+        AWSCognitoAuthConfirmSignInOptions.CognitoBuilder options = AWSCognitoAuthConfirmSignInOptions.builder();
+        Map<String, String> metadata = new HashMap<String, String>();
         metadata.put("key", "value");
         options.metadata(metadata);
         AWSCognitoAuthConfirmSignInOptions builtOptions = options.build();

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -29,6 +29,7 @@ import com.amplifyframework.auth.AuthProvider;
 import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignOutOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignUpOptions;
@@ -335,7 +336,7 @@ public final class AuthComponentTest {
      */
     @Test
     @SuppressWarnings("unchecked") // Casts final parameter to Callback to differentiate methods
-    public void confirmSignIn() throws AuthException {
+    public void confirmSign() throws AuthException {
         SignInResult amcResult = new SignInResult(
                 SignInState.DONE,
                 new UserCodeDeliveryDetails(
@@ -353,14 +354,55 @@ public final class AuthComponentTest {
         }).when(mobileClient).getTokens(any());
 
         doAnswer(invocation -> {
-            Callback<SignInResult> callback = invocation.getArgument(1);
+            Callback<SignInResult> callback = invocation.getArgument(2);
             callback.onResult(amcResult);
             return null;
-        }).when(mobileClient).confirmSignIn(any(String.class), (Callback<SignInResult>) any());
+        }).when(mobileClient).confirmSignIn(any(String.class), any(), (Callback<SignInResult>) any());
 
         AuthSignInResult result = synchronousAuth.confirmSignIn(CONFIRMATION_CODE);
         validateSignInResult(result, true, AuthSignInStep.DONE);
-        verify(mobileClient).confirmSignIn(eq(CONFIRMATION_CODE), (Callback<SignInResult>) any());
+        verify(mobileClient).confirmSignIn(eq(CONFIRMATION_CODE), any(), (Callback<SignInResult>) any());
+    }
+
+    /**
+     * Tests that the confirmSignIn method of the Auth wrapper of AWSMobileClient (AMC) calls AMC.confirmSignIn with
+     * the confirmation code and options it received and the success callback receives a valid AuthSignInResult.
+     * @throws AuthException test fails if this gets thrown since method should succeed
+     */
+    @Test
+    @SuppressWarnings("unchecked") // Casts final parameter to Callback to differentiate methods
+    public void confirmSignInWithOptions() throws AuthException {
+        SignInResult amcResult = new SignInResult(
+                SignInState.DONE,
+                new UserCodeDeliveryDetails(
+                        DESTINATION,
+                        DELIVERY_MEDIUM,
+                        ATTRIBUTE_NAME
+                )
+        );
+
+        Tokens tokensResult = new Tokens(ACCESS_TOKEN, ID_TOKEN, REFRESH_TOKEN);
+        AWSCognitoAuthConfirmSignInOptions.CognitoBuilder options =  AWSCognitoAuthConfirmSignInOptions.builder();
+        Map <String, String> metadata = new HashMap<String, String>();
+        metadata.put("key", "value");
+        options.metadata(metadata);
+        AWSCognitoAuthConfirmSignInOptions builtOptions = options.build();
+
+        doAnswer(invocation -> {
+            Callback<Tokens> callback = invocation.getArgument(0);
+            callback.onResult(tokensResult);
+            return null;
+        }).when(mobileClient).getTokens(any());
+
+        doAnswer(invocation -> {
+            Callback<SignInResult> callback = invocation.getArgument(2);
+            callback.onResult(amcResult);
+            return null;
+        }).when(mobileClient).confirmSignIn(any(String.class), any(), (Callback<SignInResult>) any());
+
+        AuthSignInResult result = synchronousAuth.confirmSignIn(CONFIRMATION_CODE, builtOptions);
+        validateSignInResult(result, true, AuthSignInStep.DONE);
+        verify(mobileClient).confirmSignIn(eq(CONFIRMATION_CODE), eq(metadata), (Callback<SignInResult>) any());
     }
 
     /**

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -25,6 +25,7 @@ import com.amplifyframework.auth.AuthSession
 import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
@@ -108,10 +109,16 @@ interface Auth {
     /**
      * Submit the confirmation code received as part of multi-factor Authentication during sign in.
      * @param confirmationCode The code received as part of the multi-factor authentication process
+     * @param options Advanced options such as a map of auth information for custom auth,
+     *                If not provided, default options will be used
      * @return A sign-in result; check the nextStep field for cues on additional sign-in challenges
      */
     @Throws(AuthException::class)
-    suspend fun confirmSignIn(confirmationCode: String): AuthSignInResult
+    suspend fun confirmSignIn(
+        confirmationCode: String,
+        options: AuthConfirmSignInOptions = AuthConfirmSignInOptions.defaults()
+    ):
+        AuthSignInResult
 
     /**
      * Launch the specified auth provider's web UI sign in experience. You should also put the

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -25,6 +25,7 @@ import com.amplifyframework.auth.AuthSession
 import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
@@ -95,10 +96,14 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
         }
     }
 
-    override suspend fun confirmSignIn(confirmationCode: String): AuthSignInResult {
+    override suspend fun confirmSignIn(
+        confirmationCode: String,
+        options: AuthConfirmSignInOptions
+    ): AuthSignInResult {
         return suspendCoroutine { continuation ->
             delegate.confirmSignIn(
                 confirmationCode,
+                options,
                 { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
             )

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -208,9 +208,9 @@ class KotlinAuthFacadeTest {
         val code = "CoolCode511"
         val signInResult = mockk<AuthSignInResult>()
         every {
-            delegate.confirmSignIn(eq(code), any(), any())
+            delegate.confirmSignIn(eq(code), any(), any(), any())
         } answers {
-            val indexOfResultConsumer = 1
+            val indexOfResultConsumer = 2
             val onResult = it.invocation.args[indexOfResultConsumer] as Consumer<AuthSignInResult>
             onResult.accept(signInResult)
         }
@@ -226,9 +226,9 @@ class KotlinAuthFacadeTest {
         val code = "IncorrectCodePerhaps"
         val error = AuthException("uh", "oh")
         every {
-            delegate.confirmSignIn(eq(code), any(), any())
+            delegate.confirmSignIn(eq(code), any(), any(), any())
         } answers {
-            val indexOfErrorConsumer = 2
+            val indexOfErrorConsumer = 3
             val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
             onError.accept(error)
         }

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -98,6 +99,16 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
             @NonNull Consumer<AuthException> onError
     ) {
         getSelectedPlugin().signIn(username, password, onSuccess, onError);
+    }
+
+    @Override
+    public void confirmSignIn(
+            @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignInOptions options,
+            @NonNull Consumer<AuthSignInResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().confirmSignIn(confirmationCode, options, onSuccess, onError);
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -108,6 +109,19 @@ public interface AuthCategoryBehavior {
     void signIn(
             @Nullable String username,
             @Nullable String password,
+            @NonNull Consumer<AuthSignInResult> onSuccess,
+            @NonNull Consumer<AuthException> onError);
+
+    /**
+     * Submit the confirmation code received as part of multi-factor Authentication during sign in.
+     * @param confirmationCode The code received as part of the multi-factor authentication process
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void confirmSignIn(
+            @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignInOptions options,
             @NonNull Consumer<AuthSignInResult> onSuccess,
             @NonNull Consumer<AuthException> onError);
 

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthConfirmSignInOptions.java
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthConfirmSignInOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthConfirmSignInOptions.java
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthConfirmSignInOptions.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * The shared options among all Auth plugins.
+ * Note: This is currently empty but exists here to support common sign in options in the future.
+ */
+public abstract class AuthConfirmSignInOptions {
+    /**
+     * Use the default conirm sign-in options.
+     * @return Default confirm sign-in options.
+     */
+    public static DefaultAuthConfirmSignInOptions defaults() {
+        return new DefaultAuthConfirmSignInOptions();
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    public abstract static class Builder<T extends Builder<T>> {
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        public abstract T getThis();
+
+        /**
+         * Build an instance of AuthConfirmSignInOptions (or one of its subclasses).
+         * @return an instance of AuthConfirmSignInOptions (or one of its subclasses)
+         */
+        @NonNull
+        public abstract AuthConfirmSignInOptions build();
+    }
+
+    /**
+     * Default sign-in options. This works like a sentinel, to be used instead of "null".
+     * The only way to create this is by calling {@link AuthConfirmSignInOptions#defaults()}.
+     */
+    public static final class DefaultAuthConfirmSignInOptions extends AuthConfirmSignInOptions {
+        private DefaultAuthConfirmSignInOptions() {}
+
+        @Override
+        public int hashCode() {
+            return DefaultAuthConfirmSignInOptions.class.hashCode();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof DefaultAuthConfirmSignInOptions;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return DefaultAuthConfirmSignInOptions.class.getSimpleName();
+        }
+    }
+}

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -30,6 +30,7 @@ import com.amplifyframework.auth.AuthSession;
 import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -88,6 +89,13 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
     @Override
     public Single<AuthSignInResult> signIn(@Nullable String username, @Nullable String password) {
         return toSingle((onResult, onError) -> delegate.signIn(username, password, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> confirmSignIn(
+            @Nullable String confirmationCode, @NonNull AuthConfirmSignInOptions options) {
+        return toSingle((onResult, onError) ->
+                delegate.confirmSignIn(confirmationCode, options, onResult, onError));
     }
 
     @Override

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -29,6 +29,7 @@ import com.amplifyframework.auth.AuthSession;
 import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -107,6 +108,18 @@ public interface RxAuthCategoryBehavior {
      *         {@link AuthException} on failure
      */
     Single<AuthSignInResult> signIn(@Nullable String username, @Nullable String password);
+
+    /**
+     * Submit the confirmation code received as part of multi-factor Authentication during sign in.
+     * @param confirmationCode The code received as part of the multi-factor authentication process
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> confirmSignIn(
+            @Nullable String confirmationCode,
+            @NonNull AuthConfirmSignInOptions options
+    );
 
     /**
      * Submit the confirmation code received as part of multi-factor Authentication during sign in.

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -27,6 +27,7 @@ import com.amplifyframework.auth.AuthProvider;
 import com.amplifyframework.auth.AuthSession;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
+import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -165,6 +166,23 @@ public final class SynchronousAuth {
     ) throws AuthException {
         return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
                 asyncDelegate.signIn(username, password, onResult, onError)
+        );
+    }
+
+    /**
+     * Confirm sign in synchronously.
+     * @param confirmationCode The code received as part of the multi-factor authentication process
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return result object
+     * @throws AuthException exception
+     */
+    @NonNull
+    public AuthSignInResult confirmSignIn(
+            @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignInOptions options
+    ) throws AuthException {
+        return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+                asyncDelegate.confirmSignIn(confirmationCode, options, onResult, onError)
         );
     }
 


### PR DESCRIPTION
*Description of changes:*
Adds ConfirmSignInOptions for Auth.confirmSignIn API. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
