### PR TITLE
feat(datastore): Add support for parsing match none predicate in AppSync request builder

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -136,7 +136,7 @@ final class AppSyncRequestFactory {
             if (!QueryPredicates.all().equals(predicate)) {
                 String filterType = "Model" + Casing.capitalizeFirst(modelSchema.getName()) + "FilterInput";
                 QueryPredicate syncPredicate = predicate;
-                if (syncPredicate instanceof QueryPredicateOperation) {
+                if (!(syncPredicate instanceof QueryPredicateGroup)) {
                     // When a filter is provided, wrap it with a predicate group of type AND.  By doing this, it enables
                     // AppSync to optimize the request by performing a DynamoDB query instead of a scan.  If the
                     // provided syncPredicate is already a QueryPredicateGroup, this is not needed.  If the provided
@@ -221,6 +221,13 @@ final class AppSyncRequestFactory {
     }
 
     static Map<String, Object> parsePredicate(QueryPredicate queryPredicate) throws DataStoreException {
+        if (QueryPredicates.all().equals(queryPredicate)) {
+            return Collections.singletonMap("id", Collections.singletonMap("ne", null));
+        }
+        if (QueryPredicates.none().equals(queryPredicate)) {
+            // id cannot be null, so match none
+            return Collections.singletonMap("id", Collections.singletonMap("eq", null));
+        }
         if (queryPredicate instanceof QueryPredicateOperation) {
             QueryPredicateOperation<?> qpo = (QueryPredicateOperation<?>) queryPredicate;
             QueryOperator<?> op = qpo.operator();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
@@ -194,7 +194,7 @@ public final class AppSyncRequestFactoryTest {
         final GraphQLRequest<Iterable<Post>> request =
                 AppSyncRequestFactory.buildSyncRequest(schema, null, null, QueryPredicates.none());
         JSONAssert.assertEquals(Resources.readAsString("base-sync-request-with-predicate-match-none.txt"),
-                request.getContent(),true);
+                request.getContent(), true);
     }
 
     /**
@@ -302,11 +302,11 @@ public final class AppSyncRequestFactoryTest {
 
         assertEquals(
             Collections.singletonMap("and", Arrays.asList(
-                    Collections.singletonMap("name", Collections.singletonMap("beginsWith", "A day in the life of a...")),
-                    Collections.singletonMap("blogOwnerId", Collections.singletonMap("eq", "DUMMY_OWNER_ID"))
+                Collections.singletonMap("name", Collections.singletonMap("beginsWith", "A day in the life of a...")),
+                Collections.singletonMap("blogOwnerId", Collections.singletonMap("eq", "DUMMY_OWNER_ID"))
             )),
             AppSyncRequestFactory.parsePredicate(
-                    Blog.NAME.beginsWith("A day in the life of a...").and(Blog.OWNER.eq("DUMMY_OWNER_ID"))
+                Blog.NAME.beginsWith("A day in the life of a...").and(Blog.OWNER.eq("DUMMY_OWNER_ID"))
             )
         );
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactoryTest.java
@@ -59,6 +59,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -182,6 +183,21 @@ public final class AppSyncRequestFactoryTest {
     }
 
     /**
+     * If a MatchNoneQueryPredicate is provided, it should be wrapped in an AND group.
+     * This enables AppSync to optimize by performing an DDB query instead of scan.
+     * @throws AmplifyException On failure to parse ModelSchema from model class
+     * @throws JSONException from JSONAssert.assertEquals.
+     */
+    @Test
+    public void validateMatchNonePredicateForSyncExpressionIsWrappedWithAnd() throws AmplifyException, JSONException {
+        ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
+        final GraphQLRequest<Iterable<Post>> request =
+                AppSyncRequestFactory.buildSyncRequest(schema, null, null, QueryPredicates.none());
+        JSONAssert.assertEquals(Resources.readAsString("base-sync-request-with-predicate-match-none.txt"),
+                request.getContent(),true);
+    }
+
+    /**
      * Checks that we're getting the expected output for a mutation with predicate.
      * @throws DataStoreException If the output does not match.
      * @throws AmplifyException On failure to parse ModelSchema from model class
@@ -279,15 +295,29 @@ public final class AppSyncRequestFactoryTest {
      */
     @Test
     public void validatePredicateGeneration() throws DataStoreException {
-        Map<String, Object> predicate =
-            AppSyncRequestFactory.parsePredicate(BlogOwner.NAME.eq("Test Dummy"));
         assertEquals(
-            "{name={eq=Test Dummy}}",
-            predicate.toString()
+            Collections.singletonMap("name", Collections.singletonMap("eq", "Test Dummy")),
+            AppSyncRequestFactory.parsePredicate(BlogOwner.NAME.eq("Test Dummy"))
         );
 
-        AppSyncRequestFactory.parsePredicate(
-            Blog.NAME.beginsWith("A day in the life of a...").and(Blog.OWNER.eq("DUMMY_OWNER_ID"))
+        assertEquals(
+            Collections.singletonMap("and", Arrays.asList(
+                    Collections.singletonMap("name", Collections.singletonMap("beginsWith", "A day in the life of a...")),
+                    Collections.singletonMap("blogOwnerId", Collections.singletonMap("eq", "DUMMY_OWNER_ID"))
+            )),
+            AppSyncRequestFactory.parsePredicate(
+                    Blog.NAME.beginsWith("A day in the life of a...").and(Blog.OWNER.eq("DUMMY_OWNER_ID"))
+            )
+        );
+
+        assertEquals(
+            Collections.singletonMap("id", Collections.singletonMap("ne", null)),
+            AppSyncRequestFactory.parsePredicate(QueryPredicates.all())
+        );
+
+        assertEquals(
+            Collections.singletonMap("id", Collections.singletonMap("eq", null)),
+            AppSyncRequestFactory.parsePredicate(QueryPredicates.none())
         );
     }
 

--- a/aws-datastore/src/test/resources/base-sync-request-with-predicate-match-none.txt
+++ b/aws-datastore/src/test/resources/base-sync-request-with-predicate-match-none.txt
@@ -1,0 +1,33 @@
+{
+  "query": "query SyncBlogOwners($filter: ModelBlogOwnerFilterInput) {
+  syncBlogOwners(filter: $filter) {
+    items {
+      _deleted
+      _lastChangedAt
+      _version
+      blog {
+        id
+      }
+      createdAt
+      id
+      name
+      updatedAt
+      wea
+    }
+    nextToken
+    startedAt
+  }
+}
+",
+  "variables": {
+    "filter": {
+        "and": [
+            {
+                "id": {
+                    "eq" : null
+                }
+            }
+        ]
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
#987

*Description of changes:*
Add match none predicate check to AppSync request predicate parser logic.

To match none, we use the assumption that every model requires an ID and filters for models whose `ID = null`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
