### PR TITLE
fix: Add ConfirmSignUpOptions for confirmSignUp API method

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -315,7 +315,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
         final Map<String, String> clientMetadata = new HashMap<>();
 
         if (options instanceof AWSCognitoAuthConfirmSignUpOptions) {
-            clientMetadata.putAll(((AWSCognitoAuthConfirmSignUpOptions) options).getClientMetadata());
+            AWSCognitoAuthConfirmSignUpOptions cognitoOptions = (AWSCognitoAuthConfirmSignUpOptions) options;
+            clientMetadata.putAll(cognitoOptions.getClientMetadata());
         }
 
         awsMobileClient.confirmSignUp(username, confirmationCode, clientMetadata, new Callback<SignUpResult>() {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -34,6 +34,7 @@ import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignInOptions;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignUpOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignOutOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignUpOptions;
@@ -42,6 +43,7 @@ import com.amplifyframework.auth.cognito.util.AuthProviderConverter;
 import com.amplifyframework.auth.cognito.util.CognitoAuthExceptionConverter;
 import com.amplifyframework.auth.cognito.util.SignInStateConverter;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -125,7 +127,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     public AWSCognitoAuthPlugin() {
         this.awsMobileClient = AWSMobileClient.getInstance();
     }
-    
+
     @VisibleForTesting
     AWSCognitoAuthPlugin(AWSMobileClient instance, String userId) {
         this.awsMobileClient = instance;
@@ -304,12 +306,19 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
     @Override
     public void confirmSignUp(
-        @NonNull String username,
-        @NonNull String confirmationCode,
-        @NonNull final Consumer<AuthSignUpResult> onSuccess,
-        @NonNull final Consumer<AuthException> onException
+            @NonNull String username,
+            @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignUpOptions options,
+            @NonNull final Consumer<AuthSignUpResult> onSuccess,
+            @NonNull final Consumer<AuthException> onException
     ) {
-        awsMobileClient.confirmSignUp(username, confirmationCode, new Callback<SignUpResult>() {
+        final Map<String, String> clientMetadata = new HashMap<>();
+
+        if (options instanceof AWSCognitoAuthConfirmSignUpOptions) {
+            clientMetadata.putAll(((AWSCognitoAuthConfirmSignUpOptions) options).getClientMetadata());
+        }
+
+        awsMobileClient.confirmSignUp(username, confirmationCode, clientMetadata, new Callback<SignUpResult>() {
             @Override
             public void onResult(SignUpResult result) {
                 onSuccess.accept(convertSignUpResult(result, username));
@@ -322,6 +331,16 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                 );
             }
         });
+    }
+
+    @Override
+    public void confirmSignUp(
+            @NonNull String username,
+            @NonNull String confirmationCode,
+            @NonNull final Consumer<AuthSignUpResult> onSuccess,
+            @NonNull final Consumer<AuthException> onException
+    ) {
+        confirmSignUp(username, confirmationCode, AuthConfirmSignUpOptions.defaults(), onSuccess, onException);
     }
 
     @Override

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignUpOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignUpOptions.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.options;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.util.Immutable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Cognito extension of confirm sign up options to add the platform specific fields.
+ */
+public final class AWSCognitoAuthConfirmSignUpOptions extends AuthConfirmSignUpOptions {
+    private final Map<String, String> clientMetadata;
+
+    /**
+     * Advanced options for confirming sign up.
+     * @param clientMetadata Additional custom attributes to be sent to the service such as information about the client
+     */
+    protected AWSCognitoAuthConfirmSignUpOptions(
+            Map<String, String> clientMetadata
+    ) {
+        this.clientMetadata = clientMetadata;
+    }
+
+    /**
+     * Get custom attributes to be sent to the service such as information about the client.
+     * @return custom attributes to be sent to the service such as information about the client
+     */
+    @NonNull
+    public Map<String, String> getClientMetadata() {
+        return clientMetadata;
+    }
+
+    /**
+     * Get a builder object.
+     * @return a builder object.
+     */
+    @NonNull
+    public static CognitoBuilder builder() {
+        return new CognitoBuilder();
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getClientMetadata()
+        );
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            AWSCognitoAuthConfirmSignUpOptions authConfirmSignUpOptions = (AWSCognitoAuthConfirmSignUpOptions) obj;
+            return ObjectsCompat.equals(getClientMetadata(), authConfirmSignUpOptions.getClientMetadata());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AWSCognitoAuthConfirmSignUpOptions{" +
+                "metadata=" + clientMetadata +
+                '}';
+    }
+
+    /**
+     * The builder for this class.
+     */
+    public static final class CognitoBuilder extends Builder<CognitoBuilder> {
+        private final Map<String, String> clientMetadata;
+
+        /**
+         * Constructor for the builder.
+         */
+        public CognitoBuilder() {
+            super();
+            this.clientMetadata = new HashMap<>();
+        }
+
+        /**
+         * Returns the type of builder this is to support proper flow with it being an extended class.
+         * @return the type of builder this is to support proper flow with it being an extended class.
+         */
+        @Override
+        public CognitoBuilder getThis() {
+            return this;
+        }
+
+        /**
+         * Set the metadata field for the object being built.
+         * @param clientMetadata Custom user metadata to be sent with the sign up request.
+         * @return The builder object to continue building.
+         */
+        @NonNull
+        public CognitoBuilder clientMetadata(@NonNull Map<String, String> clientMetadata) {
+            Objects.requireNonNull(clientMetadata);
+            this.clientMetadata.clear();
+            this.clientMetadata.putAll(clientMetadata);
+            return getThis();
+        }
+
+        /**
+         * Construct and return the object with the values set in the builder.
+         * @return a new instance of AWSCognitoAuthConfirmSignUpOptions with the values specified in the builder.
+         */
+        @NonNull
+        public AWSCognitoAuthConfirmSignUpOptions build() {
+            return new AWSCognitoAuthConfirmSignUpOptions(
+                    Immutable.of(clientMetadata));
+        }
+    }
+}

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -26,6 +26,7 @@ import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
@@ -68,11 +69,17 @@ interface Auth {
      * @param username A login identifier e.g. `tony44`; or an email/phone number,
      *                 depending on configuration
      * @param confirmationCode The confirmation code the user received
+     * @param options Advanced options such as a map of auth information for custom auth,
+     *                If not provided, default options will be used
      * @return A sign-up result; if the code has been confirmed successfully, the result
      *         will show true for isSignUpComplete().
      */
     @Throws(AuthException::class)
-    suspend fun confirmSignUp(username: String, confirmationCode: String): AuthSignUpResult
+    suspend fun confirmSignUp(
+        username: String,
+        confirmationCode: String,
+        options: AuthConfirmSignUpOptions = AuthConfirmSignUpOptions.defaults()
+    ): AuthSignUpResult
 
     /**
      * If the user's code expires or they just missed it, this method can

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -26,6 +26,7 @@ import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
@@ -58,12 +59,14 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
 
     override suspend fun confirmSignUp(
         username: String,
-        confirmationCode: String
+        confirmationCode: String,
+        options: AuthConfirmSignUpOptions
     ): AuthSignUpResult {
         return suspendCoroutine { continuation ->
             delegate.confirmSignUp(
                 username,
                 confirmationCode,
+                options,
                 { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
             )

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -97,9 +97,9 @@ class KotlinAuthFacadeTest {
         val code = "CoolCode599"
         val signUpResult = mockk<AuthSignUpResult>()
         every {
-            delegate.confirmSignUp(eq(username), eq(code), any(), any())
+            delegate.confirmSignUp(eq(username), eq(code), any(), any(), any())
         } answers {
-            val indexOfResultConsumer = 2
+            val indexOfResultConsumer = 3
             val onResult = it.invocation.args[indexOfResultConsumer] as Consumer<AuthSignUpResult>
             onResult.accept(signUpResult)
         }
@@ -116,9 +116,9 @@ class KotlinAuthFacadeTest {
         val code = "CoolCode599"
         val error = AuthException("uh", "oh")
         every {
-            delegate.confirmSignUp(eq(username), eq(code), any(), any())
+            delegate.confirmSignUp(eq(username), eq(code), any(), any(), any())
         } answers {
-            val indexOfErrorConsumer = 3
+            val indexOfErrorConsumer = 4
             val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
             onError.accept(error)
         }

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -59,6 +60,17 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
             @NonNull Consumer<AuthException> onError
     ) {
         getSelectedPlugin().signUp(username, password, options, onSuccess, onError);
+    }
+
+    @Override
+    public void confirmSignUp(
+            @NonNull String username,
+            @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignUpOptions options,
+            @NonNull Consumer<AuthSignUpResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().confirmSignUp(username, confirmationCode, options, onSuccess, onError);
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -54,6 +55,22 @@ public interface AuthCategoryBehavior {
             @NonNull String username,
             @NonNull String password,
             @NonNull AuthSignUpOptions options,
+            @NonNull Consumer<AuthSignUpResult> onSuccess,
+            @NonNull Consumer<AuthException> onError);
+
+    /**
+     * If you have attribute confirmation enabled, this will allow the user
+     * to enter the confirmation code they received to activate their account.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param confirmationCode The confirmation code the user received
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void confirmSignUp(
+            @NonNull String username,
+            @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignUpOptions options,
             @NonNull Consumer<AuthSignUpResult> onSuccess,
             @NonNull Consumer<AuthException> onError);
 

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthConfirmSignUpOptions.java
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthConfirmSignUpOptions.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * The shared options among all Auth plugins.
+ * Note: This is currently empty but exists here to support common confirm sign up options in the future.
+ */
+public abstract class AuthConfirmSignUpOptions {
+    /**
+     * Use the default confirm sign-up options.
+     * @return Default confirm sign-up options.
+     */
+    public static DefaultAuthConfirmSignUpOptions defaults() {
+        return new DefaultAuthConfirmSignUpOptions();
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    public abstract static class Builder<T extends Builder<T>> {
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        public abstract T getThis();
+
+        /**
+         * Build an instance of AuthConfirmSignUpOptions (or one of its subclasses).
+         * @return an instance of AuthConfirmSignUpOptions (or one of its subclasses)
+         */
+        @NonNull
+        public abstract AuthConfirmSignUpOptions build();
+    }
+
+    /**
+     * Default sign-in options. This works like a sentinel, to be used instead of "null".
+     * The only way to create this is by calling {@link AuthConfirmSignUpOptions#defaults()}.
+     */
+    public static final class DefaultAuthConfirmSignUpOptions extends AuthConfirmSignUpOptions {
+        private DefaultAuthConfirmSignUpOptions() {}
+
+        @Override
+        public int hashCode() {
+            return DefaultAuthConfirmSignUpOptions.class.hashCode();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof DefaultAuthConfirmSignUpOptions;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return DefaultAuthConfirmSignUpOptions.class.getSimpleName();
+        }
+    }
+}

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -31,6 +31,7 @@ import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -66,6 +67,13 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
             @NonNull String username, @NonNull String password, @NonNull AuthSignUpOptions options) {
         return toSingle((onResult, onError) ->
             delegate.signUp(username, password, options, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignUpResult> confirmSignUp(
+            @NonNull String username, @NonNull String confirmationCode, AuthConfirmSignUpOptions options) {
+        return toSingle((onResult, onError) ->
+                delegate.confirmSignUp(username, confirmationCode, options, onResult, onError));
     }
 
     @Override

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -30,6 +30,7 @@ import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -64,6 +65,21 @@ public interface RxAuthCategoryBehavior {
             @NonNull String username,
             @NonNull String password,
             @NonNull AuthSignUpOptions options
+    );
+
+    /**
+     * If you have attribute confirmation enabled, this will allow the user
+     * to enter the confirmation code they received to activate their account.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param confirmationCode The confirmation code the user received
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return An Rx {@link Single} which emits an {@link AuthSignUpResult} on successful confirmation,
+     *         or an {@link AuthException} on failure
+     */
+    Single<AuthSignUpResult> confirmSignUp(
+            @NonNull String username,
+            @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignUpOptions options
     );
 
     /**

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -28,6 +28,7 @@ import com.amplifyframework.auth.AuthSession;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
@@ -98,6 +99,25 @@ public final class SynchronousAuth {
     ) throws AuthException {
         return Await.<AuthSignUpResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
                 asyncDelegate.signUp(username, password, options, onResult, onError)
+        );
+    }
+
+    /**
+     * Confirm sign up synchronously.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param confirmationCode The confirmation code the user received
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return result object
+     * @throws AuthException exception
+     */
+    @NonNull
+    public AuthSignUpResult confirmSignUp(
+            @NonNull String username,
+            @NonNull String confirmationCode,
+            @NonNull AuthConfirmSignUpOptions options
+    ) throws AuthException {
+        return Await.<AuthSignUpResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+                asyncDelegate.confirmSignUp(username, confirmationCode, options, onResult, onError)
         );
     }
 


### PR DESCRIPTION
**Issue #, if available:**

Part 1 of fix for `amplify-flutter` issue [#575](https://github.com/aws-amplify/amplify-flutter/issues/575).
`amplify-flutter` depends on this fix to implement capability of passing `clientMetadata` via `confirmSignUp` API.

**Description of changes:**

* Replicate `ConfirmSignUpOptions` for `confirmSignUp` API method that is supported by [amplify-ios auth plugin](https://github.com/aws-amplify/amplify-ios/blob/main/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin%2BClientBehavior.swift#L29).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
