### PR TITLE
fix(auth): null-check username when getting current user

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -1053,7 +1053,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
 
     @Override
     public AuthUser getCurrentUser() {
-        if (userId != null) {
+        if (userId != null && awsMobileClient.getUsername() != null) {
             return new AuthUser(userId, awsMobileClient.getUsername());
         } else {
             return null;


### PR DESCRIPTION
*Issue #, if available:*
#1489

*Description of changes:*
`AWSCognitoAuthPlugin` erroneously assumed that `username` will be non-null as long as `userId` is non-null. This resulted in a NPE when constructing a new `AuthUser` object. This PR adds null-check for `username` before doing so, returning a `null` for current user if either value is `null`. This is in alignment with the [current iOS behavior](https://github.com/aws-amplify/amplify-ios/blob/3f700ac8b16dbfed3d7d40b461d508d6e0f7d1ab/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter.swift).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
