### PR TITLE
Jm/provide default message when null

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/graphql/GsonResponseAdapters.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/graphql/GsonResponseAdapters.java
@@ -201,6 +201,10 @@ public final class GsonResponseAdapters {
                 }
             }
 
+            if (message == null) {
+                message = "Message was null or missing while deserializing error";
+            }
+
             // Merge nonSpecifiedData into extensions, but don't overwrite anything already there.
             for (String key : nonSpecifiedData.keySet()) {
                 if (!extensionsJson.has(key)) {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
@@ -319,6 +319,34 @@ public final class GsonGraphQLResponseFactoryTest {
         assertEquals(expectedResponse, response);
     }
 
+    @Test
+    public void errorWithNullMessageCanBeParsed() throws ApiException {
+        // Arrange some JSON string from a "server"
+        final String responseJson = Resources.readAsString("error-null-message.json");
+
+        // Act! Parse it into a model.
+        Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Todo.class);
+        GraphQLRequest<PaginatedResult<Todo>> request = buildDummyRequest(responseType);
+        final GraphQLResponse<PaginatedResult<Todo>> response =
+                responseFactory.buildResponse(request, responseJson);
+
+        // Build the expected response.
+        Map<String, Object> extensions = new HashMap<>();
+        extensions.put("errorType", null);
+        extensions.put("errorInfo", null);
+        extensions.put("data", null);
+
+        final String defaultMessage = "Message was null or missing while deserializing error";
+
+        GraphQLResponse.Error expectedError =
+                new GraphQLResponse.Error(defaultMessage, null, null, extensions);
+        GraphQLResponse<PaginatedResult<Todo>> expectedResponse =
+                new GraphQLResponse<>(null, Collections.singletonList(expectedError));
+
+        // Assert that the response is expected
+        assertEquals(expectedResponse, response);
+    }
+
     /**
      * It is possible to cast the response data as a string, instead of as the strongly
      * modeled type, if you choose to do so.

--- a/aws-api/src/test/resources/error-null-message.json
+++ b/aws-api/src/test/resources/error-null-message.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "listTodos": null
+  },
+  "errors": [
+    {
+      "path": null,
+      "data": null,
+      "errorType": null,
+      "errorInfo": null,
+      "locations": null,
+      "message": null
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*
#1599

*Description of changes:*
com.amplifyframework.api.graphql.GraphQLResponse.Error#Error expects `message` parameter to be `NonNull`.
In case, the `MESSAGE_KEY (="message")` is not passed in `error` JSON, it is not initialized. 

This change adds a default string in such exceptional cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
