### PR TITLE
fix: handle null values for predicates

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -97,6 +97,28 @@ public final class SQLiteStorageAdapterQueryTest {
     }
 
     /**
+     * Test predicates that check for null/not null values.
+     * @throws DataStoreException not expected.
+     */
+    @Test
+    public void queryBasedOnNullPredicateFields() throws DataStoreException {
+        final BlogOwner blogOwner = BlogOwner.builder()
+                .name("Alan Turing")
+                .build();
+        adapter.save(blogOwner);
+
+        List<BlogOwner> blogOwners = adapter.query(
+                BlogOwner.class,
+                Where.matches(BlogOwner.WEA.eq(null)));
+        assertTrue(blogOwners.contains(blogOwner));
+
+        blogOwners = adapter.query(
+                BlogOwner.class,
+                Where.matches(BlogOwner.NAME.eq(null)));
+        assertTrue(blogOwners.isEmpty());
+    }
+
+    /**
      * Test querying the saved item in the SQLite database.
      * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
      */

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SqlKeyword.java
@@ -180,7 +180,17 @@ public enum SqlKeyword {
     /**
      * SQL keyword meaning to sort in descending order, for use with ORDER_BY.
      */
-    DESC("DESC");
+    DESC("DESC"),
+
+    /**
+     * SQL keyword for check whether a field is null.
+     */
+    IS_NULL("IS NULL"),
+
+    /**
+     * SQL keyword for check whether a field is not null.
+     */
+    IS_NOT_NULL("IS NOT NULL");
 
     private static final Map<QueryOperator.Type, SqlKeyword> QUERY_OPERATOR_TO_SQL = new HashMap<>();
     private static final Map<QueryPredicateGroup.Type, SqlKeyword> QUERY_PREDICATE_GROUP_TO_SQL = new HashMap<>();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -187,6 +187,21 @@ public final class SQLPredicate {
                         .append("?");
             case EQUAL:
             case NOT_EQUAL:
+                Object operatorValue = getOperatorValue(op);
+                if (operatorValue != null) {
+                    addBinding(operatorValue);
+                    return builder.append(column)
+                        .append(SqlKeyword.DELIMITER)
+                        .append(SqlKeyword.fromQueryOperator(op.type()))
+                        .append(SqlKeyword.DELIMITER)
+                        .append("?");
+                } else {
+                    SqlKeyword sqlNullCheck =
+                            op.type() == QueryOperator.Type.EQUAL ? SqlKeyword.IS_NULL : SqlKeyword.IS_NOT_NULL;
+                    return builder.append(column)
+                        .append(SqlKeyword.DELIMITER)
+                        .append(sqlNullCheck.toString());
+                }
             case LESS_THAN:
             case GREATER_THAN:
             case LESS_OR_EQUAL:

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -131,6 +131,7 @@ public final class SQLPredicate {
         );
     }
 
+    @SuppressWarnings("fallthrough")
     // Utility method to recursively parse a given predicate operation.
     private StringBuilder parsePredicateOperation(QueryPredicateOperation<?> operation) throws DataStoreException {
         final StringBuilder builder = new StringBuilder();
@@ -188,14 +189,7 @@ public final class SQLPredicate {
             case EQUAL:
             case NOT_EQUAL:
                 Object operatorValue = getOperatorValue(op);
-                if (operatorValue != null) {
-                    addBinding(operatorValue);
-                    return builder.append(column)
-                        .append(SqlKeyword.DELIMITER)
-                        .append(SqlKeyword.fromQueryOperator(op.type()))
-                        .append(SqlKeyword.DELIMITER)
-                        .append("?");
-                } else {
+                if (operatorValue == null) {
                     SqlKeyword sqlNullCheck =
                             op.type() == QueryOperator.Type.EQUAL ? SqlKeyword.IS_NULL : SqlKeyword.IS_NOT_NULL;
                     return builder.append(column)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLPredicateTest.java
@@ -103,6 +103,28 @@ public class SQLPredicateTest {
         validateSQLExpressionForNotContains(sqlPredicate, "tags");
     }
 
+    /**
+     * Test IS NOT NULL expression.
+     * @throws DataStoreException Not thrown.
+     */
+    @Test
+    public void testNotNull() throws DataStoreException {
+        SQLPredicate sqlPredicate = new SQLPredicate(Where.matches(Blog.NAME.ne(null)).getQueryPredicate());
+        System.out.println(sqlPredicate.toString());
+        assertEquals("name IS NOT NULL", sqlPredicate.toString());
+    }
+
+    /**
+     * Test IS NULL expression.
+     * @throws DataStoreException Not thrown.
+     */
+    @Test
+    public void testIsNull() throws DataStoreException {
+        SQLPredicate sqlPredicate = new SQLPredicate(Where.matches(Blog.NAME.eq(null)).getQueryPredicate());
+        System.out.println(sqlPredicate.toString());
+        assertEquals("name IS NULL", sqlPredicate.toString());
+    }
+
     private void validateSQLExpressionForContains(SQLPredicate sqlPredicate, String fieldName) {
         assertEquals(1, sqlPredicate.getBindings().size());
         assertEquals("something", sqlPredicate.getBindings().get(0));


### PR DESCRIPTION
*Issue #, if available:* #1434

*Description of changes:*
Predicate logic was not handling null values for equal and not equal operations.

This PR addresses this bug bug checking for null values when the operator is EQUAL or NOT EQUAL and constructs the SQL statement accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
