### PR TITLE
fix(datastore): ensure attaching nested model schema to SerializedModel

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModelAdapter.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModelAdapter.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.appsync;
 
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.SchemaRegistry;
 import com.amplifyframework.core.model.SerializedModel;
 import com.amplifyframework.util.GsonObjectConverter;
 
@@ -84,9 +85,11 @@ public final class SerializedModelAdapter
         for (Map.Entry<String, JsonElement> item : serializedDataObject.entrySet()) {
             ModelField field = modelSchema.getFields().get(item.getKey());
             if (field != null && field.isModel()) {
+                SchemaRegistry schemaRegistry = SchemaRegistry.instance();
+                ModelSchema nestedModelSchema = schemaRegistry.getModelSchemaForModelClass(field.getTargetType());
                 serializedData.put(field.getName(), SerializedModel.builder()
                     .serializedData(Collections.singletonMap("id", item.getValue().getAsString()))
-                    .modelSchema(null)
+                    .modelSchema(nestedModelSchema)
                     .build());
             }
         }

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/syncengine/MutationPersistenceInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/syncengine/MutationPersistenceInstrumentationTest.java
@@ -102,6 +102,7 @@ public final class MutationPersistenceInstrumentationTest {
     public void terminateLocalStorageAdapter() throws DataStoreException {
         storage.terminate();
         getApplicationContext().deleteDatabase(DATABASE_NAME);
+        schemaRegistry.clear();
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -904,7 +904,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
 
     private List<SerializedCustomType> getValueOfListCustomTypeField(
             String fieldTargetType, List<Map<String, Object>> listItems) {
-        // if the filed is options and has null value instead of an array
+        // if the filed is optional and has null value instead of an array
         if (listItems == null) {
             return null;
         }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverterTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/GsonPendingMutationConverterTest.java
@@ -17,11 +17,14 @@ package com.amplifyframework.datastore.syncengine;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.model.ModelSchema;
+import com.amplifyframework.core.model.SchemaRegistry;
 import com.amplifyframework.core.model.SerializedModel;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.testmodels.commentsblog.Blog;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -31,6 +34,24 @@ import static org.junit.Assert.assertNotNull;
  * Tests the functionality of the {@link GsonPendingMutationConverter}.
  */
 public final class GsonPendingMutationConverterTest {
+    private SchemaRegistry schemaRegistry;
+
+    /**
+     * Set up for the test getting the instance of {@link SchemaRegistry}.
+     */
+    @Before
+    public void setUp() {
+        schemaRegistry = SchemaRegistry.instance();
+    }
+
+    /**
+     * Clean up after the test clearing registered testing schemas from the instance of {@link SchemaRegistry}.
+     */
+    @After
+    public void tearDown() {
+        schemaRegistry.clear();
+    }
+
     /**
      * Validate that the {@link GsonPendingMutationConverter} can be
      * used to convert a sample {@link PendingMutation} to a
@@ -104,6 +125,45 @@ public final class GsonPendingMutationConverterTest {
      */
     @Test
     public void convertPendingMutationWithSerializedModelWithChildToRecordAndBack() throws AmplifyException {
+        // Arrange a PendingMutation<SerializedModel>
+        Blog blog = Blog.builder()
+                .name("A neat blog")
+                .owner(BlogOwner.builder()
+                        .name("Joe Swanson")
+                        .build())
+                .build();
+        ModelSchema schema = ModelSchema.fromModelClass(Blog.class);
+        SerializedModel serializedBlog = SerializedModel.create(blog, schema);
+        PendingMutation<SerializedModel> originalMutation = PendingMutation.creation(serializedBlog, schema);
+        String expectedMutationId = originalMutation.getMutationId().toString();
+
+        // Instantiate the object under test
+        PendingMutation.Converter converter = new GsonPendingMutationConverter();
+
+        // Try to construct a record from the PendingMutation instance.
+        PendingMutation.PersistentRecord record = converter.toRecord(originalMutation);
+        assertNotNull(record);
+        assertEquals(expectedMutationId, record.getId());
+
+        // Now, try to convert it back...
+        PendingMutation<SerializedModel> reconstructedItemChange = converter.fromRecord(record);
+        assertEquals(originalMutation, reconstructedItemChange);
+    }
+
+    /**
+     * Validate that the {@link GsonPendingMutationConverter} can be
+     * used to convert a sample {@link PendingMutation} to a
+     * {@link PendingMutation.PersistentRecord}, and vice-versa.
+     * @throws DataStoreException from DataStore conversion
+     * @throws AmplifyException On failure to arrange model schema
+     */
+    @Test
+    public void convertPendingMutationWithSerializedModelWithChildToRecordAndBackWithNestedModelSchema()
+            throws AmplifyException {
+        ModelSchema blogOwnerSchema = ModelSchema.fromModelClass(BlogOwner.class);
+        // register BlogOwner schema to ensure nested SerializedModel to be set with it's schema
+        schemaRegistry.register("BlogOwner", blogOwnerSchema);
+
         // Arrange a PendingMutation<SerializedModel>
         Blog blog = Blog.builder()
                 .name("A neat blog")


### PR DESCRIPTION
*Issue #, if available:*

Fix an issue discovered here: https://github.com/aws-amplify/amplify-flutter/pull/847#pullrequestreview-751534593

*Description of changes:*

* Ensure the serialized model sent along with mutation box enqueued event containing nested model schema
* Updated a few unit tests that involve `SchemaRegistry` to ensure the testing schemas to be cleared after tests

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
