### PR TITLE
chore: add sync expression to multi-auth test

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/MultiAuthSyncEngineInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/MultiAuthSyncEngineInstrumentationTest.java
@@ -39,7 +39,6 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.SchemaRegistry;
 import com.amplifyframework.core.model.SerializedModel;
 import com.amplifyframework.core.model.query.Where;
-import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.storage.sqlite.SQLiteStorageAdapter;
 import com.amplifyframework.datastore.storage.sqlite.TestStorageAdapter;
 import com.amplifyframework.hub.HubChannel;
@@ -811,10 +810,10 @@ public final class MultiAuthSyncEngineInstrumentationTest {
         // Setup DataStore
         DataStoreConfiguration dsConfig = DataStoreConfiguration.builder()
                                                 .errorHandler(exception -> Log.e(tag,
-                                                        "DataStore error handler received an error.",
-                                                        exception))
+                                                    "DataStore error handler received an error.",
+                                                    exception))
                                                 .syncExpression(modelSchema.getName(),
-                                                                () -> Where.id("FAKE_ID").getQueryPredicate())
+                                                    () -> Where.id("FAKE_ID").getQueryPredicate())
                                                 .build();
         CategoryConfiguration dataStoreCategoryConfiguration =
             AmplifyConfiguration.fromConfigFile(context, configResourceId)

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/MultiAuthSyncEngineInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/MultiAuthSyncEngineInstrumentationTest.java
@@ -38,6 +38,8 @@ import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.SchemaRegistry;
 import com.amplifyframework.core.model.SerializedModel;
+import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.datastore.storage.sqlite.SQLiteStorageAdapter;
 import com.amplifyframework.datastore.storage.sqlite.TestStorageAdapter;
 import com.amplifyframework.hub.HubChannel;
@@ -743,7 +745,8 @@ public final class MultiAuthSyncEngineInstrumentationTest {
             MultiAuthTestModelProvider.getInstance(Collections.singletonList(modelType));
         SchemaRegistry schemaRegistry = SchemaRegistry.instance();
 
-        schemaRegistry.register(modelType.getSimpleName(), ModelSchema.fromModelClass(modelType));
+        ModelSchema modelSchema = ModelSchema.fromModelClass(modelType);
+        schemaRegistry.register(modelType.getSimpleName(), modelSchema);
 
         StrictMode.enable();
         Context context = getApplicationContext();
@@ -807,12 +810,18 @@ public final class MultiAuthSyncEngineInstrumentationTest {
 
         // Setup DataStore
         DataStoreConfiguration dsConfig = DataStoreConfiguration.builder()
-                                                                .errorHandler(exception -> {
-                                                                    Log.e(tag,
-                                                                          "DataStore error handler received an error.",
-                                                                          exception);
-                                                                })
-                                                                .build();
+                                                .errorHandler(exception -> {
+                                                    Log.e(tag,
+                                                          "DataStore error handler received an error.",
+                                                          exception);
+                                                })
+                                                .syncExpression(modelSchema.getName(), new DataStoreSyncExpression() {
+                                                    @Override
+                                                    public QueryPredicate resolvePredicate() {
+                                                        return Where.id("FAKE_ID").getQueryPredicate();
+                                                    }
+                                                })
+                                                .build();
         CategoryConfiguration dataStoreCategoryConfiguration =
             AmplifyConfiguration.fromConfigFile(context, configResourceId)
                                 .forCategoryType(CategoryType.DATASTORE);

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/MultiAuthSyncEngineInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/MultiAuthSyncEngineInstrumentationTest.java
@@ -810,17 +810,11 @@ public final class MultiAuthSyncEngineInstrumentationTest {
 
         // Setup DataStore
         DataStoreConfiguration dsConfig = DataStoreConfiguration.builder()
-                                                .errorHandler(exception -> {
-                                                    Log.e(tag,
-                                                          "DataStore error handler received an error.",
-                                                          exception);
-                                                })
-                                                .syncExpression(modelSchema.getName(), new DataStoreSyncExpression() {
-                                                    @Override
-                                                    public QueryPredicate resolvePredicate() {
-                                                        return Where.id("FAKE_ID").getQueryPredicate();
-                                                    }
-                                                })
+                                                .errorHandler(exception -> Log.e(tag,
+                                                        "DataStore error handler received an error.",
+                                                        exception))
+                                                .syncExpression(modelSchema.getName(),
+                                                                () -> Where.id("FAKE_ID").getQueryPredicate())
                                                 .build();
         CategoryConfiguration dataStoreCategoryConfiguration =
             AmplifyConfiguration.fromConfigFile(context, configResourceId)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some of the multi-auth tests were failing sporadically likely due to the amount of data being sync'd. The sync expression should prevent that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
