### PR TITLE
fix(core): add auth provider to AuthRule

### DIFF
--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.core.model;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.util.Empty;
@@ -40,6 +41,7 @@ public final class AuthRule {
     private static final String DEFAULT_GROUP_CLAIM = "cognito:groups";
 
     private final AuthStrategy authStrategy;
+    private final String authProvider;
     private final String ownerField;
     private final String identityClaim;
     private final String groupsField;
@@ -54,6 +56,7 @@ public final class AuthRule {
      */
     public AuthRule(com.amplifyframework.core.model.annotations.AuthRule authRule) {
         this.authStrategy = authRule.allow();
+        this.authProvider = authRule.provider();
         this.ownerField = authRule.ownerField();
         this.identityClaim = authRule.identityClaim();
         this.groupClaim = authRule.groupClaim();
@@ -68,6 +71,7 @@ public final class AuthRule {
      */
     private AuthRule(@NonNull AuthRule.Builder builder) {
         this.authStrategy = builder.authStrategy;
+        this.authProvider = builder.authProvider;
         this.ownerField = builder.ownerField;
         this.identityClaim = builder.identityClaim;
         this.groupClaim = builder.groupClaim;
@@ -92,6 +96,14 @@ public final class AuthRule {
     @NonNull
     public AuthStrategy getAuthStrategy() {
         return authStrategy;
+    }
+
+    /**
+     * Returns the auth provider for this {@link AuthRule}.
+     * @return the auth provider for this {@link AuthRule}
+     */
+    public String getAuthProvider() {
+        return authProvider == null || "".equals(authProvider) ? authStrategy.getDefaultAuthProvider() : authProvider;
     }
 
     /**
@@ -228,6 +240,7 @@ public final class AuthRule {
      */
     public static final class Builder {
         private AuthStrategy authStrategy;
+        private String authProvider;
         private String ownerField;
         private String identityClaim;
         private String groupClaim;
@@ -238,7 +251,7 @@ public final class AuthRule {
         /**
          * Sets the auth strategy of this rule.
          * @param authStrategy AuthStrategy is the type of auth strategy to use.
-         * @return the association model with given name
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder authStrategy(@NonNull AuthStrategy authStrategy) {
@@ -247,9 +260,20 @@ public final class AuthRule {
         }
 
         /**
+         * Sets the auth provider of this rule.
+         * @param authProvider The name of the auth provider.
+         * @return Current builder instance.
+         */
+        @NonNull
+        public AuthRule.Builder authProvider(@Nullable String authProvider) {
+            this.authProvider = authProvider;
+            return this;
+        }
+
+        /**
          * Sets the owner field of this rule.
          * @param ownerField OwnerField is the owner authorization.
-         * @return the association model with give target name
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder ownerField(@NonNull String ownerField) {
@@ -260,7 +284,7 @@ public final class AuthRule {
         /**
          * Sets the identity claim of this rule.
          * @param identityClaim IdentityClaim specifies a custom claim.
-         * @return the association model with given associated name
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder identityClaim(@NonNull String identityClaim) {
@@ -271,7 +295,7 @@ public final class AuthRule {
         /**
          * Sets the group claim of this rule.
          * @param groupClaim GroupClaim specified a custom claim.
-         * @return the association model with given associated type
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder groupClaim(@NonNull String groupClaim) {
@@ -282,7 +306,7 @@ public final class AuthRule {
         /**
          * Sets the groups this rule applies to.
          * @param groups Groups is static group authorization.
-         * @return the association model with given associated type
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder groups(@NonNull List<String> groups) {
@@ -293,7 +317,7 @@ public final class AuthRule {
         /**
          * Sets the groupsField of this rule.
          * @param groupsField GroupsField is for dynamic group authorization.
-         * @return the association model with given associated type
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder groupsField(@NonNull String groupsField) {
@@ -304,7 +328,7 @@ public final class AuthRule {
         /**
          * Sets the operations allowed for this rule.
          * @param operations Operations specifies which {@link ModelOperation}s are protected by this {@link AuthRule}.
-         * @return the association model with given associated type
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder operations(@NonNull List<ModelOperation> operations) {

--- a/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
@@ -25,23 +25,33 @@ public enum AuthStrategy {
      * Owner authorization specifies whether a user can access or operate against an object.  To use OWNER, the API
      * must have Cognito User Pool configured.
      */
-    OWNER,
+    OWNER("userPools"),
 
     /**
      * Group authorization specifies whether a group can access or operate against an object.  To use GROUPS, the API
      * must have Cognito User Pool configured.
      */
-    GROUPS,
+    GROUPS("userPools"),
 
     /**
      * The private authorization specifies that everyone will be allowed to access the API with a valid JWT token from
      * the configured Cognito User Pool. To use PRIVATE, the API must have Cognito User Pool configured.
      */
-    PRIVATE,
+    PRIVATE("userPools"),
 
     /**
      * The public authorization specifies that everyone will be allowed to access the API, behind the scenes the API
      * will be protected with an API Key. To use PUBLIC, the API must have API Key configured.
      */
-    PUBLIC,
+    PUBLIC("apiKey");
+
+    private final String defaultAuthProvider;
+
+    AuthStrategy(String defaultAuthProvider) {
+        this.defaultAuthProvider = defaultAuthProvider;
+    }
+
+    String getDefaultAuthProvider() {
+        return defaultAuthProvider;
+    }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -161,6 +161,21 @@ public final class ModelSchema {
         }
     }
 
+    /**
+     * Returns the applicable auth rules for a given operation.
+     * @param operationType The desired operation type (read, create, update, delete).
+     * @return A list of {@link AuthRule}s for the given operation.
+     */
+    public List<AuthRule> getApplicableRules(ModelOperation operationType) {
+        List<AuthRule> result = new ArrayList<>();
+        for (AuthRule rule : authRules) {
+            if (rule.getOperationsOrDefault().contains(operationType)) {
+                result.add(rule);
+            }
+        }
+        return result;
+    }
+
     // Utility method to extract field metadata
     private static ModelField createModelField(Field field) {
         com.amplifyframework.core.model.annotations.ModelField annotation =

--- a/core/src/main/java/com/amplifyframework/core/model/annotations/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/annotations/AuthRule.java
@@ -46,6 +46,14 @@ public @interface AuthRule {
      */
     AuthStrategy allow();
 
+
+    /**
+     * Determines which auth provider will be used for a given rule. If blank, the default provider
+     * for the given AuthStrategy should be used.
+     * @return The name of the auth provider.
+     */
+    String provider() default "";
+
     /**
      * Used for owner authorization.  Defaults to "owner" when using AuthStrategy.OWNER.
      *

--- a/core/src/test/java/com/amplifyframework/core/model/ModelSchemaAuthRulesTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/ModelSchemaAuthRulesTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.datastore.appsync.SerializedModel;
+import com.amplifyframework.testmodels.ownerauth.OwnerAuth;
+import com.amplifyframework.testmodels.ownerauth.OwnerAuthNonDefaultProvider;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests auth rule functionality from {@link ModelSchema}.
+ */
+public final class ModelSchemaAuthRulesTest {
+
+    /**
+     * Given a model that has an auth rule with a non-default provider specified, that value specified
+     * in the authProvider field should be returned.
+     * @throws AmplifyException from model schema parsing.
+     */
+    @Test
+    public void modelWithDefaultAuthProviderTest() throws AmplifyException {
+        ModelSchema modelSchema = ModelSchema.fromModelClass(OwnerAuth.class);
+        assertEquals(1, modelSchema.getAuthRules().size());
+        AuthRule authRule = modelSchema.getAuthRules().get(0);
+        assertEquals("userPools", authRule.getAuthProvider());
+    }
+
+    /**
+     * Given a model that has an auth rule with a non-default provider specified, that value specified
+     * in the authProvider field should be returned.
+     * @throws AmplifyException from model schema parsing.
+     */
+    @Test
+    public void modelWithNonDefaultAuthProviderTest() throws AmplifyException {
+        ModelSchema modelSchema = ModelSchema.fromModelClass(OwnerAuthNonDefaultProvider.class);
+        assertEquals(1, modelSchema.getAuthRules().size());
+        AuthRule authRule = modelSchema.getAuthRules().get(0);
+        assertEquals("oidc", authRule.getAuthProvider());
+    }
+
+    /**
+     * Verify construction of {@link AuthRule}s created via the builder.
+     */
+    @Test
+    public void modelWithDefaultAuthProviderUsingBuilderTest() {
+        ModelSchema schema = fromBuilder(null);
+        assertEquals(1, schema.getAuthRules().size());
+        AuthRule authRule = schema.getAuthRules().get(0);
+        assertEquals("userPools", authRule.getAuthProvider());
+    }
+
+    /**
+     * Verify construction of {@link AuthRule}s created via the builder.
+     */
+    @Test
+    public void modelWithNonDefaultAuthProviderUsingBuilderTest() {
+        ModelSchema schema = fromBuilder("oidc");
+        assertEquals(1, schema.getAuthRules().size());
+        AuthRule authRule = schema.getAuthRules().get(0);
+        assertEquals("oidc", authRule.getAuthProvider());
+    }
+
+    /**
+     * Test the getApplicableRules method which filters auth rules based on a given {@link ModelOperation}.
+     */
+    @Test
+    public void getApplicableRulesTest() {
+        ModelSchema schema = fromBuilder(null);
+        List<AuthRule> rulesForCreateOperation = schema.getApplicableRules(ModelOperation.CREATE);
+        List<AuthRule> rulesForDeleteOperation = schema.getApplicableRules(ModelOperation.DELETE);
+        List<AuthRule> rulesForUpdateOperation = schema.getApplicableRules(ModelOperation.UPDATE);
+        List<AuthRule> rulesForReadOperation = schema.getApplicableRules(ModelOperation.READ);
+
+        assertEquals(1, rulesForCreateOperation.size());
+        assertEquals(0, rulesForDeleteOperation.size());
+        assertEquals(0, rulesForUpdateOperation.size());
+        assertEquals(0, rulesForReadOperation.size());
+    }
+
+    private ModelSchema fromBuilder(String authProvider) {
+        ModelField modelId = ModelField.builder()
+                                       .isRequired(true)
+                                       .targetType("ID")
+                                       .javaClassForValue(String.class)
+                                       .build();
+        ModelField title = ModelField.builder()
+                                     .isRequired(true)
+                                     .targetType("String")
+                                     .javaClassForValue(String.class)
+                                     .build();
+        Map<String, ModelField> fields = new HashMap<>();
+        fields.put("id", modelId);
+        fields.put("title", title);
+
+        return ModelSchema.builder()
+                          .name("AuthTest")
+                          .modelClass(SerializedModel.class)
+                          .fields(fields)
+                          .authRules(Collections.singletonList(AuthRule.builder()
+                                                                       .authStrategy(AuthStrategy.OWNER)
+                                                                       .authProvider(authProvider)
+                                                                       .ownerField("owner")
+                                                                       .operations(Arrays.asList(ModelOperation.CREATE))
+                                                                       .build()
+                          ))
+                          .build();
+    }
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/ownerauth/OwnerAuthNonDefaultProvider.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/ownerauth/OwnerAuthNonDefaultProvider.java
@@ -1,0 +1,177 @@
+package com.amplifyframework.testmodels.ownerauth;
+
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the OwnerAuth type in your schema. */
+@SuppressWarnings("all")
+@ModelConfig(pluralName = "OwnerAuths", authRules = {
+        @AuthRule(
+            allow = AuthStrategy.OWNER,
+            provider = "oidc",
+            ownerField = "owner",
+            identityClaim = "cognito:username",
+            operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }
+        )
+})
+public final class OwnerAuthNonDefaultProvider implements Model {
+    public static final QueryField ID = field("id");
+    public static final QueryField TITLE = field("title");
+    private final @ModelField(targetType="ID", isRequired = true) String id;
+    private final @ModelField(targetType="String", isRequired = true) String title;
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    private OwnerAuthNonDefaultProvider(String id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if(obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            OwnerAuthNonDefaultProvider ownerAuth = (OwnerAuthNonDefaultProvider) obj;
+            return ObjectsCompat.equals(getId(), ownerAuth.getId()) &&
+                    ObjectsCompat.equals(getTitle(), ownerAuth.getTitle());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return new StringBuilder()
+                .append(getId())
+                .append(getTitle())
+                .toString()
+                .hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("OwnerAuth {")
+                .append("id=" + String.valueOf(getId()) + ", ")
+                .append("title=" + String.valueOf(getTitle()))
+                .append("}")
+                .toString();
+    }
+
+    public static TitleStep builder() {
+        return new Builder();
+    }
+
+    /**
+     * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+     * This is a convenience method to return an instance of the object with only its ID populated
+     * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+     * in a relationship.
+     * @param id the id of the existing item this instance will represent
+     * @return an instance of this model with only ID populated
+     * @throws IllegalArgumentException Checks that ID is in the proper format
+     */
+    public static OwnerAuthNonDefaultProvider justId(String id) {
+        try {
+            UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+        } catch (Exception exception) {
+            throw new IllegalArgumentException(
+                    "Model IDs must be unique in the format of UUID. This method is for creating instances " +
+                            "of an existing object with only its ID field for sending as a mutation parameter. When " +
+                            "creating a new object, use the standard builder method and leave the ID field blank."
+            );
+        }
+        return new OwnerAuthNonDefaultProvider(
+                id,
+                null
+        );
+    }
+
+    public CopyOfBuilder copyOfBuilder() {
+        return new CopyOfBuilder(id,
+                title);
+    }
+    public interface TitleStep {
+        BuildStep title(String title);
+    }
+
+
+    public interface BuildStep {
+        OwnerAuthNonDefaultProvider build();
+        BuildStep id(String id) throws IllegalArgumentException;
+    }
+
+
+    public static class Builder implements TitleStep, BuildStep {
+        private String id;
+        private String title;
+        @Override
+        public OwnerAuthNonDefaultProvider build() {
+            String id = this.id != null ? this.id : UUID.randomUUID().toString();
+
+            return new OwnerAuthNonDefaultProvider(
+                    id,
+                    title);
+        }
+
+        @Override
+        public BuildStep title(String title) {
+            Objects.requireNonNull(title);
+            this.title = title;
+            return this;
+        }
+
+        /**
+         * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
+         * This should only be set when referring to an already existing object.
+         * @param id id
+         * @return Current Builder instance, for fluent method chaining
+         * @throws IllegalArgumentException Checks that ID is in the proper format
+         */
+        public BuildStep id(String id) throws IllegalArgumentException {
+            this.id = id;
+
+            try {
+                UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+            } catch (Exception exception) {
+                throw new IllegalArgumentException("Model IDs must be unique in the format of UUID.",
+                        exception);
+            }
+
+            return this;
+        }
+    }
+
+
+    public final class CopyOfBuilder extends Builder {
+        private CopyOfBuilder(String id, String title) {
+            super.id(id);
+            super.title(title);
+        }
+
+        @Override
+        public CopyOfBuilder title(String title) {
+            return (CopyOfBuilder) super.title(title);
+        }
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a field to represent the auth provider for an `AuthRule`. 

Currently, the Android generated model does not have this information, which will be needed for multi-auth support. This is intended to be a non-breaking change. Since the CLI does not generate this field yet, the default behavior is to use the default provider for the given auth strategy. 

I considered creating an enum to represent this, but decided against it for several reasons. The enum we currently use to represent an auth provider is actually called `AuthorizationType` and it lives in the `aws-api-appsync` module. Moving that to core doesn't make much sense because it's specific to AppSync. Creating a new enum would probably cause more confusion than what it's worth. We already have an enum called `AuthProvider` that is used to represent social sign-in providers.

Given the fact that the values that will be used to set this field are derived from the `@auth` directive (which already validates for valid entries), creating an enum just didn't seem worth it at this point.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
