### PR TITLE
fix(datastore): #1584 When DateTimeParseException is not available for lower apis

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/core/model/temporal/Temporal.java
@@ -26,7 +26,6 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -89,12 +88,12 @@ public final class Temporal {
                 OffsetDateTime odt = OffsetDateTime.parse(text, getOffsetDateTimeFormatter());
                 localDate = LocalDate.from(odt);
                 zoneOffset = ZoneOffset.from(odt);
-            } catch (DateTimeParseException exception) {
+            } catch (Exception exception) {
                 try {
                     // Optional timezone offset not present
                     localDate = LocalDate.parse(text, DateTimeFormatter.ISO_LOCAL_DATE);
                     zoneOffset = null;
-                } catch (DateTimeParseException dateTimeParseException) {
+                } catch (Exception dateTimeParseException) {
                     throw new IllegalArgumentException("Failed to create Temporal.Date object from " + text, exception);
                 }
             }
@@ -220,7 +219,7 @@ public final class Temporal {
         public DateTime(@NonNull String text) {
             try {
                 this.offsetDateTime = OffsetDateTime.parse(text, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-            } catch (DateTimeParseException exception) {
+            } catch (Exception exception) {
                 throw new IllegalArgumentException("Failed to create Temporal.DateTime object from " + text, exception);
             }
         }
@@ -334,11 +333,11 @@ public final class Temporal {
                 OffsetTime offsetTime = OffsetTime.parse(text, DateTimeFormatter.ISO_OFFSET_TIME);
                 localTime = LocalTime.from(offsetTime);
                 zoneOffset = ZoneOffset.from(offsetTime);
-            } catch (DateTimeParseException exception) {
+            } catch (Exception exception) {
                 try {
                     localTime = LocalTime.parse(text, DateTimeFormatter.ISO_LOCAL_TIME);
                     zoneOffset = null;
-                } catch (DateTimeParseException dateTimeParseException) {
+                } catch (Exception dateTimeParseException) {
                     throw new IllegalArgumentException("Failed to create Temporal.Time object from " + text, exception);
                 }
             }

--- a/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalDateTimeTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/core/model/temporal/TemporalDateTimeTest.java
@@ -56,7 +56,7 @@ public final class TemporalDateTimeTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void parseInvalidFormat() {
-        new Temporal.DateTime("2001-02-03T01:30:15.444+05");
+        new Temporal.DateTime("2001-02-03T01:30:15.444++05");
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteModelFieldTypeConverter.java
@@ -43,7 +43,6 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -154,7 +153,7 @@ public final class SQLiteModelFieldTypeConverter implements ModelFieldTypeConver
                     OffsetTime offsetTime = OffsetTime.parse(timeValue, DateTimeFormatter.ISO_OFFSET_TIME);
                     localTime = LocalTime.from(offsetTime);
                     zoneOffset = ZoneOffset.from(offsetTime);
-                } catch (DateTimeParseException exception) {
+                } catch (Exception exception) {
                     localTime = LocalTime.parse(timeValue, DateTimeFormatter.ISO_LOCAL_TIME);
                     zoneOffset = ZoneOffset.UTC;
                 }


### PR DESCRIPTION
*Issue #, if available:* 1584

*Description of changes:*
Updated DateTimeParseException to parent class Exception which was added in Api 1 and will not crash the app and has no bearing on the result as we do not actually do anything with the exception.
*How did you test these changes?*
I checked the unit tests to ensure they did not fail and fixed the one that did
- [ x] Updated Unit Tests
- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
