### PR TITLE
fix(aws-api-appsync): update getModelFields for flutter support

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSet.java
@@ -211,7 +211,7 @@ public final class SelectionSet {
             Objects.requireNonNull(this.operation);
             SelectionSet node = new SelectionSet(null,
                     SerializedModel.class == modelClass
-                            ? getModelFields(modelSchema, requestOptions.maxDepth())
+                            ? getModelFields(modelSchema, requestOptions.maxDepth(), operation)
                             : getModelFields(modelClass, requestOptions.maxDepth(), operation));
             if (QueryType.LIST.equals(operation) || QueryType.SYNC.equals(operation)) {
                 node = wrapPagination(node);
@@ -243,7 +243,7 @@ public final class SelectionSet {
 
         /**
          * Gets a selection set for the given class.
-         * TODO: this is mostly duplicative of {@link #getModelFields(ModelSchema, int)}.
+         * TODO: this is mostly duplicative of {@link #getModelFields(ModelSchema, int, Operation)}.
          * Long-term, we want to remove this current method and rely only on the ModelSchema-based
          * version.
          * @param clazz Class from which to build selection set
@@ -357,12 +357,16 @@ public final class SelectionSet {
 
         // TODO: this method is tech debt. We added it to support usage of the library from Flutter.
         // This version of the method needs to be unified with getModelFields(Class<? extends Model> clazz, int depth).
-        private Set<SelectionSet> getModelFields(ModelSchema modelSchema, int depth) {
+        private Set<SelectionSet> getModelFields(ModelSchema modelSchema, int depth, Operation operation) {
             if (depth < 0) {
                 return new HashSet<>();
             }
             Set<SelectionSet> result = new HashSet<>();
-            if (depth == 0 && LeafSerializationBehavior.JUST_ID.equals(requestOptions.leafSerializationBehavior())) {
+            if (
+                    depth == 0
+                    && LeafSerializationBehavior.JUST_ID.equals(requestOptions.leafSerializationBehavior())
+                    && operation != QueryType.SYNC
+            ) {
                 result.add(new SelectionSet("id"));
                 return result;
             }
@@ -379,9 +383,9 @@ public final class SelectionSet {
                                 modelSchemas.getModelSchemaForModelClass(associatedModelName);
                         Set<SelectionSet> fields;
                         if (entry.getValue().isArray()) { // If modelField is an Array
-                            fields = wrapPagination(getModelFields(associateModelSchema, depth - 1));
+                            fields = wrapPagination(getModelFields(associateModelSchema, depth - 1, operation));
                         } else {
-                            fields = getModelFields(associateModelSchema, depth - 1);
+                            fields = getModelFields(associateModelSchema, depth - 1, operation);
                         }
                         result.add(new SelectionSet(fieldName, fields));
                     }

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/JustIDGraphQLRequestOptions.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/JustIDGraphQLRequestOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/JustIDGraphQLRequestOptions.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/JustIDGraphQLRequestOptions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amplifyframework.api.aws;
 
 import androidx.annotation.NonNull;
@@ -7,9 +22,9 @@ import java.util.List;
 
 /**
  * Copy of DefaultGraphQLRequestOptions, with LeafSerializationBehavior set to JUST_ID
- * and maxDepth of 1
+ * and maxDepth of 1.
  */
-public class JustIDGraphQLRequestOptions implements GraphQLRequestOptions {
+public final class JustIDGraphQLRequestOptions implements GraphQLRequestOptions {
     private static final String ITEMS_KEY = "items";
     private static final String NEXT_TOKEN_KEY = "nextToken";
 

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/JustIDGraphQLRequestOptions.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/JustIDGraphQLRequestOptions.java
@@ -1,0 +1,44 @@
+package com.amplifyframework.api.aws;
+
+import androidx.annotation.NonNull;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Copy of DefaultGraphQLRequestOptions, with LeafSerializationBehavior set to JUST_ID
+ * and maxDepth of 1
+ */
+public class JustIDGraphQLRequestOptions implements GraphQLRequestOptions {
+    private static final String ITEMS_KEY = "items";
+    private static final String NEXT_TOKEN_KEY = "nextToken";
+
+    @NonNull
+    @Override
+    public List<String> paginationFields() {
+        return Collections.singletonList(NEXT_TOKEN_KEY);
+    }
+
+    @NonNull
+    @Override
+    public List<String> modelMetaFields() {
+        return Collections.emptyList();
+    }
+
+    @NonNull
+    @Override
+    public String listField() {
+        return ITEMS_KEY;
+    }
+
+    @Override
+    public int maxDepth() {
+        return 1;
+    }
+
+    @NonNull
+    @Override
+    public LeafSerializationBehavior leafSerializationBehavior() {
+        return LeafSerializationBehavior.JUST_ID;
+    }
+}

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
@@ -313,7 +313,6 @@ public class SelectionSetTest {
         postFields.put("title", postTitle);
         postFields.put("blog", postBlog);
 
-
         Map<String, ModelAssociation> associations = new HashMap<>();
         associations.put("blog", ModelAssociation.builder()
                 .name("BelongsTo")

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
@@ -21,6 +21,7 @@ import com.amplifyframework.core.model.AuthRule;
 import com.amplifyframework.core.model.AuthStrategy;
 import com.amplifyframework.core.model.CustomTypeField;
 import com.amplifyframework.core.model.CustomTypeSchema;
+import com.amplifyframework.core.model.ModelAssociation;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelOperation;
 import com.amplifyframework.core.model.ModelSchema;
@@ -266,5 +267,78 @@ public class SelectionSetTest {
         String result = selectionSet.toString();
         assertEquals(Resources.readAsString("selection-set-nested-serialized-model-serialized-custom-type.txt"),
                 result + "\n");
+    }
+
+    /**
+     * Test generating SelectionSet for nested ModelSchema using SerializedModel.
+     * @throws AmplifyException if a ModelSchema can't be derived from postSchema
+     */
+    @Test
+    public void nestedSerializedModel() throws AmplifyException {
+        SchemaRegistry schemaRegistry = SchemaRegistry.instance();
+        ModelField blogModelId = ModelField.builder()
+                .isRequired(true)
+                .targetType("ID")
+                .build();
+        ModelField blogName = ModelField.builder()
+                .isRequired(true)
+                .targetType("String")
+                .build();
+        Map<String, ModelField> blogFields = new HashMap<>();
+        blogFields.put("id", blogModelId);
+        blogFields.put("name", blogName);
+
+        ModelSchema blogSchema = ModelSchema.builder()
+                .name("Blog")
+                .pluralName("Blogs")
+                .modelClass(SerializedModel.class)
+                .fields(blogFields)
+                .build();
+
+        ModelField postModelId = ModelField.builder()
+                .isRequired(true)
+                .targetType("ID")
+                .build();
+        ModelField postTitle = ModelField.builder()
+                .isRequired(true)
+                .targetType("String")
+                .build();
+        ModelField postBlog = ModelField.builder()
+                .isRequired(true)
+                .targetType("Blog")
+                .isModel(true)
+                .build();
+        Map<String, ModelField> postFields = new HashMap<>();
+        postFields.put("id", postModelId);
+        postFields.put("title", postTitle);
+        postFields.put("blog", postBlog);
+
+
+        Map<String, ModelAssociation> associations = new HashMap<>();
+        associations.put("blog", ModelAssociation.builder()
+                .name("BelongsTo")
+                .targetName("blogId")
+                .associatedType("Blog")
+                .build());
+
+        ModelSchema postSchema = ModelSchema.builder()
+                .name("Post")
+                .pluralName("Posts")
+                .modelClass(SerializedModel.class)
+                .fields(postFields)
+                .associations(associations)
+                .build();
+
+        schemaRegistry.register("Blog", blogSchema);
+        schemaRegistry.register("Post", postSchema);
+
+        SelectionSet selectionSet = SelectionSet.builder()
+                .modelClass(SerializedModel.class)
+                .modelSchema(postSchema)
+                .operation(QueryType.SYNC)
+                .requestOptions(new JustIDGraphQLRequestOptions())
+                .build();
+
+        assertEquals(Resources.readAsString("selection-set-post-nested.txt"), selectionSet.toString() + "\n");
     }
 }

--- a/aws-api-appsync/src/test/resources/selection-set-post-nested.txt
+++ b/aws-api-appsync/src/test/resources/selection-set-post-nested.txt
@@ -1,0 +1,11 @@
+ {
+  items {
+    blog {
+      id
+      name
+    }
+    id
+    title
+  }
+  nextToken
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-android/issues/1610

*Description of changes:*
- Update `getModelFields` method for flutter support to match the version used for native apps. The changes are identical to the changes in https://github.com/aws-amplify/amplify-android/pull/1585/files, but are applied to the version of `getModelFields` that is used for flutter support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
