### PR TITLE
feat(geo): add convenience method for setting map style

### DIFF
--- a/aws-geo-location/build.gradle
+++ b/aws-geo-location/build.gradle
@@ -21,7 +21,6 @@ apply from: rootProject.file("configuration/publishing.gradle")
 dependencies {
     implementation project(':core')
     implementation dependency.aws.location
-    implementation dependency.kotlin.coroutines
 
     testImplementation project(':testutils')
     testImplementation dependency.junit

--- a/aws-geo-location/build.gradle
+++ b/aws-geo-location/build.gradle
@@ -21,6 +21,7 @@ apply from: rootProject.file("configuration/publishing.gradle")
 dependencies {
     implementation project(':core')
     implementation dependency.aws.location
+    implementation dependency.kotlin.coroutines
 
     testImplementation project(':testutils')
     testImplementation dependency.junit

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/Errors.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/Errors.kt
@@ -15,22 +15,36 @@
 
 package com.amplifyframework.geo.location
 
+import com.amazonaws.AmazonClientException
+import com.amazonaws.AmazonServiceException
+import com.amplifyframework.AmplifyException
 import com.amplifyframework.geo.GeoException
+
+import java.io.IOException
 import java.lang.NullPointerException
 
 /**
  * Utility object to provide helpful error messages for Geo operations.
  */
 internal object Errors {
-    fun mapsError(exception: Exception): GeoException {
-        if (exception is GeoException) {
-            return exception
+    fun mapsError(error: Throwable): GeoException {
+        if (error is GeoException) {
+            return error
         }
-        val message = when (exception) {
-            is UninitializedPropertyAccessException -> "AWSLocationGeoPlugin is not configured."
-            is NullPointerException -> "Plugin configuration is missing \"maps\" configuration."
-            else -> "Unexpected error. Failed to get available maps."
+        val (message, suggestion) = when (error) {
+            is UninitializedPropertyAccessException -> "AWSLocationGeoPlugin is not configured." to
+                    "Please verify that Geo plugin has been properly configured."
+            is NullPointerException -> "Plugin configuration is missing \"maps\" configuration." to
+                    "Please verify that Geo plugin has been properly configured."
+            is AmazonServiceException -> "There was a problem with the data in the request." to
+                    "Please verify that a valid map resource exists."
+            is AmazonClientException -> "Amplify failed to send a request to Amazon Location Service." to
+                    "Please ensure that you have a stable internet connection."
+            is IOException -> "Failed to read map style from the server response." to
+                    AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+            else -> "Unexpected error. Failed to get available maps." to
+                    AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
         }
-        return GeoException(message, exception, "Ensure that Geo plugin has been properly configured.")
+        return GeoException(message, error, suggestion)
     }
 }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
@@ -20,9 +20,9 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.services.geo.AmazonLocationClient
 import com.amazonaws.services.geo.model.GetMapStyleDescriptorRequest
-import com.amplifyframework.AmplifyException
-import com.amplifyframework.geo.GeoException
 import com.amplifyframework.util.UserAgent
+
+import kotlinx.coroutines.*
 import java.nio.ByteBuffer
 
 /**
@@ -44,16 +44,12 @@ class AmazonLocationService(
         provider.setRegion(Region.getRegion(region))
     }
 
-    override fun getStyleJson(mapName: String): String {
-        val request = GetMapStyleDescriptorRequest()
-            .withMapName(mapName)
-        val response = provider.getMapStyleDescriptor(request)
-        return try {
+    override suspend fun getStyleJson(mapName: String): String {
+        return withContext(Dispatchers.IO) {
+            val request = GetMapStyleDescriptorRequest()
+                .withMapName(mapName)
+            val response = provider.getMapStyleDescriptor(request)
             readFromBuffer(response.blob)
-        } catch (error: Exception) {
-            throw GeoException("Failed to read style descriptor blob.", error,
-                AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
-            )
         }
     }
 

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
@@ -22,7 +22,6 @@ import com.amazonaws.services.geo.AmazonLocationClient
 import com.amazonaws.services.geo.model.GetMapStyleDescriptorRequest
 import com.amplifyframework.util.UserAgent
 
-import kotlinx.coroutines.*
 import java.nio.ByteBuffer
 
 /**
@@ -31,7 +30,7 @@ import java.nio.ByteBuffer
  * @param credentialsProvider AWS credentials provider for authorizing API calls
  * @param region AWS region for the Amazon Location Service
  */
-class AmazonLocationService(
+internal class AmazonLocationService(
     credentialsProvider: AWSCredentialsProvider,
     region: String
 ) : GeoService<AmazonLocationClient> {
@@ -44,13 +43,11 @@ class AmazonLocationService(
         provider.setRegion(Region.getRegion(region))
     }
 
-    override suspend fun getStyleJson(mapName: String): String {
-        return withContext(Dispatchers.IO) {
-            val request = GetMapStyleDescriptorRequest()
-                .withMapName(mapName)
-            val response = provider.getMapStyleDescriptor(request)
-            readFromBuffer(response.blob)
-        }
+    override fun getStyleJson(mapName: String): String {
+        val request = GetMapStyleDescriptorRequest()
+            .withMapName(mapName)
+        val response = provider.getMapStyleDescriptor(request)
+        return readFromBuffer(response.blob)
     }
 
     private fun readFromBuffer(buffer: ByteBuffer): String {

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
@@ -18,7 +18,7 @@ package com.amplifyframework.geo.location.service
 /**
  * Backend provider for Geo Amazon Location Geo plugin.
  */
-interface GeoService<T> {
+internal interface GeoService<T> {
     /**
      * Backend provider for Geo data.
      */
@@ -29,5 +29,5 @@ interface GeoService<T> {
      *
      * @param mapName map name
      */
-    suspend fun getStyleJson(mapName: String): String
+    fun getStyleJson(mapName: String): String
 }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
@@ -29,5 +29,5 @@ interface GeoService<T> {
      *
      * @param mapName map name
      */
-    fun getStyleJson(mapName: String): String
+    suspend fun getStyleJson(mapName: String): String
 }

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/AmplifyMapLibreAdapter.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/AmplifyMapLibreAdapter.kt
@@ -88,6 +88,7 @@ object AmplifyMapLibreAdapter {
                 .build()
         }
 
+        // Network request must be on a worker thread
         geo.getMapStyleDescriptor(
             options,
             {


### PR DESCRIPTION
Added `setStyle` convenience method that sets map style on maplibre map instance using correct thread types for different tasks.

Previously, user would have to:
1. launch the map getter (`MapView#getMapAsync()`) from the _main UI thread_, 
2. fetch style from the worker thread (`Geo#getMapStyleDescriptor()`) from the _worker thread_,
3. and then apply style on the map (`MapboxMap#setStyle()`) from the _main UI thread_

This resulted in making one simple step of loading a style on the map quite complicated. This PR adds a service executor to the plugin to enforce that network requests are made from a worker thread, and adds a convenience method that behaves like MapLibre's `setStyle()` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
