### PR TITLE
fix(datastore): SerializedModel returns null for non-nullable list field

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -493,7 +493,7 @@ final class AppSyncRequestFactory {
         if (customTypeData instanceof List) {
             ArrayList<Object> result = new ArrayList<>();
             @SuppressWarnings("unchecked")
-            ArrayList<Object> customTypeList = (ArrayList<Object>) customTypeData;
+            List<Object> customTypeList = (List<Object>) customTypeData;
             for (Object item : customTypeList) {
                 if (item instanceof SerializedCustomType) {
                     result.add(extractCustomTypeFieldValue(fieldName, item));

--- a/core/src/main/java/com/amplifyframework/core/model/SerializedCustomType.java
+++ b/core/src/main/java/com/amplifyframework/core/model/SerializedCustomType.java
@@ -84,8 +84,8 @@ public final class SerializedCustomType {
                 if (field.isArray()) {
                     @SuppressWarnings("unchecked")
                     List<Map<String, Object>> fieldListData = (List<Map<String, Object>>) fieldValue;
+                    List<SerializedCustomType> fieldList = new ArrayList<>();
                     if (!fieldListData.isEmpty()) {
-                        List<SerializedCustomType> fieldList = new ArrayList<>();
                         for (Map<String, Object> item : fieldListData) {
                             Map<String, Object> customTypeSerializedData =
                                     parseSerializedData(item, field.getTargetType(), schemaRegistry);
@@ -95,8 +95,8 @@ public final class SerializedCustomType {
                                             schemaRegistry.getCustomTypeSchemaForCustomTypeClass(field.getTargetType()))
                                     .build());
                         }
-                        result.put(key, fieldList);
                     }
+                    result.put(key, fieldList);
                 } else {
                     @SuppressWarnings("unchecked")
                     Map<String, Object> fieldData = (Map<String, Object>) fieldValue;

--- a/core/src/main/java/com/amplifyframework/core/model/SerializedModel.java
+++ b/core/src/main/java/com/amplifyframework/core/model/SerializedModel.java
@@ -162,8 +162,8 @@ public final class SerializedModel implements Model {
                 if (field.isArray()) {
                     @SuppressWarnings("unchecked")
                     List<Map<String, Object>> fieldListData = (List<Map<String, Object>>) fieldValue;
+                    List<SerializedCustomType> fieldList = new ArrayList<>();
                     if (!fieldListData.isEmpty()) {
-                        List<SerializedCustomType> fieldList = new ArrayList<>();
                         for (Map<String, Object> item : fieldListData) {
                             Map<String, Object> customTypeSerializedData =
                                     SerializedCustomType.parseSerializedData(
@@ -174,8 +174,8 @@ public final class SerializedModel implements Model {
                                             schemaRegistry.getCustomTypeSchemaForCustomTypeClass(field.getTargetType()))
                                     .build());
                         }
-                        result.put(key, fieldList);
                     }
+                    result.put(key, fieldList);
                 } else {
                     @SuppressWarnings("unchecked")
                     Map<String, Object> fieldData = (Map<String, Object>) fieldValue;

--- a/core/src/test/java/com/amplifyframework/core/model/SerializedModeTest.java
+++ b/core/src/test/java/com/amplifyframework/core/model/SerializedModeTest.java
@@ -71,6 +71,7 @@ public final class SerializedModeTest {
         assertEquals(serializedData.size(), parsedSerializedData.size());
         assertEquals(serializedData.get("name"), parsedSerializedData.get("name"));
         assertTrue(parsedSerializedData.get("mailingAddresses") instanceof List);
+        assertTrue(parsedSerializedData.get("requiredMailingAddresses") instanceof List);
 
         @SuppressWarnings("unchecked")
         List<Object> mailingAddresses = (List<Object>) parsedSerializedData.get("mailingAddresses");
@@ -204,6 +205,13 @@ public final class SerializedModeTest {
                 .isCustomType(true)
                 .isArray(true)
                 .build();
+        ModelField requiredPersonMailingAddressesField = ModelField.builder()
+                .name("requiredMailingAddresses")
+                .targetType("Address")
+                .isCustomType(true)
+                .isArray(true)
+                .isRequired(true)
+                .build();
         ModelField personIdField = ModelField.builder()
                 .name("id")
                 .targetType("String")
@@ -213,6 +221,7 @@ public final class SerializedModeTest {
         personFields.put("contact", personContactField);
         personFields.put("name", personNameField);
         personFields.put("mailingAddresses", personMailingAddressesField);
+        personFields.put("requiredMailingAddresses", requiredPersonMailingAddressesField);
         personFields.put("id", personIdField);
         ModelSchema personSchema = ModelSchema.builder()
                 .name("Person")

--- a/core/src/test/resources/serialized-model-nests-custom-type-data.json
+++ b/core/src/test/resources/serialized-model-nests-custom-type-data.json
@@ -15,6 +15,7 @@
       "line1": "444 Somewhere close"
     }
   ],
+  "requiredMailingAddresses": [],
   "contact": {
     "phone": {
       "areaCode": "415",


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-flutter/issues/1370

*Description of changes:*

Ensure `SerializedModel` and `SerializedCustomType` to return an empty list for non-nullable field with type `[ACustomType]` to support amplify-flutter use cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
