### PR TITLE
chore: use GH-generated token

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -39,7 +39,7 @@ jobs:
         git checkout -b $branch_name
     - name: Create PR for next release
       env:
-        RELEASE_MANAGER_TOKEN: ${{ secrets.RELEASE_MANAGER_TOKEN }}
+        RELEASE_MANAGER_TOKEN: ${{secrets.GITHUB_TOKEN}}
       run: |
         cd scripts
         bundle exec fastlane android create_next_release_pr


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By switching to using `${{secrets.GITHUB_TOKEN}}`, we have one less secret to rotate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
