### PR TITLE
fix(datastore): add syncExpression method to configuration builder that takes a ModelSchema

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
@@ -341,6 +341,23 @@ public final class DataStoreConfiguration {
             return Builder.this;
         }
 
+        /**
+         * Sets a sync expression for a particular model to filter which data is synced locally.  The expression
+         * is evaluated each time DataStore is started.  The QueryPredicate is applied on both sync and subscriptions.
+         * @param modelName the name of the model for which the filter applies
+         * @param syncExpression DataStoreSyncExpression that should be used to filter the data that is synced.
+         * @return Current builder
+         */
+        @NonNull
+        public Builder syncExpression(@NonNull String modelName,
+                                      @NonNull DataStoreSyncExpression syncExpression) {
+            this.syncExpressions.put(
+                    Objects.requireNonNull(modelName),
+                    Objects.requireNonNull(syncExpression)
+            );
+            return Builder.this;
+        }
+
         private void populateSettingsFromJson() throws DataStoreException {
             if (pluginJson == null) {
                 return;


### PR DESCRIPTION
Customers today can configure DataStore syncExpressions like this: 
```
Amplify.addPlugin(new AWSDataStorePlugin(DataStoreConfiguration.builder()
    .syncExpression(Post.class, () -> Post.RATING.gt(5))
    .build()));
```

Support for sync expressions is now being added to Flutter, but in Flutter, there are no generated Java model classes.  We need to provide an alternative way of specifying sync expressions.    This PR adds a new method to the `DataStoreConfiguration.Builder` so that sync expressions can be declared using a `ModelSchema`, instead of a `Class<? extends Model>`.    This will enable Flutter to do something like this:

```
ModelSchema postModelSchema = ...
Amplify.addPlugin(new AWSDataStorePlugin(DataStoreConfiguration.builder()
    .syncExpression(postModelSchema, () -> Post.RATING.gt(5))
    .build()));
```

This is very similar to the API provided today by iOS: ([reference](https://docs.amplify.aws/lib/datastore/sync/q/platform/ios#selectively-syncing-a-subset-of-your-data)) , so this PR closes this parity gap.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
