### PR TITLE
fix(datastore): compare datetime values in consistent format when querying

### DIFF
--- a/aws-datastore/src/androidTest/assets/schemas/phonecall/call.json
+++ b/aws-datastore/src/androidTest/assets/schemas/phonecall/call.json
@@ -23,10 +23,10 @@
             "name": "id",
             "targetType": "ID"
         },
-        "minutes": {
+        "startTime": {
             "authRules": [],
-            "javaClassForValue": "Integer",
-            "targetType": "Int",
+            "javaClassForValue": "com.amplifyframework.core.model.temporal.Temporal$Time",
+            "targetType": "AWSTime",
             "isRequired": true,
             "isArray": false,
             "isEnum": false,

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterModelConverterTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterModelConverterTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public final class SQLiteStorageAdapterModelConverterTest {
     private static final Temporal.DateTime MAY_THE_FOURTH =
-            new Temporal.DateTime("2020-05-04T14:20:00-07:00");
+            new Temporal.DateTime("2020-05-04T14:20:00Z");
 
     private SynchronousStorageAdapter adapter;
 

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -209,7 +209,7 @@ public final class SQLiteStorageAdapterQueryTest {
                 .build();
         
         final Call phoneCall = Call.builder()
-                .minutes(10)
+                .startTime(new Temporal.Time("10:35:22Z"))
                 .caller(phoneCalling)
                 .callee(phoneCalled)
                 .build();
@@ -360,7 +360,7 @@ public final class SQLiteStorageAdapterQueryTest {
     }
 
     /**
-     * Test querying the saved item in the SQLite database with
+     * Test querying the saved item in the SQLite database with DateTime
      * predicate conditions.
      * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
      */
@@ -373,7 +373,7 @@ public final class SQLiteStorageAdapterQueryTest {
                 new Temporal.DateTime("2020-01-01T19:30:45.100000000Z"),
                 new Temporal.DateTime("2020-01-01T19:30:45.100250000Z"),
                 new Temporal.DateTime("2020-01-01T19:30:45.1000Z"),
-                new Temporal.DateTime("2020-01-01T19:30:45.111Z"),
+                new Temporal.DateTime("2020-01-01T20:30:45.111Z"),
                 new Temporal.DateTime("2020-01-01T19:30:45.111+00:00"),
                 new Temporal.DateTime("2020-01-01T19:30:45.111+01:00"),
                 new Temporal.DateTime("2020-01-01T19:30:45.111222333Z")
@@ -400,6 +400,76 @@ public final class SQLiteStorageAdapterQueryTest {
                         .blockingGet(),
                 Observable.fromIterable(adapter.query(BlogOwner.class, Where.matches(predicate)))
                         .map(BlogOwner::getId)
+                        .toList()
+                        .map(HashSet::new)
+                        .blockingGet()
+        );
+    }
+
+    /**
+     * Test querying the saved item in the SQLite database with Time
+     * predicate conditions.
+     * @throws DataStoreException On unexpected failure manipulating items in/out of DataStore
+     */
+    @Test
+    public void querySavedDataWithTimePredicates() throws DataStoreException {
+        setupForCallModel();
+        final Person personCalling = Person.builder()
+                .name("Alan Turing")
+                .build();
+        final Person personCalled = Person.builder()
+                .name("Grace Hopper")
+                .build();
+
+        final Phone phoneCalling = Phone.builder()
+                .number("123-456-7890")
+                .ownedBy(personCalling)
+                .build();
+        final Phone phoneCalled = Phone.builder()
+                .number("567-890-1234")
+                .ownedBy(personCalled)
+                .build();
+
+        adapter.save(personCalling);
+        adapter.save(personCalled);
+        adapter.save(phoneCalling);
+        adapter.save(phoneCalled);
+
+        final List<Call> savedModels = new ArrayList<>();
+        final int numModels = 8;
+        final List<Temporal.Time> callStartTimes = Arrays.asList(
+                new Temporal.Time("19:30:45.000000000"),
+                new Temporal.Time("19:30:45.100000000Z"),
+                new Temporal.Time("19:30:45.100250000Z"),
+                new Temporal.Time("19:30:45.1000Z"),
+                new Temporal.Time("20:30:45.111Z"),
+                new Temporal.Time("19:30:45.111+00:00"),
+                new Temporal.Time("19:30:45.111+01:00"),
+                new Temporal.Time("19:30:45.111222333Z")
+        );
+
+        for (int counter = 0; counter < numModels; counter++) {
+            Call phoneCall = Call.builder()
+                    .startTime(callStartTimes.get(counter))
+                    .caller(phoneCalling)
+                    .callee(phoneCalled)
+                    .build();
+            adapter.save(phoneCall);
+            savedModels.add(phoneCall);
+        }
+
+        // 0, 1, 3, 6
+        QueryPredicate predicate = Call.STARTTIME.le(new Temporal.Time("19:30:45.100000000Z"));
+
+        assertEquals(
+                Observable.fromArray(0, 1, 3, 6)
+                        .map(savedModels::get)
+                        .map(Call::getId)
+                        .toList()
+                        .map(HashSet::new)
+                        .blockingGet(),
+                Observable.fromIterable(adapter.query(Call.class, Where.matches(predicate)))
+                        .map(Call::getId)
                         .toList()
                         .map(HashSet::new)
                         .blockingGet()

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -366,9 +366,6 @@ public final class SQLiteStorageAdapterQueryTest {
      */
     @Test
     public void querySavedDataWithDateTimePredicates() throws DataStoreException {
-        
-        // TODO
-        
         final List<BlogOwner> savedModels = new ArrayList<>();
         final int numModels = 8;
         final List<Temporal.DateTime> createdAtTimes = Arrays.asList(
@@ -393,14 +390,16 @@ public final class SQLiteStorageAdapterQueryTest {
 
         // 0, 1, 3, 6
         QueryPredicate predicate = BlogOwner.CREATED_AT.le(new Temporal.DateTime("2020-01-01T19:30:45.100000000Z"));
-
+        
         assertEquals(
                 Observable.fromArray(0, 1, 3, 6)
                         .map(savedModels::get)
+                        .map(BlogOwner::getId)
                         .toList()
                         .map(HashSet::new)
                         .blockingGet(),
                 Observable.fromIterable(adapter.query(BlogOwner.class, Where.matches(predicate)))
+                        .map(BlogOwner::getId)
                         .toList()
                         .map(HashSet::new)
                         .blockingGet()

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -136,8 +136,8 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
                     offsetDateTime = OffsetDateTime.parse(newValue.format());
                 }
                 DateTimeFormatter dateTimeFormatter = DateTimeFormatter
-                        .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
-                return offsetDateTime.toInstant().atOffset(ZoneOffset.UTC).format(dateTimeFormatter) + "Z";
+                        .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'");
+                return offsetDateTime.toInstant().atOffset(ZoneOffset.UTC).format(dateTimeFormatter);
             case TIME:
                 return value instanceof String ? value : ((Temporal.Time) value).format();
             case TIMESTAMP:

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -128,20 +128,16 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
             case DATE:
                 return value instanceof String ? value : ((Temporal.Date) value).format();
             case DATE_TIME:
+                OffsetDateTime offsetDateTime;
                 if (value instanceof String) {
-                    // TODO : need format this too
-                    return value;
+                    offsetDateTime = OffsetDateTime.parse((String) value);
                 } else {
-                    // TODO : factor out this code and put it in a private method
                     Temporal.DateTime newValue = (Temporal.DateTime) value;
-                    DateTimeFormatter dateTimeFormatter = DateTimeFormatter
-                            .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
-                    String formattedDateTime = OffsetDateTime.parse(newValue.format()).toInstant()
-                            .atOffset(ZoneOffset.UTC).format(dateTimeFormatter) + "Z";
-                    return formattedDateTime;
-                    // return new Temporal.DateTime(formattedDateTime);
+                    offsetDateTime = OffsetDateTime.parse(newValue.format());
                 }
-                // return value instanceof String ? value : ((Temporal.DateTime) value).format();
+                DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+                        .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
+                return offsetDateTime.toInstant().atOffset(ZoneOffset.UTC).format(dateTimeFormatter) + "Z";
             case TIME:
                 return value instanceof String ? value : ((Temporal.Time) value).format();
             case TIMESTAMP:
@@ -235,12 +231,6 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
                 case DATE:
                     return new Temporal.Date(valueAsString);
                 case DATE_TIME:
-                    /*Temporal.DateTime newValue = new Temporal.DateTime(valueAsString);
-                    DateTimeFormatter dateTimeFormatter = DateTimeFormatter
-                            .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
-                    String formattedDateTime = OffsetDateTime.parse(newValue.format()).toInstant()
-                            .atOffset(ZoneOffset.UTC).format(dateTimeFormatter) + "Z";
-                    return new Temporal.DateTime(formattedDateTime);*/
                     return new Temporal.DateTime(valueAsString);
                 case TIME:
                     return new Temporal.Time(valueAsString);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -38,6 +38,9 @@ import com.amplifyframework.logging.Logger;
 import com.google.gson.Gson;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -125,7 +128,20 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
             case DATE:
                 return value instanceof String ? value : ((Temporal.Date) value).format();
             case DATE_TIME:
-                return value instanceof String ? value : ((Temporal.DateTime) value).format();
+                if (value instanceof String) {
+                    // TODO : need format this too
+                    return value;
+                } else {
+                    // TODO : factor out this code and put it in a private method
+                    Temporal.DateTime newValue = (Temporal.DateTime) value;
+                    DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+                            .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
+                    String formattedDateTime = OffsetDateTime.parse(newValue.format()).toInstant()
+                            .atOffset(ZoneOffset.UTC).format(dateTimeFormatter) + "Z";
+                    return formattedDateTime;
+                    // return new Temporal.DateTime(formattedDateTime);
+                }
+                // return value instanceof String ? value : ((Temporal.DateTime) value).format();
             case TIME:
                 return value instanceof String ? value : ((Temporal.Time) value).format();
             case TIMESTAMP:
@@ -219,6 +235,12 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
                 case DATE:
                     return new Temporal.Date(valueAsString);
                 case DATE_TIME:
+                    /*Temporal.DateTime newValue = new Temporal.DateTime(valueAsString);
+                    DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+                            .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
+                    String formattedDateTime = OffsetDateTime.parse(newValue.format()).toInstant()
+                            .atOffset(ZoneOffset.UTC).format(dateTimeFormatter) + "Z";
+                    return new Temporal.DateTime(formattedDateTime);*/
                     return new Temporal.DateTime(valueAsString);
                 case TIME:
                     return new Temporal.Time(valueAsString);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -226,9 +226,9 @@ public final class SQLPredicate {
         if (opValue instanceof Temporal.DateTime) {
             Temporal.DateTime newOpValue = (Temporal.DateTime) opValue;
             DateTimeFormatter dateTimeFormatter = DateTimeFormatter
-                    .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
+                    .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'");
             return OffsetDateTime.parse(newOpValue.format()).toInstant().atOffset(ZoneOffset.UTC)
-                    .format(dateTimeFormatter) + "Z";
+                    .format(dateTimeFormatter);
         }
         return opValue;
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLPredicate.java
@@ -223,8 +223,8 @@ public final class SQLPredicate {
         }
     }
     
-    // Utility method to check if the given operator value is a Temporal.DateTime and if so,
-    // format it as yyyy-MM-ddTHH:mm:ss.SSSSSSSSSZ
+    // Utility method to check if the given operator value is a Temporal.DateTime or Temporal.Time
+    // and if so, format it as yyyy-MM-ddTHH:mm:ss.SSSSSSSSSZ or HH:mm:ss.SSSSSSSSSZ, respectively
     private Object formatIfTemporalDateTimeOrTime(Object opValue) {
         if (opValue instanceof Temporal.DateTime) {
             Temporal.DateTime newOpValue = (Temporal.DateTime) opValue;

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/phonecall/Call.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/phonecall/Call.java
@@ -19,11 +19,11 @@ import java.util.UUID;
 @ModelConfig(pluralName = "Calls")
 public final class Call implements Model {
   public static final QueryField ID = field("Call", "id");
-  public static final QueryField MINUTES = field("Call", "minutes");
+  public static final QueryField STARTTIME = field("Call", "startTime");
   public static final QueryField CALLER = field("Call", "callerId");
   public static final QueryField CALLEE = field("Call", "calleeId");
   private final @ModelField(targetType="ID", isRequired = true) String id;
-  private final @ModelField(targetType="Int", isRequired = true) Integer minutes;
+  private final @ModelField(targetType="AWSTime", isRequired = true) Temporal.Time startTime;
   private final @ModelField(targetType="Phone", isRequired = true) @BelongsTo(targetName = "callerId", type = Phone.class) Phone caller;
   private final @ModelField(targetType="Phone", isRequired = true) @BelongsTo(targetName = "calleeId", type = Phone.class) Phone callee;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime createdAt;
@@ -32,8 +32,8 @@ public final class Call implements Model {
       return id;
   }
   
-  public Integer getMinutes() {
-      return minutes;
+  public Temporal.Time getStartTime() {
+      return startTime;
   }
   
   public Phone getCaller() {
@@ -52,9 +52,9 @@ public final class Call implements Model {
       return updatedAt;
   }
   
-  private Call(String id, Integer minutes, Phone caller, Phone callee) {
+  private Call(String id, Temporal.Time startTime, Phone caller, Phone callee) {
     this.id = id;
-    this.minutes = minutes;
+    this.startTime = startTime;
     this.caller = caller;
     this.callee = callee;
   }
@@ -68,7 +68,7 @@ public final class Call implements Model {
       } else {
       Call call = (Call) obj;
       return ObjectsCompat.equals(getId(), call.getId()) &&
-              ObjectsCompat.equals(getMinutes(), call.getMinutes()) &&
+              ObjectsCompat.equals(getStartTime(), call.getStartTime()) &&
               ObjectsCompat.equals(getCaller(), call.getCaller()) &&
               ObjectsCompat.equals(getCallee(), call.getCallee()) &&
               ObjectsCompat.equals(getCreatedAt(), call.getCreatedAt()) &&
@@ -80,7 +80,7 @@ public final class Call implements Model {
    public int hashCode() {
     return new StringBuilder()
       .append(getId())
-      .append(getMinutes())
+      .append(getStartTime())
       .append(getCaller())
       .append(getCallee())
       .append(getCreatedAt())
@@ -94,7 +94,7 @@ public final class Call implements Model {
     return new StringBuilder()
       .append("Call {")
       .append("id=" + String.valueOf(getId()) + ", ")
-      .append("minutes=" + String.valueOf(getMinutes()) + ", ")
+      .append("startTime=" + String.valueOf(getStartTime()) + ", ")
       .append("caller=" + String.valueOf(getCaller()) + ", ")
       .append("callee=" + String.valueOf(getCallee()) + ", ")
       .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
@@ -103,7 +103,7 @@ public final class Call implements Model {
       .toString();
   }
   
-  public static MinutesStep builder() {
+  public static StartTimeStep builder() {
       return new Builder();
   }
   
@@ -136,12 +136,12 @@ public final class Call implements Model {
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      minutes,
+      startTime,
       caller,
       callee);
   }
-  public interface MinutesStep {
-    CallerStep minutes(Integer minutes);
+  public interface StartTimeStep {
+    CallerStep startTime(Temporal.Time startTime);
   }
   
 
@@ -161,9 +161,9 @@ public final class Call implements Model {
   }
   
 
-  public static class Builder implements MinutesStep, CallerStep, CalleeStep, BuildStep {
+  public static class Builder implements StartTimeStep, CallerStep, CalleeStep, BuildStep {
     private String id;
-    private Integer minutes;
+    private Temporal.Time startTime;
     private Phone caller;
     private Phone callee;
     @Override
@@ -172,15 +172,15 @@ public final class Call implements Model {
         
         return new Call(
           id,
-          minutes,
+          startTime,
           caller,
           callee);
     }
     
     @Override
-     public CallerStep minutes(Integer minutes) {
-        Objects.requireNonNull(minutes);
-        this.minutes = minutes;
+     public CallerStep startTime(Temporal.Time startTime) {
+        Objects.requireNonNull(startTime);
+        this.startTime = startTime;
         return this;
     }
     
@@ -221,16 +221,16 @@ public final class Call implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, Integer minutes, Phone caller, Phone callee) {
+    private CopyOfBuilder(String id, Temporal.Time startTime, Phone caller, Phone callee) {
       super.id(id);
-      super.minutes(minutes)
+      super.startTime(startTime)
         .caller(caller)
         .callee(callee);
     }
     
     @Override
-     public CopyOfBuilder minutes(Integer minutes) {
-      return (CopyOfBuilder) super.minutes(minutes);
+     public CopyOfBuilder startTime(Temporal.Time startTime) {
+      return (CopyOfBuilder) super.startTime(startTime);
     }
     
     @Override

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/phonecall/schema.graphql
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/phonecall/schema.graphql
@@ -13,7 +13,7 @@ type Phone @model {
 
 type Call @model {
     id: ID!
-    minutes: Int!
+    startTime: AWSTime!
     callerId: ID!
     calleeId: ID!
     caller: Phone! @connection(fields: ["callerId"])


### PR DESCRIPTION
*Issue #, if available:* #1621

*Description of changes:* When querying a model with an AWSDateTime or AWSTime field(s) and a predicate of the same type, places those fields in a consistent format so they can be accurately compared to return the correct query results.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
