### PR TITLE
chore: config files no longer get generated inside project directory

### DIFF
--- a/scripts/pull_backend_config_from_amplify
+++ b/scripts/pull_backend_config_from_amplify
@@ -30,8 +30,9 @@ mkdir -p $res_dir
 for config_file in "$tmp_amplify_dir/config_files/raw"/*
 do
   filename="$(basename "$config_file")"
-  ln -s "$config_file" "$res_dir/$filename"
+  ln -s "$config_file" "$res_dir/$filename" &
 done
+wait
 ls -al $res_dir
 cd $base_dir
 echo "Completed project $project_name"

--- a/scripts/pull_backend_config_from_amplify
+++ b/scripts/pull_backend_config_from_amplify
@@ -1,9 +1,12 @@
+#!/bin/bash
+
 base_dir=`pwd`
+dest_dir="$HOME/.aws-amplify/amplify-android"
 project_name=$1
 module_name=$2
 echo "base_dir=$base_dir"
 echo "Starting project $project_name"
-tmp_amplify_dir="$module_name/build/amplify_config/$project_name"
+tmp_amplify_dir="$dest_dir/$project_name"
 
 echo "Removing $tmp_amplify_dir"
 rm -rf $tmp_amplify_dir
@@ -24,7 +27,11 @@ amplify pull \
   --yes
 echo "Current dir is $(pwd)"
 mkdir -p $res_dir
-cp -R ./config_files/raw/* $res_dir
+for config_file in "$tmp_amplify_dir/config_files/raw"/*
+do
+  filename="$(basename "$config_file")"
+  ln -s "$config_file" "$res_dir/$filename"
+done
 ls -al $res_dir
 cd $base_dir
 echo "Completed project $project_name"

--- a/scripts/pull_backend_config_from_s3
+++ b/scripts/pull_backend_config_from_s3
@@ -51,12 +51,15 @@ readonly config_files=(
 declare -r dest_dir=$HOME/.aws-amplify/amplify-android
 mkdir -p "$dest_dir"
 
-# Copy remote files into the local directory.
+# Download remote files into a local directory outside of the project.
 for config_file in ${config_files[@]}; do
-    mkdir -p "$(dirname "$config_file")" &
     aws s3 cp "s3://$config_bucket/$config_file" "$dest_dir/$config_file" &
-    ln -s "$dest_dir/$config_file" "$config_file" &
-
 done
+wait
 
+# Create a symlink for each configuration file.
+for config_file in ${config_files[@]}; do
+    mkdir -p "$(dirname "$config_file")"
+    ln -s "$dest_dir/$config_file" "$config_file" &
+done
 wait

--- a/scripts/pull_backend_config_from_s3
+++ b/scripts/pull_backend_config_from_s3
@@ -47,9 +47,16 @@ readonly config_files=(
     "maplibre-adapter/src/androidTest/res/raw/credentials.json"
 )
 
+# Set up output path
+declare -r dest_dir=$HOME/.aws-amplify/amplify-android
+mkdir -p "$dest_dir"
+
 # Copy remote files into the local directory.
 for config_file in ${config_files[@]}; do
-    aws s3 cp "s3://$config_bucket/$config_file" "$config_file" &
+    mkdir -p "$(dirname "$config_file")" &
+    aws s3 cp "s3://$config_bucket/$config_file" "$dest_dir/$config_file" &
+    ln -s "$dest_dir/$config_file" "$config_file" &
+
 done
 
 wait


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Test setup scripts `pull_backend_config_from_s3` and `pull_backend_from_amplify` no longer store configuration files inside `amplify-android` project directory. They will be generated in an external location and be referenced by a symlink. 

Note: for this change to take place, the existing configuration files must be deleted and the script must be executed again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
