### PR TITLE
fix(api): check for null ModelSchema to prevent crash in SerializedModel toString method

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java
@@ -151,7 +151,7 @@ public final class SerializedModel implements Model {
         return "SerializedModel{" +
             "id='" + modelId + '\'' +
             ", serializedData=" + serializedData +
-            ", modelSchema=" + modelSchema.getName() +
+            ", modelName=" + getModelName() +
             '}';
     }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-android/issues/1340

Fixes bug introduced in https://github.com/aws-amplify/amplify-android/pull/1319/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
