### PR TITLE
fix(maplibre-adapter): add content attribution info to map view

### DIFF
--- a/aws-geo-location/gradle.properties
+++ b/aws-geo-location/gradle.properties
@@ -3,4 +3,4 @@ POM_NAME=Amplify Framework for Android - Geo
 POM_DESCRIPTION=Amplify Framework for Android - Geo Plugin for Amazon Location Service
 POM_PACKAGING=aar
 
-VERSION_NAME=0.2.0
+VERSION_NAME=0.2.1

--- a/maplibre-adapter/gradle.properties
+++ b/maplibre-adapter/gradle.properties
@@ -3,4 +3,4 @@ POM_NAME=MapLibre Adapter for Amplify Android Framework - Geo
 POM_DESCRIPTION=Amplify Framework for Android - Adapter for Amplify Geo Plugin
 POM_PACKAGING=aar
 
-VERSION_NAME=0.2.0
+VERSION_NAME=0.2.1

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/MapLibreView.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/MapLibreView.kt
@@ -18,11 +18,15 @@ package com.amplifyframework.geo.maplibre.view
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
+import android.view.Gravity
 import androidx.annotation.UiThread
-import androidx.lifecycle.*
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.geo.GeoCategory
 import com.amplifyframework.geo.maplibre.AmplifyMapLibreAdapter
+import com.amplifyframework.geo.maplibre.R
+import com.amplifyframework.geo.maplibre.view.support.AttributionInfoView
 import com.amplifyframework.geo.models.MapStyle
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.maps.MapboxMap
@@ -57,8 +61,23 @@ class MapLibreView
         AmplifyMapLibreAdapter(context, geo)
     }
 
+    private val attributionInfoView by lazy {
+        AttributionInfoView(context)
+    }
+
     init {
         setup(context, options)
+        addView(
+            attributionInfoView,
+            LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
+                gravity = Gravity.BOTTOM or Gravity.START
+
+                val margin = context.resources.getDimensionPixelSize(R.dimen.map_defaultMargin)
+                marginEnd = margin
+                marginStart = margin
+                bottomMargin = margin
+            }
+        )
     }
 
     @SuppressLint("MissingSuperCall")

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/support/AttributionInfoView.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/support/AttributionInfoView.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.maplibre.view.support
+
+import android.content.Context
+import android.graphics.Color
+import android.util.TypedValue
+import android.view.Gravity
+import android.widget.FrameLayout
+import android.widget.ImageButton
+import android.widget.TextView
+import com.amplifyframework.geo.maplibre.R
+
+/**
+ * Support view that displays a clickable info icon that shows the map content attribution text.
+ */
+internal class AttributionInfoView(context: Context) : FrameLayout(context) {
+
+    private val attributionInfoIcon by lazy {
+        ImageButton(context).apply {
+            contentDescription = context.getString(R.string.map_attributionIconDescription)
+            setImageResource(R.drawable.ic_twotone_info_24)
+            setBackgroundColor(Color.TRANSPARENT)
+
+            val padding = context.resources
+                .getDimensionPixelSize(R.dimen.map_attributionIconPadding)
+            setPaddingRelative(padding, padding, padding, padding)
+
+            setOnClickListener { show() }
+        }
+    }
+
+    private val attributionText by lazy {
+        TextView(context).apply {
+            text = context.getString(R.string.map_attributionText)
+            visibility = GONE
+
+            setBackgroundResource(R.drawable.map_attribution_text_background)
+
+            val padding = context.resources
+                .getDimensionPixelSize(R.dimen.map_attributionTextPadding)
+            setPaddingRelative(padding, padding, padding, padding)
+
+            val size = context.resources
+                .getDimensionPixelSize(R.dimen.map_attributionTextSize)
+                .toFloat()
+            setTextSize(TypedValue.COMPLEX_UNIT_PX, size)
+            setOnClickListener { hide() }
+        }
+    }
+
+    init {
+        addView(
+            attributionInfoIcon,
+            LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
+                gravity = Gravity.BOTTOM or Gravity.START
+            }
+        )
+        addView(
+            attributionText,
+            LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+        )
+    }
+
+    private fun show() {
+        attributionInfoIcon.fadeOut()
+        attributionText.fadeIn()
+    }
+
+    private fun hide() {
+        attributionText.fadeOut()
+        attributionInfoIcon.fadeIn()
+    }
+}

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/support/ViewFadeVisibility.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/support/ViewFadeVisibility.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.maplibre.view.support
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.view.View
+import android.widget.FrameLayout
+
+/**
+ * Utility to show the view using an alpha animation that animates from current alpha to 1f.
+ * @see fadeOut
+ */
+fun View.fadeIn() {
+    visibility = FrameLayout.VISIBLE
+    animate()
+        .alpha(1f)
+        .setListener(null)
+}
+
+/**
+ * Utility to hide the view using an alpha animation that animates from current alpha to 0f.
+ *
+ * **Note:** if the view initial state is hidden, make sure you also set the alpha to 0f.
+ * @see fadeIn
+ */
+fun View.fadeOut() {
+    animate()
+        .alpha(0f)
+        .setListener(object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator?) {
+                visibility = FrameLayout.GONE
+            }
+        })
+}

--- a/maplibre-adapter/src/main/res/drawable/ic_twotone_info_24.xml
+++ b/maplibre-adapter/src/main/res/drawable/ic_twotone_info_24.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:alpha="0.7"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillAlpha="0.2"
+        android:fillColor="@android:color/white"
+        android:pathData="M12,4c-4.41,0 -8,3.59 -8,8s3.59,8 8,8 8,-3.59 8,-8 -3.59,-8 -8,-8zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"
+        android:strokeAlpha="0.3" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z" />
+</vector>

--- a/maplibre-adapter/src/main/res/drawable/map_attribution_text_background.xml
+++ b/maplibre-adapter/src/main/res/drawable/map_attribution_text_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/map_attributionTextBackground" />
+    <corners android:radius="@dimen/map_attributionTextBorderRadius" />
+</shape>

--- a/maplibre-adapter/src/main/res/values/colors.xml
+++ b/maplibre-adapter/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="map_attributionTextBackground">#B3FBFBFB</color>
+</resources>

--- a/maplibre-adapter/src/main/res/values/dimens.xml
+++ b/maplibre-adapter/src/main/res/values/dimens.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="map_defaultMargin">10dp</dimen>
+
+    <dimen name="map_attributionIconPadding">2dp</dimen>
+    <dimen name="map_attributionTextPadding">6dp</dimen>
+    <dimen name="map_attributionTextSize">14sp</dimen>
+    <dimen name="map_attributionTextBorderRadius">2dp</dimen>
+</resources>

--- a/maplibre-adapter/src/main/res/values/strings.xml
+++ b/maplibre-adapter/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="map_attributionIconDescription">Attribution icon. Activate to show attribution dialog.</string>
+    <string name="map_attributionText">Esri, HERE, Garmin, FAO, NOAA, USGS, © OpenStreetMap contributors, and the GIS User Community</string>
+</resources>


### PR DESCRIPTION
*Description of changes:*

- force-disable MapLibre's logo and attribution info by overriding the map options
- introduce a support view to display an info icon and toggle the content attribution text (see attached screenshots for reference)
  - the icon comes from the standard Android library to respect platform UX guidelines
  - the visibility state toggle performs a cross-fade between icon and text for a smooth UX
  - text functionality is not exposed as a public API (i.e. cannot be overridden by developers)

**Default state (icon):**

![map_attribution_icon](https://user-images.githubusercontent.com/319413/144153470-b8599e0e-c95e-4a55-bfc0-b0f5c5e28040.png)

**Expanded state (text):**

![map_attribution_text](https://user-images.githubusercontent.com/319413/144153547-90260fe4-4ce9-4a94-82aa-b50e560a0d91.png)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
