### PR TITLE
fix(api): default to mobile client for iam auth mode

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/auth/ApiRequestDecoratorFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/auth/ApiRequestDecoratorFactory.java
@@ -29,6 +29,9 @@ import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.logging.Logger;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.mobile.client.AWSMobileClient;
+
 import java.util.Objects;
 
 import okhttp3.Request;
@@ -38,6 +41,7 @@ import okhttp3.Request;
  */
 public final class ApiRequestDecoratorFactory {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-api");
+    private static final String AUTH_DEPENDENCY_PLUGIN_KEY = "awsCognitoAuthPlugin";
     private static final RequestDecorator NO_OP_REQUEST_DECORATOR = new RequestDecorator() {
         @Override
         public Request decorate(Request request) {
@@ -103,49 +107,62 @@ public final class ApiRequestDecoratorFactory {
      * @return the appropriate request decorator for the given authorization type.
      */
     private RequestDecorator forAuthType(@NonNull AuthorizationType authorizationType) throws ApiException {
-        if (AuthorizationType.AMAZON_COGNITO_USER_POOLS.equals(authorizationType)) {
-            // Note that if there was no user-provided cognito provider passed in to initialize
-            // the API plugin, we will try to default to using the DefaultCognitoUserPoolsAuthProvider.
-            //  If that fails, we then have no choice but to bubble up the error.
-            CognitoUserPoolsAuthProvider cognitoUserPoolsAuthProvider =
-                apiAuthProviders.getCognitoUserPoolsAuthProvider() != null ?
-                    apiAuthProviders.getCognitoUserPoolsAuthProvider() :
-                    new DefaultCognitoUserPoolsAuthProvider();
-            // By calling getLatestAuthToken() here instead of inside the lambda block, makes the exception
-            // handling a little bit cleaner. If getLatestAuthToken() is called from inside the lambda expression
-            // below, we'd have to surround it with a try catch. By doing it this way, if there's a problem,
-            // the ApiException will just be bubbled up. Same for OPENID_CONNECT.
-            final String token = cognitoUserPoolsAuthProvider.getLatestAuthToken();
-            return new JWTTokenRequestDecorator(() -> token);
-        } else if (AuthorizationType.OPENID_CONNECT.equals(authorizationType)) {
-            if (apiAuthProviders.getOidcAuthProvider() == null) {
-                throw new ApiException("Attempting to use OPENID_CONNECT authorization " +
-                                           "without an OIDC provider.",
-                                       "Configure an OidcAuthProvider when initializing the API plugin.");
-            }
-            final String token = apiAuthProviders.getOidcAuthProvider().getLatestAuthToken();
-            return new JWTTokenRequestDecorator(() -> token);
-        } else if (AuthorizationType.API_KEY.equals(authorizationType)) {
-            if (apiAuthProviders.getApiKeyAuthProvider() != null) {
-                return new ApiKeyRequestDecorator(apiAuthProviders.getApiKeyAuthProvider());
-            } else if (apiKey != null) {
-                return new ApiKeyRequestDecorator(() -> apiKey);
-            } else {
-                throw new ApiException("Attempting to use API_KEY authorization without an API key provider or " +
-                                           "an API key in the config file",
-                                       "Verify that an API key is in the config file or an " +
-                                           "ApiKeyAuthProvider is setup during the API plugin initialization.");
-            }
-        } else if (AuthorizationType.AWS_IAM.equals(authorizationType)) {
-            if (apiAuthProviders.getAWSCredentialsProvider() == null) {
-                throw new ApiException("Attempting to use AWS_IAM authorization without " +
-                                           "an AWS credentials provider.",
-                                       "Configure an AWSCredentialsProvider when initializing the API plugin.");
-            }
-            AppSyncV4Signer appSyncV4Signer = new AppSyncV4Signer(region);
-            return new IamRequestDecorator(appSyncV4Signer, apiAuthProviders.getAWSCredentialsProvider());
-        } else {
-            return NO_OP_REQUEST_DECORATOR;
+        switch (authorizationType) {
+            case AMAZON_COGNITO_USER_POOLS:
+                // Note that if there was no user-provided cognito provider passed in to initialize
+                // the API plugin, we will try to default to using the DefaultCognitoUserPoolsAuthProvider.
+                //  If that fails, we then have no choice but to bubble up the error.
+                CognitoUserPoolsAuthProvider cognitoUserPoolsAuthProvider =
+                        apiAuthProviders.getCognitoUserPoolsAuthProvider() != null ?
+                                apiAuthProviders.getCognitoUserPoolsAuthProvider() :
+                                new DefaultCognitoUserPoolsAuthProvider();
+                // By calling getLatestAuthToken() here instead of inside the lambda block, makes the exception
+                // handling a little bit cleaner. If getLatestAuthToken() is called from inside the lambda expression
+                // below, we'd have to surround it with a try catch. By doing it this way, if there's a problem,
+                // the ApiException will just be bubbled up. Same for OPENID_CONNECT.
+                final String token = cognitoUserPoolsAuthProvider.getLatestAuthToken();
+                return new JWTTokenRequestDecorator(() -> token);
+            case OPENID_CONNECT:
+                if (apiAuthProviders.getOidcAuthProvider() == null) {
+                    throw new ApiException("Attempting to use OPENID_CONNECT authorization " +
+                            "without an OIDC provider.",
+                            "Configure an OidcAuthProvider when initializing the API plugin.");
+                }
+                final String oidcToken = apiAuthProviders.getOidcAuthProvider().getLatestAuthToken();
+                return new JWTTokenRequestDecorator(() -> oidcToken);
+            case API_KEY:
+                if (apiAuthProviders.getApiKeyAuthProvider() != null) {
+                    return new ApiKeyRequestDecorator(apiAuthProviders.getApiKeyAuthProvider());
+                } else if (apiKey != null) {
+                    return new ApiKeyRequestDecorator(() -> apiKey);
+                } else {
+                    throw new ApiException("Attempting to use API_KEY authorization without an API key provider or " +
+                            "an API key in the config file",
+                            "Verify that an API key is in the config file or an " +
+                                    "ApiKeyAuthProvider is setup during the API plugin initialization.");
+                }
+            case AWS_IAM:
+                AWSCredentialsProvider credentialsProvider = apiAuthProviders.getAWSCredentialsProvider() != null
+                        ? apiAuthProviders.getAWSCredentialsProvider()
+                        : getDefaultCredentialsProvider();
+                AppSyncV4Signer appSyncV4Signer = new AppSyncV4Signer(region);
+                return new IamRequestDecorator(appSyncV4Signer, credentialsProvider);
+            case NONE:
+            default:
+                return NO_OP_REQUEST_DECORATOR;
+        }
+    }
+
+    private AWSCredentialsProvider getDefaultCredentialsProvider() throws ApiException {
+        // Obtains AWSMobileClient from Auth Category.
+        // Throw if AWSCognitoAuthPlugin not configured.
+        try {
+            return (AWSMobileClient) Amplify.Auth.getPlugin(AUTH_DEPENDENCY_PLUGIN_KEY).getEscapeHatch();
+        } catch (IllegalStateException exception) {
+            throw new ApiException("Attempting to use AWS_IAM authorization without " +
+                    "an AWS credentials provider.",
+                    "Configure an AWSCredentialsProvider when initializing the API plugin or register" +
+                            "an instance of AWSCognitoAuthPlugin to Amplify.");
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#1350 

*Description of changes:*
`ApiRequestDecoratorFactory` would throw if no `AWSCredentialsProvider` was explicitly provided when configuring the API plugin, but the intended behavior was to use `AWSMobileClient` by default. This additional logic is added in this PR.

(Also changed to switch statements for slight performance boost :) )

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
