### PR TITLE
refactor:add enum to represent auth rule provider

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthorizationType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthorizationType.java
@@ -89,13 +89,13 @@ public enum AuthorizationType {
         }
         AuthStrategy.Provider authRuleProvider = AuthStrategy.Provider.valueOf(providerName);
         switch (authRuleProvider) {
-            case userPools:
+            case USER_POOLS:
                 return AMAZON_COGNITO_USER_POOLS;
-            case oidc:
+            case OIDC:
                 return OPENID_CONNECT;
-            case iam:
+            case IAM:
                 return AWS_IAM;
-            case apiKey:
+            case API_KEY:
                 return API_KEY;
             default:
                 throw new IllegalArgumentException("No such authorization type: " + providerName);

--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthorizationType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthorizationType.java
@@ -80,6 +80,7 @@ public enum AuthorizationType {
      * Look up an AuthorizationType by inspecting an AuthRule annotation.
      * @param authRuleAnnotation The annotation obtained from a model.
      * @return The AuthorizationType for the provider
+     * @throws IllegalArgumentException if AuthRule's provider does not match an authorization type
      */
     public static AuthorizationType from(AuthRule authRuleAnnotation) {
         String providerName = authRuleAnnotation.provider();
@@ -101,4 +102,3 @@ public enum AuthorizationType {
         }
     }
 }
-

--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthorizationType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthorizationType.java
@@ -15,6 +15,10 @@
 
 package com.amplifyframework.api.aws;
 
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.util.Empty;
+
 /**
  * The types of authorization one can use while talking to an Amazon
  * AppSync GraphQL backend.
@@ -70,6 +74,31 @@ public enum AuthorizationType {
         }
 
         throw new IllegalArgumentException("No such authorization type: " + name);
+    }
+
+    /**
+     * Look up an AuthorizationType by inspecting an AuthRule annotation.
+     * @param authRuleAnnotation The annotation obtained from a model.
+     * @return The AuthorizationType for the provider
+     */
+    public static AuthorizationType from(AuthRule authRuleAnnotation) {
+        String providerName = authRuleAnnotation.provider();
+        if (Empty.check(providerName)) {
+            providerName = authRuleAnnotation.allow().getDefaultAuthProvider().name();
+        }
+        AuthStrategy.Provider authRuleProvider = AuthStrategy.Provider.valueOf(providerName);
+        switch (authRuleProvider) {
+            case userPools:
+                return AMAZON_COGNITO_USER_POOLS;
+            case oidc:
+                return OPENID_CONNECT;
+            case iam:
+                return AWS_IAM;
+            case apiKey:
+                return API_KEY;
+            default:
+                throw new IllegalArgumentException("No such authorization type: " + providerName);
+        }
     }
 }
 

--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthorizationType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthorizationType.java
@@ -87,7 +87,17 @@ public enum AuthorizationType {
         if (Empty.check(providerName)) {
             providerName = authRuleAnnotation.allow().getDefaultAuthProvider().name();
         }
-        AuthStrategy.Provider authRuleProvider = AuthStrategy.Provider.valueOf(providerName);
+        AuthStrategy.Provider authRuleProvider = AuthStrategy.Provider.from(providerName);
+        return from(authRuleProvider);
+    }
+
+    /**
+     * Look up an AuthorizationType by {@link AuthStrategy.Provider}.
+     * @param authRuleProvider The auth rule provider value.
+     * @return The AuthorizationType for the given provider.
+     * @throws IllegalArgumentException if AuthRule's provider does not map to an authorization type
+     */
+    public static AuthorizationType from(AuthStrategy.Provider authRuleProvider) {
         switch (authRuleProvider) {
             case USER_POOLS:
                 return AMAZON_COGNITO_USER_POOLS;
@@ -98,7 +108,7 @@ public enum AuthorizationType {
             case API_KEY:
                 return API_KEY;
             default:
-                throw new IllegalArgumentException("No such authorization type: " + providerName);
+                throw new IllegalArgumentException("No such authorization type: " + authRuleProvider.name());
         }
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -54,16 +54,17 @@ public final class AuthRule {
      * @param authRule an {@link com.amplifyframework.core.model.annotations.AuthRule} annotation.
      */
     public AuthRule(com.amplifyframework.core.model.annotations.AuthRule authRule) {
-        this.authStrategy = authRule.allow();
-        this.authProvider = Empty.check(authRule.provider()) ?
-                                        authStrategy.getDefaultAuthProvider() :
-                                        AuthStrategy.Provider.valueOf(authRule.provider());
-        this.ownerField = authRule.ownerField();
-        this.identityClaim = authRule.identityClaim();
-        this.groupClaim = authRule.groupClaim();
-        this.groups = Arrays.asList(authRule.groups());
-        this.groupsField = authRule.groupsField();
-        this.operations = Arrays.asList(authRule.operations());
+        this(builder().authStrategy(authRule.allow())
+                      .authProvider(Empty.check(authRule.provider()) ?
+                                        authRule.allow().getDefaultAuthProvider() :
+                                        AuthStrategy.Provider.valueOf(authRule.provider()))
+                      .ownerField(authRule.ownerField())
+                      .identityClaim(authRule.identityClaim())
+                      .groupClaim(authRule.groupClaim())
+                      .groups(Arrays.asList(authRule.groups()))
+                      .groupsField(authRule.groupsField())
+                      .operations(Arrays.asList(authRule.operations()))
+        );
     }
 
     /**
@@ -103,8 +104,9 @@ public final class AuthRule {
      * Returns the auth provider for this {@link AuthRule}.
      * @return the auth provider for this {@link AuthRule}
      */
+    @NonNull
     public AuthStrategy.Provider getAuthProvider() {
-        return authProvider == null ? authStrategy.getDefaultAuthProvider() : authProvider;
+        return this.authProvider;
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -40,6 +40,7 @@ public final class AuthRule {
     private static final String DEFAULT_GROUP_CLAIM = "cognito:groups";
 
     private final AuthStrategy authStrategy;
+    private final AuthStrategy.Provider authProvider;
     private final String ownerField;
     private final String identityClaim;
     private final String groupsField;
@@ -54,6 +55,9 @@ public final class AuthRule {
      */
     public AuthRule(com.amplifyframework.core.model.annotations.AuthRule authRule) {
         this.authStrategy = authRule.allow();
+        this.authProvider = Empty.check(authRule.provider()) ?
+                                        authStrategy.getDefaultAuthProvider() :
+                                        AuthStrategy.Provider.valueOf(authRule.provider());
         this.ownerField = authRule.ownerField();
         this.identityClaim = authRule.identityClaim();
         this.groupClaim = authRule.groupClaim();
@@ -68,6 +72,7 @@ public final class AuthRule {
      */
     private AuthRule(@NonNull AuthRule.Builder builder) {
         this.authStrategy = builder.authStrategy;
+        this.authProvider = builder.authProvider;
         this.ownerField = builder.ownerField;
         this.identityClaim = builder.identityClaim;
         this.groupClaim = builder.groupClaim;
@@ -92,6 +97,14 @@ public final class AuthRule {
     @NonNull
     public AuthStrategy getAuthStrategy() {
         return authStrategy;
+    }
+
+    /**
+     * Returns the auth provider for this {@link AuthRule}.
+     * @return the auth provider for this {@link AuthRule}
+     */
+    public AuthStrategy.Provider getAuthProvider() {
+        return authProvider == null ? authStrategy.getDefaultAuthProvider() : authProvider;
     }
 
     /**
@@ -228,6 +241,7 @@ public final class AuthRule {
      */
     public static final class Builder {
         private AuthStrategy authStrategy;
+        private AuthStrategy.Provider authProvider;
         private String ownerField;
         private String identityClaim;
         private String groupClaim;
@@ -238,7 +252,7 @@ public final class AuthRule {
         /**
          * Sets the auth strategy of this rule.
          * @param authStrategy AuthStrategy is the type of auth strategy to use.
-         * @return the association model with given name
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder authStrategy(@NonNull AuthStrategy authStrategy) {
@@ -247,9 +261,20 @@ public final class AuthRule {
         }
 
         /**
+         * Sets the auth provider of this rule.
+         * @param authProvider The name of the auth provider.
+         * @return Current builder instance.
+         */
+        @NonNull
+        public AuthRule.Builder authProvider(AuthStrategy.Provider authProvider) {
+            this.authProvider = Objects.requireNonNull(authProvider);
+            return this;
+        }
+
+        /**
          * Sets the owner field of this rule.
          * @param ownerField OwnerField is the owner authorization.
-         * @return the association model with give target name
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder ownerField(@NonNull String ownerField) {
@@ -260,7 +285,7 @@ public final class AuthRule {
         /**
          * Sets the identity claim of this rule.
          * @param identityClaim IdentityClaim specifies a custom claim.
-         * @return the association model with given associated name
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder identityClaim(@NonNull String identityClaim) {
@@ -271,7 +296,7 @@ public final class AuthRule {
         /**
          * Sets the group claim of this rule.
          * @param groupClaim GroupClaim specified a custom claim.
-         * @return the association model with given associated type
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder groupClaim(@NonNull String groupClaim) {
@@ -282,7 +307,7 @@ public final class AuthRule {
         /**
          * Sets the groups this rule applies to.
          * @param groups Groups is static group authorization.
-         * @return the association model with given associated type
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder groups(@NonNull List<String> groups) {
@@ -293,7 +318,7 @@ public final class AuthRule {
         /**
          * Sets the groupsField of this rule.
          * @param groupsField GroupsField is for dynamic group authorization.
-         * @return the association model with given associated type
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder groupsField(@NonNull String groupsField) {
@@ -304,7 +329,7 @@ public final class AuthRule {
         /**
          * Sets the operations allowed for this rule.
          * @param operations Operations specifies which {@link ModelOperation}s are protected by this {@link AuthRule}.
-         * @return the association model with given associated type
+         * @return Current builder instance.
          */
         @NonNull
         public AuthRule.Builder operations(@NonNull List<ModelOperation> operations) {

--- a/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthRule.java
@@ -57,7 +57,7 @@ public final class AuthRule {
         this(builder().authStrategy(authRule.allow())
                       .authProvider(Empty.check(authRule.provider()) ?
                                         authRule.allow().getDefaultAuthProvider() :
-                                        AuthStrategy.Provider.valueOf(authRule.provider()))
+                                        AuthStrategy.Provider.from(authRule.provider()))
                       .ownerField(authRule.ownerField())
                       .identityClaim(authRule.identityClaim())
                       .groupClaim(authRule.groupClaim())

--- a/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
@@ -25,23 +25,62 @@ public enum AuthStrategy {
      * Owner authorization specifies whether a user can access or operate against an object.  To use OWNER, the API
      * must have Cognito User Pool configured.
      */
-    OWNER,
+    OWNER(Provider.userPools),
 
     /**
      * Group authorization specifies whether a group can access or operate against an object.  To use GROUPS, the API
      * must have Cognito User Pool configured.
      */
-    GROUPS,
+    GROUPS(Provider.userPools),
 
     /**
      * The private authorization specifies that everyone will be allowed to access the API with a valid JWT token from
      * the configured Cognito User Pool. To use PRIVATE, the API must have Cognito User Pool configured.
      */
-    PRIVATE,
+    PRIVATE(Provider.userPools),
 
     /**
      * The public authorization specifies that everyone will be allowed to access the API, behind the scenes the API
      * will be protected with an API Key. To use PUBLIC, the API must have API Key configured.
      */
-    PUBLIC,
+    PUBLIC(Provider.apiKey);
+
+    private final Provider defaultAuthProvider;
+
+    AuthStrategy(Provider defaultAuthProvider) {
+        this.defaultAuthProvider = defaultAuthProvider;
+    }
+
+    /**
+     * Returns the default provider for the strategy.
+     * @return The default provider for the strategy.
+     */
+    public Provider getDefaultAuthProvider() {
+        return defaultAuthProvider;
+    }
+
+    /**
+     * Represents the the value of the provider field of the @auth directive.
+     */
+    public enum Provider {
+        /**
+         * The userPools provider of the @auth rule directive.
+         */
+        userPools,
+
+        /**
+         * The userPools provider of the @auth rule directive.
+         */
+        oidc,
+
+        /**
+         * The userPools provider of the @auth rule directive.
+         */
+        iam,
+
+        /**
+         * The userPools provider of the @auth rule directive.
+         */
+        apiKey;
+    }
 }

--- a/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
@@ -15,6 +15,10 @@
 
 package com.amplifyframework.core.model;
 
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+
 /**
  *  The type of strategy for an @auth directive rule.
  * @see <a href="https://docs.amplify.aws/cli/graphql-transformer/directives#auth">GraphQL Transformer @auth directive
@@ -25,25 +29,25 @@ public enum AuthStrategy {
      * Owner authorization specifies whether a user can access or operate against an object.  To use OWNER, the API
      * must have Cognito User Pool configured.
      */
-    OWNER(Provider.userPools),
+    OWNER(Provider.USER_POOLS),
 
     /**
      * Group authorization specifies whether a group can access or operate against an object.  To use GROUPS, the API
      * must have Cognito User Pool configured.
      */
-    GROUPS(Provider.userPools),
+    GROUPS(Provider.USER_POOLS),
 
     /**
      * The private authorization specifies that everyone will be allowed to access the API with a valid JWT token from
      * the configured Cognito User Pool. To use PRIVATE, the API must have Cognito User Pool configured.
      */
-    PRIVATE(Provider.userPools),
+    PRIVATE(Provider.USER_POOLS),
 
     /**
      * The public authorization specifies that everyone will be allowed to access the API, behind the scenes the API
      * will be protected with an API Key. To use PUBLIC, the API must have API Key configured.
      */
-    PUBLIC(Provider.apiKey);
+    PUBLIC(Provider.API_KEY);
 
     private final Provider defaultAuthProvider;
 
@@ -66,21 +70,53 @@ public enum AuthStrategy {
         /**
          * The userPools provider of the @auth rule directive.
          */
-        userPools,
+        USER_POOLS("userPools"),
 
         /**
          * The userPools provider of the @auth rule directive.
          */
-        oidc,
+        OIDC("oidc"),
 
         /**
          * The userPools provider of the @auth rule directive.
          */
-        iam,
+        IAM("iam"),
 
         /**
          * The userPools provider of the @auth rule directive.
          */
-        apiKey;
+        API_KEY("apiKey");
+
+        private final String authDirectiveProviderName;
+
+        Provider(String authDirectiveProviderName) {
+            this.authDirectiveProviderName = authDirectiveProviderName;
+        }
+
+        /**
+         * Returns the provider name used in the @auth rule directive to represent the current enum item.
+         * @return The name associated with the enum item.
+         */
+        public String getAuthDirectiveProviderName() {
+            return this.authDirectiveProviderName;
+        }
+
+        /**
+         * Retrieve the enum value for the given name.
+         * @param authDirectiveProviderName String value of the provider attribute of the @auth directive.
+         * @return The associated {@link Provider} item associated with the name.
+         * @throws IllegalArgumentException If the value provided in the parameter does not
+         * have a matching element in the enum.
+         */
+        public static Provider from(@NonNull String authDirectiveProviderName) {
+            Objects.requireNonNull(authDirectiveProviderName);
+            for (Provider provider : Provider.values()) {
+                if (authDirectiveProviderName.equals(provider.authDirectiveProviderName)) {
+                    return provider;
+                }
+            }
+            throw new IllegalArgumentException("Unable to find a matching " +
+                                                   "auth strategy for " + authDirectiveProviderName);
+        }
     }
 }

--- a/core/src/test/java/com/amplifyframework/core/model/ModelSchemaAuthRulesTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/ModelSchemaAuthRulesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.aws.AuthorizationType;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Verifies that the provider string values from {@link AuthRule} annotations are mapped
+ * to the appropriate {@link AuthStrategy.Provider} and subsequently {@link AuthorizationType}.
+ */
+public class ModelSchemaAuthRulesTest {
+
+    /**
+     * Verifies that the string values from the AuthRule annotation map to a valid enum item
+     * from AuthStrategy.Provider
+     */
+    @Test
+    public void authProviderMappingTest() throws AmplifyException {
+        ModelSchema modelSchema = ModelSchema.fromModelClass(Post.class);
+        assertNotNull(modelSchema);
+        List<com.amplifyframework.core.model.AuthRule> authRules = modelSchema.getAuthRules();
+        assertEquals(4, authRules.size());
+        assertEquals(AuthStrategy.Provider.USER_POOLS, authRules.get(0).getAuthProvider());
+        assertEquals(AuthStrategy.Provider.OIDC, authRules.get(1).getAuthProvider());
+        assertEquals(AuthStrategy.Provider.IAM, authRules.get(2).getAuthProvider());
+        assertEquals(AuthStrategy.Provider.API_KEY, authRules.get(3).getAuthProvider());
+    }
+
+    /**
+     * Verifies that an invalid provider value in the auth rule annotation causes an exception.
+     * @throws AmplifyException Expected because "invalid" is not a valid {@link AuthStrategy.Provider}.
+     */
+    @Test(expected = AmplifyException.class)
+    public void authProviderMappingInvalidRuleTest() throws AmplifyException {
+        ModelSchema.fromModelClass(PostWithInvalidRule.class);
+    }
+
+    /**
+     * Verifies the mapping of {@link AuthStrategy.Provider} to {@link AuthorizationType}.
+     * @throws AmplifyException Not expected.
+     */
+    @Test
+    public void authorizationTypeMappingTest() throws AmplifyException {
+        ModelSchema modelSchema = ModelSchema.fromModelClass(Post.class);
+        assertNotNull(modelSchema);
+        List<com.amplifyframework.core.model.AuthRule> authRules = modelSchema.getAuthRules();
+        assertEquals(4, authRules.size());
+        assertEquals(AuthorizationType.AMAZON_COGNITO_USER_POOLS, AuthorizationType.from(authRules.get(0)
+                                                                                                  .getAuthProvider()));
+        assertEquals(AuthorizationType.OPENID_CONNECT, AuthorizationType.from(authRules.get(1)
+                                                                                       .getAuthProvider()));
+        assertEquals(AuthorizationType.AWS_IAM, AuthorizationType.from(authRules.get(2)
+                                                                                .getAuthProvider()));
+        assertEquals(AuthorizationType.API_KEY, AuthorizationType.from(authRules.get(3)
+                                                                                .getAuthProvider()));
+    }
+
+    @ModelConfig(authRules = {
+        @AuthRule(allow = AuthStrategy.OWNER, provider = "userPools"),
+        @AuthRule(allow = AuthStrategy.GROUPS, provider = "oidc"),
+        @AuthRule(allow = AuthStrategy.PRIVATE, provider = "iam"),
+        @AuthRule(allow = AuthStrategy.PUBLIC, provider = "apiKey")
+
+    })
+    private abstract static class Post implements Model {}
+
+    @ModelConfig(authRules = {
+        @AuthRule(allow = AuthStrategy.PUBLIC, provider = "invalid")
+    })
+    private abstract static class PostWithInvalidRule implements Model {}
+}

--- a/core/src/test/java/com/amplifyframework/core/model/ModelSchemaAuthRulesTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/ModelSchemaAuthRulesTest.java
@@ -35,7 +35,8 @@ public class ModelSchemaAuthRulesTest {
 
     /**
      * Verifies that the string values from the AuthRule annotation map to a valid enum item
-     * from AuthStrategy.Provider
+     * from AuthStrategy.Provider.
+     * @throws AmplifyException Not expected.
      */
     @Test
     public void authProviderMappingTest() throws AmplifyException {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR replaces #1314, which was moving `AuthorizationType` to core. This PR does the following instead:

- Adds an enum (`AuthStrategy.Provider`) to represent the `provider` field of an @auth rule.
- Adds an `authProvider` field to the `AuthRule` model. This field transforms the string value from the `AuthRule` annotation interface into one of enum values. If the `AuthRule` annotation has an empty string for its `provider` field, we use the default provider for the strategy.
- Creates a method on the `AuthorizationType` enum to translate an `AuthStrategy.Provider` into an `AuthorizationType`.

**NOTE** I made the `Provider` enum nested to `AuthStrategy` to make their association clearer. I though creating an `AuthProvider` enum would probably lead to more confusion since there is already an enum called `AuthProvider` in core which is used for social sign-in providers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
