### PR TITLE
feat(geo): add getMapStyleDescriptor API to Geo

### DIFF
--- a/aws-geo-location/build.gradle
+++ b/aws-geo-location/build.gradle
@@ -25,5 +25,12 @@ dependencies {
     testImplementation project(':testutils')
     testImplementation dependency.junit
     testImplementation dependency.robolectric
+
+    androidTestImplementation project(':testutils')
+    androidTestImplementation project(':aws-auth-cognito')
+    androidTestImplementation dependency.androidx.annotation
+    androidTestImplementation dependency.androidx.test.core
+    androidTestImplementation dependency.androidx.test.runner
+    androidTestImplementation dependency.androidx.test.junit
 }
 

--- a/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/Credentials.kt
+++ b/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/Credentials.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.location
+
+import android.content.Context
+import com.amplifyframework.core.Resources
+
+/**
+ * Utility to load Cognito user credentials from a json document.
+ * The document must be formatted as following:
+ *
+ * <pre>
+ * {
+ *   "username": "username123",
+ *   "password": "kool@pass22"
+ * }
+ * </pre>
+ */
+object Credentials {
+    private const val DEFAULT_ID = "credentials" // credentials.json
+    private var credentials: Pair<String, String>? = null
+
+    fun load(context: Context, identifier: String = DEFAULT_ID): Pair<String, String> {
+        if (credentials == null) {
+            credentials = synchronized(this) {
+                val json = Resources.readJsonResource(context, identifier)
+                val username = json.getString("username")
+                val password = json.getString("password")
+                username to password
+            }
+        }
+        return credentials!!
+    }
+}

--- a/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/MapsApiTest.kt
+++ b/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/MapsApiTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.location
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+
+import com.amplifyframework.auth.AuthCategory
+import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
+import com.amplifyframework.geo.GeoCategory
+import com.amplifyframework.geo.GeoException
+import com.amplifyframework.geo.options.GetMapStyleDescriptorOptions
+import com.amplifyframework.testutils.sync.SynchronousAuth
+import com.amplifyframework.testutils.sync.SynchronousGeo
+import com.amplifyframework.testutils.sync.TestCategory
+import org.json.JSONObject
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests various functionalities related to Maps API in [AWSLocationGeoPlugin].
+ */
+class MapsApiTest {
+    private var auth: SynchronousAuth? = null
+    private var geo: SynchronousGeo? = null
+
+    /**
+     * Set up test categories to be used for testing.
+     */
+    @Before
+    fun setUp() {
+        // Auth plugin uses default configuration
+        val authPlugin = AWSCognitoAuthPlugin()
+        val authCategory = TestCategory.forPlugin(authPlugin) as AuthCategory
+        auth = SynchronousAuth.delegatingTo(authCategory)
+
+        // Geo plugin uses above auth category to authenticate users
+        val geoPlugin = AWSLocationGeoPlugin(authProvider = authCategory)
+        val geoCategory = TestCategory.forPlugin(geoPlugin) as GeoCategory
+        geo = SynchronousGeo.delegatingTo(geoCategory)
+    }
+
+    /**
+     * Tests that default map resource's style document can be fetched from
+     * Amazon Location Service using [AWSLocationGeoPlugin.getMapStyleDescriptor].
+     *
+     * Fetched document must follow the specifications for Mapbox Style format.
+     * Both "layers" and "sources" are critical information required for rendering
+     * a map, so assert that both fields exist in the document.
+     */
+    @Test
+    fun styleDescriptorLoadsProperly() {
+        signInWithCognito()
+        val style = geo?.getMapStyleDescriptor(GetMapStyleDescriptorOptions.defaults())
+        assertNotNull(style)
+        assertNotNull(style?.json)
+
+        // assert that style document is aligned with specs
+        // https://docs.mapbox.com/mapbox-gl-js/style-spec/
+        val json = JSONObject(style!!.json)
+        assertTrue(json.has("layers"))
+        assertTrue(json.has("sources"))
+    }
+
+    /**
+     * Tests that user must be authenticated in order to fetch map resource from
+     * Amazon Location Service.
+     *
+     * @throws GeoException will be thrown due to service exception.
+     */
+    @Test(expected = GeoException::class)
+    fun cannotFetchStyleWithoutAuth() {
+        signOutFromCognito()
+        // should not be authorized to fetch map resource from Amazon Location Service
+        geo?.getMapStyleDescriptor(GetMapStyleDescriptorOptions.defaults())
+    }
+
+    private fun signInWithCognito() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val (username, password) = Credentials.load(context)
+        auth?.signIn(username, password)
+    }
+
+    private fun signOutFromCognito() {
+        auth?.signOut()
+    }
+}

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
@@ -102,7 +102,7 @@ class AWSLocationGeoPlugin(
         onResult: Consumer<MapStyleDescriptor>,
         onError: Consumer<GeoException>
     ) {
-        val options = GetMapStyleDescriptorOptions.builder().build()
+        val options = GetMapStyleDescriptorOptions.defaults()
         getMapStyleDescriptor(options, onResult, onError)
     }
 

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
@@ -29,6 +29,8 @@ import com.amplifyframework.geo.location.configuration.GeoConfiguration
 import com.amplifyframework.geo.location.service.AmazonLocationService
 import com.amplifyframework.geo.location.service.GeoService
 import com.amplifyframework.geo.models.MapStyle
+import com.amplifyframework.geo.models.MapStyleDescriptor
+import com.amplifyframework.geo.options.GetMapStyleDescriptorOptions
 
 import org.json.JSONObject
 
@@ -46,6 +48,10 @@ class AWSLocationGeoPlugin(
 
     private lateinit var configuration: GeoConfiguration
     private lateinit var geoService: GeoService<AmazonLocationClient>
+
+    private val defaultMapName: String by lazy {
+        configuration.maps!!.default.mapName
+    }
 
     override fun getPluginKey(): String {
         return GEO_PLUGIN_KEY
@@ -87,6 +93,28 @@ class AWSLocationGeoPlugin(
     ) {
         try {
             onResult.accept(configuration.maps!!.default)
+        } catch (error: Exception) {
+            onError.accept(Errors.mapsError(error))
+        }
+    }
+
+    override fun getMapStyleDescriptor(
+        onResult: Consumer<MapStyleDescriptor>,
+        onError: Consumer<GeoException>
+    ) {
+        val options = GetMapStyleDescriptorOptions.builder().build()
+        getMapStyleDescriptor(options, onResult, onError)
+    }
+
+    override fun getMapStyleDescriptor(
+        options: GetMapStyleDescriptorOptions,
+        onResult: Consumer<MapStyleDescriptor>,
+        onError: Consumer<GeoException>
+    ) {
+        try {
+            val mapName = options.mapName ?: defaultMapName
+            val json = geoService.getStyleJson(mapName)
+            onResult.accept(MapStyleDescriptor(json))
         } catch (error: Exception) {
             onError.accept(Errors.mapsError(error))
         }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/Errors.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/Errors.kt
@@ -23,6 +23,9 @@ import java.lang.NullPointerException
  */
 internal object Errors {
     fun mapsError(exception: Exception): GeoException {
+        if (exception is GeoException) {
+            return exception
+        }
         val message = when (exception) {
             is UninitializedPropertyAccessException -> "AWSLocationGeoPlugin is not configured."
             is NullPointerException -> "Plugin configuration is missing \"maps\" configuration."

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
@@ -20,7 +20,8 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.services.geo.AmazonLocationClient
 import com.amazonaws.services.geo.model.GetMapStyleDescriptorRequest
-import com.amplifyframework.geo.models.MapStyle
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.geo.GeoException
 import com.amplifyframework.util.UserAgent
 import java.nio.ByteBuffer
 
@@ -43,11 +44,17 @@ class AmazonLocationService(
         provider.setRegion(Region.getRegion(region))
     }
 
-    override fun getStyleJson(map: MapStyle): String {
+    override fun getStyleJson(mapName: String): String {
         val request = GetMapStyleDescriptorRequest()
-            .withMapName(map.mapName)
+            .withMapName(mapName)
         val response = provider.getMapStyleDescriptor(request)
-        return readFromBuffer(response.blob)
+        return try {
+            readFromBuffer(response.blob)
+        } catch (error: Exception) {
+            throw GeoException("Failed to read style descriptor blob.", error,
+                AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+            )
+        }
     }
 
     private fun readFromBuffer(buffer: ByteBuffer): String {

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.location.service
+
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.services.geo.AmazonLocationClient
+import com.amazonaws.services.geo.model.GetMapStyleDescriptorRequest
+import com.amplifyframework.geo.models.MapStyle
+import com.amplifyframework.util.UserAgent
+import java.nio.ByteBuffer
+
+/**
+ * Implements the backend provider for the location plugin using
+ * AWS Mobile SDK's [AmazonLocationClient].
+ * @param credentialsProvider AWS credentials provider for authorizing API calls
+ * @param region AWS region for the Amazon Location Service
+ */
+class AmazonLocationService(
+    credentialsProvider: AWSCredentialsProvider,
+    region: String
+) : GeoService<AmazonLocationClient> {
+    override val provider: AmazonLocationClient
+
+    init {
+        val configuration = ClientConfiguration()
+        configuration.userAgent = UserAgent.string()
+        provider = AmazonLocationClient(credentialsProvider, configuration)
+        provider.setRegion(Region.getRegion(region))
+    }
+
+    override fun getStyleJson(map: MapStyle): String {
+        val request = GetMapStyleDescriptorRequest()
+            .withMapName(map.mapName)
+        val response = provider.getMapStyleDescriptor(request)
+        return readFromBuffer(response.blob)
+    }
+
+    private fun readFromBuffer(buffer: ByteBuffer): String {
+        return if (buffer.hasArray()) {
+            val startIndex = buffer.arrayOffset() + buffer.position()
+            val endIndex = startIndex + buffer.remaining()
+            buffer.array().decodeToString(startIndex, endIndex)
+        } else {
+            val bytes = ByteArray(buffer.remaining())
+            buffer.get(bytes)
+            bytes.decodeToString()
+        }
+    }
+}

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
@@ -15,8 +15,6 @@
 
 package com.amplifyframework.geo.location.service
 
-import com.amplifyframework.geo.models.MapStyle
-
 /**
  * Backend provider for Geo Amazon Location Geo plugin.
  */
@@ -29,7 +27,7 @@ interface GeoService<T> {
     /**
      * Gets map's style JSON in string format.
      *
-     * @param map map style
+     * @param mapName map name
      */
-    fun getStyleJson(map: MapStyle): String
+    fun getStyleJson(mapName: String): String
 }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.location.service
+
+import com.amplifyframework.geo.models.MapStyle
+
+/**
+ * Backend provider for Geo Amazon Location Geo plugin.
+ */
+interface GeoService<T> {
+    /**
+     * Backend provider for Geo data.
+     */
+    val provider: T
+
+    /**
+     * Gets map's style JSON in string format.
+     *
+     * @param map map style
+     */
+    fun getStyleJson(map: MapStyle): String
+}

--- a/core/src/main/java/com/amplifyframework/geo/GeoCategory.java
+++ b/core/src/main/java/com/amplifyframework/geo/GeoCategory.java
@@ -21,6 +21,10 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.geo.models.MapStyle;
+import com.amplifyframework.geo.models.MapStyleDescriptor;
+import com.amplifyframework.geo.options.GetMapStyleDescriptorOptions;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 
@@ -61,5 +65,28 @@ public final class GeoCategory
             @NonNull Consumer<GeoException> onError
     ) {
         getSelectedPlugin().getDefaultMap(onResult, onError);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void getMapStyleDescriptor(
+            @NonNull Consumer<MapStyleDescriptor> onResult,
+            @NonNull Consumer<GeoException> onError
+    ) {
+        getSelectedPlugin().getMapStyleDescriptor(onResult, onError);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void getMapStyleDescriptor(
+            @NonNull GetMapStyleDescriptorOptions options,
+            @NonNull Consumer<MapStyleDescriptor> onResult,
+            @NonNull Consumer<GeoException> onError
+    ) {
+        getSelectedPlugin().getMapStyleDescriptor(options, onResult, onError);
     }
 }

--- a/core/src/main/java/com/amplifyframework/geo/GeoCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/geo/GeoCategoryBehavior.java
@@ -19,6 +19,8 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.geo.models.MapStyle;
+import com.amplifyframework.geo.models.MapStyleDescriptor;
+import com.amplifyframework.geo.options.GetMapStyleDescriptorOptions;
 
 import java.util.Collection;
 
@@ -46,6 +48,30 @@ public interface GeoCategoryBehavior {
      */
     void getDefaultMap(
             @NonNull Consumer<MapStyle> onResult,
+            @NonNull Consumer<GeoException> onError
+    );
+
+    /**
+     * Uses default options to get map style descriptor JSON.
+     *
+     * @param onResult Called upon successfully fetching map style descriptor.
+     * @param onError  Called upon failure to fetch map style descriptor.
+     */
+    void getMapStyleDescriptor(
+            @NonNull Consumer<MapStyleDescriptor> onResult,
+            @NonNull Consumer<GeoException> onError
+    );
+
+    /**
+     * Uses given options to get map style descriptor JSON.
+     *
+     * @param options  Options to specify for this operation.
+     * @param onResult Called upon successfully fetching map style descriptor.
+     * @param onError  Called upon failure to fetch map style descriptor.
+     */
+    void getMapStyleDescriptor(
+            @NonNull GetMapStyleDescriptorOptions options,
+            @NonNull Consumer<MapStyleDescriptor> onResult,
             @NonNull Consumer<GeoException> onError
     );
 }

--- a/core/src/main/java/com/amplifyframework/geo/models/MapStyleDescriptor.java
+++ b/core/src/main/java/com/amplifyframework/geo/models/MapStyleDescriptor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.models;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
+
+import java.util.Objects;
+
+/**
+ * Stores the style descriptor of a map resource.
+ */
+public final class MapStyleDescriptor {
+    private final String json;
+
+    /**
+     * Creates a new {@link MapStyleDescriptor} object.
+     *
+     * @param json Map style descriptor JSON.
+     */
+    public MapStyleDescriptor(@NonNull String json) {
+        this.json = Objects.requireNonNull(json);
+    }
+    /**
+     * Returns the style descriptor.
+     *
+     * @return the style descriptor.
+     */
+    @NonNull
+    public String getJson() {
+        return json;
+    }
+
+    @Override
+    public String toString() {
+        return "MapStyleDescriptor{" +
+                "json='" + json + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        MapStyleDescriptor that = (MapStyleDescriptor) obj;
+        return ObjectsCompat.equals(json, that.json);
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectsCompat.hash(json);
+    }
+}

--- a/core/src/main/java/com/amplifyframework/geo/options/GetMapStyleDescriptorOptions.java
+++ b/core/src/main/java/com/amplifyframework/geo/options/GetMapStyleDescriptorOptions.java
@@ -50,6 +50,16 @@ public class GetMapStyleDescriptorOptions {
     }
 
     /**
+     * Returns a new options instance with default values.
+     *
+     * @return a default options instance.
+     */
+    @NonNull
+    public static GetMapStyleDescriptorOptions defaults() {
+        return builder().build();
+    }
+
+    /**
      * Builder class for conveniently constructing options instance.
      */
     public static class Builder {

--- a/core/src/main/java/com/amplifyframework/geo/options/GetMapStyleDescriptorOptions.java
+++ b/core/src/main/java/com/amplifyframework/geo/options/GetMapStyleDescriptorOptions.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.geo.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Stores options to use when fetching map style descriptor data.
+ */
+public class GetMapStyleDescriptorOptions {
+    private final String mapName;
+
+    private GetMapStyleDescriptorOptions(Builder builder) {
+        this.mapName = builder.mapName;
+    }
+
+    /**
+     * Returns the name of map resource to fetch style descriptor for.
+     *
+     * @return the name of map resource
+     */
+    @Nullable
+    public String getMapName() {
+        return mapName;
+    }
+
+    /**
+     * Returns a new builder instance for constructing {@link GetMapStyleDescriptorOptions}.
+     *
+     * @return a new builder instance.
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for conveniently constructing options instance.
+     */
+    public static class Builder {
+        private String mapName;
+
+        private Builder() {}
+
+        /**
+         * Sets the name of map resource and returns itself.
+         *
+         * @param mapName the name of map resource.
+         * @return this builder instance.
+         */
+        @NonNull
+        public Builder mapName(@NonNull String mapName) {
+            this.mapName = Objects.requireNonNull(mapName);
+            return this;
+        }
+
+        /**
+         * Constructs options instance with the parameters in this builder.
+         *
+         * @return Immutable options instance.
+         */
+        @NonNull
+        public GetMapStyleDescriptorOptions build() {
+            return new GetMapStyleDescriptorOptions(this);
+        }
+    }
+}

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousGeo.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousGeo.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils.sync;
+
+import androidx.annotation.NonNull;
+
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.geo.GeoCategory;
+import com.amplifyframework.geo.GeoCategoryBehavior;
+import com.amplifyframework.geo.GeoException;
+import com.amplifyframework.geo.models.MapStyle;
+import com.amplifyframework.geo.models.MapStyleDescriptor;
+import com.amplifyframework.geo.options.GetMapStyleDescriptorOptions;
+import com.amplifyframework.testutils.Await;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * A utility to perform synchronous calls to the {@link GeoCategory}.
+ * This code is not well suited for production use, but is useful in test
+ * code, where we want to make a series of sequential assertions after
+ * performing various operations.
+ */
+public final class SynchronousGeo {
+    private final GeoCategoryBehavior asyncDelegate;
+
+    private SynchronousGeo(GeoCategoryBehavior asyncDelegate) {
+        this.asyncDelegate = asyncDelegate;
+    }
+
+    /**
+     * Creates a synchronous geo wrapper which delegates calls to the provided geo
+     * category behavior.
+     *
+     * @param asyncDelegate Performs the actual geo operations
+     * @return A synchronous geo wrapper
+     */
+    @NonNull
+    public static SynchronousGeo delegatingTo(@NonNull GeoCategoryBehavior asyncDelegate) {
+        Objects.requireNonNull(asyncDelegate);
+        return new SynchronousGeo(asyncDelegate);
+    }
+
+    /**
+     * Creates a synchronous geo wrapper which delegates to the {@link Amplify#Geo} facade.
+     *
+     * @return A synchronous geo wrapper
+     */
+    @NonNull
+    public static SynchronousGeo delegatingToAmplify() {
+        return new SynchronousGeo(Amplify.Geo);
+    }
+
+    /**
+     * Fetches the list of available map styles from configuration.
+     *
+     * @return a collection of map styles
+     * @throws GeoException if maps are not configured.
+     */
+    public Collection<MapStyle> getAvailableMaps() throws GeoException {
+        return Await.result(asyncDelegate::getAvailableMaps);
+    }
+
+    /**
+     * Fetches the default map style among configured map resources.
+     *
+     * @return the map style object
+     * @throws GeoException if default map is not configured.
+     */
+    public MapStyle getDefaultMap() throws GeoException {
+        return Await.result(asyncDelegate::getDefaultMap);
+    }
+
+    /**
+     * Fetches the list of available map styles from configuration.
+     *
+     * @return a collection of map styles
+     * @throws GeoException if maps are not configured.
+     */
+    public MapStyleDescriptor getMapStyleDescriptor(
+            GetMapStyleDescriptorOptions options
+    ) throws GeoException {
+        return Await.<MapStyleDescriptor, GeoException>result((onResult, onError) ->
+                asyncDelegate.getMapStyleDescriptor(options, onResult, onError));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added `getMapStyleDescriptor` API to Geo category for fetching map style document.
* Implemented `getMapStyleDescriptor` in plugin using `AmazonLocationClient`
* Added instrumentation test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
