### PR TITLE
fix: increase timeout for subscriptions to be established on slow networks

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -66,8 +66,8 @@ import io.reactivex.rxjava3.subjects.ReplaySubject;
  */
 final class SubscriptionProcessor {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
-    private static final long TIMEOUT_SECONDS_PER_MODEL = 2;
-    private static final long NETWORK_OP_TIMEOUT_SECONDS = 10;
+    private static final long TIMEOUT_SECONDS_PER_MODEL = 20;
+    private static final long NETWORK_OP_TIMEOUT_SECONDS = 60;
 
     private final AppSync appSync;
     private final ModelProvider modelProvider;
@@ -91,8 +91,9 @@ final class SubscriptionProcessor {
 
         this.ongoingOperationsDisposable = new CompositeDisposable();
 
-        // Operation times out after 10 seconds. If there are more than 5 models,
-        // then 2 seconds are added to the timer per additional model count.
+        // Operation times out after the greater of 60 seconds or 20 seconds per model.
+        // Previously this was the greater of 10 seconds or 2 seconds per model, but customers
+        // reported timeouts on 3G connections.
         this.adjustedTimeoutSeconds = Math.max(
             NETWORK_OP_TIMEOUT_SECONDS,
             TIMEOUT_SECONDS_PER_MODEL * modelProvider.modelSchemas().size()


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-android/issues/1388

*Description of changes:* Increases timeout in `SubscriptionProcessor` to the same timeouts used in the `Orchestrator` to account for slow network connections.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
