### PR TITLE
feat(api) add CUSTOM case to AuthStrategy

### DIFF
--- a/aws-api/src/test/java/com/amplifyframework/api/aws/auth/AuthRuleRequestDecoratorTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/auth/AuthRuleRequestDecoratorTest.java
@@ -202,6 +202,13 @@ public final class AuthRuleRequestDecoratorTest {
             GraphQLRequest<Group> modifiedRequest = decorator.decorate(originalRequest, mode);
             assertNull(getOwnerField(modifiedRequest));
         }
+
+        // Custom auth with function provider does not add owner field.
+        for (SubscriptionType subscriptionType : SubscriptionType.values()) {
+            GraphQLRequest<CustomFunction> originalRequest = createRequest(CustomFunction.class, subscriptionType);
+            GraphQLRequest<CustomFunction> modifiedRequest = decorator.decorate(originalRequest, mode);
+            assertNull(getOwnerField(modifiedRequest));
+        }
     }
 
     /**
@@ -349,6 +356,9 @@ public final class AuthRuleRequestDecoratorTest {
 
     @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.PRIVATE) })
     private abstract static class Private implements Model {}
+
+    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.CUSTOM, provider = "function") })
+    private abstract static class CustomFunction implements Model {}
 
     @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER) })
     private abstract static class Owner implements Model {}

--- a/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
+++ b/core/src/main/java/com/amplifyframework/core/model/AuthStrategy.java
@@ -26,28 +26,34 @@ import java.util.Objects;
  */
 public enum AuthStrategy {
     /**
+     * Custom authorization restricts access based on anything, as defined by the customer, such as via an AWS Lambda
+     * serverless function.  To use CUSTOM, the API must have the AWS_LAMBDA auth type configured.
+     */
+    CUSTOM(Provider.FUNCTION, 1),
+
+    /**
      * Owner authorization specifies whether a user can access or operate against an object.  To use OWNER, the API
      * must have Cognito User Pool configured.
      */
-    OWNER(Provider.USER_POOLS, 1),
+    OWNER(Provider.USER_POOLS, 2),
 
     /**
      * Group authorization specifies whether a group can access or operate against an object.  To use GROUPS, the API
      * must have Cognito User Pool configured.
      */
-    GROUPS(Provider.USER_POOLS, 2),
+    GROUPS(Provider.USER_POOLS, 3),
 
     /**
      * The private authorization specifies that everyone will be allowed to access the API with a valid JWT token from
      * the configured Cognito User Pool. To use PRIVATE, the API must have Cognito User Pool configured.
      */
-    PRIVATE(Provider.USER_POOLS, 3),
+    PRIVATE(Provider.USER_POOLS, 4),
 
     /**
      * The public authorization specifies that everyone will be allowed to access the API, behind the scenes the API
      * will be protected with an API Key. To use PUBLIC, the API must have API Key configured.
      */
-    PUBLIC(Provider.API_KEY, 4);
+    PUBLIC(Provider.API_KEY, 5);
 
     private final Provider defaultAuthProvider;
     private final int priority;


### PR DESCRIPTION
The CLI does not support the `AWS_LAMBDA` auth type yet, but will soon.  When it does, the code-generated models will have this annotation:  

`@ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.CUSTOM, provider = "function") })`

The following table shows the allowed combinations of authorization strategies and providers.

|  | owner | groups | public | private | custom |
| --- | --- | --- | --- | --- | --- |
| userPools | X | X |  | X |  |
| oidc | X | X |  |  |  |
| apiKey |  |  | X |  |  |
| iam |  |  | X | X |  |
| function |  |  |  |  | X | 

This PR adds the CUSTOM case to the `AuthStrategy` enum, which the code generated models will rely on.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
