### PR TITLE
fix(datastore): Specify model name when querying with Where.id

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -329,6 +329,30 @@ public final class SQLiteStorageAdapterQueryTest {
     }
 
     /**
+     * Test querying with Where.Id predicate condition on connected model.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void querySavedDataWithIdPredicateOnForeignKey() throws DataStoreException {
+        final BlogOwner blogOwner = BlogOwner.builder()
+                .name("Jane Doe")
+                .build();
+        adapter.save(blogOwner);
+
+        final Blog blog = Blog.builder()
+                .name("Jane's Commercial Real Estate Blog")
+                .owner(blogOwner)
+                .build();
+        adapter.save(blog);
+
+        final List<Blog> blogsOwnedByJaneDoe = adapter.query(
+                Blog.class,
+                Where.id(blog.getId())
+        );
+        assertTrue(blogsOwnedByJaneDoe.contains(blog));
+    }
+
+    /**
      * Test query with SQL injection.
      * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
      */


### PR DESCRIPTION
*Issue #, if available:* [Comment on 1268](https://github.com/aws-amplify/amplify-android/issues/1268#issuecomment-862718673)

*Description of changes:* When querying with Where.id, adds the model name to the primary key field in the where clause of the query to address the SQLite ambiguous column exception that occurs when the model has a foreign key.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
