### PR TITLE
feat(maplibre-adapter): add clustering to map view

### DIFF
--- a/aws-geo-location/gradle.properties
+++ b/aws-geo-location/gradle.properties
@@ -3,4 +3,4 @@ POM_NAME=Amplify Framework for Android - Geo
 POM_DESCRIPTION=Amplify Framework for Android - Geo Plugin for Amazon Location Service
 POM_PACKAGING=aar
 
-VERSION_NAME=0.3.1
+VERSION_NAME=0.4.0

--- a/maplibre-adapter/gradle.properties
+++ b/maplibre-adapter/gradle.properties
@@ -3,4 +3,4 @@ POM_NAME=MapLibre Adapter for Amplify Android Framework - Geo
 POM_DESCRIPTION=Amplify Framework for Android - Adapter for Amplify Geo Plugin
 POM_PACKAGING=aar
 
-VERSION_NAME=0.3.1
+VERSION_NAME=0.4.0

--- a/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/Credentials.kt
+++ b/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/Credentials.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.maplibre
+
+import android.content.Context
+import com.amplifyframework.core.Resources
+
+/**
+ * Utility to load Cognito user credentials from a json document.
+ * The document must be formatted as following:
+ *
+ * <pre>
+ * {
+ *   "username": "username123",
+ *   "password": "kool@pass22"
+ * }
+ * </pre>
+ */
+object Credentials {
+    private const val DEFAULT_ID = "credentials" // credentials.json
+    private var credentials: Pair<String, String>? = null
+
+    fun load(context: Context, identifier: String = DEFAULT_ID): Pair<String, String> {
+        if (credentials == null) {
+            credentials = synchronized(this) {
+                val json = Resources.readJsonResource(context, identifier)
+                val username = json.getString("username")
+                val password = json.getString("password")
+                username to password
+            }
+        }
+        return credentials!!
+    }
+}

--- a/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/MapViewTestActivity.kt
+++ b/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/MapViewTestActivity.kt
@@ -23,15 +23,18 @@ import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
 import com.amplifyframework.geo.GeoCategory
 import com.amplifyframework.geo.location.AWSLocationGeoPlugin
 import com.amplifyframework.geo.maplibre.view.MapLibreView
+import com.amplifyframework.testutils.sync.SynchronousAuth
 import com.amplifyframework.testutils.sync.TestCategory
 
 /**
  * Activity that initializes MapLibre SDK with adapter on create.
  */
 class MapViewTestActivity : AppCompatActivity() {
+    internal var auth: SynchronousAuth? = null
 
     private val geo: GeoCategory by lazy {
         val authCategory = TestCategory.forPlugin(AWSCognitoAuthPlugin()) as AuthCategory
+        auth = SynchronousAuth.delegatingTo(authCategory)
         TestCategory.forPlugin(AWSLocationGeoPlugin(authProvider = authCategory)) as GeoCategory
     }
 

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/AmplifyMapView.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/AmplifyMapView.kt
@@ -266,7 +266,10 @@ class AmplifyMapView
                 updateSearchBounds(map.projection.visibleRegion.latLngBounds)
                 updatePlaceInfoViewPosition()
             }
-            mapView.symbolManager.addClickListener(this::handlePlaceMarkerClick)
+            mapView.symbolOnClickListener = { symbol ->
+                handlePlaceMarkerClick(symbol, true)
+            }
+            mapView.symbolManager.addClickListener(mapView.symbolOnClickListener)
         }
     }
 

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/ClusteringOptions.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/ClusteringOptions.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.maplibre.view
+
+import android.graphics.Color
+import com.mapbox.geojson.Feature
+import com.mapbox.geojson.Point
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import kotlin.math.min
+
+/**
+ * Stores options to use when clustering.
+ */
+class ClusteringOptions private constructor(
+    // The color for the cluster circles. Default is blue.
+    val clusterColor: Int,
+    // The color for cluster circles at different cluster steps (map from number of points
+    // in the cluster to the cluster circle color). Default is no cluster color steps.
+    val clusterColorSteps: Map<Int, Int>,
+    // The color for the number shown in the cluster circles. Default is white.
+    val clusterNumberColor: Int,
+    // The behavior when a cluster (feature) on the map is clicked. Default is to zoom
+    // in on the cluster clicked.
+    val onClusterClicked: (MapLibreView, Feature) -> Unit,
+    // The maximum zoom level to cluster points at. Default is 13.
+    val maxClusterZoomLevel: Int,
+    // The radius each cluster should cover on the map. Default is 75.
+    val clusterRadius: Int
+) {
+    companion object {
+        /**
+         * Returns a new builder instance for constructing ClusteringOptions.
+         * @return a new builder instance.
+         */
+        @JvmStatic fun builder() = Builder()
+
+        /**
+         * Returns a new ClusteringOptions instance with default values.
+         * @return a default instance.
+         */
+        @JvmStatic fun defaults() = builder().build()
+    }
+
+    /**
+     * Builder class for constructing a ClusteringOptions instance.
+     */
+    class Builder {
+        var clusterColor: Int = Color.BLUE
+            private set
+        var clusterColorSteps: Map<Int, Int> = emptyMap()
+            private set
+        var clusterNumberColor: Int = Color.WHITE
+            private set
+        var onClusterClicked: (MapLibreView, Feature) -> Unit = { mapLibreView, feature ->
+            mapLibreView.getMapAsync { map ->
+                val featureLocation = feature.geometry() as Point
+                val featureLatLng = LatLng(featureLocation.latitude(), featureLocation.longitude())
+                val zoomLevel = min(map.maxZoomLevel, map.cameraPosition.zoom + 1)
+                map.animateCamera(CameraUpdateFactory.newLatLngZoom(featureLatLng, zoomLevel))
+            }
+        }
+            private set
+        var maxClusterZoomLevel: Int = 13
+            private set
+        var clusterRadius: Int = 75
+            private set
+
+        /**
+         * Sets the color for the cluster circles.
+         * @param clusterColor the color for the cluster circles.
+         * @return this builder instance.
+         */
+        fun clusterColor(clusterColor: Int) = apply { this.clusterColor = clusterColor }
+
+        /**
+         * Sets the color for cluster circles at different cluster steps (number of points in the cluster).
+         * @param clusterColorSteps a map from number of points in the cluster to the cluster circle color.
+         * @return this builder instance.
+         */
+        fun clusterColorSteps(clusterColorSteps: Map<Int, Int>) = apply { this.clusterColorSteps = clusterColorSteps}
+
+        /**
+         * Sets the color for the number shown in the cluster circles.
+         * @param clusterNumberColor the color for the number in the cluster circles.
+         * @return this builder instance.
+         */
+        fun clusterNumberColor(clusterNumberColor: Int) = apply { this.clusterNumberColor = clusterNumberColor }
+
+        /**
+         * Sets the behavior when a cluster (feature) on the map is clicked.
+         * @param onClusterClicked the behavior when a cluster (feature) is clicked.
+         * @return this builder instance.
+         */
+        fun onClusterClicked(onClusterClicked: (MapLibreView, Feature) -> Unit) = apply { this.onClusterClicked = onClusterClicked }
+
+        /**
+         * Sets the maximum zoom level to cluster points at.
+         * @param maxClusterZoomLevel the maximum zoom level to cluster points at.
+         * @return this builder instance.
+         */
+        fun maxClusterZoomLevel(maxClusterZoomLevel: Int) = apply { this.maxClusterZoomLevel = maxClusterZoomLevel }
+
+        /**
+         * Sets the radius each cluster should cover on the map.
+         * @param clusterRadius the radius each cluster should cover on the map.
+         * @return this builder instance.
+         */
+        fun clusterRadius(clusterRadius: Int) = apply { this.clusterRadius = clusterRadius }
+
+        /**
+         * Constructs a clustering options instance with the specified options.
+         * @return an instance of ClusteringOptions.
+         */
+        fun build() = ClusteringOptions(
+            clusterColor,
+            clusterColorSteps,
+            clusterNumberColor,
+            onClusterClicked,
+            maxClusterZoomLevel,
+            clusterRadius
+        )
+    }
+}

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/ClusteringOptions.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/ClusteringOptions.kt
@@ -59,11 +59,11 @@ class ClusteringOptions private constructor(
      * Builder class for constructing a ClusteringOptions instance.
      */
     class Builder {
-        var clusterColor: Int = Color.BLUE
+        var clusterColor: Int = Color.parseColor("#1E88E5")
             private set
-        var clusterColorSteps: Map<Int, Int> = emptyMap()
+        var clusterColorSteps: Map<Int, Int> = mapOf(20 to Color.parseColor("#EF5350"), 50 to Color.parseColor("#FFEB3B"))
             private set
-        var clusterNumberColor: Int = Color.WHITE
+        var clusterNumberColor: Int = Color.BLACK
             private set
         var onClusterClicked: (MapLibreView, Feature) -> Unit = { mapLibreView, feature ->
             mapLibreView.getMapAsync { map ->

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/MapLibreView.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/MapLibreView.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.geo.maplibre.view
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.BitmapFactory
+import android.graphics.Color
 import android.util.AttributeSet
 import android.view.Gravity
 import androidx.annotation.UiThread
@@ -29,10 +30,18 @@ import com.amplifyframework.geo.maplibre.AmplifyMapLibreAdapter
 import com.amplifyframework.geo.maplibre.R
 import com.amplifyframework.geo.maplibre.view.support.AttributionInfoView
 import com.amplifyframework.geo.models.MapStyle
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager
+import com.mapbox.mapboxsdk.style.expressions.Expression
+import com.mapbox.mapboxsdk.style.layers.CircleLayer
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import java.lang.Double.min
 
 
 typealias MapLibreOptions = com.mapbox.mapboxsdk.maps.MapboxMapOptions
@@ -59,6 +68,9 @@ class MapLibreView
     companion object {
         private val log = Amplify.Logging.forNamespace("amplify:maplibre-adapter")
 
+        private const val CLUSTER_CIRCLE_LAYER_ID = "cluster-circles"
+        private const val CLUSTER_NUMBER_LAYER_ID = "cluster-numbers"
+
         const val PLACE_ICON_NAME = "place"
         const val PLACE_ACTIVE_ICON_NAME = "place-active"
     }
@@ -75,6 +87,9 @@ class MapLibreView
 
     var defaultPlaceIcon = R.drawable.place
     var defaultPlaceActiveIcon = R.drawable.place_active
+
+    private var shouldCluster = true
+    private var mapStyle: MapStyle? = null
 
     init {
         setup(context, options)
@@ -111,7 +126,7 @@ class MapLibreView
     }
 
     /**
-     * Get the both the map and its style asynchronously.
+     * Get both the map and its style asynchronously.
      *
      * **Implementation notes:** This is a shortcut to the existing nested callback solution:
      *
@@ -134,7 +149,7 @@ class MapLibreView
     }
 
     /**
-     * Update the map using the passed style. If no style is style is set, the default
+     * Update the map using the passed style. If no style is set, the default
      * configured using the Amplify CLI is used.
      *
      * @param style the map style object
@@ -143,6 +158,7 @@ class MapLibreView
     fun setStyle(style: MapStyle? = null, callback: Style.OnStyleLoaded) {
         getMapAsync { map ->
             adapter.setStyle(map, style) {
+                mapStyle = style
                 // setup the symbol manager
                 it.apply {
                     addImage(
@@ -154,13 +170,93 @@ class MapLibreView
                         BitmapFactory.decodeResource(resources, defaultPlaceActiveIcon)
                     )
                 }
-                this.symbolManager = SymbolManager(this, map, it, null, null).apply {
-                    iconAllowOverlap = true
-                    iconIgnorePlacement = true
+
+                // Clear the current symbols from the map since a new SymbolManager will be created
+                if (this::symbolManager.isInitialized) {
+                    this.symbolManager.deleteAll()
+                }
+
+                removeClusterLayers(it)
+                if (shouldCluster) {
+                    enableClustering(map, it)
+                } else {
+                    this.symbolManager = SymbolManager(this, map, it, null, null).apply {
+                        iconAllowOverlap = true
+                        iconIgnorePlacement = true
+                    }
                 }
 
                 callback.onStyleLoaded(it)
             }
+        }
+    }
+
+    // TODO : add a Javadoc comment here
+    fun setClusterBehavior(shouldCluster: Boolean, callback: () -> Unit) {
+        this.shouldCluster = shouldCluster
+        setStyle(mapStyle) {
+            callback()
+        }
+    }
+
+    private fun removeClusterLayers(style: Style) {
+        style.removeLayer(CLUSTER_CIRCLE_LAYER_ID)
+        style.removeLayer(CLUSTER_NUMBER_LAYER_ID)
+    }
+
+    private fun enableClustering(map: MapboxMap, style: Style) {
+        val clusterMaxZoom = 13
+        val geoJsonClusterOptions = GeoJsonOptions().withCluster(true).withClusterMaxZoom(clusterMaxZoom).withClusterRadius(75)
+        this.symbolManager = SymbolManager(this, map, style, null, geoJsonClusterOptions).apply {
+            iconAllowOverlap = true
+            iconIgnorePlacement = true
+        }
+
+        val geoJsonSources = style.sources.filterIsInstance<GeoJsonSource>()
+        var geoJsonSourceId = geoJsonSources[0].id
+        if (geoJsonSources.size > 1) {
+            geoJsonSourceId = geoJsonSources[1].id
+        }
+
+        // Create a circle layer for cluster circles
+        val clusterCircleLayer = CircleLayer(CLUSTER_CIRCLE_LAYER_ID, geoJsonSourceId)
+        val circleRadiusExpression = Expression.interpolate(Expression.exponential(1.75), Expression.zoom(),
+            Expression.stop(map.minZoomLevel, 60), Expression.stop(clusterMaxZoom, 20))
+        val circleColorStops = arrayOf(Expression.stop(15, Expression.rgb(0, 255, 0)),
+            Expression.stop(30, Expression.rgb(255, 0, 0)))
+        val circleColorExpression = Expression.step(Expression.get("point_count"),
+            Expression.rgb(0, 0, 255), *circleColorStops)
+        clusterCircleLayer.setProperties(
+            PropertyFactory.circleColor(circleColorExpression),
+            PropertyFactory.circleRadius(circleRadiusExpression)
+        )
+        clusterCircleLayer.setFilter(Expression.has("point_count"))
+
+        // Create a symbol layer for cluster numbers (point count)
+        val clusterNumberLayer = SymbolLayer(CLUSTER_NUMBER_LAYER_ID, geoJsonSourceId)
+        clusterNumberLayer.setProperties(
+            PropertyFactory.textField(Expression.toString(Expression.get("point_count"))),
+            PropertyFactory.textFont(arrayOf("Arial Bold")),
+            PropertyFactory.textColor(Color.WHITE),
+            PropertyFactory.textIgnorePlacement(true),
+            PropertyFactory.textAllowOverlap(true)
+        )
+
+        style.apply {
+            addLayer(clusterCircleLayer)
+            addLayer(clusterNumberLayer)
+        }
+
+        // Set the behavior when a cluster is clicked
+        map.addOnMapClickListener { latLngPoint ->
+            val pointClicked = map.projection.toScreenLocation(latLngPoint)
+            val features = map.queryRenderedFeatures(pointClicked, "cluster-circles")
+            if (features.isNotEmpty()) {
+                // Center the cluster that was clicked within the map view and zoom in
+                val zoomLevel = min(map.maxZoomLevel, map.cameraPosition.zoom + 1)
+                map.animateCamera(CameraUpdateFactory.newLatLngZoom(latLngPoint, zoomLevel))
+            }
+            true
         }
     }
 

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/MapLibreView.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/MapLibreView.kt
@@ -66,8 +66,9 @@ class MapLibreView
     companion object {
         private val log = Amplify.Logging.forNamespace("amplify:maplibre-adapter")
 
-        private const val CLUSTER_CIRCLE_LAYER_ID = "cluster-circles"
-        private const val CLUSTER_NUMBER_LAYER_ID = "cluster-numbers"
+        // Marked as internal for testing purposes
+        internal const val CLUSTER_CIRCLE_LAYER_ID = "cluster-circles"
+        internal const val CLUSTER_NUMBER_LAYER_ID = "cluster-numbers"
 
         const val PLACE_ICON_NAME = "place"
         const val PLACE_ACTIVE_ICON_NAME = "place-active"

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/MapLibreView.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/view/MapLibreView.kt
@@ -32,6 +32,7 @@ import com.amplifyframework.geo.models.MapStyle
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.plugins.annotation.Symbol
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager
 import com.mapbox.mapboxsdk.style.expressions.Expression
 import com.mapbox.mapboxsdk.style.layers.CircleLayer
@@ -81,6 +82,7 @@ class MapLibreView
     }
 
     lateinit var symbolManager: SymbolManager
+    internal lateinit var symbolOnClickListener: (Symbol) -> Boolean
 
     var defaultPlaceIcon = R.drawable.place
     var defaultPlaceActiveIcon = R.drawable.place_active
@@ -184,6 +186,10 @@ class MapLibreView
                     }
                 }
 
+                if (this::symbolOnClickListener.isInitialized) {
+                    this.symbolManager.addClickListener(symbolOnClickListener)
+                }
+
                 callback.onStyleLoaded(it)
             }
         }
@@ -268,10 +274,12 @@ class MapLibreView
         map.addOnMapClickListener { latLngPoint ->
             val pointClicked = map.projection.toScreenLocation(latLngPoint)
             val features = map.queryRenderedFeatures(pointClicked, "cluster-circles")
-            if (features.isNotEmpty()) {
+            if (features.isEmpty()) {
+                false
+            } else {
                 clusteringOptions.onClusterClicked(this, features[0])
+                true
             }
-            true
         }
     }
 


### PR DESCRIPTION
*Description of changes:* Adds the ability to enable clustering on the map and customize various properties of the clusters (e.g., cluster color). Also fixes an issue where calling MapLibreView.setStyle(...) would remove the symbol on click listener, meaning the popup with place info would not show up when clicking on a place on the map.

Clustering enabled with the default clustering options:
![Screen Shot 2022-04-06 at 3 22 01 PM](https://user-images.githubusercontent.com/67125657/162055481-3ebafea8-2216-473c-8200-e7cfcabd6a89.png)

![Screen Shot 2022-04-06 at 3 22 40 PM](https://user-images.githubusercontent.com/67125657/162055520-2abcf935-879d-4640-a117-40988a31b6ed.png)

![Screen Shot 2022-04-06 at 3 23 05 PM](https://user-images.githubusercontent.com/67125657/162055565-965f1854-8397-4203-b40c-ef68911abb17.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
