### PR TITLE
fix(datastore): explicitly include id field for update mutations, to support types with custom primary keys

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterCustomPrimaryKeyTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterCustomPrimaryKeyTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite;
+
+import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.datastore.StrictMode;
+import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
+import com.amplifyframework.testmodels.ecommerce.AmplifyModelProvider;
+import com.amplifyframework.testmodels.ecommerce.Customer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test the functionality of {@link SQLiteStorageAdapter} operations with types that use a custom primary key.
+ */
+public final class SQLiteStorageAdapterCustomPrimaryKeyTest {
+
+    private SynchronousStorageAdapter adapter;
+
+    /**
+     * Enable Android Strict Mode, to help catch common errors while using SQLite,
+     * such as forgetting to close a database (from source).
+     */
+    @BeforeClass
+    public static void enableStrictMode() {
+        StrictMode.enable();
+    }
+
+    /**
+     * Remove any old SQLite database files. Setup a new storage adapter, which is able
+     * to warehouse the ecommerce (Customer, Item, Order) family of models.
+     */
+    @Before
+    public void setup() {
+        TestStorageAdapter.cleanup();
+        this.adapter = TestStorageAdapter.create(AmplifyModelProvider.getInstance());
+    }
+
+    /**
+     * Close the storage adapter and delete any SQLite database files that it may
+     * have left.
+     */
+    @After
+    public void teardown() {
+        TestStorageAdapter.cleanup(adapter);
+    }
+
+    /**
+     * Validate that a model with a custom primary key can be updated.
+     * @throws DataStoreException on failure to create or update the model.
+     */
+    @Test
+    public void updateModelWithCustomPrimaryKey() throws DataStoreException {
+        // Create a model
+        Customer jeff = Customer.builder()
+                .email("jeff@amazon.com")
+                .username("jeff")
+                .build();
+        adapter.save(jeff);
+
+        // Then update it
+        Customer updatedJeff = jeff.copyOfBuilder()
+                .username("jeffbezos")
+                .build();
+        adapter.save(updatedJeff);
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/SerializedModel.java
+++ b/core/src/main/java/com/amplifyframework/core/model/SerializedModel.java
@@ -23,9 +23,10 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.util.Immutable;
 
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A container for model data, when passed from hybrid platforms.
@@ -78,7 +79,13 @@ public final class SerializedModel implements Model {
         Map<String, Object> originalMap = ModelConverter.toMap(original, modelSchema);
         Map<String, Object> patchMap = new HashMap<>();
         for (String key : updatedMap.keySet()) {
-            List<String> primaryIndexFields = modelSchema.getPrimaryIndexFields();
+            Set<String> primaryIndexFields = new HashSet<>();
+
+            // This can be removed once we fully support custom primary keys.  For now, it is required though, since
+            // SerializedModel requires the `id` field.
+            primaryIndexFields.add(PrimaryKey.fieldName());
+
+            primaryIndexFields.addAll(modelSchema.getPrimaryIndexFields());
             if (primaryIndexFields.contains(key) || !ObjectsCompat.equals(originalMap.get(key), updatedMap.get(key))) {
                 patchMap.put(key, updatedMap.get(key));
             }

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/ecommerce/AmplifyModelProvider.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/ecommerce/AmplifyModelProvider.java
@@ -1,0 +1,60 @@
+package com.amplifyframework.testmodels.ecommerce;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.testmodels.commentsblog.Author;
+import com.amplifyframework.testmodels.commentsblog.Blog;
+import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testmodels.commentsblog.Comment;
+import com.amplifyframework.testmodels.commentsblog.Post;
+import com.amplifyframework.testmodels.commentsblog.PostAuthorJoin;
+import com.amplifyframework.util.Immutable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ *  Contains the set of model classes that implement {@link Model}
+ * interface.
+ */
+
+public final class AmplifyModelProvider implements ModelProvider {
+  private static final String AMPLIFY_MODEL_VERSION = "291b773087e72b546d24c87e137d7b91";
+  private static AmplifyModelProvider amplifyGeneratedModelInstance;
+  private AmplifyModelProvider() {
+    
+  }
+  
+  public static AmplifyModelProvider getInstance() {
+    if (amplifyGeneratedModelInstance == null) {
+      amplifyGeneratedModelInstance = new AmplifyModelProvider();
+    }
+    return amplifyGeneratedModelInstance;
+  }
+  
+  /** 
+   * Get a set of the model classes.
+   * 
+   * @return a set of the model classes.
+   */
+  @Override
+   public Set<Class<? extends Model>> models() {
+    final Set<Class<? extends Model>> modifiableSet = new HashSet<>(
+          Arrays.<Class<? extends Model>>asList(Customer.class, Item.class, Order.class)
+        );
+    
+        return Immutable.of(modifiableSet);
+        
+  }
+  
+  /** 
+   * Get the version of the models.
+   * 
+   * @return the version string of the models.
+   */
+  @Override
+   public String version() {
+    return AMPLIFY_MODEL_VERSION;
+  }
+}


### PR DESCRIPTION
Currently, when you do a `DataStore.save(…)`, we query for the item in SQLite, and compute the difference in fields.  Then, when the mutation gets sent to AppSync, it only sends the fields that have changed, as well as the partition key and all sort keys, since those are always required.   

If the model being saved defines a custom primary key other than `id`, an error occurs on [this line](https://github.com/aws-amplify/amplify-android/blob/release_v1.18.0/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModel.java#L90) in the method that computes the difference of fields.    Essentially, since `id` is not part of the primary key, it isn’t getting included, but `SerializedModel` actually still requires a hardcoded `id` field. 

This PR resolves the issue by always including the `id` field on update mutations.  Once we add complete support for custom primary keys though, this won't be necessary anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
