### PR TITLE
feat: Add support for custom prefix resolver

### DIFF
--- a/aws-storage-s3/build.gradle
+++ b/aws-storage-s3/build.gradle
@@ -16,6 +16,8 @@
 apply plugin: 'com.android.library'
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
+apply plugin: 'kotlin-android'
+apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 dependencies {
     implementation project(path: ':core')
@@ -33,5 +35,9 @@ dependencies {
     androidTestImplementation dependency.androidx.annotation
     androidTestImplementation dependency.androidx.test.runner
     androidTestImplementation dependency.androidx.test.junit
+}
+
+ktlint {
+    android.set(true)
 }
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -107,7 +107,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     AWSS3StoragePlugin(CognitoAuthProvider cognitoAuthProvider) {
         this((context, region, bucket) ->
                         new AWSS3StorageService(context, region, bucket, cognitoAuthProvider, false),
-                cognitoAuthProvider, new AWSS3StoragePluginConfiguration(null));
+                cognitoAuthProvider, new AWSS3StoragePluginConfiguration());
     }
 
     @VisibleForTesting

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -94,25 +94,31 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
         this(new AWSMobileClientAuthProvider());
     }
 
+    /**
+     * Constructs the AWS S3 Storage Plugin with the plugin configuration.
+     * @param awsS3StoragePluginConfiguration storage plugin configuration
+     */
+    @SuppressWarnings("unused") // This is a public API.
+    public AWSS3StoragePlugin(AWSS3StoragePluginConfiguration awsS3StoragePluginConfiguration) {
+        this(new AWSMobileClientAuthProvider(), awsS3StoragePluginConfiguration);
+    }
+
     @VisibleForTesting
     AWSS3StoragePlugin(CognitoAuthProvider cognitoAuthProvider) {
         this((context, region, bucket) ->
                         new AWSS3StorageService(context, region, bucket, cognitoAuthProvider, false),
-                cognitoAuthProvider);
+                cognitoAuthProvider, new AWSS3StoragePluginConfiguration(null));
     }
 
     @VisibleForTesting
-    AWSS3StoragePlugin(
-            StorageService.Factory storageServiceFactory,
-            CognitoAuthProvider cognitoAuthProvider
-    ) {
-        super();
-        this.storageServiceFactory = storageServiceFactory;
-        this.executorService = Executors.newCachedThreadPool();
-        this.cognitoAuthProvider = cognitoAuthProvider;
-        this.awsS3StoragePluginConfiguration = new AWSS3StoragePluginConfiguration(null);
+    AWSS3StoragePlugin(CognitoAuthProvider cognitoAuthProvider,
+                       AWSS3StoragePluginConfiguration awss3StoragePluginConfiguration) {
+        this((context, region, bucket) ->
+                        new AWSS3StorageService(context, region, bucket, cognitoAuthProvider, false),
+                cognitoAuthProvider, awss3StoragePluginConfiguration);
     }
 
+    @VisibleForTesting
     AWSS3StoragePlugin(
             StorageService.Factory storageServiceFactory,
             CognitoAuthProvider cognitoAuthProvider,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -107,7 +107,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<AmazonS3Client> {
     AWSS3StoragePlugin(CognitoAuthProvider cognitoAuthProvider) {
         this((context, region, bucket) ->
                         new AWSS3StorageService(context, region, bucket, cognitoAuthProvider, false),
-                cognitoAuthProvider, new AWSS3StoragePluginConfiguration());
+                cognitoAuthProvider, new AWSS3StoragePluginConfiguration.Builder().build());
     }
 
     @VisibleForTesting

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/configuration/AWSS3PluginPrefixResolver.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/configuration/AWSS3PluginPrefixResolver.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.configuration
+
+import com.amplifyframework.core.Consumer
+import com.amplifyframework.storage.StorageAccessLevel
+import com.amplifyframework.storage.StorageException
+import com.amplifyframework.storage.s3.CognitoAuthProvider
+import com.amplifyframework.storage.s3.utils.S3Keys
+
+/**
+ * Resolves the final prefix prepended to the S3 key for a given request.
+ **/
+interface AWSS3PluginPrefixResolver {
+
+    /**
+     * Resolves the final prefix prepended to the S3 key
+     * @param accessLevel Storage access level of the request
+     * @param targetIdentity Identity ID of the user
+     * @param onSuccess success callback with the resolved prefix string
+     * @param onError error callback with storage excetion
+     */
+    fun resolvePrefix(
+        accessLevel: StorageAccessLevel,
+        targetIdentity: String?,
+        onSuccess: Consumer<String>,
+        onError: Consumer<StorageException>
+    )
+}
+
+/**
+ * Default prefix resolver based on the storage access level.
+ **/
+internal class StorageAccessLevelAwarePrefixResolver(
+    private val cognitoAuthProvider: CognitoAuthProvider
+) :
+    AWSS3PluginPrefixResolver {
+
+    override fun resolvePrefix(
+        accessLevel: StorageAccessLevel,
+        targetIdentity: String?,
+        onSuccess: Consumer<String>,
+        onError: Consumer<StorageException>
+    ) {
+        val identityId = runCatching {
+            cognitoAuthProvider.identityId
+        }
+        when {
+            identityId.isSuccess -> {
+                val resultIdentityId = targetIdentity ?: identityId.getOrThrow()
+                onSuccess.accept(S3Keys.getAccessLevelPrefix(accessLevel, resultIdentityId))
+            }
+            else -> {
+                onError.accept(identityId.exceptionOrNull() as StorageException)
+            }
+        }
+    }
+}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfiguration.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfiguration.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.configuration
+
+import com.amplifyframework.storage.s3.CognitoAuthProvider
+
+class AWSS3StoragePluginConfiguration(builder: Builder?) {
+
+    private val awsS3PluginPrefixResolver = builder?.awsS3PluginPrefixResolver
+
+    fun getAWSS3PluginPrefixResolver(cognitoAuthProvider: CognitoAuthProvider):
+        AWSS3PluginPrefixResolver {
+            return awsS3PluginPrefixResolver ?: StorageAccessLevelAwarePrefixResolver(
+                cognitoAuthProvider
+            )
+        }
+
+    class Builder {
+        var awsS3PluginPrefixResolver: AWSS3PluginPrefixResolver? = null
+    }
+}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfiguration.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfiguration.kt
@@ -17,9 +17,16 @@ package com.amplifyframework.storage.s3.configuration
 
 import com.amplifyframework.storage.s3.CognitoAuthProvider
 
-class AWSS3StoragePluginConfiguration @JvmOverloads constructor(builder: Builder = Builder()) {
+class AWSS3StoragePluginConfiguration private constructor(builder: Builder) {
 
     private val awsS3PluginPrefixResolver = builder.awsS3PluginPrefixResolver
+
+    companion object {
+        operator fun invoke(block: Builder.() -> Unit): AWSS3StoragePluginConfiguration =
+            Builder()
+                .apply(block)
+                .build()
+    }
 
     fun getAWSS3PluginPrefixResolver(cognitoAuthProvider: CognitoAuthProvider):
         AWSS3PluginPrefixResolver {
@@ -30,5 +37,7 @@ class AWSS3StoragePluginConfiguration @JvmOverloads constructor(builder: Builder
 
     class Builder {
         var awsS3PluginPrefixResolver: AWSS3PluginPrefixResolver? = null
+
+        fun build(): AWSS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration(this)
     }
 }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfiguration.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfiguration.kt
@@ -17,9 +17,9 @@ package com.amplifyframework.storage.s3.configuration
 
 import com.amplifyframework.storage.s3.CognitoAuthProvider
 
-class AWSS3StoragePluginConfiguration(builder: Builder?) {
+class AWSS3StoragePluginConfiguration @JvmOverloads constructor(builder: Builder = Builder()) {
 
-    private val awsS3PluginPrefixResolver = builder?.awsS3PluginPrefixResolver
+    private val awsS3PluginPrefixResolver = builder.awsS3PluginPrefixResolver
 
     fun getAWSS3PluginPrefixResolver(cognitoAuthProvider: CognitoAuthProvider):
         AWSS3PluginPrefixResolver {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperation.java
@@ -23,9 +23,9 @@ import com.amplifyframework.storage.StorageItem;
 import com.amplifyframework.storage.operation.StorageListOperation;
 import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.s3.CognitoAuthProvider;
+import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration;
 import com.amplifyframework.storage.s3.request.AWSS3StorageListRequest;
 import com.amplifyframework.storage.s3.service.StorageService;
-import com.amplifyframework.storage.s3.utils.S3Keys;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -40,21 +40,26 @@ public final class AWSS3StorageListOperation extends StorageListOperation<AWSS3S
     private final CognitoAuthProvider cognitoAuthProvider;
     private final Consumer<StorageListResult> onSuccess;
     private final Consumer<StorageException> onError;
+    private final AWSS3StoragePluginConfiguration awsS3StoragePluginConfiguration;
 
     /**
      * Constructs a new AWSS3StorageListOperation.
-     * @param storageService S3 client wrapper
-     * @param executorService Executor service used for running blocking operations on a separate thread
+     *
+     * @param storageService      S3 client wrapper
+     * @param executorService     Executor service used for running blocking operations on a
+     *                            separate thread
      * @param cognitoAuthProvider Interface to retrieve AWS specific auth information
-     * @param request list request parameters
-     * @param onSuccess notified when list operation results are available
-     * @param onError notified when list results cannot be obtained due to error
+     * @param request             list request parameters
+     * @param awss3StoragePluginConfiguration s3Plugin configuration
+     * @param onSuccess           notified when list operation results are available
+     * @param onError             notified when list results cannot be obtained due to error
      */
     public AWSS3StorageListOperation(
             @NonNull StorageService storageService,
             @NonNull ExecutorService executorService,
             @NonNull CognitoAuthProvider cognitoAuthProvider,
             @NonNull AWSS3StorageListRequest request,
+            @NonNull AWSS3StoragePluginConfiguration awss3StoragePluginConfiguration,
             @NonNull Consumer<StorageListResult> onSuccess,
             @NonNull Consumer<StorageException> onError
     ) {
@@ -64,40 +69,35 @@ public final class AWSS3StorageListOperation extends StorageListOperation<AWSS3S
         this.cognitoAuthProvider = cognitoAuthProvider;
         this.onSuccess = onSuccess;
         this.onError = onError;
+        this.awsS3StoragePluginConfiguration = awss3StoragePluginConfiguration;
     }
 
     @SuppressWarnings("SyntheticAccessor")
     @Override
     public void start() {
         executorService.submit(() -> {
-            try {
-                String currentIdentityId;
-
-                try {
-                    currentIdentityId = cognitoAuthProvider.getIdentityId();
-                } catch (StorageException exception) {
-                    onError.accept(exception);
-                    return;
-                }
-
-                String serviceKey = S3Keys.createServiceKey(
-                        getRequest().getAccessLevel(),
-                        getRequest().getTargetIdentityId() != null
-                                ? getRequest().getTargetIdentityId()
-                                : currentIdentityId,
-                        getRequest().getPath()
-                );
-
-                List<StorageItem> listedItems = storageService.listFiles(serviceKey);
-
-                onSuccess.accept(StorageListResult.fromItems(listedItems));
-            } catch (Exception exception) {
-                onError.accept(new StorageException(
-                    "Something went wrong with your AWS S3 Storage list operation",
-                    exception,
-                    "See attached exception for more information and suggestions"
-                ));
+            awsS3StoragePluginConfiguration.
+                getAWSS3PluginPrefixResolver(cognitoAuthProvider).
+                resolvePrefix(getRequest().getAccessLevel(),
+                    getRequest().getTargetIdentityId(),
+                    prefix -> {
+                        try {
+                            String serviceKey = prefix.concat(getRequest().getPath());
+                            List<StorageItem> listedItems = storageService.listFiles(serviceKey);
+                            onSuccess.accept(StorageListResult.fromItems(listedItems));
+                        } catch (Exception exception) {
+                            onError.accept(new StorageException(
+                                    "Something went wrong with your AWS S3 Storage list operation",
+                                    exception,
+                                    "See attached exception for more information and suggestions"
+                            ));
+                        }
+                        String serviceKey = prefix.concat(getRequest().getPath());
+                        List<StorageItem> listedItems = storageService.listFiles(serviceKey);
+                        onSuccess.accept(StorageListResult.fromItems(listedItems));
+                    },
+                    onError);
             }
-        });
+        );
     }
 }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperation.java
@@ -92,9 +92,6 @@ public final class AWSS3StorageListOperation extends StorageListOperation<AWSS3S
                                     "See attached exception for more information and suggestions"
                             ));
                         }
-                        String serviceKey = prefix.concat(getRequest().getPath());
-                        List<StorageItem> listedItems = storageService.listFiles(serviceKey);
-                        onSuccess.accept(StorageListResult.fromItems(listedItems));
                     },
                     onError);
             }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.java
@@ -29,6 +29,7 @@ import com.amplifyframework.storage.result.StorageTransferProgress;
 import com.amplifyframework.storage.result.StorageUploadInputStreamResult;
 import com.amplifyframework.storage.s3.CognitoAuthProvider;
 import com.amplifyframework.storage.s3.ServerSideEncryption;
+import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration;
 import com.amplifyframework.storage.s3.request.AWSS3StorageUploadRequest;
 import com.amplifyframework.storage.s3.service.StorageService;
 import com.amplifyframework.storage.s3.utils.S3Keys;
@@ -53,20 +54,24 @@ public final class AWSS3StorageUploadInputStreamOperation
     private final Consumer<StorageUploadInputStreamResult> onSuccess;
     private final Consumer<StorageException> onError;
     private TransferObserver transferObserver;
+    private final AWSS3StoragePluginConfiguration awsS3StoragePluginConfiguration;
 
     /**
      * Constructs a new AWSS3StorageUploadInputStreamOperation.
-     * @param storageService S3 client wrapper
+     *
+     * @param storageService      S3 client wrapper
      * @param cognitoAuthProvider Interface to retrieve AWS specific auth information
-     * @param request upload request parameters
-     * @param onProgress Notified upon advancements in upload progress
-     * @param onSuccess Will be notified when results of upload are available
-     * @param onError Notified when upload fails with an error
+     * @param request             upload request parameters
+     * @param awsS3StoragePluginConfiguration s3Plugin configuration
+     * @param onProgress          Notified upon advancements in upload progress
+     * @param onSuccess           Will be notified when results of upload are available
+     * @param onError             Notified when upload fails with an error
      */
     public AWSS3StorageUploadInputStreamOperation(
             @NonNull StorageService storageService,
             @NonNull CognitoAuthProvider cognitoAuthProvider,
             @NonNull AWSS3StorageUploadRequest<InputStream> request,
+            @NonNull AWSS3StoragePluginConfiguration awsS3StoragePluginConfiguration,
             @NonNull Consumer<StorageTransferProgress> onProgress,
             @NonNull Consumer<StorageUploadInputStreamResult> onSuccess,
             @NonNull Consumer<StorageException> onError
@@ -78,6 +83,7 @@ public final class AWSS3StorageUploadInputStreamOperation
         this.onSuccess = Objects.requireNonNull(onSuccess);
         this.onError = Objects.requireNonNull(onError);
         this.transferObserver = null;
+        this.awsS3StoragePluginConfiguration = awsS3StoragePluginConfiguration;
     }
 
     @SuppressLint("SyntheticAccessor")
@@ -118,17 +124,24 @@ public final class AWSS3StorageUploadInputStreamOperation
             objectMetadata.setSSEAlgorithm(storageServerSideEncryption.getName());
         }
 
-        // Upload!
-        try {
-            transferObserver = storageService.uploadInputStream(serviceKey, inputStream, objectMetadata);
-            transferObserver.setTransferListener(new UploadTransferListener());
-        } catch (IOException ioException) {
-            onError.accept(new StorageException(
-                    "Issue uploading inputStream.",
-                    ioException,
-                    "See included exception for more details and suggestions to fix."
-            ));
-        }
+        awsS3StoragePluginConfiguration.getAWSS3PluginPrefixResolver(cognitoAuthProvider).
+                resolvePrefix(getRequest().getAccessLevel(),
+                getRequest().getTargetIdentityId(),
+                    prefix -> {
+                        try {
+                            transferObserver = storageService.uploadInputStream(serviceKey,
+                                    inputStream,
+                                    objectMetadata);
+                            transferObserver.setTransferListener(new UploadTransferListener());
+                        } catch (IOException ioException) {
+                            onError.accept(new StorageException(
+                                    "Issue uploading inputStream.",
+                                    ioException,
+                                    "See included exception for more details and suggestions to fix."
+                            ));
+                        }
+                    },
+                onError);
     }
 
     @Override

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.java
@@ -32,7 +32,6 @@ import com.amplifyframework.storage.s3.ServerSideEncryption;
 import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration;
 import com.amplifyframework.storage.s3.request.AWSS3StorageUploadRequest;
 import com.amplifyframework.storage.s3.service.StorageService;
-import com.amplifyframework.storage.s3.utils.S3Keys;
 
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferListener;
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferObserver;
@@ -94,23 +93,6 @@ public final class AWSS3StorageUploadInputStreamOperation
             return;
         }
 
-        String currentIdentityId;
-
-        try {
-            currentIdentityId = cognitoAuthProvider.getIdentityId();
-        } catch (StorageException exception) {
-            onError.accept(exception);
-            return;
-        }
-
-        String serviceKey = S3Keys.createServiceKey(
-                getRequest().getAccessLevel(),
-                getRequest().getTargetIdentityId() != null
-                        ? getRequest().getTargetIdentityId()
-                        : currentIdentityId,
-                getRequest().getKey()
-        );
-
         // Grab the inputStream to upload...
         InputStream inputStream = getRequest().getLocal();
 
@@ -129,7 +111,9 @@ public final class AWSS3StorageUploadInputStreamOperation
                 getRequest().getTargetIdentityId(),
                     prefix -> {
                         try {
-                            transferObserver = storageService.uploadInputStream(serviceKey,
+                            String serviceKey = prefix.concat(getRequest().getKey());
+                            transferObserver = storageService.uploadInputStream(
+                                    serviceKey,
                                     inputStream,
                                     objectMetadata);
                             transferObserver.setTransferListener(new UploadTransferListener());

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/utils/S3Keys.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/utils/S3Keys.java
@@ -55,18 +55,28 @@ public final class S3Keys {
             @NonNull String identityId,
             @NonNull String amplifyKey
     ) {
-        return getAccessLevelPrefix(accessLevel, identityId) + BUCKET_SEPARATOR + amplifyKey;
+        return getAccessLevelPrefix(accessLevel, identityId) + amplifyKey;
     }
 
+    /**
+     * Amplify Storage implementation with S3 integrates access level.
+     *
+     * This method helps construct a correctly formatted access level prefix to give
+     * user the correct level of access into the bucket.
+     *
+     * @param accessLevel Storage access level of the request
+     * @param identityId Identity ID of the user
+     * @return Formatted key to be used internally by S3 plugin
+     */
     @NonNull
-    private static String getAccessLevelPrefix(
+    public static String getAccessLevelPrefix(
             @NonNull StorageAccessLevel accessLevel,
             @NonNull String identityId
     ) {
         if (StorageAccessLevel.PRIVATE.equals(accessLevel) || StorageAccessLevel.PROTECTED.equals(accessLevel)) {
-            return accessLevel.name().toLowerCase(Locale.US) + BUCKET_SEPARATOR + identityId;
+            return accessLevel.name().toLowerCase(Locale.US) + BUCKET_SEPARATOR + identityId + BUCKET_SEPARATOR;
         } else {
-            return accessLevel.name().toLowerCase(Locale.US);
+            return accessLevel.name().toLowerCase(Locale.US) + BUCKET_SEPARATOR;
         }
     }
 

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
@@ -89,8 +89,7 @@ public final class StorageComponentTest {
         CognitoAuthProvider cognitoAuthProvider = mock(CognitoAuthProvider.class);
         doReturn(RandomString.string()).when(cognitoAuthProvider).getIdentityId();
         this.storage.addPlugin(new AWSS3StoragePlugin(storageServiceFactory,
-                cognitoAuthProvider,
-                new AWSS3StoragePluginConfiguration())
+                cognitoAuthProvider, new AWSS3StoragePluginConfiguration.Builder().build())
         );
         this.storage.configure(buildConfiguration(), getApplicationContext());
         this.storage.initialize(getApplicationContext());

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
@@ -90,7 +90,7 @@ public final class StorageComponentTest {
         doReturn(RandomString.string()).when(cognitoAuthProvider).getIdentityId();
         this.storage.addPlugin(new AWSS3StoragePlugin(storageServiceFactory,
                 cognitoAuthProvider,
-                new AWSS3StoragePluginConfiguration(null))
+                new AWSS3StoragePluginConfiguration())
         );
         this.storage.configure(buildConfiguration(), getApplicationContext());
         this.storage.initialize(getApplicationContext());

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
@@ -26,6 +26,7 @@ import com.amplifyframework.storage.result.StorageListResult;
 import com.amplifyframework.storage.result.StorageRemoveResult;
 import com.amplifyframework.storage.result.StorageUploadFileResult;
 import com.amplifyframework.storage.result.StorageUploadInputStreamResult;
+import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration;
 import com.amplifyframework.storage.s3.service.StorageService;
 import com.amplifyframework.testutils.Await;
 import com.amplifyframework.testutils.random.RandomBytes;
@@ -87,7 +88,10 @@ public final class StorageComponentTest {
         StorageService.Factory storageServiceFactory = (context, region, bucket) -> storageService;
         CognitoAuthProvider cognitoAuthProvider = mock(CognitoAuthProvider.class);
         doReturn(RandomString.string()).when(cognitoAuthProvider).getIdentityId();
-        this.storage.addPlugin(new AWSS3StoragePlugin(storageServiceFactory, cognitoAuthProvider));
+        this.storage.addPlugin(new AWSS3StoragePlugin(storageServiceFactory,
+                cognitoAuthProvider,
+                new AWSS3StoragePluginConfiguration(null))
+        );
         this.storage.configure(buildConfiguration(), getApplicationContext());
         this.storage.initialize(getApplicationContext());
     }

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfigurationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfigurationTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.configuration
+
+import com.amplifyframework.core.Consumer
+import com.amplifyframework.storage.StorageAccessLevel
+import com.amplifyframework.storage.StorageException
+import com.amplifyframework.storage.s3.CognitoAuthProvider
+import junit.framework.TestCase
+import org.mockito.Mockito
+
+class AWSS3StoragePluginConfigurationTest : TestCase() {
+
+    fun testGetAWSS3PluginPrefixResolver() {
+        val customAWSS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+            override fun resolvePrefix(
+                accessLevel: StorageAccessLevel,
+                targetIdentity: String?,
+                onSuccess: Consumer<String>,
+                onError: Consumer<StorageException>
+            ) {
+                onSuccess.accept("")
+            }
+        }
+        val cognitoAuthProvider = Mockito.mock(CognitoAuthProvider::class.java)
+        val awsS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration(
+            AWSS3StoragePluginConfiguration.Builder().apply {
+                awsS3PluginPrefixResolver = customAWSS3PluginPrefixResolver
+            }
+        )
+        val resultS3PluginPrefixResolver =
+            awsS3StoragePluginConfiguration.getAWSS3PluginPrefixResolver(cognitoAuthProvider)
+        assertEquals(resultS3PluginPrefixResolver, customAWSS3PluginPrefixResolver)
+    }
+
+    fun testGetDefaultAWSS3PluginPrefixResolver() {
+        val awsS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration(null)
+        val cognitoAuthProvider = Mockito.mock(CognitoAuthProvider::class.java)
+        val awsS3PluginPrefixResolver =
+            awsS3StoragePluginConfiguration.getAWSS3PluginPrefixResolver(cognitoAuthProvider)
+        assert(awsS3PluginPrefixResolver is StorageAccessLevelAwarePrefixResolver)
+    }
+}

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfigurationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfigurationTest.kt
@@ -36,18 +36,16 @@ class AWSS3StoragePluginConfigurationTest : TestCase() {
             }
         }
         val cognitoAuthProvider = Mockito.mock(CognitoAuthProvider::class.java)
-        val awsS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration(
-            AWSS3StoragePluginConfiguration.Builder().apply {
-                awsS3PluginPrefixResolver = customAWSS3PluginPrefixResolver
-            }
-        )
+        val awsS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration {
+            awsS3PluginPrefixResolver = customAWSS3PluginPrefixResolver
+        }
         val resultS3PluginPrefixResolver =
             awsS3StoragePluginConfiguration.getAWSS3PluginPrefixResolver(cognitoAuthProvider)
         assertEquals(resultS3PluginPrefixResolver, customAWSS3PluginPrefixResolver)
     }
 
     fun testGetDefaultAWSS3PluginPrefixResolver() {
-        val awsS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration()
+        val awsS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration {}
         val cognitoAuthProvider = Mockito.mock(CognitoAuthProvider::class.java)
         val awsS3PluginPrefixResolver =
             awsS3StoragePluginConfiguration.getAWSS3PluginPrefixResolver(cognitoAuthProvider)

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfigurationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/configuration/AWSS3StoragePluginConfigurationTest.kt
@@ -47,7 +47,7 @@ class AWSS3StoragePluginConfigurationTest : TestCase() {
     }
 
     fun testGetDefaultAWSS3PluginPrefixResolver() {
-        val awsS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration(null)
+        val awsS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration()
         val cognitoAuthProvider = Mockito.mock(CognitoAuthProvider::class.java)
         val awsS3PluginPrefixResolver =
             awsS3StoragePluginConfiguration.getAWSS3PluginPrefixResolver(cognitoAuthProvider)

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperationTest.kt
@@ -56,7 +56,7 @@ class AWSS3StorageDownloadFileOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(),
+            AWSS3StoragePluginConfiguration {},
             {},
             {},
             {}
@@ -81,20 +81,18 @@ class AWSS3StorageDownloadFileOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("")
                     }
                 }
-            ),
+            },
             {},
             {},
             {}
@@ -119,20 +117,18 @@ class AWSS3StorageDownloadFileOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("customPublic/")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("customPublic/")
                     }
                 }
-            ),
+            },
             {},
             {},
             {}

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperationTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.operation
+
+import com.amplifyframework.core.Consumer
+import com.amplifyframework.storage.StorageAccessLevel
+import com.amplifyframework.storage.StorageException
+import com.amplifyframework.storage.s3.CognitoAuthProvider
+import com.amplifyframework.storage.s3.configuration.AWSS3PluginPrefixResolver
+import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration
+import com.amplifyframework.storage.s3.request.AWSS3StorageDownloadFileRequest
+import com.amplifyframework.storage.s3.service.StorageService
+import java.io.File
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+class AWSS3StorageDownloadFileOperationTest {
+
+    private lateinit var awsS3StorageDownloadFileOperation: AWSS3StorageDownloadFileOperation
+    private lateinit var storageService: StorageService
+    private lateinit var cognitoAuthProvider: CognitoAuthProvider
+
+    @Before
+    fun setup() {
+        storageService = Mockito.spy(StorageService::class.java)
+        cognitoAuthProvider = Mockito.mock(CognitoAuthProvider::class.java)
+    }
+
+    @Test
+    fun defaultPrefixResolverAWSS3PluginConfigTest() {
+        val key = "123"
+        val tempFile = File.createTempFile("new", "file.tmp")
+        val expectedKey = "public/123"
+        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
+            key,
+            tempFile,
+            StorageAccessLevel.PUBLIC,
+            null
+        )
+        Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
+        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+            storageService,
+            cognitoAuthProvider,
+            request,
+            AWSS3StoragePluginConfiguration(null),
+            {},
+            {},
+            {}
+        )
+        awsS3StorageDownloadFileOperation.start()
+        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+    }
+
+    @Test
+    fun customPrefixResolverAWSS3PluginConfigTest() {
+        val key = "123"
+        val tempFile = File.createTempFile("new", "file.tmp")
+        val expectedKey = "123"
+        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
+            key,
+            tempFile,
+            StorageAccessLevel.PUBLIC,
+            null
+        )
+        Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
+        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+            storageService,
+            cognitoAuthProvider,
+            request,
+            AWSS3StoragePluginConfiguration(
+                AWSS3StoragePluginConfiguration.Builder().apply {
+                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                        override fun resolvePrefix(
+                            accessLevel: StorageAccessLevel,
+                            targetIdentity: String?,
+                            onSuccess: Consumer<String>,
+                            onError: Consumer<StorageException>
+                        ) {
+                            onSuccess.accept("")
+                        }
+                    }
+                }
+            ),
+            {},
+            {},
+            {}
+        )
+        awsS3StorageDownloadFileOperation.start()
+        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+    }
+}

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageGetPresignedUrlOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageGetPresignedUrlOperationTest.kt
@@ -12,25 +12,25 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 package com.amplifyframework.storage.s3.operation
 
+import android.util.Log
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.storage.StorageAccessLevel
 import com.amplifyframework.storage.StorageException
 import com.amplifyframework.storage.s3.CognitoAuthProvider
 import com.amplifyframework.storage.s3.configuration.AWSS3PluginPrefixResolver
 import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration
-import com.amplifyframework.storage.s3.request.AWSS3StorageDownloadFileRequest
+import com.amplifyframework.storage.s3.request.AWSS3StorageGetPresignedUrlRequest
 import com.amplifyframework.storage.s3.service.StorageService
-import java.io.File
+import com.google.common.util.concurrent.MoreExecutors
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 
-class AWSS3StorageDownloadFileOperationTest {
+public class AWSS3StorageGetPresignedUrlOperationTest {
 
-    private lateinit var awsS3StorageDownloadFileOperation: AWSS3StorageDownloadFileOperation
+    private lateinit var awsS3StorageGetPresignedUrlOperation: AWSS3StorageGetPresignedUrlOperation
     private lateinit var storageService: StorageService
     private lateinit var cognitoAuthProvider: CognitoAuthProvider
 
@@ -43,42 +43,41 @@ class AWSS3StorageDownloadFileOperationTest {
     @Test
     fun defaultPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
         val expectedKey = "public/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
+        val request = AWSS3StorageGetPresignedUrlRequest(
             key,
-            tempFile,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
+            1
         )
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageGetPresignedUrlOperation = AWSS3StorageGetPresignedUrlOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(),
             {},
-            {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageGetPresignedUrlOperation.start()
+        Mockito.verify(storageService).getPresignedUrl(expectedKey, 1)
     }
 
     @Test
     fun customEmptyPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
         val expectedKey = "123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
+        val request = AWSS3StorageGetPresignedUrlRequest(
             key,
-            tempFile,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
+            1
         )
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageGetPresignedUrlOperation = AWSS3StorageGetPresignedUrlOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(
@@ -96,27 +95,26 @@ class AWSS3StorageDownloadFileOperationTest {
                 }
             ),
             {},
-            {},
-            {}
+            { Log.e("TAG", "$it") }
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageGetPresignedUrlOperation.start()
+        Mockito.verify(storageService).getPresignedUrl(expectedKey, 1)
     }
 
     @Test
     fun customPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
-        val expectedKey = "customPublic/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
+        val expectedKey = "publicCustom/123"
+        val request = AWSS3StorageGetPresignedUrlRequest(
             key,
-            tempFile,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
+            1
         )
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageGetPresignedUrlOperation = AWSS3StorageGetPresignedUrlOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(
@@ -128,16 +126,15 @@ class AWSS3StorageDownloadFileOperationTest {
                             onSuccess: Consumer<String>,
                             onError: Consumer<StorageException>
                         ) {
-                            onSuccess.accept("customPublic/")
+                            onSuccess.accept("publicCustom/")
                         }
                     }
                 }
             ),
             {},
-            {},
-            {}
+            { Log.e("TAG", "$it") }
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageGetPresignedUrlOperation.start()
+        Mockito.verify(storageService).getPresignedUrl(expectedKey, 1)
     }
 }

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageGetPresignedUrlOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageGetPresignedUrlOperationTest.kt
@@ -56,7 +56,7 @@ public class AWSS3StorageGetPresignedUrlOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(),
+            AWSS3StoragePluginConfiguration {},
             {},
             {}
         )
@@ -80,20 +80,18 @@ public class AWSS3StorageGetPresignedUrlOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("")
                     }
                 }
-            ),
+            },
             {},
             { Log.e("TAG", "$it") }
         )
@@ -117,20 +115,18 @@ public class AWSS3StorageGetPresignedUrlOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("publicCustom/")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("publicCustom/")
                     }
                 }
-            ),
+            },
             {},
             { Log.e("TAG", "$it") }
         )

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperationTest.kt
@@ -21,16 +21,16 @@ import com.amplifyframework.storage.StorageException
 import com.amplifyframework.storage.s3.CognitoAuthProvider
 import com.amplifyframework.storage.s3.configuration.AWSS3PluginPrefixResolver
 import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration
-import com.amplifyframework.storage.s3.request.AWSS3StorageDownloadFileRequest
+import com.amplifyframework.storage.s3.request.AWSS3StorageListRequest
 import com.amplifyframework.storage.s3.service.StorageService
-import java.io.File
+import com.google.common.util.concurrent.MoreExecutors
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 
-class AWSS3StorageDownloadFileOperationTest {
+public class AWSS3StorageListOperationTest {
 
-    private lateinit var awsS3StorageDownloadFileOperation: AWSS3StorageDownloadFileOperation
+    private lateinit var awsS3StorageListOperation: AWSS3StorageListOperation
     private lateinit var storageService: StorageService
     private lateinit var cognitoAuthProvider: CognitoAuthProvider
 
@@ -42,43 +42,40 @@ class AWSS3StorageDownloadFileOperationTest {
 
     @Test
     fun defaultPrefixResolverAWSS3PluginConfigTest() {
-        val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
-        val expectedKey = "public/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
+        val path = ""
+        val expectedKey = "public/"
+        val request = AWSS3StorageListRequest(
+            path,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
         )
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageListOperation = AWSS3StorageListOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(),
             {},
-            {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageListOperation.start()
+        Mockito.verify(storageService).listFiles(expectedKey)
     }
 
     @Test
-    fun customEmptyPrefixResolverAWSS3PluginConfigTest() {
-        val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
-        val expectedKey = "123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
+    fun customEmptyResolverAWSS3PluginConfigTest() {
+        val path = ""
+        val expectedKey = ""
+        val request = AWSS3StorageListRequest(
+            path,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
         )
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageListOperation = AWSS3StorageListOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(
@@ -96,27 +93,25 @@ class AWSS3StorageDownloadFileOperationTest {
                 }
             ),
             {},
-            {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageListOperation.start()
+        Mockito.verify(storageService).listFiles(expectedKey)
     }
 
     @Test
-    fun customPrefixResolverAWSS3PluginConfigTest() {
-        val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
-        val expectedKey = "customPublic/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
+    fun customResolverAWSS3PluginConfigTest() {
+        val path = ""
+        val expectedKey = "publicCustom/"
+        val request = AWSS3StorageListRequest(
+            path,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
         )
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageListOperation = AWSS3StorageListOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(
@@ -128,16 +123,15 @@ class AWSS3StorageDownloadFileOperationTest {
                             onSuccess: Consumer<String>,
                             onError: Consumer<StorageException>
                         ) {
-                            onSuccess.accept("customPublic/")
+                            onSuccess.accept("publicCustom/")
                         }
                     }
                 }
             ),
             {},
-            {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageListOperation.start()
+        Mockito.verify(storageService).listFiles(expectedKey)
     }
 }

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperationTest.kt
@@ -55,7 +55,7 @@ public class AWSS3StorageListOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(),
+            AWSS3StoragePluginConfiguration {},
             {},
             {}
         )
@@ -78,20 +78,18 @@ public class AWSS3StorageListOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("")
                     }
                 }
-            ),
+            },
             {},
             {}
         )
@@ -114,20 +112,18 @@ public class AWSS3StorageListOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("publicCustom/")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("publicCustom/")
                     }
                 }
-            ),
+            },
             {},
             {}
         )

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageRemoveOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageRemoveOperationTest.kt
@@ -50,7 +50,7 @@ class AWSS3StorageRemoveOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(),
+            AWSS3StoragePluginConfiguration {},
             {},
             {}
         )
@@ -69,20 +69,18 @@ class AWSS3StorageRemoveOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("")
                     }
                 }
-            ),
+            },
             {},
             {}
         )
@@ -101,20 +99,18 @@ class AWSS3StorageRemoveOperationTest {
             MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("publicCustom/")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("publicCustom/")
                     }
                 }
-            ),
+            },
             {},
             {}
         )

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageRemoveOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageRemoveOperationTest.kt
@@ -12,7 +12,6 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 package com.amplifyframework.storage.s3.operation
 
 import com.amplifyframework.core.Consumer
@@ -21,16 +20,16 @@ import com.amplifyframework.storage.StorageException
 import com.amplifyframework.storage.s3.CognitoAuthProvider
 import com.amplifyframework.storage.s3.configuration.AWSS3PluginPrefixResolver
 import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration
-import com.amplifyframework.storage.s3.request.AWSS3StorageDownloadFileRequest
+import com.amplifyframework.storage.s3.request.AWSS3StorageRemoveRequest
 import com.amplifyframework.storage.s3.service.StorageService
-import java.io.File
+import com.google.common.util.concurrent.MoreExecutors
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 
-class AWSS3StorageDownloadFileOperationTest {
+class AWSS3StorageRemoveOperationTest {
 
-    private lateinit var awsS3StorageDownloadFileOperation: AWSS3StorageDownloadFileOperation
+    private lateinit var awsS3StorageRemoveOperation: AWSS3StorageRemoveOperation
     private lateinit var storageService: StorageService
     private lateinit var cognitoAuthProvider: CognitoAuthProvider
 
@@ -43,42 +42,31 @@ class AWSS3StorageDownloadFileOperationTest {
     @Test
     fun defaultPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
         val expectedKey = "public/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
-            StorageAccessLevel.PUBLIC,
-            null
-        )
+        val request = AWSS3StorageRemoveRequest(key, StorageAccessLevel.PUBLIC, "")
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageRemoveOperation = AWSS3StorageRemoveOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(),
             {},
-            {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageRemoveOperation.start()
+        Mockito.verify(storageService).deleteObject(expectedKey)
     }
 
     @Test
     fun customEmptyPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
         val expectedKey = "123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
-            StorageAccessLevel.PUBLIC,
-            null
-        )
+        val request = AWSS3StorageRemoveRequest(key, StorageAccessLevel.PUBLIC, "")
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageRemoveOperation = AWSS3StorageRemoveOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(
@@ -96,27 +84,21 @@ class AWSS3StorageDownloadFileOperationTest {
                 }
             ),
             {},
-            {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageRemoveOperation.start()
+        Mockito.verify(storageService).deleteObject(expectedKey)
     }
 
     @Test
     fun customPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
-        val expectedKey = "customPublic/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
-            StorageAccessLevel.PUBLIC,
-            null
-        )
+        val expectedKey = "publicCustom/123"
+        val request = AWSS3StorageRemoveRequest(key, StorageAccessLevel.PUBLIC, "")
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageRemoveOperation = AWSS3StorageRemoveOperation(
             storageService,
+            MoreExecutors.newDirectExecutorService(),
             cognitoAuthProvider,
             request,
             AWSS3StoragePluginConfiguration(
@@ -128,16 +110,15 @@ class AWSS3StorageDownloadFileOperationTest {
                             onSuccess: Consumer<String>,
                             onError: Consumer<StorageException>
                         ) {
-                            onSuccess.accept("customPublic/")
+                            onSuccess.accept("publicCustom/")
                         }
                     }
                 }
             ),
             {},
-            {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageRemoveOperation.start()
+        Mockito.verify(storageService).deleteObject(expectedKey)
     }
 }

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperationTest.kt
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -12,25 +13,26 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 package com.amplifyframework.storage.s3.operation
 
+import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.storage.StorageAccessLevel
 import com.amplifyframework.storage.StorageException
 import com.amplifyframework.storage.s3.CognitoAuthProvider
+import com.amplifyframework.storage.s3.ServerSideEncryption
 import com.amplifyframework.storage.s3.configuration.AWSS3PluginPrefixResolver
 import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration
-import com.amplifyframework.storage.s3.request.AWSS3StorageDownloadFileRequest
+import com.amplifyframework.storage.s3.request.AWSS3StorageUploadRequest
 import com.amplifyframework.storage.s3.service.StorageService
 import java.io.File
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 
-class AWSS3StorageDownloadFileOperationTest {
+class AWSS3StorageUploadFileOperationTest {
 
-    private lateinit var awsS3StorageDownloadFileOperation: AWSS3StorageDownloadFileOperation
+    private lateinit var awsS3StorageUploadFileOperation: AWSS3StorageUploadFileOperation
     private lateinit var storageService: StorageService
     private lateinit var cognitoAuthProvider: CognitoAuthProvider
 
@@ -43,16 +45,18 @@ class AWSS3StorageDownloadFileOperationTest {
     @Test
     fun defaultPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
         val expectedKey = "public/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
+        val tempFile = File.createTempFile("new", "file.tmp")
+        val request = AWSS3StorageUploadRequest<File>(
             key,
             tempFile,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
+            "/image",
+            ServerSideEncryption.NONE,
+            mutableMapOf()
         )
-        Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageUploadFileOperation = AWSS3StorageUploadFileOperation(
             storageService,
             cognitoAuthProvider,
             request,
@@ -61,23 +65,29 @@ class AWSS3StorageDownloadFileOperationTest {
             {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageUploadFileOperation.start()
+        Mockito.verify(storageService).uploadFile(
+            Mockito.eq(expectedKey),
+            Mockito.eq(tempFile),
+            Mockito.any(ObjectMetadata::class.java)
+        )
     }
 
     @Test
     fun customEmptyPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
         val expectedKey = "123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
+        val tempFile = File.createTempFile("new", "file.tmp")
+        val request = AWSS3StorageUploadRequest<File>(
             key,
             tempFile,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
+            "/image",
+            ServerSideEncryption.NONE,
+            mutableMapOf()
         )
-        Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageUploadFileOperation = AWSS3StorageUploadFileOperation(
             storageService,
             cognitoAuthProvider,
             request,
@@ -99,23 +109,29 @@ class AWSS3StorageDownloadFileOperationTest {
             {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageUploadFileOperation.start()
+        Mockito.verify(storageService).uploadFile(
+            Mockito.eq(expectedKey),
+            Mockito.eq(tempFile),
+            Mockito.any(ObjectMetadata::class.java)
+        )
     }
 
     @Test
     fun customPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
+        val expectedKey = "publicCustom/123"
         val tempFile = File.createTempFile("new", "file.tmp")
-        val expectedKey = "customPublic/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
+        val request = AWSS3StorageUploadRequest<File>(
             key,
             tempFile,
             StorageAccessLevel.PUBLIC,
-            null
+            "",
+            "/image",
+            ServerSideEncryption.NONE,
+            mutableMapOf()
         )
-        Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        awsS3StorageUploadFileOperation = AWSS3StorageUploadFileOperation(
             storageService,
             cognitoAuthProvider,
             request,
@@ -128,7 +144,7 @@ class AWSS3StorageDownloadFileOperationTest {
                             onSuccess: Consumer<String>,
                             onError: Consumer<StorageException>
                         ) {
-                            onSuccess.accept("customPublic/")
+                            onSuccess.accept("publicCustom/")
                         }
                     }
                 }
@@ -137,7 +153,11 @@ class AWSS3StorageDownloadFileOperationTest {
             {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        awsS3StorageUploadFileOperation.start()
+        Mockito.verify(storageService).uploadFile(
+            Mockito.eq(expectedKey),
+            Mockito.eq(tempFile),
+            Mockito.any(ObjectMetadata::class.java)
+        )
     }
 }

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperationTest.kt
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -60,7 +59,7 @@ class AWSS3StorageUploadFileOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(),
+            AWSS3StoragePluginConfiguration {},
             {},
             {},
             {}
@@ -91,20 +90,18 @@ class AWSS3StorageUploadFileOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("")
                     }
                 }
-            ),
+            },
             {},
             {},
             {}
@@ -135,20 +132,18 @@ class AWSS3StorageUploadFileOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("publicCustom/")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("publicCustom/")
                     }
                 }
-            ),
+            },
             {},
             {},
             {}

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperationTest.kt
@@ -70,7 +70,7 @@ class AWSS3StorageUploadInputStreamOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(),
+            AWSS3StoragePluginConfiguration {},
             {},
             {},
             {}
@@ -110,20 +110,18 @@ class AWSS3StorageUploadInputStreamOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("")
                     }
                 }
-            ),
+            },
             {},
             {},
             {}
@@ -163,20 +161,18 @@ class AWSS3StorageUploadInputStreamOperationTest {
             storageService,
             cognitoAuthProvider,
             request,
-            AWSS3StoragePluginConfiguration(
-                AWSS3StoragePluginConfiguration.Builder().apply {
-                    awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
-                        override fun resolvePrefix(
-                            accessLevel: StorageAccessLevel,
-                            targetIdentity: String?,
-                            onSuccess: Consumer<String>,
-                            onError: Consumer<StorageException>
-                        ) {
-                            onSuccess.accept("publicCustom/")
-                        }
+            AWSS3StoragePluginConfiguration {
+                awsS3PluginPrefixResolver = object : AWSS3PluginPrefixResolver {
+                    override fun resolvePrefix(
+                        accessLevel: StorageAccessLevel,
+                        targetIdentity: String?,
+                        onSuccess: Consumer<String>,
+                        onError: Consumer<StorageException>
+                    ) {
+                        onSuccess.accept("publicCustom/")
                     }
                 }
-            ),
+            },
             {},
             {},
             {}

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperationTest.kt
@@ -12,25 +12,28 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 package com.amplifyframework.storage.s3.operation
 
+import com.amazonaws.mobileconnectors.s3.transferutility.TransferObserver
+import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.storage.StorageAccessLevel
 import com.amplifyframework.storage.StorageException
 import com.amplifyframework.storage.s3.CognitoAuthProvider
+import com.amplifyframework.storage.s3.ServerSideEncryption
 import com.amplifyframework.storage.s3.configuration.AWSS3PluginPrefixResolver
 import com.amplifyframework.storage.s3.configuration.AWSS3StoragePluginConfiguration
-import com.amplifyframework.storage.s3.request.AWSS3StorageDownloadFileRequest
+import com.amplifyframework.storage.s3.request.AWSS3StorageUploadRequest
 import com.amplifyframework.storage.s3.service.StorageService
 import java.io.File
+import java.io.InputStream
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 
-class AWSS3StorageDownloadFileOperationTest {
+class AWSS3StorageUploadInputStreamOperationTest {
 
-    private lateinit var awsS3StorageDownloadFileOperation: AWSS3StorageDownloadFileOperation
+    private lateinit var inputStreamOperation: AWSS3StorageUploadInputStreamOperation
     private lateinit var storageService: StorageService
     private lateinit var cognitoAuthProvider: CognitoAuthProvider
 
@@ -43,16 +46,27 @@ class AWSS3StorageDownloadFileOperationTest {
     @Test
     fun defaultPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
         val expectedKey = "public/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
-            StorageAccessLevel.PUBLIC,
-            null
-        )
+        val tempInputStream = File.createTempFile("new", "file.tmp").inputStream()
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        Mockito.`when`(
+            storageService.uploadInputStream(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
+            )
+        )
+            .thenReturn(Mockito.mock(TransferObserver::class.java))
+        val request = AWSS3StorageUploadRequest<InputStream>(
+            key,
+            tempInputStream,
+            StorageAccessLevel.PUBLIC,
+            "",
+            "/image",
+            ServerSideEncryption.NONE,
+            mutableMapOf()
+        )
+        inputStreamOperation = AWSS3StorageUploadInputStreamOperation(
             storageService,
             cognitoAuthProvider,
             request,
@@ -61,23 +75,38 @@ class AWSS3StorageDownloadFileOperationTest {
             {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        inputStreamOperation.start()
+        Mockito.verify(storageService).uploadInputStream(
+            Mockito.eq(expectedKey),
+            Mockito.eq(tempInputStream),
+            Mockito.any(ObjectMetadata::class.java)
+        )
     }
 
     @Test
     fun customEmptyPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
         val expectedKey = "123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
-            StorageAccessLevel.PUBLIC,
-            null
-        )
+        val tempInputStream = File.createTempFile("new", "file.tmp").inputStream()
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        Mockito.`when`(
+            storageService.uploadInputStream(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
+            )
+        )
+            .thenReturn(Mockito.mock(TransferObserver::class.java))
+        val request = AWSS3StorageUploadRequest<InputStream>(
+            key,
+            tempInputStream,
+            StorageAccessLevel.PUBLIC,
+            "",
+            "/image",
+            ServerSideEncryption.NONE,
+            mutableMapOf()
+        )
+        inputStreamOperation = AWSS3StorageUploadInputStreamOperation(
             storageService,
             cognitoAuthProvider,
             request,
@@ -99,23 +128,38 @@ class AWSS3StorageDownloadFileOperationTest {
             {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        inputStreamOperation.start()
+        Mockito.verify(storageService).uploadInputStream(
+            Mockito.eq(expectedKey),
+            Mockito.eq(tempInputStream),
+            Mockito.any(ObjectMetadata::class.java)
+        )
     }
 
     @Test
     fun customPrefixResolverAWSS3PluginConfigTest() {
         val key = "123"
-        val tempFile = File.createTempFile("new", "file.tmp")
-        val expectedKey = "customPublic/123"
-        val request: AWSS3StorageDownloadFileRequest = AWSS3StorageDownloadFileRequest(
-            key,
-            tempFile,
-            StorageAccessLevel.PUBLIC,
-            null
-        )
+        val expectedKey = "publicCustom/123"
+        val tempInputStream = File.createTempFile("new", "file.tmp").inputStream()
         Mockito.`when`(cognitoAuthProvider.identityId).thenReturn("abc")
-        awsS3StorageDownloadFileOperation = AWSS3StorageDownloadFileOperation(
+        Mockito.`when`(
+            storageService.uploadInputStream(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
+            )
+        )
+            .thenReturn(Mockito.mock(TransferObserver::class.java))
+        val request = AWSS3StorageUploadRequest<InputStream>(
+            key,
+            tempInputStream,
+            StorageAccessLevel.PUBLIC,
+            "",
+            "/image",
+            ServerSideEncryption.NONE,
+            mutableMapOf()
+        )
+        inputStreamOperation = AWSS3StorageUploadInputStreamOperation(
             storageService,
             cognitoAuthProvider,
             request,
@@ -128,7 +172,7 @@ class AWSS3StorageDownloadFileOperationTest {
                             onSuccess: Consumer<String>,
                             onError: Consumer<StorageException>
                         ) {
-                            onSuccess.accept("customPublic/")
+                            onSuccess.accept("publicCustom/")
                         }
                     }
                 }
@@ -137,7 +181,11 @@ class AWSS3StorageDownloadFileOperationTest {
             {},
             {}
         )
-        awsS3StorageDownloadFileOperation.start()
-        Mockito.verify(storageService).downloadToFile(expectedKey, tempFile)
+        inputStreamOperation.start()
+        Mockito.verify(storageService).uploadInputStream(
+            Mockito.eq(expectedKey),
+            Mockito.eq(tempInputStream),
+            Mockito.any(ObjectMetadata::class.java)
+        )
     }
 }

--- a/maplibre-adapter/build.gradle
+++ b/maplibre-adapter/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    def lifecycleVersion = "2.4.0"
+    def lifecycleVersion = "2.4.1"
 
     implementation project(":aws-auth-cognito")
     implementation project(":aws-geo-location")


### PR DESCRIPTION
*Issue #, if available:*
#910 
*Description of changes:*
- Add support for custom prefix resolver for storage category.
```
Amplify.addPlugin<Plugin<*>>(AWSS3StoragePlugin(AWSS3StoragePluginConfiguration {
            awsS3PluginPrefixResolver = object: AWSS3PluginPrefixResolver {
                override fun resolvePrefix(
                    accessLevel: StorageAccessLevel,
                    targetIdentity: String?,
                    onSuccess: Consumer<String>,
                    onError: Consumer<StorageException>
                ) {
                    /*
                    * Add code to resolve custom prefix
                    * */
                    onSuccess.accept("custom/bucket/path/")
                }
            }
        }))
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
