### PR TITLE
chore:fix dependabot alert for addressable gem

### DIFF
--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "addressable", ">= 2.8.0"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/scripts/Gemfile.lock
+++ b/scripts/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     artifactory (3.0.15)
     atomos (0.1.3)
@@ -58,7 +58,7 @@ GEM
     fastimage (2.2.3)
     fastlane (2.180.1)
       CFPropertyList (>= 2.3, < 4.0.0)
-      addressable (>= 2.3, < 3.0.0)
+      addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
       aws-sdk-s3 (~> 1.0)
       babosa (>= 1.0.3, < 2.0.0)
@@ -97,7 +97,7 @@ GEM
     fastlane-plugin-semantic_release (1.13.1)
     gh_inspector (1.1.3)
     google-api-client (0.38.0)
-      addressable (~> 2.5, >= 2.5.1)
+      addressable (~> 2.8, >= 2.5.1)
       googleauth (~> 0.9)
       httpclient (>= 2.8.1, < 3.0)
       mini_mime (~> 1.0)
@@ -105,7 +105,7 @@ GEM
       retriable (>= 2.0, < 4.0)
       signet (~> 0.12)
     google-apis-core (0.3.0)
-      addressable (~> 2.5, >= 2.5.1)
+      addressable (~> 2.8, >= 2.5.1)
       googleauth (~> 0.14)
       httpclient (>= 2.8.1, < 3.0)
       mini_mime (~> 1.0)
@@ -125,7 +125,7 @@ GEM
       faraday (>= 0.17.3, < 2.0)
     google-cloud-errors (1.1.0)
     google-cloud-storage (1.31.0)
-      addressable (~> 2.5)
+      addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
       google-apis-storage_v1 (~> 0.1)
@@ -168,7 +168,7 @@ GEM
     rubyzip (2.3.0)
     security (0.1.3)
     signet (0.15.0)
-      addressable (~> 2.3)
+      addressable (~> 2.8)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
@@ -205,6 +205,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (>= 2.8.0)
   fastlane
   fastlane-plugin-release_actions!
   fastlane-plugin-semantic_release


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing dependabot alerts received for `addressable` gem

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
