### PR TITLE
feat: add supporting types for multi-auth

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthModeStrategyType.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AuthModeStrategyType.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws;
+
+/**
+ * Represents that different auth strategies supported by the client that
+ * interfaces with the AppSync backend.
+ */
+public enum AuthModeStrategyType {
+    /**
+     * Uses the default authorization type from the API configuration
+     * unless the incoming request specifies one.
+     */
+    DEFAULT("default"),
+
+    /**
+     * Leverages schema metadata to create a list of potential authorization types
+     * that could be used for a given request. The underlying client then
+     * iterates through that list until one of the modes succeeds or all of them fail.
+     * This setting also respects authorization types set in the request.
+     */
+    MULTIAUTH("multiauth");
+
+    private final String strategyName;
+
+    AuthModeStrategyType(String strategyName) {
+        this.strategyName = strategyName;
+    }
+
+    /**
+     * Retrieve the strategy enum based on a name.
+     * Comparison is case insensitive.
+     * @param value The string value to try to match.
+     * @return One of the enum items or an exception if one is not found.
+     */
+    public AuthModeStrategyType from(String value) {
+        for (AuthModeStrategyType strategy : AuthModeStrategyType.values()) {
+            if (strategy.name().equalsIgnoreCase(value) || strategy.strategyName.equalsIgnoreCase(value)) {
+                return strategy;
+            }
+        }
+        throw new IllegalArgumentException("Cannot find an authorization strategy for " + value);
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
@@ -21,6 +21,7 @@ import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.aws.AppSyncGraphQLRequest;
+import com.amplifyframework.api.aws.AuthModeStrategyType;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.PaginatedResult;
@@ -467,7 +468,11 @@ public final class AppSyncMocking {
                 Long lastSync = invocation.getArgument(1);
                 Integer syncPageSize = invocation.getArgument(2);
                 QueryPredicate queryPredicate = invocation.getArgument(3);
-                return AppSyncRequestFactory.buildSyncRequest(schema, lastSync, syncPageSize, queryPredicate);
+                return AppSyncRequestFactory.buildSyncRequest(schema,
+                                                              lastSync,
+                                                              syncPageSize,
+                                                              queryPredicate,
+                                                              AuthModeStrategyType.DEFAULT);
             }).when(appSync).buildSyncRequest(any(), any(), any(), any());
             return this;
         }
@@ -534,7 +539,11 @@ public final class AppSyncMocking {
             if (nextToken != null) {
                 ModelSchema schema = ModelSchema.fromModelClass(modelClass);
                 requestForNextResult =
-                    AppSyncRequestFactory.buildSyncRequest(schema, null, null, QueryPredicates.all())
+                    AppSyncRequestFactory.buildSyncRequest(schema,
+                                                           null,
+                                                           null,
+                                                           QueryPredicates.all(),
+                                                           AuthModeStrategyType.DEFAULT)
                         .newBuilder()
                         .variable("nextToken", "String", nextToken)
                         .build();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.aws.AppSyncGraphQLRequest;
+import com.amplifyframework.api.aws.AuthModeStrategyType;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.model.AuthStrategy;
@@ -61,6 +62,8 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(RobolectricTestRunner.class) // Adds Android library to make TextUtils.join available for tests.
 public final class AppSyncRequestFactoryTest {
+    private static final AuthModeStrategyType DEFAULT_STRATEGY =
+        AuthModeStrategyType.DEFAULT;
 
     /**
      * Validates the construction of a base-sync query document.
@@ -73,7 +76,11 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
         JSONAssert.assertEquals(
             Resources.readAsString("base-sync-request-document-for-blog-owner.txt"),
-            AppSyncRequestFactory.buildSyncRequest(schema, null, null, QueryPredicates.all()).getContent(),
+            AppSyncRequestFactory.buildSyncRequest(schema,
+                                                   null,
+                                                   null,
+                                                   QueryPredicates.all(),
+                                                   DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -89,7 +96,11 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(Parent.class);
         JSONAssert.assertEquals(
             Resources.readAsString("base-sync-request-document-for-parent.txt"),
-            AppSyncRequestFactory.buildSyncRequest(schema, null, null, QueryPredicates.all()).getContent(),
+            AppSyncRequestFactory.buildSyncRequest(schema,
+                                                   null,
+                                                   null,
+                                                   QueryPredicates.all(),
+                                                   DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -104,7 +115,11 @@ public final class AppSyncRequestFactoryTest {
     public void validateRequestGenerationForDeltaSync() throws AmplifyException, JSONException {
         ModelSchema schema = ModelSchema.fromModelClass(Post.class);
         JSONAssert.assertEquals(Resources.readAsString("delta-sync-request-document-for-post.txt"),
-            AppSyncRequestFactory.buildSyncRequest(schema, 123123123L, null, QueryPredicates.all()).getContent(),
+                                AppSyncRequestFactory.buildSyncRequest(schema,
+                                                                       123123123L,
+                                                                       null,
+                                                                       QueryPredicates.all(),
+                                                                       DEFAULT_STRATEGY).getContent(),
             true);
     }
 
@@ -119,7 +134,7 @@ public final class AppSyncRequestFactoryTest {
         Integer limit = 1000;
         ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
         final GraphQLRequest<Iterable<Post>> request =
-                AppSyncRequestFactory.buildSyncRequest(schema, null, limit, QueryPredicates.all());
+                AppSyncRequestFactory.buildSyncRequest(schema, null, limit, QueryPredicates.all(), DEFAULT_STRATEGY);
         JSONAssert.assertEquals(Resources.readAsString("base-sync-request-paginating-blog-owners.txt"),
                 request.getContent(),
                 true);
@@ -170,8 +185,11 @@ public final class AppSyncRequestFactoryTest {
         String blogOwnerId = "926d7ee8-4ea5-40c0-8e62-3fb80b2a2edd";
         BlogOwner owner = BlogOwner.builder().name("John Doe").id(blogOwnerId).build();
         ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
-        AppSyncGraphQLRequest<?> request =
-            AppSyncRequestFactory.buildUpdateRequest(schema, owner, 42, BlogOwner.WEA.contains("ther"));
+        AppSyncGraphQLRequest<?> request = AppSyncRequestFactory.buildUpdateRequest(schema,
+                                                                                    owner,
+                                                                                    42,
+                                                                                    BlogOwner.WEA.contains("ther"),
+                                                                                    DEFAULT_STRATEGY);
         JSONAssert.assertEquals(
             Resources.readAsString("update-blog-owner-with-predicate.txt"),
             request.getContent(),
@@ -194,7 +212,8 @@ public final class AppSyncRequestFactoryTest {
                         schema,
                         buildTestParentModel(),
                         42,
-                        Parent.NAME.contains("Jane Doe")
+                        Parent.NAME.contains("Jane Doe"),
+                        DEFAULT_STRATEGY
                 ).getContent(),
                 true
         );
@@ -212,7 +231,11 @@ public final class AppSyncRequestFactoryTest {
         Person person = Person.justId("17521540-ccaa-4357-a622-34c42d8cfa24");
         JSONAssert.assertEquals(
             Resources.readAsString("delete-person-with-predicate.txt"),
-            AppSyncRequestFactory.buildDeletionRequest(schema, person, 456, Person.AGE.gt(40)).getContent(),
+            AppSyncRequestFactory.buildDeletionRequest(schema,
+                                                       person,
+                                                       456,
+                                                       Person.AGE.gt(40),
+                                                       DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -234,7 +257,11 @@ public final class AppSyncRequestFactoryTest {
                 .build();
         JSONAssert.assertEquals(
             Resources.readAsString("delete-item.txt"),
-            AppSyncRequestFactory.buildDeletionRequest(schema, item, 1, QueryPredicates.all()).getContent(),
+            AppSyncRequestFactory.buildDeletionRequest(schema,
+                                                       item,
+                                                       1,
+                                                       QueryPredicates.all(),
+                                                       DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -269,7 +296,9 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(Blog.class);
         JSONAssert.assertEquals(
             Resources.readAsString("on-create-request-for-blog.txt"),
-            AppSyncRequestFactory.buildSubscriptionRequest(schema, SubscriptionType.ON_CREATE).getContent(),
+            AppSyncRequestFactory.buildSubscriptionRequest(schema,
+                                                           SubscriptionType.ON_CREATE,
+                                                           DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -286,7 +315,9 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(Parent.class);
         JSONAssert.assertEquals(
             Resources.readAsString("on-create-request-for-parent.txt"),
-            AppSyncRequestFactory.buildSubscriptionRequest(schema, SubscriptionType.ON_CREATE).getContent(),
+            AppSyncRequestFactory.buildSubscriptionRequest(schema,
+                                                           SubscriptionType.ON_CREATE,
+                                                           DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -303,7 +334,9 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(Post.class);
         JSONAssert.assertEquals(
             Resources.readAsString("on-update-request-for-post.txt"),
-            AppSyncRequestFactory.buildSubscriptionRequest(schema, SubscriptionType.ON_UPDATE).getContent(),
+            AppSyncRequestFactory.buildSubscriptionRequest(schema,
+                                                           SubscriptionType.ON_UPDATE,
+                                                           DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -320,7 +353,9 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
         JSONAssert.assertEquals(
             Resources.readAsString("on-delete-request-for-blog-owner.txt"),
-            AppSyncRequestFactory.buildSubscriptionRequest(schema, SubscriptionType.ON_DELETE).getContent(),
+            AppSyncRequestFactory.buildSubscriptionRequest(schema,
+                                                           SubscriptionType.ON_DELETE,
+                                                           DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -342,7 +377,7 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(Comment.class);
         JSONAssert.assertEquals(
             Resources.readAsString("create-comment-request.txt"),
-            AppSyncRequestFactory.buildCreationRequest(schema, comment).getContent(),
+            AppSyncRequestFactory.buildCreationRequest(schema, comment, DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -358,7 +393,7 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(Parent.class);
         JSONAssert.assertEquals(
             Resources.readAsString("create-parent-request.txt"),
-            AppSyncRequestFactory.buildCreationRequest(schema, buildTestParentModel()).getContent(),
+            AppSyncRequestFactory.buildCreationRequest(schema, buildTestParentModel(), DEFAULT_STRATEGY).getContent(),
             true
         );
     }
@@ -386,7 +421,7 @@ public final class AppSyncRequestFactoryTest {
         // Assert
         JSONAssert.assertEquals(Resources.readAsString("update-blog-owner-only-changed-fields.txt"),
             AppSyncRequestFactory.buildUpdateRequest(
-                modelSchema, blogOwner, 1, QueryPredicates.all()).getContent(), true);
+                modelSchema, blogOwner, 1, QueryPredicates.all(), DEFAULT_STRATEGY).getContent(), true);
     }
 
     private Parent buildTestParentModel() {
@@ -437,7 +472,7 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(Todo.class);
         @SuppressWarnings("unchecked")
         Map<String, Object> actual = (Map<String, Object>)
-            AppSyncRequestFactory.buildUpdateRequest(schema, todo, 1, QueryPredicates.all())
+            AppSyncRequestFactory.buildUpdateRequest(schema, todo, 1, QueryPredicates.all(), DEFAULT_STRATEGY)
                 .getVariables()
                 .get("input");
 
@@ -462,7 +497,7 @@ public final class AppSyncRequestFactoryTest {
         ModelSchema schema = ModelSchema.fromModelClass(Todo.class);
         @SuppressWarnings("unchecked")
         Map<String, Object> actual = (Map<String, Object>)
-            AppSyncRequestFactory.buildCreationRequest(schema, todo)
+            AppSyncRequestFactory.buildCreationRequest(schema, todo, DEFAULT_STRATEGY)
                 .getVariables()
                 .get("input");
 

--- a/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelSchema.java
@@ -161,6 +161,15 @@ public final class ModelSchema {
         }
     }
 
+    /**
+     * Indicates whether this model has any auth rules at the model level. This should be
+     * used to assert whether the API's default auth provider should be used.
+     * @return True if there are no model-level auth rules; false otherwise.
+     */
+    public boolean hasModelLevelRules() {
+        return this.authRules.size() > 0;
+    }
+
     // Utility method to extract field metadata
     private static ModelField createModelField(Field field) {
         com.amplifyframework.core.model.annotations.ModelField annotation =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR does the following:

- **aws-api-appsync**
  * Adds `AuthModeStrategyType` that represents the auth mode strategies supported by the API plugin. Current values are MULTIAUTH and DEFAULT.
  * Adds an `authModeStrategyType` field to the `AppSyncGraphQLRequest` object. This will effectively serve as the flag that indicates whether an API request should be handled in multi-auth mode or not. Not setting this field when constructing the request means using the DEFAULT strategy which is the current behavior.
- **aws-datastore**
  * Adds a field called `authModeStrategy` (to be consistent with the JS implementation) of type `AuthModeStrategyType`. Customers will be able to set this value via the `AWSDataStore.Builder` when constructing the plugin. Again, not setting this field means using the DEFAULT strategy which is the current behavior. The sync engine will use the value in this field to set the `authModeStrategyType` field of the `AppSyncGraphQLRequest`
  * Modified the `AppSyncRequestFactory` so the sync engine can set the `authModeStrategyType` field when constructing API requests. **NOTE** this factory can only be used by the sync engine due to its visibility (package private). Essentially, we're limiting MULTIAUTH requests to be made only from the sync engine.
  * Added the necessary parameters to `AppSyncClient` so it can be used when constructing API requests.
- **core**
  * Add a method called `hasModelLevelRules` to model schema. This is a convenience method that will be used when determining whether or not the default auth type should be used for models that don't specify any rules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
