### PR TITLE
Fix #651 Adding Javadocs to Maven when publishing

### DIFF
--- a/configuration/publishing.gradle
+++ b/configuration/publishing.gradle
@@ -208,14 +208,21 @@ afterEvaluate { project ->
             classifier = 'sources'
             from sourceSets.main.allSource
         }
+
+        task javadocJar(type: Jar, dependsOn: javadoc) {
+            classifier = 'javadoc'
+            from javadoc.destinationDir
+        }
     }
 
     artifacts {
         if (project.getPlugins().hasPlugin('com.android.application') ||
             project.getPlugins().hasPlugin('com.android.library')) {
             archives androidSourcesJar
+            archives androidJavadocsJar
         } else {
             archives sourcesJar
+            archives javadocsJar
         }
     }
 


### PR DESCRIPTION
Publishing the Javadoc to Maven along with the source

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
