### PR TITLE
fix(auth): throw correct auth exception for code mismatch

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -553,11 +553,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
                 @Override
                 public void onError(Exception exception) {
-                    onException.accept(new AuthException(
-                            "An error occurred while attempting to retrieve your user details",
-                            exception,
-                            "See attached exception for more details"
-                    ));
+                    onException.accept(CognitoAuthExceptionConverter.lookup(
+                            exception, "Fetching authorization session failed."));
                 }
             });
         } catch (Throwable exception) {
@@ -582,11 +579,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception exception) {
-                onException.accept(new AuthException(
-                        "An error occurred while remembering a device",
-                        exception,
-                        "See attached exception for more details"
-                ));
+                onException.accept(CognitoAuthExceptionConverter.lookup(
+                        exception, "Remember device failed."));
             }
         });
     }
@@ -604,11 +598,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception exception) {
-                onException.accept(new AuthException(
-                        "An error occurred while forgetting a device",
-                        exception,
-                        "See attached exception for more details"
-                ));
+                onException.accept(CognitoAuthExceptionConverter.lookup(
+                        exception, "Forget device failed."));
             }
         });
     }
@@ -627,11 +618,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception exception) {
-                onException.accept(new AuthException(
-                        "An error occurred while forgetting a device",
-                        exception,
-                        "See attached exception for more details"
-                ));
+                onException.accept(CognitoAuthExceptionConverter.lookup(
+                        exception, "Forget device failed."));
             }
         });
     }
@@ -653,11 +641,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception exception) {
-                onException.accept(new AuthException(
-                        "An error occurred while fetching remembered devices.",
-                        exception,
-                        "See attached exception for more details"
-                ));
+                onException.accept(CognitoAuthExceptionConverter.lookup(
+                        exception, "Fetching devices failed."));
             }
         });
     }
@@ -690,11 +675,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception exception) {
-                onException.accept(new AuthException(
-                        "An error occurred triggering password recovery",
-                        exception,
-                        "See attached exception for more details"
-                ));
+                onException.accept(CognitoAuthExceptionConverter.lookup(
+                        exception, "Reset password failed."));
             }
         });
     }
@@ -746,12 +728,9 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             }
 
             @Override
-            public void onError(Exception error) {
-                onException.accept(new AuthException(
-                        "Failed to change password",
-                        error,
-                        "See attached exception for more details"
-                ));
+            public void onError(Exception exception) {
+                onException.accept(CognitoAuthExceptionConverter.lookup(
+                        exception, "Update password failed."));
             }
         });
     }
@@ -774,11 +753,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
             @Override
             public void onError(Exception error) {
-                onError.accept(new AuthException(
-                        "Failed to fetch user attributes",
-                        error,
-                        "Ensure that you are logged in and online"
-                ));
+                onError.accept(CognitoAuthExceptionConverter.lookup(
+                        error, "Fetching user attributes failed."));
             }
         });
     }
@@ -929,11 +905,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
                     @Override
                     public void onError(Exception error) {
-                        onError.accept(new AuthException(
-                                "An error occurred confirming user attribute",
-                                error,
-                                "See attached exception for more details"
-                        ));
+                        onError.accept(CognitoAuthExceptionConverter.lookup(
+                                error, "Confirming user attributes failed."));
                     }
                 });
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -725,11 +725,8 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
                 @Override
                 public void onError(Exception error) {
-                    onException.accept(new AuthException(
-                            "An error occurred confirming password recovery code",
-                            error,
-                            "See attached exception for more details"
-                    ));
+                    onException.accept(CognitoAuthExceptionConverter.lookup(
+                            error, "Confirm reset password failed."));
                 }
             }
         );

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -33,9 +33,9 @@ import com.amazonaws.services.cognitoidentityprovider.model.ResourceNotFoundExce
 import com.amazonaws.services.cognitoidentityprovider.model.SoftwareTokenMFANotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttemptsException;
 import com.amazonaws.services.cognitoidentityprovider.model.TooManyRequestsException;
-import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotFoundException;
+import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
 
 /**
  * Convert AWS Cognito Exceptions to AuthExceptions.

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -32,6 +32,7 @@ import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttempt
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
+import com.amazonaws.services.cognitoidentityprovider.model.MFAMethodNotFoundException;
 
 /**
  * Convert AWS Cognito Exceptions to AuthExceptions.
@@ -89,6 +90,10 @@ public final class CognitoAuthExceptionConverter {
 
         if (error instanceof LimitExceededException) {
             return new AuthException.LimitExceededException(error);
+        }
+
+        if (error instanceof MFAMethodNotFoundException) {
+            return new AuthException.MFAMethodNotFoundException(error);
         }
 
         if (error instanceof ResourceNotFoundException) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -27,10 +27,12 @@ import com.amazonaws.services.cognitoidentityprovider.model.InvalidParameterExce
 import com.amazonaws.services.cognitoidentityprovider.model.InvalidPasswordException;
 import com.amazonaws.services.cognitoidentityprovider.model.LimitExceededException;
 import com.amazonaws.services.cognitoidentityprovider.model.MFAMethodNotFoundException;
+import com.amazonaws.services.cognitoidentityprovider.model.NotAuthorizedException;
 import com.amazonaws.services.cognitoidentityprovider.model.PasswordResetRequiredException;
 import com.amazonaws.services.cognitoidentityprovider.model.ResourceNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.SoftwareTokenMFANotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttemptsException;
+import com.amazonaws.services.cognitoidentityprovider.model.TooManyRequestsException;
 import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotFoundException;
@@ -97,6 +99,10 @@ public final class CognitoAuthExceptionConverter {
             return new AuthException.MFAMethodNotFoundException(error);
         }
 
+        if (error instanceof NotAuthorizedException) {
+            return new AuthException.NotAuthorizedException(error);
+        }
+
         if (error instanceof ResourceNotFoundException) {
             return new AuthException.ResourceNotFoundException(error);
         }
@@ -107,6 +113,10 @@ public final class CognitoAuthExceptionConverter {
 
         if (error instanceof TooManyFailedAttemptsException) {
             return new AuthException.FailedAttemptsLimitExceededException(error);
+        }
+
+        if (error instanceof TooManyRequestsException) {
+            return new AuthException.TooManyRequestsException(error);
         }
 
         if (error instanceof PasswordResetRequiredException) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -29,9 +29,9 @@ import com.amazonaws.services.cognitoidentityprovider.model.LimitExceededExcepti
 import com.amazonaws.services.cognitoidentityprovider.model.PasswordResetRequiredException;
 import com.amazonaws.services.cognitoidentityprovider.model.ResourceNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttemptsException;
+import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotFoundException;
-import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
 import com.amazonaws.services.cognitoidentityprovider.model.MFAMethodNotFoundException;
 
 /**

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -29,6 +29,7 @@ import com.amazonaws.services.cognitoidentityprovider.model.LimitExceededExcepti
 import com.amazonaws.services.cognitoidentityprovider.model.MFAMethodNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.PasswordResetRequiredException;
 import com.amazonaws.services.cognitoidentityprovider.model.ResourceNotFoundException;
+import com.amazonaws.services.cognitoidentityprovider.model.SoftwareTokenMFANotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttemptsException;
 import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
@@ -98,6 +99,10 @@ public final class CognitoAuthExceptionConverter {
 
         if (error instanceof ResourceNotFoundException) {
             return new AuthException.ResourceNotFoundException(error);
+        }
+
+        if (error instanceof SoftwareTokenMFANotFoundException) {
+            return new AuthException.SoftwareTokenMFANotFoundException(error);
         }
 
         if (error instanceof TooManyFailedAttemptsException) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -26,13 +26,13 @@ import com.amazonaws.services.cognitoidentityprovider.model.ExpiredCodeException
 import com.amazonaws.services.cognitoidentityprovider.model.InvalidParameterException;
 import com.amazonaws.services.cognitoidentityprovider.model.InvalidPasswordException;
 import com.amazonaws.services.cognitoidentityprovider.model.LimitExceededException;
+import com.amazonaws.services.cognitoidentityprovider.model.MFAMethodNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.PasswordResetRequiredException;
 import com.amazonaws.services.cognitoidentityprovider.model.ResourceNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.TooManyFailedAttemptsException;
 import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotFoundException;
-import com.amazonaws.services.cognitoidentityprovider.model.MFAMethodNotFoundException;
 
 /**
  * Convert AWS Cognito Exceptions to AuthExceptions.

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/datastore/KotlinDataStoreFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/datastore/KotlinDataStoreFacade.kt
@@ -67,10 +67,10 @@ class KotlinDataStoreFacade(private val delegate: Delegate = Amplify.DataStore) 
     }
 
     @Throws(DataStoreException::class)
-    override suspend fun <T : Model> delete(itemClass: KClass<T>, filter: QueryPredicate) {
+    override suspend fun <T : Model> delete(byClass: KClass<T>, filter: QueryPredicate) {
         return suspendCoroutine { continuation ->
             delegate.delete(
-                itemClass.java,
+                byClass.java,
                 filter,
                 { continuation.resume(Unit) },
                 { continuation.resumeWithException(it) }

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -418,7 +418,7 @@ public class AuthException extends AmplifyException {
      */
     public static class NotAuthorizedException extends AuthException {
         private static final long serialVersionUID = 1L;
-        private static final String MESSAGE = "";
+        private static final String MESSAGE = "Failed since user is not authorized.";
         private static final String RECOVERY_SUGGESTION =
                 "Check whether the given values are correct and the user is authorized to perform the operation.";
 

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -402,7 +402,8 @@ public class AuthException extends AmplifyException {
     public static class MFAMethodNotFoundException extends AuthException {
         private static final long serialVersionUID = 1L;
         private static final String MESSAGE = "Could not find multi-factor authentication (MFA) method.";
-        private static final String RECOVERY_SUGGESTION = "Configure multi-factor authentication using Amplify CLI or AWS Cognito console.";
+        private static final String RECOVERY_SUGGESTION =
+                "Configure multi-factor authentication using Amplify CLI or AWS Cognito console.";
 
         /**
          * Default message/recovery suggestion with a cause.

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -449,6 +449,24 @@ public class AuthException extends AmplifyException {
     }
 
     /**
+     * Could not find software token MFA for the user.
+     */
+    public static class SoftwareTokenMFANotFoundException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Could not find software token MFA.";
+        private static final String RECOVERY_SUGGESTION =
+                "Enable the software token MFA for the user.";
+
+        /**
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
+         */
+        public SoftwareTokenMFANotFoundException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
+        }
+    }
+
+    /**
      * Could not perform the action because user made too many failed attempts for a given action.
      */
     public static class FailedAttemptsLimitExceededException extends AuthException {

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -414,6 +414,24 @@ public class AuthException extends AmplifyException {
     }
 
     /**
+     *
+     */
+    public static class NotAuthorizedException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "";
+        private static final String RECOVERY_SUGGESTION =
+                "Check whether the given values are correct and the user is authorized to perform the operation.";
+
+        /**
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
+         */
+        public NotAuthorizedException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
+        }
+    }
+
+    /**
      * Could not perform the action because password needs to be reset.
      */
     public static class PasswordResetRequiredException extends AuthException {
@@ -480,6 +498,24 @@ public class AuthException extends AmplifyException {
          * @param cause The original error.
          */
         public FailedAttemptsLimitExceededException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
+        }
+    }
+
+    /**
+     *
+     */
+    public static class TooManyRequestsException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "";
+        private static final String RECOVERY_SUGGESTION =
+                "Make sure the requests send are controlled and the errors are properly handled.";
+
+        /**
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
+         */
+        public TooManyRequestsException(Throwable cause) {
             super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
     }

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -397,6 +397,23 @@ public class AuthException extends AmplifyException {
     }
 
     /**
+     * Could not find multi-factor authentication (MFA) method in AWS Cognito.
+     */
+    public static class MFAMethodNotFoundException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "Could not find multi-factor authentication (MFA) method.";
+        private static final String RECOVERY_SUGGESTION = "Configure multi-factor authentication using Amplify CLI or AWS Cognito console.";
+
+        /**
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
+         */
+        public MFAMethodNotFoundException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
+        }
+    }
+
+    /**
      * Could not perform the action because password needs to be reset.
      */
     public static class PasswordResetRequiredException extends AuthException {

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -507,7 +507,7 @@ public class AuthException extends AmplifyException {
      */
     public static class TooManyRequestsException extends AuthException {
         private static final long serialVersionUID = 1L;
-        private static final String MESSAGE = "";
+        private static final String MESSAGE = "Failed since the user made too many requests.";
         private static final String RECOVERY_SUGGESTION =
                 "Make sure the requests send are controlled and the errors are properly handled.";
 

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -414,7 +414,7 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     *
+     * Could not perform the operation since user is not authorized.
      */
     public static class NotAuthorizedException extends AuthException {
         private static final long serialVersionUID = 1L;
@@ -503,7 +503,7 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     *
+     * Could not perform the operation since user made too many requests.
      */
     public static class TooManyRequestsException extends AuthException {
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
*Issue #, if available:*  #1102 

*Description of changes:*
Throw AuthException with correct message and recovery suggestion mapped to Cognito exception instead of generic exception.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
