### PR TITLE
Connectivity crash fix

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -316,7 +316,11 @@ final class MutationProcessor {
             @NonNull PublicationStrategy<T> publicationStrategy) {
         return Single
             .<GraphQLResponse<ModelWithMetadata<T>>>create(subscriber ->
-                publicationStrategy.publish(mutation.getMutatedItem(), subscriber::onSuccess, subscriber::onError)
+                publicationStrategy.publish(mutation.getMutatedItem(), subscriber::onSuccess, (exception)->{
+                    if(!subscriber.isDisposed()){
+                        subscriber.onError(exception);
+                    }
+                })
             )
             .flatMap(response -> {
                 // If there are no errors, and the response has data, just return.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -316,8 +316,8 @@ final class MutationProcessor {
             @NonNull PublicationStrategy<T> publicationStrategy) {
         return Single
             .<GraphQLResponse<ModelWithMetadata<T>>>create(subscriber ->
-                publicationStrategy.publish(mutation.getMutatedItem(), subscriber::onSuccess, (exception)->{
-                    if(!subscriber.isDisposed()){
+                publicationStrategy.publish(mutation.getMutatedItem(), subscriber::onSuccess, (exception) -> {
+                    if (!subscriber.isDisposed()) {
                         subscriber.onError(exception);
                     }
                 })


### PR DESCRIPTION
*Issue #, if available:*
[1667](https://github.com/aws-amplify/amplify-android/issues/1667)
*Description of changes:*
Fixing the crash on connectivity error caused because rx subscription is already disposed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
