### PR TITLE
fix(aws-datastore): halt cascading delete if foreign key not found

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelTree.java
@@ -127,8 +127,8 @@ final class SQLiteModelTree {
                                 .get(association.getAssociatedName()) // get @BelongsTo association linked to this field
                                 .getTargetName(); // get the target field (parent) name
                     } catch (NullPointerException unexpectedAssociation) {
-                        LOG.warn("Schema uses unsupported model association type. " +
-                                "Failed to cascade deletion.",
+                        LOG.warn("Foreign key was not found due to unidirectional relationship without @BelongsTo. " +
+                                "Failed to publish cascading mutations.",
                                 unexpectedAssociation);
                         return;
                     }


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-flutter/issues/767

Currently, implicit belongs to relationship in the GraphQL schema (e.g. `Blog` has many `Comment`, but `Comment` does not have an explicit belongs to field) does not form foreign key relationship in the SQLite database. This causes cascading deletion logic to fail with an NPE. This error will be swallowed with this change to prevent unexpected crashes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
