### PR TITLE
fix: signed in hub event is now fired after currentUser is set, instead of before

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -198,14 +198,15 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                                 }
                                 break;
                             case SIGNED_IN:
-                                fetchAndSetUserId(() -> { /* No response needed */ });
-                                if (lastEvent != AuthChannelEventName.SIGNED_IN) {
-                                    lastEvent = AuthChannelEventName.SIGNED_IN;
-                                    Amplify.Hub.publish(
-                                            HubChannel.AUTH,
-                                            HubEvent.create(AuthChannelEventName.SIGNED_IN)
-                                    );
-                                }
+                                fetchAndSetUserId(() -> {
+                                    if (lastEvent != AuthChannelEventName.SIGNED_IN) {
+                                        lastEvent = AuthChannelEventName.SIGNED_IN;
+                                        Amplify.Hub.publish(
+                                                HubChannel.AUTH,
+                                                HubEvent.create(AuthChannelEventName.SIGNED_IN)
+                                        );
+                                    }
+                                });
                                 break;
                             case SIGNED_OUT_FEDERATED_TOKENS_INVALID:
                             case SIGNED_OUT_USER_POOLS_TOKENS_INVALID:


### PR DESCRIPTION
If you call `Amplify.Auth.getCurrentUser()` immediately after receiving the `AuthChannelEventName.SIGNED_IN` event from `HubChannel.AUTH`, it will return null.  This is because the hub event is getting fired before the sign in is fully completed. 

This PR updates logic so that the Hub event doesn't fire until after the current user is set. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
