### PR TITLE
fix(datastore): Ensure not to parse SerializedCustomType if value is …

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -448,10 +448,11 @@ final class AppSyncRequestFactory {
             SerializedModel serializedModel = (SerializedModel) instance;
             Map<String, Object> serializedData = serializedModel.getSerializedData();
             ModelField field = schema.getFields().get(fieldName);
-            if (field != null && field.isCustomType()) {
+            Object fieldValue = serializedData.get(fieldName);
+            if (fieldValue != null && field != null && field.isCustomType()) {
                 return extractCustomTypeFieldValue(fieldName, serializedData.get(fieldName));
             }
-            return serializedData.get(fieldName);
+            return fieldValue;
         }
         try {
             Field privateField = instance.getClass().getDeclaredField(fieldName);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -875,7 +875,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 continue;
             }
 
-            if (field.isCustomType()) {
+            if (field.isCustomType() && entry.getValue() != null) {
                 if (field.isArray()) {
                     @SuppressWarnings("unchecked")
                     List<Map<String, Object>> listItems = (List<Map<String, Object>>) entry.getValue();


### PR DESCRIPTION
…null

*Issue #, if available:*

*Description of changes:*

Missed `null` value check before invoking `CustomType` field value serialization/deserialization logic.
This PR is for adding the necessary `null` value check.

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
