### PR TITLE
fix(datastore):predicate handling for observe

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -621,7 +621,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             itemChange -> {
                 try {
                     if (itemChange.modelSchema().getName().equals(itemClass.getSimpleName()) &&
-                            selectionCriteria.evaluate(itemChange)) {
+                            selectionCriteria.evaluate(itemChange.item())) {
                         @SuppressWarnings("unchecked") // itemClass() was just inspected above. This is safe.
                         StorageItemChange<T> typedChange = (StorageItemChange<T>) itemChange;
                         onDataStoreItemChange.accept(ItemChangeMapper.map(typedChange));

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -36,12 +36,10 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.InitializationStatus;
 import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.core.model.ModelProvider;
-import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.datastore.appsync.ModelMetadata;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
 import com.amplifyframework.datastore.model.SimpleModelProvider;
-import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.logging.Logger;
@@ -579,7 +577,7 @@ public final class AWSDataStorePluginTest {
             }
         });
         awsDataStorePlugin.observe(Person.class,
-            QueryField.field("type").eq(StorageItemChange.Type.CREATE),
+            Person.FIRST_NAME.eq("Test"),
             value -> { },
             onObserveResult,
             error -> {
@@ -620,7 +618,7 @@ public final class AWSDataStorePluginTest {
             }
         });
         awsDataStorePlugin.observe(Person.class,
-            QueryField.field("type").eq(StorageItemChange.Type.UPDATE),
+            Person.FIRST_NAME.eq("NO MATCH"),
             value -> { },
             onObserveResult,
             error -> {


### PR DESCRIPTION
*Issue #, if available:* #1525

*Description of changes:*
Predicate was being evaluated against StorageItemChange instead of the actual model. The unit test was passing because StorageItemChange was being used as the model type. I've modified that so it uses Person.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
