### PR TITLE
[FIX][651]Adding Dokka to the core-kotlin module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31'
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.4.1'
     }
 }

--- a/core-kotlin/build.gradle
+++ b/core-kotlin/build.gradle
@@ -17,7 +17,19 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 apply from: rootProject.file("configuration/publishing.gradle")
+apply plugin: 'org.jetbrains.dokka'
 
+dokkaHtml {
+    dokkaSourceSets {
+        named("main") {
+            includeNonPublic.set(false)
+            skipEmptyPackages.set(true)
+            skipDeprecated.set(true)
+            reportUndocumented.set(true)
+            jdkVersion.set(8)
+        }
+    }
+}
 dependencies {
     implementation dependency.kotlin.stdlib
     implementation dependency.kotlin.coroutines


### PR DESCRIPTION
Currently we are not publishing JavaDoc for core-kotlin for Amplify-Android and the SDK and hence adding Dokka to publish it.

- Added Dokka and corresponding configuration
- Applied it in core-kotlin package


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
