### PR TITLE
fix(datastore): fix subscription timeout period not increasing

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -95,7 +95,7 @@ final class SubscriptionProcessor {
         // then 2 seconds are added to the timer per additional model count.
         this.adjustedTimeoutSeconds = Math.max(
             NETWORK_OP_TIMEOUT_SECONDS,
-            TIMEOUT_SECONDS_PER_MODEL * modelProvider.models().size()
+            TIMEOUT_SECONDS_PER_MODEL * modelProvider.modelSchemas().size()
         );
     }
 


### PR DESCRIPTION
**Issue #, if available:**

Flutter open issues: [#615](https://github.com/aws-amplify/amplify-flutter/issues/615)

**Description of changes:**

`amplify-flutter` relies on `ModelProvider.modelSchemas` to leverage `amplify-android` functionality. The original subscription timeout period incrementing mechanism doesn't cover `modelSchemas`, thus, we saw subscription timeout issues when attempting subscribe more than 5 models in Flutter.

Changed to use  `modelSchemas` method to get the number of models. This change should be safe, as `ModelProvider` has the [default method](https://github.com/aws-amplify/amplify-android/blob/891ae1c5fdd5bf008315f82c343ed1868739d635/core/src/main/java/com/amplifyframework/core/model/ModelProvider.java#L49) that ensures the coherence of `models` and `modelSchemas`.

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
