### PR TITLE
chore: add builders for DS and SubscriptionOperation

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionOperation.java
@@ -45,28 +45,19 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
     private String subscriptionId;
     private Future<?> subscriptionFuture;
 
-    @SuppressWarnings("ParameterNumber")
-    private SubscriptionOperation(
-            GraphQLRequest<T> graphQlRequest,
-            GraphQLResponse.Factory responseFactory,
-            SubscriptionEndpoint subscriptionEndpoint,
-            Consumer<String> onSubscriptionStart,
-            Consumer<GraphQLResponse<T>> onNextItem,
-            Consumer<ApiException> onSubscriptionError,
-            Action onSubscriptionComplete,
-            ExecutorService executorService) {
-        super(graphQlRequest, responseFactory);
-        this.subscriptionEndpoint = subscriptionEndpoint;
-        this.onSubscriptionStart = onSubscriptionStart;
-        this.onNextItem = onNextItem;
-        this.onSubscriptionError = onSubscriptionError;
-        this.onSubscriptionComplete = onSubscriptionComplete;
-        this.executorService = executorService;
+    private SubscriptionOperation(Builder<T> builder) {
+        super(builder.graphQlRequest, builder.responseFactory);
+        this.subscriptionEndpoint = builder.subscriptionEndpoint;
+        this.onSubscriptionStart = builder.onSubscriptionStart;
+        this.onNextItem = builder.onNextItem;
+        this.onSubscriptionError = builder.onSubscriptionError;
+        this.onSubscriptionComplete = builder.onSubscriptionComplete;
+        this.executorService = builder.executorService;
         this.canceled = new AtomicBoolean(false);
     }
 
     @NonNull
-    static <T> SubscriptionManagerStep<T> builder() {
+    static <T> Builder<T> builder() {
         return new Builder<>();
     }
 
@@ -113,16 +104,7 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
         }
     }
 
-    static final class Builder<T> implements
-            SubscriptionManagerStep<T>,
-            GraphQlRequestStep<T>,
-            ResponseFactoryStep<T>,
-            ExecutorServiceStep<T>,
-            OnSubscriptionStartStep<T>,
-            OnNextItemStep<T>,
-            OnSubscriptionErrorStep<T>,
-            OnSubscriptionCompleteStep<T>,
-            BuilderStep<T> {
+    static final class Builder<T> {
         private SubscriptionEndpoint subscriptionEndpoint;
         private GraphQLRequest<T> graphQlRequest;
         private GraphQLResponse.Factory responseFactory;
@@ -133,119 +115,56 @@ final class SubscriptionOperation<T> extends GraphQLOperation<T> {
         private Action onSubscriptionComplete;
 
         @NonNull
-        @Override
-        public GraphQlRequestStep<T> subscriptionEndpoint(@NonNull SubscriptionEndpoint subscriptionEndpoint) {
+        public Builder<T> subscriptionEndpoint(@NonNull SubscriptionEndpoint subscriptionEndpoint) {
             this.subscriptionEndpoint = Objects.requireNonNull(subscriptionEndpoint);
             return this;
         }
 
         @NonNull
-        @Override
-        public ResponseFactoryStep<T> graphQlRequest(@NonNull GraphQLRequest<T> graphQlRequest) {
+        public Builder<T> graphQlRequest(@NonNull GraphQLRequest<T> graphQlRequest) {
             this.graphQlRequest = Objects.requireNonNull(graphQlRequest);
             return this;
         }
 
         @NonNull
-        @Override
-        public ExecutorServiceStep<T> responseFactory(@NonNull GraphQLResponse.Factory responseFactory) {
+        public Builder<T> responseFactory(@NonNull GraphQLResponse.Factory responseFactory) {
             this.responseFactory = Objects.requireNonNull(responseFactory);
             return this;
         }
 
         @NonNull
-        @Override
-        public OnSubscriptionStartStep<T> executorService(@NonNull ExecutorService executorService) {
+        public Builder<T> executorService(@NonNull ExecutorService executorService) {
             this.executorService = Objects.requireNonNull(executorService);
             return this;
         }
 
         @NonNull
-        @Override
-        public OnNextItemStep<T> onSubscriptionStart(@NonNull Consumer<String> onSubscriptionStart) {
+        public Builder<T> onSubscriptionStart(@NonNull Consumer<String> onSubscriptionStart) {
             this.onSubscriptionStart = Objects.requireNonNull(onSubscriptionStart);
             return this;
         }
 
         @NonNull
-        @Override
-        public OnSubscriptionErrorStep<T> onNextItem(@NonNull Consumer<GraphQLResponse<T>> onNextItem) {
+        public Builder<T> onNextItem(@NonNull Consumer<GraphQLResponse<T>> onNextItem) {
             this.onNextItem = Objects.requireNonNull(onNextItem);
             return this;
         }
 
         @NonNull
-        @Override
-        public OnSubscriptionCompleteStep<T> onSubscriptionError(@NonNull Consumer<ApiException> onSubscriptionError) {
+        public Builder<T> onSubscriptionError(@NonNull Consumer<ApiException> onSubscriptionError) {
             this.onSubscriptionError = Objects.requireNonNull(onSubscriptionError);
             return this;
         }
 
         @NonNull
-        @Override
-        public BuilderStep<T> onSubscriptionComplete(@NonNull Action onSubscriptionComplete) {
+        public Builder<T> onSubscriptionComplete(@NonNull Action onSubscriptionComplete) {
             this.onSubscriptionComplete = Objects.requireNonNull(onSubscriptionComplete);
             return this;
         }
 
         @NonNull
-        @Override
         public SubscriptionOperation<T> build() {
-            return new SubscriptionOperation<>(
-                Objects.requireNonNull(Builder.this.graphQlRequest),
-                Objects.requireNonNull(Builder.this.responseFactory),
-                Objects.requireNonNull(Builder.this.subscriptionEndpoint),
-                Objects.requireNonNull(Builder.this.onSubscriptionStart),
-                Objects.requireNonNull(Builder.this.onNextItem),
-                Objects.requireNonNull(Builder.this.onSubscriptionError),
-                Objects.requireNonNull(Builder.this.onSubscriptionComplete),
-                Objects.requireNonNull(Builder.this.executorService)
-            );
+            return new SubscriptionOperation<>(this);
         }
-    }
-
-    interface SubscriptionManagerStep<T> {
-        @NonNull
-        GraphQlRequestStep<T> subscriptionEndpoint(@NonNull SubscriptionEndpoint subscriptionEndpoint);
-    }
-
-    interface GraphQlRequestStep<T> {
-        @NonNull
-        ResponseFactoryStep<T> graphQlRequest(@NonNull GraphQLRequest<T> graphQlRequest);
-    }
-
-    interface ResponseFactoryStep<T> {
-        @NonNull
-        ExecutorServiceStep<T> responseFactory(@NonNull GraphQLResponse.Factory responseFactory);
-    }
-
-    interface ExecutorServiceStep<T> {
-        @NonNull
-        OnSubscriptionStartStep<T> executorService(@NonNull ExecutorService executorService);
-    }
-
-    interface OnSubscriptionStartStep<T> {
-        @NonNull
-        OnNextItemStep<T> onSubscriptionStart(@NonNull Consumer<String> onSubscriptionStart);
-    }
-
-    interface OnNextItemStep<T> {
-        @NonNull
-        OnSubscriptionErrorStep<T> onNextItem(@NonNull Consumer<GraphQLResponse<T>> onNextItem);
-    }
-
-    interface OnSubscriptionErrorStep<T> {
-        @NonNull
-        OnSubscriptionCompleteStep<T> onSubscriptionError(@NonNull Consumer<ApiException> onSubscriptionError);
-    }
-
-    interface OnSubscriptionCompleteStep<T> {
-        @NonNull
-        BuilderStep<T> onSubscriptionComplete(@NonNull Action onSubscriptionComplete);
-    }
-
-    interface BuilderStep<T> {
-        @NonNull
-        SubscriptionOperation<T> build();
     }
 }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/DataStoreCategoryConfigurator.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/DataStoreCategoryConfigurator.java
@@ -114,7 +114,10 @@ final class DataStoreCategoryConfigurator {
             AmplifyConfiguration.fromConfigFile(context, resourceId)
                 .forCategoryType(CategoryType.DATASTORE);
 
-        AWSDataStorePlugin awsDataStorePlugin = new AWSDataStorePlugin(modelProvider, api);
+        AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
+                                                                  .modelProvider(modelProvider)
+                                                                  .apiCategory(api)
+                                                                  .build();
         DataStoreCategory dataStoreCategory = new DataStoreCategory();
         dataStoreCategory.addPlugin(awsDataStorePlugin);
         dataStoreCategory.configure(dataStoreConfiguration, context);

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/HybridOfflineInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/HybridOfflineInstrumentationTest.java
@@ -73,7 +73,7 @@ public final class HybridOfflineInstrumentationTest {
         HubAccumulator initializationObserver =
             HubAccumulator.create(HubChannel.DATASTORE, InitializationStatus.SUCCEEDED, 1)
                 .start();
-        AWSDataStorePlugin plugin = new AWSDataStorePlugin(schemaProvider);
+        AWSDataStorePlugin plugin = AWSDataStorePlugin.builder().modelProvider(schemaProvider).build();
         DataStoreCategory dataStoreCategory = new DataStoreCategory();
         dataStoreCategory.addPlugin(plugin);
         dataStoreCategory.configure(new DataStoreCategoryConfiguration(), getApplicationContext());

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -101,6 +101,30 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         this.userProvidedConfiguration = userProvidedConfiguration;
     }
 
+    private AWSDataStorePlugin(@NonNull Builder builder) throws DataStoreException {
+        ModelSchemaRegistry modelSchemaRegistry = builder.modelSchemaRegistry == null ?
+            ModelSchemaRegistry.instance() :
+            builder.modelSchemaRegistry;
+        ModelProvider modelProvider = builder.modelProvider == null ?
+            ModelProviderLocator.locate() :
+            builder.modelProvider;
+
+        ApiCategory api = builder.apiCategory == null ? Amplify.API : builder.apiCategory;
+        this.userProvidedConfiguration = builder.dataStoreConfiguration;
+        this.sqliteStorageAdapter = SQLiteStorageAdapter.forModels(modelSchemaRegistry, modelProvider);
+        this.categoryInitializationsPending = new CountDownLatch(1);
+
+        // Used to interrogate plugins, to understand if sync should be automatically turned on
+        this.orchestrator = new Orchestrator(
+            modelProvider,
+            modelSchemaRegistry,
+            sqliteStorageAdapter,
+            AppSyncClient.via(api),
+            () -> pluginConfiguration,
+            () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API
+        );
+    }
+
     /**
      * Constructs an {@link AWSDataStorePlugin} which can warehouse the model types provided by
      * your application's code-generated model provider. This model provider is expected to have the
@@ -115,7 +139,9 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
      * If remote synchronization is enabled, it will be performed via {@link Amplify#API}.
      *
      * @throws DataStoreException If it is not possible to access the code-generated model provider
+     * @deprecated Use {@link Builder} instead.
      */
+    @Deprecated
     public AWSDataStorePlugin() throws DataStoreException {
         this(ModelProviderLocator.locate(), Amplify.API);
     }
@@ -132,7 +158,9 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
      * @throws DataStoreException
      *         If not possible to locate the code-generated model provider,
      *         com.amplifyframework.datastore.generated.model.AmplifyModelProvider.
+     * @deprecated Use {@link Builder} instead.
      */
+    @Deprecated
     public AWSDataStorePlugin(@NonNull DataStoreConfiguration userProvidedConfiguration) throws DataStoreException {
         this(
             ModelProviderLocator.locate(),
@@ -147,7 +175,9 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
      * the supplied {@link ModelProvider}. If the API plugin is present and configured,
      * then remote synchronization will be performed through {@link Amplify#API}.
      * @param modelProvider Provider of models to be usable by plugin
+     * @deprecated Use {@link Builder} instead.
      */
+    @Deprecated
     public AWSDataStorePlugin(@NonNull ModelProvider modelProvider) {
         this(Objects.requireNonNull(modelProvider), Amplify.API);
     }
@@ -158,7 +188,9 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
      * through the provided {@link GraphQLBehavior}.
      * @param modelProvider Provides the set of models to be warehouse-able by this system
      * @param api Interface to a remote system where models will be synchronized
+     * @deprecated Use {@link Builder} instead.
      */
+    @Deprecated
     @VisibleForTesting
     AWSDataStorePlugin(@NonNull ModelProvider modelProvider, @NonNull ApiCategory api) {
         this(
@@ -550,5 +582,72 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull Consumer<DataStoreException> onObservationFailure,
             @NonNull Action onObservationCompleted) {
         onObservationFailure.accept(new DataStoreException("Not implemented yet, buster!", "Check back later!"));
+    }
+
+    /**
+     * Creates a builder that provides available options to be set when creating
+     * a DataStore plugin.
+     * @return A new instance of the DataStore plugin builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder object for the DataStore plugin.
+     */
+    public static final class Builder {
+        private DataStoreConfiguration dataStoreConfiguration;
+        private ModelProvider modelProvider;
+        private ModelSchemaRegistry modelSchemaRegistry;
+        private ApiCategory apiCategory;
+
+        private Builder() {}
+
+        /**
+         * Sets the user-provided configuration options.
+         * @param dataStoreConfiguration An instance of {@link DataStoreConfiguration} with the
+         *                               desired options set.
+         * @return Current builder instance, for fluent construction of plugin.
+         */
+        public Builder dataStoreConfiguration(DataStoreConfiguration dataStoreConfiguration) {
+            this.dataStoreConfiguration = dataStoreConfiguration;
+            return this;
+        }
+
+        /**
+         * Sets the model provider field of the builder.
+         * @param modelProvider An implementation of the {@link ModelProvider} interface.
+         * @return Current builder instance, for fluent construction of plugin.
+         */
+        public Builder modelProvider(ModelProvider modelProvider) {
+            this.modelProvider = modelProvider;
+            return this;
+        }
+
+        /**
+         * Sets the model schema registry of the builder.
+         * @param modelSchemaRegistry An instance of {@link ModelSchemaRegistry}.
+         * @return An implementation of the {@link ModelProvider} interface.
+         */
+        public Builder modelSchemaRegistry(ModelSchemaRegistry modelSchemaRegistry) {
+            this.modelSchemaRegistry = modelSchemaRegistry;
+            return this;
+        }
+
+        @VisibleForTesting
+        Builder apiCategory(ApiCategory apiCategory) {
+            this.apiCategory = apiCategory;
+            return this;
+        }
+
+        /**
+         * Builds the DataStore plugin.
+         * @return An instance of the DataStore plugin ready for use.
+         * @throws DataStoreException If unable to locate a model provider.
+         */
+        public AWSDataStorePlugin build() throws DataStoreException {
+            return new AWSDataStorePlugin(Builder.this);
+        }
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -139,11 +139,9 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
      * If remote synchronization is enabled, it will be performed via {@link Amplify#API}.
      *
      * @throws DataStoreException If it is not possible to access the code-generated model provider
-     * @deprecated Use {@link Builder} instead.
      */
-    @Deprecated
     public AWSDataStorePlugin() throws DataStoreException {
-        this(ModelProviderLocator.locate(), Amplify.API);
+        this(AWSDataStorePlugin.builder());
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -114,7 +114,10 @@ public final class AWSDataStorePluginTest {
     public void configureAndInitialize() throws AmplifyException {
         //Configure DataStore with an empty config (All defaults)
         ApiCategory emptyApiCategory = spy(ApiCategory.class);
-        AWSDataStorePlugin standAloneDataStorePlugin = new AWSDataStorePlugin(modelProvider, emptyApiCategory);
+        AWSDataStorePlugin standAloneDataStorePlugin = AWSDataStorePlugin.builder()
+                                                                         .modelProvider(modelProvider)
+                                                                         .apiCategory(emptyApiCategory)
+                                                                         .build();
         standAloneDataStorePlugin.configure(new JSONObject(), context);
         standAloneDataStorePlugin.initialize(context);
     }
@@ -130,7 +133,10 @@ public final class AWSDataStorePluginTest {
             HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.READY, 1)
                 .start();
         ApiCategory emptyApiCategory = spy(ApiCategory.class);
-        AWSDataStorePlugin standAloneDataStorePlugin = new AWSDataStorePlugin(modelProvider, emptyApiCategory);
+        AWSDataStorePlugin standAloneDataStorePlugin = AWSDataStorePlugin.builder()
+                                                                         .modelProvider(modelProvider)
+                                                                         .apiCategory(emptyApiCategory)
+                                                                         .build();
         SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(standAloneDataStorePlugin);
         standAloneDataStorePlugin.configure(new JSONObject(), context);
         standAloneDataStorePlugin.initialize(context);
@@ -168,7 +174,10 @@ public final class AWSDataStorePluginTest {
         ApiCategory mockApiCategory = mockApiCategoryWithGraphQlApi();
         JSONObject dataStorePluginJson = new JSONObject()
             .put("syncIntervalInMinutes", 60);
-        AWSDataStorePlugin awsDataStorePlugin = new AWSDataStorePlugin(modelProvider, mockApiCategory);
+        AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
+                                                                  .modelProvider(modelProvider)
+                                                                  .apiCategory(mockApiCategory)
+                                                                  .build();
         SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(awsDataStorePlugin);
         awsDataStorePlugin.configure(dataStorePluginJson, context);
         awsDataStorePlugin.initialize(context);
@@ -202,7 +211,10 @@ public final class AWSDataStorePluginTest {
         ApiCategory mockApiCategory = mockApiPluginWithExceptions();
         JSONObject dataStorePluginJson = new JSONObject()
             .put("syncIntervalInMinutes", 60);
-        AWSDataStorePlugin awsDataStorePlugin = new AWSDataStorePlugin(modelProvider, mockApiCategory);
+        AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
+                                                                  .modelProvider(modelProvider)
+                                                                  .apiCategory(mockApiCategory)
+                                                                  .build();
         SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(awsDataStorePlugin);
         awsDataStorePlugin.configure(dataStorePluginJson, context);
         awsDataStorePlugin.initialize(context);
@@ -231,7 +243,10 @@ public final class AWSDataStorePluginTest {
         ApiPlugin<?> mockApiPlugin = mockApiCategory.getPlugin(MOCK_API_PLUGIN_NAME);
         JSONObject dataStorePluginJson = new JSONObject()
             .put("syncIntervalInMinutes", 60);
-        AWSDataStorePlugin awsDataStorePlugin = new AWSDataStorePlugin(modelProvider, mockApiCategory);
+        AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
+                                                                  .modelProvider(modelProvider)
+                                                                  .apiCategory(mockApiCategory)
+                                                                  .build();
         SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(awsDataStorePlugin);
         awsDataStorePlugin.configure(dataStorePluginJson, context);
         awsDataStorePlugin.initialize(context);
@@ -319,7 +334,10 @@ public final class AWSDataStorePluginTest {
         ApiPlugin<?> mockApiPlugin = mockApiCategory.getPlugin(MOCK_API_PLUGIN_NAME);
         JSONObject dataStorePluginJson = new JSONObject()
                 .put("syncIntervalInMinutes", 60);
-        AWSDataStorePlugin awsDataStorePlugin = new AWSDataStorePlugin(modelProvider, mockApiCategory);
+        AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
+                                                                  .modelProvider(modelProvider)
+                                                                  .apiCategory(mockApiCategory)
+                                                                  .build();
         SynchronousDataStore synchronousDataStore = SynchronousDataStore.delegatingTo(awsDataStorePlugin);
         awsDataStorePlugin.configure(dataStorePluginJson, context);
         awsDataStorePlugin.initialize(context);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In preparation for some of the upcoming multiauth work. 

Added a builder for the DataStore plugin since we're going to be adding a new parameter. Rather than keep the constructor growing, I figured I might as well refactor if. No change in functionality. Users will have the option to use the builder or continue to use the constructors, which are marked as deprecated, but are still around. 

Simplified the builder for SubscriptionOperation. Rather than the multi-interface approach, I'm just following the same pattern we do for all the other builders throughout our codebase. No change in functionality

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
