### PR TITLE
[aws-api] Fix DELETE rest calls not working with IamRequestDecorator

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/auth/IamRequestDecorator.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/auth/IamRequestDecorator.java
@@ -84,7 +84,7 @@ public class IamRequestDecorator implements RequestDecorator {
         RequestBody body = req.body();
         boolean isEmptyRequestBody = false;
         try {
-            if (body != null) {
+            if (body != null && body.contentLength() > 0) {
                 //write the body to a byte array.
                 final Buffer buffer = new Buffer();
                 body.writeTo(buffer);


### PR DESCRIPTION
DELETE REST API calls have the "content-type: application/json" header added to them. The AWS backend does not allow this for requests with an empty body. This issue was originally fixed in the AppSyncSigV4SignerInterceptor but was reintroduced due to a switch to the new system of signing requests.

Resolves: https://github.com/aws-amplify/amplify-android/issues/1683

*Description of changes:*
Added a check to see if the `contentLength()` of a request body is more then 0 to the `isEmptyRequest` definition. (Same as the original fix)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.