### PR TITLE
fix: remove duplicate error callback in storage

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.java
@@ -173,11 +173,7 @@ public final class AWSS3StorageDownloadFileOperation
                     onSuccess.accept(StorageDownloadFileResult.fromFile(file));
                     return;
                 case FAILED:
-                    onError.accept(new StorageException(
-                            "Storage download operation was interrupted.",
-                            "Please verify that you have a stable internet connection."
-                    ));
-                    return;
+                    // no-op;
                 default:
                     // no-op;
             }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.java
@@ -185,11 +185,7 @@ public final class AWSS3StorageUploadFileOperation extends StorageUploadFileOper
                     onSuccess.accept(StorageUploadFileResult.fromKey(getRequest().getKey()));
                     return;
                 case FAILED:
-                    onError.accept(new StorageException(
-                            "Storage upload operation was interrupted.",
-                            "Please verify that you have a stable internet connection."
-                    ));
-                    return;
+                    // no-op;
                 default:
                     // no-op;
             }

--- a/testutils/src/main/java/com/amplifyframework/testutils/Await.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/Await.java
@@ -146,6 +146,9 @@ public final class Await {
                         resultContainer.set(result);
                         latch.countDown();
                     }, error -> {
+                        if (errorContainer.get() != null) {
+                            throw new RuntimeException("Error callback called more than once with error: " + error);
+                        }
                         errorContainer.set(error);
                         latch.countDown();
                     }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-android/issues/1345

*Description of changes:*
- Remove invocation of error callback in the download/upload state change listener
- Add test for duplicate error callbacks 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
