### PR TITLE
fix(Auth): prevent multiple invocations of success callback for updateUserAttributes

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -849,8 +849,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                                                         null)
                                         ));
                             }
-                            onSuccess.accept(resultMap);
                         }
+                        onSuccess.accept(resultMap);
                     }
 
                     @Override

--- a/testutils/src/main/java/com/amplifyframework/testutils/Await.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Await.java
@@ -146,9 +146,6 @@ public final class Await {
                         resultContainer.set(result);
                         latch.countDown();
                     }, error -> {
-                        if (errorContainer.get() != null) {
-                            throw new RuntimeException("Error callback called more than once with error: " + error);
-                        }
                         errorContainer.set(error);
                         latch.countDown();
                     }

--- a/testutils/src/main/java/com/amplifyframework/testutils/Await.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Await.java
@@ -140,9 +140,15 @@ public final class Await {
             try {
                 resultErrorEmitter.emitTo(
                     result -> {
+                        if (resultContainer.get() != null) {
+                            throw new RuntimeException("Result callback called more than once with result: " + result);
+                        }
                         resultContainer.set(result);
                         latch.countDown();
                     }, error -> {
+                        if (errorContainer.get() != null) {
+                            throw new RuntimeException("Error callback called more than once with error: " + error);
+                        }
                         errorContainer.set(error);
                         latch.countDown();
                     }


### PR DESCRIPTION
*Issue #, if available:* #1263

*Description of changes:*
- Move the onSuccess callback outside of the for loop so that it is only invoked one time

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
