### PR TITLE
feat(auth): Add deleteUser API

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -1109,6 +1109,30 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
             signOutLocally(options, onSuccess, onError);
         }
     }
+    
+    @Override
+    public void deleteUser(@NonNull Action onSuccess, @NonNull Consumer<AuthException> onError) {
+        awsMobileClient.deleteUser(new Callback<Void>() {
+            @Override
+            public void onResult(Void result) {
+                Amplify.Hub.publish(
+                        HubChannel.AUTH,
+                        HubEvent.create(AuthChannelEventName.SIGNED_OUT)
+                );
+                Amplify.Hub.publish(
+                        HubChannel.AUTH,
+                        HubEvent.create(AuthChannelEventName.USER_DELETED)
+                );
+                onSuccess.call();
+            }
+
+            @Override
+            public void onError(Exception exception) {
+                onError.accept(CognitoAuthExceptionConverter.lookup(
+                        exception, "Delete user failed."));
+            }
+        });
+    }
 
     @NonNull
     @Override

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -1115,10 +1115,7 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
         awsMobileClient.deleteUser(new Callback<Void>() {
             @Override
             public void onResult(Void result) {
-                Amplify.Hub.publish(
-                        HubChannel.AUTH,
-                        HubEvent.create(AuthChannelEventName.SIGNED_OUT)
-                );
+                // Note: the SIGNED_OUT Auth event is also emitted
                 Amplify.Hub.publish(
                         HubChannel.AUTH,
                         HubEvent.create(AuthChannelEventName.USER_DELETED)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/util/CognitoAuthExceptionConverter.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.cognitoidentityprovider.model.CodeMismatchExceptio
 import com.amazonaws.services.cognitoidentityprovider.model.ExpiredCodeException;
 import com.amazonaws.services.cognitoidentityprovider.model.InvalidParameterException;
 import com.amazonaws.services.cognitoidentityprovider.model.InvalidPasswordException;
+import com.amazonaws.services.cognitoidentityprovider.model.InvalidUserPoolConfigurationException;
 import com.amazonaws.services.cognitoidentityprovider.model.LimitExceededException;
 import com.amazonaws.services.cognitoidentityprovider.model.MFAMethodNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.NotAuthorizedException;
@@ -77,6 +78,10 @@ public final class CognitoAuthExceptionConverter {
 
         if (error instanceof InvalidParameterException) {
             return new AuthException.InvalidParameterException(error);
+        }
+        
+        if (error instanceof InvalidUserPoolConfigurationException) {
+            return new AuthException.InvalidUserPoolConfigurationException(error);
         }
 
         if (error instanceof ExpiredCodeException) {

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -1319,6 +1319,40 @@ public final class AuthComponentTest {
     }
 
     /**
+     * Tests the deleteUser method of the Auth wrapper of AWSMobileClient (AMC) calls
+     * AMC.deleteUser
+     * @throws AuthException test fails if this gets thrown since method should succeed
+     */
+    @Test
+    public void deleteUser() throws AuthException {
+        doAnswer(invocation -> {
+            Callback<Void> callback = invocation.getArgument(0);
+            callback.onResult(null);
+            return null;
+        }).when(mobileClient).deleteUser(Mockito.any());
+        
+        synchronousAuth.deleteUser();
+        verify(mobileClient).deleteUser(Mockito.any());
+    }
+
+    /**
+     * Tests that if delete user fails, the returned Exception gets wrapped in an AuthException.
+     * @throws AuthException expected exception
+     */
+    @Test(expected = AuthException.class)
+    public void deleteUserFails() throws AuthException {
+        Exception exception = new Exception("Test exception");
+        
+        doAnswer(invocation -> {
+            Callback<Void> callback = invocation.getArgument(0);
+            callback.onError(exception);
+            return null;
+        }).when(mobileClient).deleteUser(Mockito.any());
+        
+        synchronousAuth.deleteUser();
+    }
+
+    /**
      * Test that a signed in account with user and identity pool support returns all proper success results.
      * @throws AuthException test fails if this gets thrown since method should succeed
      */

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthComponentTest.java
@@ -1320,7 +1320,7 @@ public final class AuthComponentTest {
 
     /**
      * Tests the deleteUser method of the Auth wrapper of AWSMobileClient (AMC) calls
-     * AMC.deleteUser
+     * AMC.deleteUser.
      * @throws AuthException test fails if this gets thrown since method should succeed
      */
     @Test

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -315,4 +315,10 @@ interface Auth {
      */
     @Throws(AuthException::class)
     suspend fun signOut(options: AuthSignOutOptions = AuthSignOutOptions.builder().build())
+
+    /**
+     * Delete the account of the currently signed in user.
+     */
+    @Throws(AuthException::class)
+    suspend fun deleteUser()
 }

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -321,4 +321,13 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
             )
         }
     }
+
+    override suspend fun deleteUser() {
+        return suspendCoroutine { continuation ->
+            delegate.deleteUser(
+                { continuation.resume(Unit) },
+                { continuation.resumeWithException(it) }
+            )
+        }
+    }
 }

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -882,7 +882,7 @@ class KotlinAuthFacadeTest {
      * be bubbled up through the coroutine API as well.
      */
     @Test(expected = AuthException::class)
-    fun deleteUserThrows(): Unit = runBlocking { 
+    fun deleteUserThrows(): Unit = runBlocking {
         val error = AuthException("uh", "oh")
         every {
             delegate.deleteUser(any(), any())

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -376,5 +376,12 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
             @NonNull Consumer<AuthException> onError) {
         getSelectedPlugin().signOut(options, onSuccess, onError);
     }
+    
+    @Override
+    public void deleteUser(
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError) {
+        getSelectedPlugin().deleteUser(onSuccess, onError);
+    }
 }
 

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -483,4 +483,13 @@ public interface AuthCategoryBehavior {
             @NonNull AuthSignOutOptions options,
             @NonNull Action onSuccess,
             @NonNull Consumer<AuthException> onError);
+
+    /**
+     * Delete the account of the currently signed in user.
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void deleteUser(
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError);
 }

--- a/core/src/main/java/com/amplifyframework/auth/AuthChannelEventName.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthChannelEventName.java
@@ -38,5 +38,10 @@ public enum AuthChannelEventName {
      * The authorization credentials have expired and require the user to re-sign in to be refreshed. Auth remains in a
      * Signed In authentication state but the user is no longer authorized to perform any operations.
      */
-    SESSION_EXPIRED;
+    SESSION_EXPIRED,
+
+    /**
+     * The account for a user has been deleted.
+     */
+    USER_DELETED;
 }

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -379,7 +379,8 @@ public class AuthException extends AmplifyException {
     }
 
     /**
-     * Could not perform the action because the password given is invalid.
+     * Could not perform the action because the user pool is not configured or
+     * is configured incorrectly.
      */
     public static class InvalidUserPoolConfigurationException extends AuthException {
         private static final long serialVersionUID = 1L;

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -379,6 +379,23 @@ public class AuthException extends AmplifyException {
     }
 
     /**
+     * Could not perform the action because the password given is invalid.
+     */
+    public static class InvalidUserPoolConfigurationException extends AuthException {
+        private static final long serialVersionUID = 1L;
+        private static final String MESSAGE = "The user pool configuration is missing or invalid.";
+        private static final String RECOVERY_SUGGESTION = "Please check your user pool configuration.";
+
+        /**
+         * Default message/recovery suggestion with a cause.
+         * @param cause The original error.
+         */
+        public InvalidUserPoolConfigurationException(Throwable cause) {
+            super(MESSAGE, cause, RECOVERY_SUGGESTION);
+        }
+    }
+
+    /**
      * Could not perform the action because number of allowed operation has exceeded.
      */
     public static class LimitExceededException extends AuthException {

--- a/maplibre-adapter/build.gradle
+++ b/maplibre-adapter/build.gradle
@@ -43,8 +43,11 @@ dependencies {
     implementation dependency.okhttp
     implementation dependency.kotlin.coroutines
 
+    //noinspection GradleDependency
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
+    //noinspection GradleDependency
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
+    //noinspection GradleDependency
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     //noinspection GradleDependency
     implementation "com.google.android.material:material:1.4.0"

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -287,6 +287,11 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
         return toCompletable((onComplete, onError) ->
             delegate.signOut(options, onComplete, onError));
     }
+    
+    @Override
+    public Completable deleteUser() {
+        return toCompletable(delegate::deleteUser);
+    }
 
     private <T> Single<T> toSingle(VoidBehaviors.ResultEmitter<T, AuthException> behavior) {
         return VoidBehaviors.toSingle(behavior);

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -414,4 +414,11 @@ public interface RxAuthCategoryBehavior {
      *         emits an {@link AuthException} otherwise
      */
     Completable signOut(@NonNull AuthSignOutOptions options);
+
+    /**
+     * Delete the account of the currently signed in user.
+     * @return An Rx {@link Completable} which completes upon successfully deleting the user;
+     *         emits an {@link AuthException} otherwise
+     */
+    Completable deleteUser();
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -560,4 +560,14 @@ public final class SynchronousAuth {
                 )
         );
     }
+
+    /**
+     * Delete the account of the currently signed in user.
+     * @throws AuthException exception
+     */
+    public void deleteUser() throws AuthException {
+        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) -> 
+                asyncDelegate.deleteUser(() -> onResult.accept(VoidResult.instance()), onError)
+        );
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adds the deleteUser API to Amplify.Auth to delete a user from the user pool.

**Note:** This PR is not ready to be merged in yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
