### PR TITLE
fix(api): Add null check before cancelling Call object.

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
@@ -17,6 +17,7 @@ package com.amplifyframework.api.aws;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
@@ -58,6 +59,7 @@ public final class AppSyncGraphQLOperation<R> extends GraphQLOperation<R> {
     private final Consumer<ApiException> onFailure;
     private final ApiRequestDecoratorFactory apiRequestDecoratorFactory;
 
+    @Nullable
     private Call ongoingCall;
 
     /**
@@ -118,8 +120,10 @@ public final class AppSyncGraphQLOperation<R> extends GraphQLOperation<R> {
     }
 
     @Override
-    public void cancel() {
-        ongoingCall.cancel();
+    public synchronized void cancel() {
+        if (ongoingCall != null) {
+            ongoingCall.cancel();
+        }
     }
 
     static <R> Builder<R> builder() {


### PR DESCRIPTION
*Issue #, if available:*
#1444

*Description of changes:*
The `onGoingCall` object of `Call` type can be null if the `start()` is either not called or fails before initializing `onGoingCall`. Hence, adding null check before calling `cancel` on it is necessary. 

Note: NPE check is necessary but might not be satisfactory fix to the mentioned issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
