### PR TITLE
feat(auth): add options for updateAttribute, updateAttributes, resendUserAttributeConfirmationCode

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -35,18 +35,24 @@ import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignUpOptions;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignOutOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignUpOptions;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributeOptions;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthWebUISignInOptions;
 import com.amplifyframework.auth.cognito.util.AuthProviderConverter;
 import com.amplifyframework.auth.cognito.util.CognitoAuthExceptionConverter;
 import com.amplifyframework.auth.cognito.util.SignInStateConverter;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSessionResult;
@@ -765,12 +771,21 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     @Override
     public void updateUserAttribute(
             @NonNull AuthUserAttribute attribute,
+            @NonNull AuthUpdateUserAttributeOptions options,
             @NonNull Consumer<AuthUpdateAttributeResult> onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
 
+        final Map<String, String> clientMetadata = new HashMap<>();
+        if (options instanceof AWSCognitoAuthUpdateUserAttributeOptions) {
+            AWSCognitoAuthUpdateUserAttributeOptions cognitoOptions =
+                    (AWSCognitoAuthUpdateUserAttributeOptions) options;
+            clientMetadata.putAll(cognitoOptions.getMetadata());
+        }
+
         awsMobileClient.updateUserAttributes(
                 Collections.singletonMap(attribute.getKey().getKeyString(), attribute.getValue()),
+                clientMetadata,
                 new Callback<List<UserCodeDeliveryDetails>>() {
                     @Override
                     public void onResult(List<UserCodeDeliveryDetails> result) {
@@ -806,11 +821,29 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     }
 
     @Override
+    public void updateUserAttribute(
+            @NonNull AuthUserAttribute attribute,
+            @NonNull Consumer<AuthUpdateAttributeResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        updateUserAttribute(attribute, AuthUpdateUserAttributeOptions.defaults(), onSuccess, onError);
+    }
+
+    @Override
     public void updateUserAttributes(
             @NonNull List<AuthUserAttribute> attributes,
+            @NonNull AuthUpdateUserAttributesOptions options,
             @NonNull Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
+
+        final Map<String, String> clientMetadata = new HashMap<>();
+        if (options instanceof AWSCognitoAuthUpdateUserAttributesOptions) {
+            AWSCognitoAuthUpdateUserAttributesOptions cognitoOptions =
+                    (AWSCognitoAuthUpdateUserAttributesOptions) options;
+            clientMetadata.putAll(cognitoOptions.getMetadata());
+        }
+
         Map<String, String> attributesMap = new HashMap<>();
         for (AuthUserAttribute attribute : attributes) {
             attributesMap.put(attribute.getKey().getKeyString(), attribute.getValue());
@@ -818,6 +851,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
         awsMobileClient.updateUserAttributes(
                 attributesMap,
+                clientMetadata,
                 new Callback<List<UserCodeDeliveryDetails>>() {
                     @Override
                     public void onResult(List<UserCodeDeliveryDetails> result) {
@@ -866,27 +900,67 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
     }
 
     @Override
+    public void updateUserAttributes(
+            @NonNull List<AuthUserAttribute> attributes,
+            @NonNull Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        updateUserAttributes(
+                attributes,
+                AuthUpdateUserAttributesOptions.defaults(),
+                onSuccess,
+                onError
+        );
+    }
+
+    @Override
+    public void resendUserAttributeConfirmationCode(
+            @NonNull AuthUserAttributeKey attributeKey,
+            @NonNull AuthResendUserAttributeConfirmationCodeOptions options,
+            @NonNull Consumer<AuthCodeDeliveryDetails> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+
+        final Map<String, String> clientMetadata = new HashMap<>();
+        if (options instanceof AWSCognitoAuthResendUserAttributeConfirmationCodeOptions) {
+            AWSCognitoAuthResendUserAttributeConfirmationCodeOptions cognitoOptions =
+                    (AWSCognitoAuthResendUserAttributeConfirmationCodeOptions) options;
+            clientMetadata.putAll(cognitoOptions.getMetadata());
+        }
+
+        String attributeName = attributeKey.getKeyString();
+        awsMobileClient.verifyUserAttribute(
+                attributeName,
+                clientMetadata,
+                new Callback<UserCodeDeliveryDetails>() {
+                    @Override
+                    public void onResult(UserCodeDeliveryDetails result) {
+                        onSuccess.accept(convertCodeDeliveryDetails(result));
+                    }
+
+                    @Override
+                    public void onError(Exception error) {
+                        onError.accept(new AuthException(
+                                "Failed to resend user attribute confirmation code",
+                                error,
+                                "See attached exception for more details"
+                        ));
+                    }
+                });
+    }
+
+    @Override
     public void resendUserAttributeConfirmationCode(
             @NonNull AuthUserAttributeKey attributeKey,
             @NonNull Consumer<AuthCodeDeliveryDetails> onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
-        String attributeName = attributeKey.getKeyString();
-        awsMobileClient.verifyUserAttribute(attributeName, new Callback<UserCodeDeliveryDetails>() {
-            @Override
-            public void onResult(UserCodeDeliveryDetails result) {
-                onSuccess.accept(convertCodeDeliveryDetails(result));
-            }
-
-            @Override
-            public void onError(Exception error) {
-                onError.accept(new AuthException(
-                        "Failed to resend user attribute confirmation code",
-                        error,
-                        "See attached exception for more details"
-                ));
-            }
-        });
+        resendUserAttributeConfirmationCode(
+                attributeKey,
+                AuthResendUserAttributeConfirmationCodeOptions.defaults(),
+                onSuccess,
+                onError
+        );
     }
 
     @Override

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthResendUserAttributeConfirmationCodeOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthResendUserAttributeConfirmationCodeOptions.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.options;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
+import com.amplifyframework.util.Immutable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Cognito extension of resend user attribute confirmation code options to add the platform specific fields.
+ */
+public final class AWSCognitoAuthResendUserAttributeConfirmationCodeOptions
+        extends AuthResendUserAttributeConfirmationCodeOptions {
+    private final Map<String, String> metadata;
+
+    /**
+     * Advanced options for resend user attribute confirmation code.
+     * @param metadata Additional custom attributes to be sent to the service such as information about the client
+     */
+    protected AWSCognitoAuthResendUserAttributeConfirmationCodeOptions(
+            Map<String, String> metadata
+    ) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Get custom attributes to be sent to the service such as information about the client.
+     * @return custom attributes to be sent to the service such as information about the client
+     */
+    @NonNull
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Get a builder object.
+     * @return a builder object.
+     */
+    @NonNull
+    public static CognitoBuilder builder() {
+        return new CognitoBuilder();
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getMetadata()
+        );
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            AWSCognitoAuthResendUserAttributeConfirmationCodeOptions authResendUserAttributeConfirmationCodeOptions =
+                    (AWSCognitoAuthResendUserAttributeConfirmationCodeOptions) obj;
+            return ObjectsCompat.equals(getMetadata(), authResendUserAttributeConfirmationCodeOptions.getMetadata());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AWSCognitoAuthResendUserAttributeConfirmationCodeOptions{" +
+                "metadata=" + metadata +
+                '}';
+    }
+
+    /**
+     * The builder for this class.
+     */
+    public static final class CognitoBuilder extends Builder<CognitoBuilder> {
+        private Map<String, String> metadata;
+
+        /**
+         * Constructor for the builder.
+         */
+        public CognitoBuilder() {
+            super();
+            this.metadata = new HashMap<>();
+        }
+
+        /**
+         * Returns the type of builder this is to support proper flow with it being an extended class.
+         * @return the type of builder this is to support proper flow with it being an extended class.
+         */
+        @Override
+        public CognitoBuilder getThis() {
+            return this;
+        }
+
+        /**
+         * Set the metadata field for the object being built.
+         * @param metadata Custom user metadata to be sent with the resend user attribute confirmation code request.
+         * @return The builder object to continue building.
+         */
+        @NonNull
+        public CognitoBuilder metadata(@NonNull Map<String, String> metadata) {
+            Objects.requireNonNull(metadata);
+            this.metadata.clear();
+            this.metadata.putAll(metadata);
+            return getThis();
+        }
+
+        /**
+         * Construct and return the object with the values set in the builder.
+         * @return a new instance of AWSCognitoAuthResendUserAttributeConfirmationCodeOptions
+         * with the values specified in the builder.
+         */
+        @NonNull
+        public AWSCognitoAuthResendUserAttributeConfirmationCodeOptions build() {
+            return new AWSCognitoAuthResendUserAttributeConfirmationCodeOptions(
+                    Immutable.of(metadata));
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthUpdateUserAttributeOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthUpdateUserAttributeOptions.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.options;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
+import com.amplifyframework.util.Immutable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Cognito extension of update user attribute options to add the platform specific fields.
+ */
+public final class AWSCognitoAuthUpdateUserAttributeOptions extends AuthUpdateUserAttributeOptions {
+    private final Map<String, String> metadata;
+
+    /**
+     * Advanced options for update user attribute.
+     * @param metadata Additional custom attributes to be sent to the service such as information about the client
+     */
+    protected AWSCognitoAuthUpdateUserAttributeOptions(
+            Map<String, String> metadata
+    ) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Get custom attributes to be sent to the service such as information about the client.
+     * @return custom attributes to be sent to the service such as information about the client
+     */
+    @NonNull
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Get a builder object.
+     * @return a builder object.
+     */
+    @NonNull
+    public static CognitoBuilder builder() {
+        return new CognitoBuilder();
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getMetadata()
+        );
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            AWSCognitoAuthUpdateUserAttributeOptions authUpdateUserAttributeOptions =
+                    (AWSCognitoAuthUpdateUserAttributeOptions) obj;
+            return ObjectsCompat.equals(getMetadata(), authUpdateUserAttributeOptions.getMetadata());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AWSCognitoAuthUpdateUserAttributeOptions{" +
+                "metadata=" + metadata +
+                '}';
+    }
+
+    /**
+     * The builder for this class.
+     */
+    public static final class CognitoBuilder extends Builder<CognitoBuilder> {
+        private Map<String, String> metadata;
+
+        /**
+         * Constructor for the builder.
+         */
+        public CognitoBuilder() {
+            super();
+            this.metadata = new HashMap<>();
+        }
+
+        /**
+         * Returns the type of builder this is to support proper flow with it being an extended class.
+         * @return the type of builder this is to support proper flow with it being an extended class.
+         */
+        @Override
+        public CognitoBuilder getThis() {
+            return this;
+        }
+
+        /**
+         * Set the metadata field for the object being built.
+         * @param metadata Custom user metadata to be sent with the update user attribute request.
+         * @return The builder object to continue building.
+         */
+        @NonNull
+        public CognitoBuilder metadata(@NonNull Map<String, String> metadata) {
+            Objects.requireNonNull(metadata);
+            this.metadata.clear();
+            this.metadata.putAll(metadata);
+            return getThis();
+        }
+
+        /**
+         * Construct and return the object with the values set in the builder.
+         * @return a new instance of AWSCognitoAuthUpdateUserAttributeOptions with the values specified in the builder.
+         */
+        @NonNull
+        public AWSCognitoAuthUpdateUserAttributeOptions build() {
+            return new AWSCognitoAuthUpdateUserAttributeOptions(
+                    Immutable.of(metadata));
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthUpdateUserAttributesOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthUpdateUserAttributesOptions.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.options;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
+import com.amplifyframework.util.Immutable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Cognito extension of update user attributes options to add the platform specific fields.
+ */
+public final class AWSCognitoAuthUpdateUserAttributesOptions extends AuthUpdateUserAttributesOptions {
+    private final Map<String, String> metadata;
+
+    /**
+     * Advanced options for update user attributes.
+     * @param metadata Additional custom attributes to be sent to the service such as information about the client
+     */
+    protected AWSCognitoAuthUpdateUserAttributesOptions(
+            Map<String, String> metadata
+    ) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Get custom attributes to be sent to the service such as information about the client.
+     * @return custom attributes to be sent to the service such as information about the client
+     */
+    @NonNull
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Get a builder object.
+     * @return a builder object.
+     */
+    @NonNull
+    public static CognitoBuilder builder() {
+        return new CognitoBuilder();
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(
+                getMetadata()
+        );
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            AWSCognitoAuthUpdateUserAttributesOptions authUpdateUserAttributesOptions =
+                    (AWSCognitoAuthUpdateUserAttributesOptions) obj;
+            return ObjectsCompat.equals(getMetadata(), authUpdateUserAttributesOptions.getMetadata());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AWSCognitoAuthUpdateUserAttributesOptions{" +
+                "metadata=" + metadata +
+                '}';
+    }
+
+    /**
+     * The builder for this class.
+     */
+    public static final class CognitoBuilder extends Builder<CognitoBuilder> {
+        private Map<String, String> metadata;
+
+        /**
+         * Constructor for the builder.
+         */
+        public CognitoBuilder() {
+            super();
+            this.metadata = new HashMap<>();
+        }
+
+        /**
+         * Returns the type of builder this is to support proper flow with it being an extended class.
+         * @return the type of builder this is to support proper flow with it being an extended class.
+         */
+        @Override
+        public CognitoBuilder getThis() {
+            return this;
+        }
+
+        /**
+         * Set the metadata field for the object being built.
+         * @param metadata Custom user metadata to be sent with the update user attributes request.
+         * @return The builder object to continue building.
+         */
+        @NonNull
+        public CognitoBuilder metadata(@NonNull Map<String, String> metadata) {
+            Objects.requireNonNull(metadata);
+            this.metadata.clear();
+            this.metadata.putAll(metadata);
+            return getThis();
+        }
+
+        /**
+         * Construct and return the object with the values set in the builder.
+         * @return a new instance of AWSCognitoAuthUpdateUserAttributesOptions with the values specified in the builder.
+         */
+        @NonNull
+        public AWSCognitoAuthUpdateUserAttributesOptions build() {
+            return new AWSCognitoAuthUpdateUserAttributesOptions(
+                    Immutable.of(metadata));
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -31,9 +31,12 @@ import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignUpOptions;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignOutOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignUpOptions;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributeOptions;
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSessionResult;
@@ -651,11 +654,14 @@ public final class AuthComponentTest {
                 new UserCodeDeliveryDetails(DESTINATION, DELIVERY_MEDIUM, ATTRIBUTE_NAME));
 
         doAnswer(invocation -> {
-            Callback<List<UserCodeDeliveryDetails>> callback = invocation.getArgument(1);
+            Callback<List<UserCodeDeliveryDetails>> callback = invocation.getArgument(2);
             callback.onResult(userCodeDeliveryDetailsList);
             return null;
-        }).when(mobileClient)
-                .updateUserAttributes(any(), Mockito.<Callback<List<UserCodeDeliveryDetails>>>any());
+        }).when(mobileClient).updateUserAttributes(
+                any(),
+                any(),
+                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any()
+        );
 
         AuthUpdateAttributeResult result = synchronousAuth.updateUserAttribute(attribute);
 
@@ -665,8 +671,58 @@ public final class AuthComponentTest {
                 result.getNextStep().getUpdateAttributeStep()
         );
         validateCodeDeliveryDetails(result.getNextStep().getCodeDeliveryDetails());
-        verify(mobileClient).updateUserAttributes(eq(attributeMap),
-                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any());
+        verify(mobileClient).updateUserAttributes(
+                eq(attributeMap),
+                any(),
+                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any()
+        );
+    }
+
+    /**
+     * Tests that updateUserAttribute method of the Auth wrapper of AWSMobileClient (AMC) calls
+     * AMC.updateUserAttributes with the user attribute and options it received.
+     * Also ensures that in the onResult case, the success callback receives a valid AuthUpdateAttributeResult and in
+     * the onError case, the error call back receives an AuthException with the root cause attached.
+     * @throws AuthException test fails if this gets thrown since method should succeed
+     */
+    @Test
+    public void updateUserAttributeWithOptions() throws AuthException {
+        AuthUserAttribute attribute = new AuthUserAttribute(AuthUserAttributeKey.custom(ATTRIBUTE_KEY), ATTRIBUTE_VAL);
+        Map<String, String> attributeMap =
+                Collections.singletonMap(attribute.getKey().getKeyString(), attribute.getValue());
+        List<UserCodeDeliveryDetails> userCodeDeliveryDetailsList = Collections.singletonList(
+                new UserCodeDeliveryDetails(DESTINATION, DELIVERY_MEDIUM, ATTRIBUTE_NAME));
+
+        AWSCognitoAuthUpdateUserAttributeOptions.CognitoBuilder options =
+                AWSCognitoAuthUpdateUserAttributeOptions.builder();
+        Map<String, String> metadata = new HashMap<String, String>();
+        metadata.put("key", "value");
+        options.metadata(metadata);
+        AWSCognitoAuthUpdateUserAttributeOptions builtOptions = options.build();
+
+        doAnswer(invocation -> {
+            Callback<List<UserCodeDeliveryDetails>> callback = invocation.getArgument(2);
+            callback.onResult(userCodeDeliveryDetailsList);
+            return null;
+        }).when(mobileClient).updateUserAttributes(
+                any(),
+                any(),
+                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any()
+        );
+
+        AuthUpdateAttributeResult result = synchronousAuth.updateUserAttribute(attribute, builtOptions);
+
+        assertTrue(result.isUpdated());
+        assertEquals(
+                AuthUpdateAttributeStep.CONFIRM_ATTRIBUTE_WITH_CODE,
+                result.getNextStep().getUpdateAttributeStep()
+        );
+        validateCodeDeliveryDetails(result.getNextStep().getCodeDeliveryDetails());
+        verify(mobileClient).updateUserAttributes(
+                eq(attributeMap),
+                eq(metadata),
+                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any()
+        );
     }
 
     /**
@@ -698,11 +754,14 @@ public final class AuthComponentTest {
                 ));
 
         doAnswer(invocation -> {
-            Callback<List<UserCodeDeliveryDetails>> callback = invocation.getArgument(1);
+            Callback<List<UserCodeDeliveryDetails>> callback = invocation.getArgument(2);
             callback.onResult(userCodeDeliveryDetailsList);
             return null;
-        }).when(mobileClient)
-                .updateUserAttributes(any(), Mockito.<Callback<List<UserCodeDeliveryDetails>>>any());
+        }).when(mobileClient).updateUserAttributes(
+                any(),
+                any(),
+                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any()
+        );
 
         Map<AuthUserAttributeKey, AuthUpdateAttributeResult> result =
                 synchronousAuth.updateUserAttributes(attributes);
@@ -719,7 +778,76 @@ public final class AuthComponentTest {
         );
         validateCodeDeliveryDetails(result.get(attributeKey).getNextStep().getCodeDeliveryDetails());
         verify(mobileClient).updateUserAttributes(
-                eq(attributesMap), Mockito.<Callback<List<UserCodeDeliveryDetails>>>any());
+                eq(attributesMap),
+                any(),
+                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any()
+        );
+    }
+
+    /**
+     * Tests that updateUserAttributes method of the Auth wrapper of AWSMobileClient (AMC) Calls
+     * AMC.updateUserAttributes with the user attributes and options it received.
+     * Also ensures that in the onResult case, the success callback receives a valid Map which maps
+     * AuthUserAttributeKey into AuthUpdateAttributeResult, and in the onError case, the error call
+     * back receives an AuthException with the root cause attached.
+     * @throws AuthException test fails if this gets thrown since method should succeed
+     */
+    @Test
+    public void updateUserAttributesWithOptions() throws AuthException {
+        List<AuthUserAttribute> attributes = new ArrayList<>();
+        AuthUserAttributeKey attributeKey = AuthUserAttributeKey.custom(ATTRIBUTE_KEY);
+        AuthUserAttributeKey attributeKeyWithoutCode = AuthUserAttributeKey.custom(ATTRIBUTE_KEY_WITHOUT_CODE_DELIVERY);
+        attributes.add(new AuthUserAttribute(attributeKey, ATTRIBUTE_VAL));
+        attributes.add(new AuthUserAttribute(attributeKeyWithoutCode, ATTRIBUTE_VAL_WITHOUT_CODE_DELIVERY));
+
+        Map<String, String> attributesMap = new HashMap<>();
+        for (AuthUserAttribute attribute : attributes) {
+            attributesMap.put(attribute.getKey().getKeyString(), attribute.getValue());
+        }
+
+        List<UserCodeDeliveryDetails> userCodeDeliveryDetailsList = Collections.singletonList(
+                new UserCodeDeliveryDetails(
+                        DESTINATION,
+                        DELIVERY_MEDIUM,
+                        ATTRIBUTE_NAME
+                ));
+
+        AWSCognitoAuthUpdateUserAttributesOptions.CognitoBuilder options =
+                AWSCognitoAuthUpdateUserAttributesOptions.builder();
+        Map<String, String> metadata = new HashMap<String, String>();
+        metadata.put("key", "value");
+        options.metadata(metadata);
+        AWSCognitoAuthUpdateUserAttributesOptions builtOptions = options.build();
+
+        doAnswer(invocation -> {
+            Callback<List<UserCodeDeliveryDetails>> callback = invocation.getArgument(2);
+            callback.onResult(userCodeDeliveryDetailsList);
+            return null;
+        }).when(mobileClient).updateUserAttributes(
+                any(),
+                any(),
+                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any()
+        );
+
+        Map<AuthUserAttributeKey, AuthUpdateAttributeResult> result =
+                synchronousAuth.updateUserAttributes(attributes, builtOptions);
+
+        assertTrue(result.get(attributeKey).isUpdated());
+        assertTrue(result.get(attributeKeyWithoutCode).isUpdated());
+        assertEquals(
+                AuthUpdateAttributeStep.CONFIRM_ATTRIBUTE_WITH_CODE,
+                result.get(attributeKey).getNextStep().getUpdateAttributeStep()
+        );
+        assertEquals(
+                AuthUpdateAttributeStep.DONE,
+                result.get(attributeKeyWithoutCode).getNextStep().getUpdateAttributeStep()
+        );
+        validateCodeDeliveryDetails(result.get(attributeKey).getNextStep().getCodeDeliveryDetails());
+        verify(mobileClient).updateUserAttributes(
+                eq(attributesMap),
+                eq(metadata),
+                Mockito.<Callback<List<UserCodeDeliveryDetails>>>any()
+        );
     }
 
     /**
@@ -737,16 +865,65 @@ public final class AuthComponentTest {
         );
 
         doAnswer(invocation -> {
-            Callback<UserCodeDeliveryDetails> callback = invocation.getArgument(1);
+            Callback<UserCodeDeliveryDetails> callback = invocation.getArgument(2);
             callback.onResult(userCodeDeliveryDetails);
             return null;
-        }).when(mobileClient)
-                .verifyUserAttribute(any(), Mockito.<Callback<UserCodeDeliveryDetails>>any());
+        }).when(mobileClient).verifyUserAttribute(
+                any(),
+                any(),
+                Mockito.<Callback<UserCodeDeliveryDetails>>any()
+        );
 
         AuthCodeDeliveryDetails result = synchronousAuth.resendUserAttributeConfirmationCode(attributeKey);
         validateCodeDeliveryDetails(result);
-        verify(mobileClient).verifyUserAttribute(eq(attributeKey.getKeyString()),
-                Mockito.<Callback<UserCodeDeliveryDetails>>any());
+        verify(mobileClient).verifyUserAttribute(
+                eq(attributeKey.getKeyString()),
+                any(),
+                Mockito.<Callback<UserCodeDeliveryDetails>>any()
+        );
+    }
+
+    /**
+     * Tests the resendUserAttributeConfirmationCode method of the Auth wrapper of AWSMobileClient (AMC) Calls
+     * AMC.verifyUserAttribute with the user attribute key to be verified and options it received.
+     * @throws AuthException test fails if this gets thrown since method should succeed
+     */
+    @Test
+    public void resendUserAttributeConfirmationCodeWithOptions() throws AuthException {
+        AuthUserAttributeKey attributeKey = AuthUserAttributeKey.custom(ATTRIBUTE_KEY);
+        UserCodeDeliveryDetails userCodeDeliveryDetails = new UserCodeDeliveryDetails(
+                DESTINATION,
+                DELIVERY_MEDIUM,
+                ATTRIBUTE_NAME
+        );
+
+        AWSCognitoAuthResendUserAttributeConfirmationCodeOptions.CognitoBuilder options =
+                AWSCognitoAuthResendUserAttributeConfirmationCodeOptions.builder();
+        Map<String, String> metadata = new HashMap<String, String>();
+        metadata.put("key", "value");
+        options.metadata(metadata);
+        AWSCognitoAuthResendUserAttributeConfirmationCodeOptions builtOptions = options.build();
+
+        doAnswer(invocation -> {
+            Callback<UserCodeDeliveryDetails> callback = invocation.getArgument(2);
+            callback.onResult(userCodeDeliveryDetails);
+            return null;
+        }).when(mobileClient).verifyUserAttribute(
+                any(),
+                any(),
+                Mockito.<Callback<UserCodeDeliveryDetails>>any()
+        );
+
+        AuthCodeDeliveryDetails result = synchronousAuth.resendUserAttributeConfirmationCode(
+                attributeKey,
+                builtOptions
+        );
+        validateCodeDeliveryDetails(result);
+        verify(mobileClient).verifyUserAttribute(
+                eq(attributeKey.getKeyString()),
+                eq(metadata),
+                Mockito.<Callback<UserCodeDeliveryDetails>>any()
+        );
     }
 
     /**

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -27,9 +27,12 @@ import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions
 import com.amplifyframework.auth.options.AuthWebUISignInOptions
 import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
@@ -233,29 +236,43 @@ interface Auth {
     /**
      * Update a single user attribute.
      * @param attribute Attribute to be updated
+     * @param options Advanced options such as a map of auth information for custom auth,
+     *                If not provided, default options will be used
      * @return The result of updating the provided attribute
      */
     @Throws(AuthException::class)
-    suspend fun updateUserAttribute(attribute: AuthUserAttribute): AuthUpdateAttributeResult
+    suspend fun updateUserAttribute(
+        attribute: AuthUserAttribute,
+        options: AuthUpdateUserAttributeOptions = AuthUpdateUserAttributeOptions.defaults()
+    ): AuthUpdateAttributeResult
 
     /**
      * Update multiple user attributes.
      * @param attributes Attributes to be updated
+     * @param options Advanced options such as a map of auth information for custom auth,
+     *                If not provided, default options will be used
      * @return The result of updating the provided attribute
      */
     @Throws(AuthException::class)
-    suspend fun updateUserAttributes(attributes: List<AuthUserAttribute>):
-        Map<AuthUserAttributeKey, AuthUpdateAttributeResult>
+    suspend fun updateUserAttributes(
+        attributes: List<AuthUserAttribute>,
+        options: AuthUpdateUserAttributesOptions = AuthUpdateUserAttributesOptions.defaults()
+    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult>
 
     /**
      * If the user's confirmation code expires or they just missed it, this method
      * can be used to send them a new one.
      * @param attributeKey Key of attribute that user wants to operate on
+     * @param options Advanced options such as a map of auth information for custom auth,
+     *                If not provided, default options will be used
      * @return Details about the delivery of an authentication code
      */
     @Throws(AuthException::class)
-    suspend fun resendUserAttributeConfirmationCode(attributeKey: AuthUserAttributeKey):
-        AuthCodeDeliveryDetails
+    suspend fun resendUserAttributeConfirmationCode(
+        attributeKey: AuthUserAttributeKey,
+        options: AuthResendUserAttributeConfirmationCodeOptions =
+            AuthResendUserAttributeConfirmationCodeOptions.defaults()
+    ): AuthCodeDeliveryDetails
 
     /**
      * Use attribute key and confirmation code to confirm user attribute.

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -27,9 +27,12 @@ import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions
 import com.amplifyframework.auth.options.AuthWebUISignInOptions
 import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
@@ -234,34 +237,41 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
     }
 
     override suspend fun updateUserAttribute(
-        attribute: AuthUserAttribute
+        attribute: AuthUserAttribute,
+        options: AuthUpdateUserAttributeOptions
     ): AuthUpdateAttributeResult {
         return suspendCoroutine { continuation ->
             delegate.updateUserAttribute(
                 attribute,
+                options,
                 { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
             )
         }
     }
 
-    override suspend fun updateUserAttributes(attributes: List<AuthUserAttribute>):
-        Map<AuthUserAttributeKey, AuthUpdateAttributeResult> {
-            return suspendCoroutine { continuation ->
-                delegate.updateUserAttributes(
-                    attributes,
-                    { continuation.resume(it) },
-                    { continuation.resumeWithException(it) }
-                )
-            }
+    override suspend fun updateUserAttributes(
+        attributes: List<AuthUserAttribute>,
+        options: AuthUpdateUserAttributesOptions
+    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> {
+        return suspendCoroutine { continuation ->
+            delegate.updateUserAttributes(
+                attributes,
+                options,
+                { continuation.resume(it) },
+                { continuation.resumeWithException(it) }
+            )
         }
+    }
 
     override suspend fun resendUserAttributeConfirmationCode(
-        attributeKey: AuthUserAttributeKey
+        attributeKey: AuthUserAttributeKey,
+        options: AuthResendUserAttributeConfirmationCodeOptions
     ): AuthCodeDeliveryDetails {
         return suspendCoroutine { continuation ->
             delegate.resendUserAttributeConfirmationCode(
                 attributeKey,
+                options,
                 { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
             )

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -611,9 +611,10 @@ class KotlinAuthFacadeTest {
         val attribute = AuthUserAttribute(AuthUserAttributeKey.nickname(), "T-bird")
         val updateAttributeResult = mockk<AuthUpdateAttributeResult>()
         every {
-            delegate.updateUserAttribute(attribute, any(), any())
+            delegate.updateUserAttribute(attribute, any(), any(), any())
         } answers {
-            val onResultArg = it.invocation.args[/* index of result consumer = */ 1]
+            val indexOfResultConsumer = 2
+            val onResultArg = it.invocation.args[indexOfResultConsumer]
             val onResult = onResultArg as Consumer<AuthUpdateAttributeResult>
             onResult.accept(updateAttributeResult)
         }
@@ -631,9 +632,9 @@ class KotlinAuthFacadeTest {
         )
         val error = AuthException("uh", "oh")
         every {
-            delegate.updateUserAttribute(eq(attribute), any(), any())
+            delegate.updateUserAttribute(eq(attribute), any(), any(), any())
         } answers {
-            val indexOfErrorConsumer = 2
+            val indexOfErrorConsumer = 3
             val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
             onError.accept(error)
         }
@@ -655,9 +656,9 @@ class KotlinAuthFacadeTest {
             AuthUserAttributeKey.givenName() to mockk()
         )
         every {
-            delegate.updateUserAttributes(genderAffirmation, any(), any())
+            delegate.updateUserAttributes(genderAffirmation, any(), any(), any())
         } answers {
-            val indexOfResultConsumer = 1
+            val indexOfResultConsumer = 2
             val onResult = it.invocation.args[indexOfResultConsumer]
                 as Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>
             onResult.accept(affirmed)
@@ -677,9 +678,9 @@ class KotlinAuthFacadeTest {
         val attributes = listOf(tonyEmail)
         val error = AuthException("uh", "oh")
         every {
-            delegate.updateUserAttributes(eq(attributes), any(), any())
+            delegate.updateUserAttributes(eq(attributes), any(), any(), any())
         } answers {
-            val indexOfErrorConsumer = 2
+            val indexOfErrorConsumer = 3
             val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
             onError.accept(error)
         }
@@ -695,9 +696,10 @@ class KotlinAuthFacadeTest {
         val attributeKey = AuthUserAttributeKey.email()
         val authCodeDeliveryDetails = AuthCodeDeliveryDetails("+1-206-555-2020", SMS)
         every {
-            delegate.resendUserAttributeConfirmationCode(eq(attributeKey), any(), any())
+            delegate.resendUserAttributeConfirmationCode(eq(attributeKey), any(), any(), any())
         } answers {
-            val onResultArg = it.invocation.args[/* index of result consumer = */ 1]
+            val indexOfResultConsumer = 2
+            val onResultArg = it.invocation.args[indexOfResultConsumer]
             val onResult = onResultArg as Consumer<AuthCodeDeliveryDetails>
             onResult.accept(authCodeDeliveryDetails)
         }
@@ -716,9 +718,9 @@ class KotlinAuthFacadeTest {
         val attributeKey = AuthUserAttributeKey.email()
         val error = AuthException("uh", "oh")
         every {
-            delegate.resendUserAttributeConfirmationCode(eq(attributeKey), any(), any())
+            delegate.resendUserAttributeConfirmationCode(eq(attributeKey), any(), any(), any())
         } answers {
-            val indexOfErrorConsumer = 2
+            val indexOfErrorConsumer = 3
             val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
             onError.accept(error)
         }

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -22,9 +22,12 @@ import androidx.annotation.Nullable;
 
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
@@ -258,6 +261,16 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     @Override
     public void updateUserAttribute(
             @NonNull AuthUserAttribute attribute,
+            @NonNull AuthUpdateUserAttributeOptions options,
+            @NonNull Consumer<AuthUpdateAttributeResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().updateUserAttribute(attribute, options, onSuccess, onError);
+    }
+
+    @Override
+    public void updateUserAttribute(
+            @NonNull AuthUserAttribute attribute,
             @NonNull Consumer<AuthUpdateAttributeResult> onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
@@ -267,10 +280,30 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     @Override
     public void updateUserAttributes(
             @NonNull List<AuthUserAttribute> attributes,
+            @NonNull AuthUpdateUserAttributesOptions options,
+            @NonNull Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().updateUserAttributes(attributes, options, onSuccess, onError);
+    }
+
+    @Override
+    public void updateUserAttributes(
+            @NonNull List<AuthUserAttribute> attributes,
             @NonNull Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
         getSelectedPlugin().updateUserAttributes(attributes, onSuccess, onError);
+    }
+
+    @Override
+    public void resendUserAttributeConfirmationCode(
+            @NonNull AuthUserAttributeKey attributeKey,
+            @NonNull AuthResendUserAttributeConfirmationCodeOptions options,
+            @NonNull Consumer<AuthCodeDeliveryDetails> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().resendUserAttributeConfirmationCode(attributeKey, options, onSuccess, onError);
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -22,9 +22,12 @@ import androidx.annotation.Nullable;
 
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
@@ -320,6 +323,20 @@ public interface AuthCategoryBehavior {
     /**
      * Update a single user attribute.
      * @param attribute Attribute to be updated
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void updateUserAttribute(
+            @NonNull AuthUserAttribute attribute,
+            @NonNull AuthUpdateUserAttributeOptions options,
+            @NonNull Consumer<AuthUpdateAttributeResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Update a single user attribute.
+     * @param attribute Attribute to be updated
      * @param onSuccess Success callback
      * @param onError Error callback
      */
@@ -331,12 +348,41 @@ public interface AuthCategoryBehavior {
     /**
      * Update multiple user attributes.
      * @param attributes Attributes to be updated
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void updateUserAttributes(
+            @NonNull List<AuthUserAttribute> attributes,
+            @NonNull AuthUpdateUserAttributesOptions options,
+            @NonNull Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Update multiple user attributes.
+     * @param attributes Attributes to be updated
      * @param onSuccess Success callback
      * @param onError Error callback
      */
     void updateUserAttributes(
             @NonNull List<AuthUserAttribute> attributes,
             @NonNull Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * If the user's confirmation code expires or they just missed it, this method
+     * can be used to send them a new one.
+     * @param attributeKey Key of attribute that user wants to operate on
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void resendUserAttributeConfirmationCode(
+            @NonNull AuthUserAttributeKey attributeKey,
+            @NonNull AuthResendUserAttributeConfirmationCodeOptions options,
+            @NonNull Consumer<AuthCodeDeliveryDetails> onSuccess,
             @NonNull Consumer<AuthException> onError
     );
 

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthResendUserAttributeConfirmationCodeOptions.java
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthResendUserAttributeConfirmationCodeOptions.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * The shared options among all Auth plugins.
+ * Note: This is currently empty but exists here to support common sign in options in the future.
+ */
+public abstract class AuthResendUserAttributeConfirmationCodeOptions {
+    /**
+     * Use the default resend user attribute confirmation code options.
+     * @return Default resend user attribute confirmation code options.
+     */
+    public static DefaultAuthResendUserAttributeConfirmationCodeOptions defaults() {
+        return new DefaultAuthResendUserAttributeConfirmationCodeOptions();
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    public abstract static class Builder<T extends Builder<T>> {
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        public abstract T getThis();
+
+        /**
+         * Build an instance of AuthResendUserAttributeConfirmationCodeOptions (or one of its subclasses).
+         * @return an instance of AuthResendUserAttributeConfirmationCodeOptions (or one of its subclasses)
+         */
+        @NonNull
+        public abstract AuthResendUserAttributeConfirmationCodeOptions build();
+    }
+
+    /**
+     * Default resend user attribute confirmation code options.
+     * This works like a sentinel, to be used instead of "null".
+     * The only way to create this is by calling {@link AuthResendUserAttributeConfirmationCodeOptions#defaults()}.
+     */
+    public static final class DefaultAuthResendUserAttributeConfirmationCodeOptions
+            extends AuthResendUserAttributeConfirmationCodeOptions {
+        private DefaultAuthResendUserAttributeConfirmationCodeOptions() {}
+
+        @Override
+        public int hashCode() {
+            return DefaultAuthResendUserAttributeConfirmationCodeOptions.class.hashCode();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof DefaultAuthResendUserAttributeConfirmationCodeOptions;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return DefaultAuthResendUserAttributeConfirmationCodeOptions.class.getSimpleName();
+        }
+    }
+}

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthUpdateUserAttributeOptions.java
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthUpdateUserAttributeOptions.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * The shared options among all Auth plugins.
+ * Note: This is currently empty but exists here to support common sign in options in the future.
+ */
+public abstract class AuthUpdateUserAttributeOptions {
+    /**
+     * Use the default update user attribute options.
+     * @return Default update user attribute options.
+     */
+    public static DefaultAuthUpdateUserAttributeOptions defaults() {
+        return new DefaultAuthUpdateUserAttributeOptions();
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    public abstract static class Builder<T extends Builder<T>> {
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        public abstract T getThis();
+
+        /**
+         * Build an instance of AuthUpdateUserAttributeOptions (or one of its subclasses).
+         * @return an instance of AuthUpdateUserAttributeOptions (or one of its subclasses)
+         */
+        @NonNull
+        public abstract AuthUpdateUserAttributeOptions build();
+    }
+
+    /**
+     * Default update user attribute options. This works like a sentinel, to be used instead of "null".
+     * The only way to create this is by calling {@link AuthUpdateUserAttributeOptions#defaults()}.
+     */
+    public static final class DefaultAuthUpdateUserAttributeOptions extends AuthUpdateUserAttributeOptions {
+        private DefaultAuthUpdateUserAttributeOptions() {}
+
+        @Override
+        public int hashCode() {
+            return DefaultAuthUpdateUserAttributeOptions.class.hashCode();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof DefaultAuthUpdateUserAttributeOptions;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return DefaultAuthUpdateUserAttributeOptions.class.getSimpleName();
+        }
+    }
+}

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthUpdateUserAttributesOptions.java
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthUpdateUserAttributesOptions.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * The shared options among all Auth plugins.
+ * Note: This is currently empty but exists here to support common sign in options in the future.
+ */
+public abstract class AuthUpdateUserAttributesOptions {
+    /**
+     * Use the default update user attributes options.
+     * @return Default update user attributes options.
+     */
+    public static DefaultAuthUpdateUserAttributesOptions defaults() {
+        return new DefaultAuthUpdateUserAttributesOptions();
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    public abstract static class Builder<T extends Builder<T>> {
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        public abstract T getThis();
+
+        /**
+         * Build an instance of AuthUpdateUserAttributesOptions (or one of its subclasses).
+         * @return an instance of AuthUpdateUserAttributesOptions (or one of its subclasses)
+         */
+        @NonNull
+        public abstract AuthUpdateUserAttributesOptions build();
+    }
+
+    /**
+     * Default update user attributes options. This works like a sentinel, to be used instead of "null".
+     * The only way to create this is by calling {@link AuthUpdateUserAttributesOptions#defaults()}.
+     */
+    public static final class DefaultAuthUpdateUserAttributesOptions extends AuthUpdateUserAttributesOptions {
+        private DefaultAuthUpdateUserAttributesOptions() {}
+
+        @Override
+        public int hashCode() {
+            return DefaultAuthUpdateUserAttributesOptions.class.hashCode();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof DefaultAuthUpdateUserAttributesOptions;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return DefaultAuthUpdateUserAttributesOptions.class.getSimpleName();
+        }
+    }
+}

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -32,9 +32,12 @@ import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
@@ -193,14 +196,39 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
     }
 
     @Override
+    public Single<AuthUpdateAttributeResult> updateUserAttribute(
+            @NonNull AuthUserAttribute attribute,
+            @NonNull AuthUpdateUserAttributeOptions options
+    ) {
+        return toSingle((onResult, onError) -> delegate.updateUserAttribute(attribute, options, onResult, onError));
+    }
+
+    @Override
     public Single<AuthUpdateAttributeResult> updateUserAttribute(@NonNull AuthUserAttribute attribute) {
         return toSingle((onResult, onError) -> delegate.updateUserAttribute(attribute, onResult, onError));
     }
 
     @Override
     public Single<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> updateUserAttributes(
+            @NonNull List<AuthUserAttribute> attributes,
+            @NonNull AuthUpdateUserAttributesOptions options
+    ) {
+        return toSingle((onResult, onError) -> delegate.updateUserAttributes(attributes, options, onResult, onError));
+    }
+
+    @Override
+    public Single<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> updateUserAttributes(
             @NonNull List<AuthUserAttribute> attributes) {
         return toSingle((onResult, onError) -> delegate.updateUserAttributes(attributes, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthCodeDeliveryDetails> resendUserAttributeConfirmationCode(
+            @NonNull AuthUserAttributeKey attributeKey,
+            @NonNull AuthResendUserAttributeConfirmationCodeOptions options
+    ) {
+        return toSingle((onResult, onError) ->
+                delegate.resendUserAttributeConfirmationCode(attributeKey, options, onResult, onError));
     }
 
     @Override

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -31,9 +31,12 @@ import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
@@ -281,10 +284,34 @@ public interface RxAuthCategoryBehavior {
     /**
      * Update a user attribute of a user who is signed in.
      * @param attribute The user attribute to be updated
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return An Rx {@link Single} which emits {@link AuthUpdateAttributeResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthUpdateAttributeResult> updateUserAttribute(
+            @NonNull AuthUserAttribute attribute,
+            @NonNull AuthUpdateUserAttributeOptions options
+    );
+
+    /**
+     * Update a user attribute of a user who is signed in.
+     * @param attribute The user attribute to be updated
      * @return An Rx {@link Single} which emits {@link AuthUpdateAttributeResult} on success,
      *         {@link AuthException} on failure
      */
     Single<AuthUpdateAttributeResult> updateUserAttribute(@NonNull AuthUserAttribute attribute);
+
+    /**
+     * Update a list of user attributes of a user who is signed in.
+     * @param attributes A list of user attributes to be updated
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return An Rx {@link Single} which emits a map which maps {@link AuthUserAttributeKey} into
+     *         {@link AuthUpdateAttributeResult} on success, {@link AuthException} on failure
+     */
+    Single<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> updateUserAttributes(
+            @NonNull List<AuthUserAttribute> attributes,
+            @NonNull AuthUpdateUserAttributesOptions options
+    );
 
     /**
      * Update a list of user attributes of a user who is signed in.
@@ -294,6 +321,18 @@ public interface RxAuthCategoryBehavior {
      */
     Single<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> updateUserAttributes(
             @NonNull List<AuthUserAttribute> attributes);
+
+    /**
+     * Resend user attribute confirmation code to verify user attribute.
+     * @param attributeKey The attribute key to be confirmed.
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return An Rx {@link Single} which emits {@link AuthCodeDeliveryDetails} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthCodeDeliveryDetails> resendUserAttributeConfirmationCode(
+            @NonNull AuthUserAttributeKey attributeKey,
+            @NonNull AuthResendUserAttributeConfirmationCodeOptions options
+    );
 
     /**
      * Resend user attribute confirmation code to verify user attribute.

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -29,9 +29,12 @@ import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.auth.options.AuthSignOutOptions;
 import com.amplifyframework.auth.options.AuthSignUpOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
@@ -370,6 +373,22 @@ public final class SynchronousAuth {
     /**
      * Update user attribute synchronously.
      * @param attribute The user attribute to be updated
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return result object
+     * @throws AuthException exception
+     */
+    public AuthUpdateAttributeResult updateUserAttribute(
+            @NonNull AuthUserAttribute attribute,
+            @NonNull AuthUpdateUserAttributeOptions options
+    ) throws AuthException {
+        return Await.<AuthUpdateAttributeResult, AuthException>result((onResult, onError) -> {
+            asyncDelegate.updateUserAttribute(attribute, options, onResult, onError);
+        });
+    }
+
+    /**
+     * Update user attribute synchronously.
+     * @param attribute The user attribute to be updated
      * @return result object
      * @throws AuthException exception
      */
@@ -377,6 +396,23 @@ public final class SynchronousAuth {
         return Await.<AuthUpdateAttributeResult, AuthException>result((onResult, onError) -> {
             asyncDelegate.updateUserAttribute(attribute, onResult, onError);
         });
+    }
+
+    /**
+     * Update user attributes synchronously.
+     * @param attributes The user attributes to be updated
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return result object
+     * @throws AuthException exception
+     */
+    public Map<AuthUserAttributeKey, AuthUpdateAttributeResult> updateUserAttributes(
+            @NonNull List<AuthUserAttribute> attributes,
+            @NonNull AuthUpdateUserAttributesOptions options
+    ) throws AuthException {
+        return Await.<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>, AuthException>result((
+            (onResult, onError) -> {
+                asyncDelegate.updateUserAttributes(attributes, options, onResult, onError);
+            }));
     }
 
     /**
@@ -391,6 +427,22 @@ public final class SynchronousAuth {
             (onResult, onError) -> {
                 asyncDelegate.updateUserAttributes(attributes, onResult, onError);
             }));
+    }
+
+    /**
+     * Resend user attribute confirmation code to verify user attribute synchronously.
+     * @param attributeKey The user attribute key
+     * @param options Advanced options such as a map of auth information for custom auth
+     * @return result object
+     * @throws AuthException exception
+     */
+    public AuthCodeDeliveryDetails resendUserAttributeConfirmationCode(
+            @NonNull AuthUserAttributeKey attributeKey,
+            @NonNull AuthResendUserAttributeConfirmationCodeOptions options
+    ) throws AuthException {
+        return Await.<AuthCodeDeliveryDetails, AuthException>result((onResult, onError) -> {
+            asyncDelegate.resendUserAttributeConfirmationCode(attributeKey, options, onResult, onError);
+        });
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
- Add options/metadata to updateAttribute
- Add options/metadata to updateAttributes
- Add options/metadata to resendUserAttributeConfirmationCode

*Testing Info:*

I have manually tested that metadata added to each of these methods is accessible in Lambda triggers. I have also tested the edge cases listed below, by first confirming the behavior of each method in v1.22.0, and then confirming the behavior is the same with these changes.

**updateAttribute & updateAttributes**
- No Network → AuthException, cause = AmazonClientException
- Non-existent attribute → AuthException, cause = InvalidParameterException
- Invalid Attribute value → AuthException, cause = InvalidParameterException
- Lambda Exception → AuthException, cause = UserLambdaValidationException

resendUserAttributeConfirmationCode
- No Network → AuthException, cause = AmazonClientException
- Non-existent attribute → InvalidParameterException
- 5 + attempts → AuthException, cause = LimitExceededException
- Lambda Exception → AuthException, cause = UserLambdaValidationException

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
