### PR TITLE
fix: check for canceled call to fix RxJava crash

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
@@ -86,8 +86,8 @@ public final class AppSyncGraphQLOperation<R> extends GraphQLOperation<R> {
 
     @Override
     public void start() {
-        // No-op if start() is called post-execution
-        if (ongoingCall != null && ongoingCall.isExecuted()) {
+        // No-op if start() is called post-execution or canceled
+        if (ongoingCall != null && (ongoingCall.isExecuted() || ongoingCall.isCanceled())) {
             return;
         }
 
@@ -153,9 +153,11 @@ public final class AppSyncGraphQLOperation<R> extends GraphQLOperation<R> {
 
         @Override
         public void onFailure(@NonNull Call call, @NonNull IOException exception) {
-            onFailure.accept(new ApiException(
-                "OkHttp client request failed.", exception, "See attached exception for more details."
-            ));
+            if (!call.isCanceled()) {
+                onFailure.accept(new ApiException(
+                        "OkHttp client request failed.", exception, "See attached exception for more details."
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#1273 

*Description of changes:*
Fix crash due to attempting to invoke client of already canceled call.
- added  isCanceled() check in start to guard against calls that were canceled but still in queue
- added isCanceled() check in failure callback (for calls that hit 20sec socket timeout)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
