### PR TITLE
chore: remove deprecated WRITE_EXTERNAL_STORAGE permission

### DIFF
--- a/aws-datastore/src/androidTest/AndroidManifest.xml
+++ b/aws-datastore/src/androidTest/AndroidManifest.xml
@@ -17,5 +17,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.amplifyframework.datastore">
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/aws-storage-s3/src/main/AndroidManifest.xml
+++ b/aws-storage-s3/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.amplifyframework.storage.s3" >
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application>
         <service android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService" android:enabled="true" />


### PR DESCRIPTION
Resolves https://github.com/aws-amplify/amplify-android/issues/896

`WRITE_EXTERNAL_STORAGE` was deprecated in Android 10.  It was used for accessing files on an external disc, or other locations outside of the app sandbox.  As far as I know, we don't need it, and I'm not sure why it was added in the first place.  If we did need it, any customer building an app that targets Android 10 (released almost 2 years ago) or above would have reported an issue to us about it, and that hasn't happened.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
