### PR TITLE
fix(api): expose selectionSet in request builder

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequest.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequest.java
@@ -320,6 +320,16 @@ public final class AppSyncGraphQLRequest<R> extends GraphQLRequest<R> {
         }
 
         /**
+         * Sets the selectionSet and returns this builder.
+         * @param selectionSet the subset of model for this request to operate on.
+         * @return this builder instance.
+         */
+        public Builder selectionSet(@NonNull SelectionSet selectionSet) {
+            this.selectionSet = Objects.requireNonNull(selectionSet);
+            return Builder.this;
+        }
+
+        /**
          * Sets the authorization type for the request. If this field is set,
          * {@link Builder#authModeStrategyType} will be ignored.
          * @param authorizationType the desired authorization type.


### PR DESCRIPTION
*Description of changes:*
Selection set could not be specified in `AppSyncGraphQLRequest` could not be set by the builder because its setter was never exposed. Added public `AppSyncGraphQLRequest.Builder#selectionSet(SelectionSet)` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
