### PR TITLE
fix(api): create RequestDecorator in interceptor

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -155,9 +155,9 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             if (EndpointType.REST.equals(endpointType)) {
                 if (apiConfiguration.getAuthorizationType() != AuthorizationType.NONE) {
                     AuthorizationType authorizationType = apiConfiguration.getAuthorizationType();
-                    RequestDecorator decorator = requestDecoratorFactory.forAuthType(authorizationType);
                     okHttpClientBuilder.addInterceptor(chain -> {
                         try {
+                            RequestDecorator decorator = requestDecoratorFactory.forAuthType(authorizationType);
                             return chain.proceed(decorator.decorate(chain.request()));
                         } catch (ApiException.ApiAuthException apiAuthException) {
                             throw new IOException("Failed to decorate request for authorization.", apiAuthException);


### PR DESCRIPTION
*Issue #, if available:* #1606

*Description of changes:* When configuring the AWSApiPlugin for REST with `AMAZON_COGNITO_USER_POOLS` as the authorization type, configuration fails due to trying to fetch auth tokens when creating the `RequestDecorator`. This PR moves the creation of the `RequestDecorator` inside the interceptor so the auth tokens aren't retrieved when configuring the AWSApiPlugin.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
