### PR TITLE
fix: Update logic to extract S3 keys from list api response

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperation.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperation.java
@@ -83,7 +83,7 @@ public final class AWSS3StorageListOperation extends StorageListOperation<AWSS3S
                     prefix -> {
                         try {
                             String serviceKey = prefix.concat(getRequest().getPath());
-                            List<StorageItem> listedItems = storageService.listFiles(serviceKey);
+                            List<StorageItem> listedItems = storageService.listFiles(serviceKey, prefix);
                             onSuccess.accept(StorageListResult.fromItems(listedItems));
                         } catch (Exception exception) {
                             onError.accept(new StorageException(

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/service/AWSS3StorageService.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/service/AWSS3StorageService.java
@@ -175,10 +175,11 @@ public final class AWSS3StorageService implements StorageService {
     /**
      * List items inside an S3 path.
      * @param path The path to list items from
+     * @param prefix path appended to S3 keys
      * @return A list of parsed items
      */
     @NonNull
-    public List<StorageItem> listFiles(@NonNull String path) {
+    public List<StorageItem> listFiles(@NonNull String path, @NonNull String prefix) {
         startServiceIfNotAlreadyStarted();
         ArrayList<StorageItem> itemList = new ArrayList<>();
         ListObjectsV2Request request =
@@ -191,7 +192,7 @@ public final class AWSS3StorageService implements StorageService {
             for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
                 // Remove the access level prefix from service key
                 String serviceKey = objectSummary.getKey();
-                String amplifyKey = S3Keys.extractAmplifyKey(serviceKey);
+                String amplifyKey = S3Keys.extractAmplifyKey(serviceKey, prefix);
 
                 itemList.add(new StorageItem(
                         amplifyKey,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/service/StorageService.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/service/StorageService.java
@@ -84,9 +84,10 @@ public interface StorageService {
     /**
      * Returns a list of items from provided path inside the storage.
      * @param path path inside storage to inspect for list of items
+     * @param prefix path appended to S3 keys
      * @return A list of parsed items present inside given path
      */
-    List<StorageItem> listFiles(@NonNull String path);
+    List<StorageItem> listFiles(@NonNull String path, @NonNull String prefix);
 
     /**
      * Delete an object with specific key inside the storage.

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/utils/S3Keys.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/utils/S3Keys.java
@@ -85,32 +85,12 @@ public final class S3Keys {
      * a user-friendly key for Amplify. It strips the access level
      * prefix as well as the associated identity ID.
      * @param serviceKey S3 specific key containing access level an identity ID
+     * @param prefix string to be removed from the serviceKey
      * @return Amplify storage key devoid of S3 specific details
      * @throws IllegalArgumentException for wrong service key format
      */
     @NonNull
-    public static String extractAmplifyKey(@NonNull String serviceKey) {
-        try {
-            int accessLevelIndex = serviceKey.indexOf(BUCKET_SEPARATOR);
-            if (accessLevelIndex < 0) {
-                throw new IllegalArgumentException("Missing access level.");
-            }
-            String accessLevelString = serviceKey.substring(0, accessLevelIndex).toUpperCase(Locale.US);
-            StorageAccessLevel accessLevel = StorageAccessLevel.valueOf(accessLevelString);
-
-            // public keys are formatted as "public/{key}"
-            if (StorageAccessLevel.PUBLIC.equals(accessLevel)) {
-                return serviceKey.substring(accessLevelIndex + 1);
-            }
-
-            // private and protected keys are formatted as "{access-level}/{identity-id}/{key}"
-            int identityIdIndex = serviceKey.indexOf(BUCKET_SEPARATOR, accessLevelIndex + 1);
-            if (identityIdIndex < 0) {
-                throw new IllegalArgumentException("Missing identity ID.");
-            }
-            return serviceKey.substring(identityIdIndex + 1);
-        } catch (RuntimeException exception) {
-            throw new IllegalArgumentException("Service key is incorrectly formatted.", exception);
-        }
+    public static String extractAmplifyKey(@NonNull String serviceKey, @NonNull String prefix) {
+        return serviceKey.replace(prefix, "");
     }
 }

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
@@ -406,7 +406,7 @@ public final class StorageComponentTest {
                 null
         );
 
-        when(storageService.listFiles(anyString()))
+        when(storageService.listFiles(anyString(), anyString()))
                 .thenReturn(Collections.singletonList(item));
 
         StorageListResult result =

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperationTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/operation/AWSS3StorageListOperationTest.kt
@@ -60,7 +60,7 @@ public class AWSS3StorageListOperationTest {
             {}
         )
         awsS3StorageListOperation.start()
-        Mockito.verify(storageService).listFiles(expectedKey)
+        Mockito.verify(storageService).listFiles(expectedKey, "public/")
     }
 
     @Test
@@ -94,7 +94,7 @@ public class AWSS3StorageListOperationTest {
             {}
         )
         awsS3StorageListOperation.start()
-        Mockito.verify(storageService).listFiles(expectedKey)
+        Mockito.verify(storageService).listFiles(expectedKey, "")
     }
 
     @Test
@@ -128,6 +128,6 @@ public class AWSS3StorageListOperationTest {
             {}
         )
         awsS3StorageListOperation.start()
-        Mockito.verify(storageService).listFiles(expectedKey)
+        Mockito.verify(storageService).listFiles(expectedKey, "publicCustom/")
     }
 }

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/utils/S3KeysTest.java
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/utils/S3KeysTest.java
@@ -72,7 +72,7 @@ public final class S3KeysTest {
     @Test
     public void amplifyKeyIsExtractedFromPublicServiceKey() {
         final String publicServiceKey = "public/foo/bar";
-        assertEquals("foo/bar", S3Keys.extractAmplifyKey(publicServiceKey));
+        assertEquals("foo/bar", S3Keys.extractAmplifyKey(publicServiceKey, "public/"));
     }
 
     /**
@@ -82,7 +82,7 @@ public final class S3KeysTest {
     @Test
     public void amplifyKeyIsExtractedFromProtectedServiceKey() {
         final String serviceKey = "protected/foo/bar";
-        assertEquals("bar", S3Keys.extractAmplifyKey(serviceKey));
+        assertEquals("bar", S3Keys.extractAmplifyKey(serviceKey, "protected/foo/"));
     }
 
     /**
@@ -92,26 +92,16 @@ public final class S3KeysTest {
     @Test
     public void amplifyKeyIsExtractedFromPrivateServiceKey() {
         final String serviceKey = "private/foo/bar";
-        assertEquals("bar", S3Keys.extractAmplifyKey(serviceKey));
+        assertEquals("bar", S3Keys.extractAmplifyKey(serviceKey, "private/foo/"));
     }
 
     /**
-     * An attempt to extract an Amplify key from a service key that has a non-existent accessor
-     * should throw an error.
+     * Validates the extraction of an Amplify key, from a private service key.
+     * Service key should not be stripped off since the prefix is empty.
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void extractKeyFromServiceKeyWithBadAccessor() {
-        final String serviceKey = "master/foo/bar";
-        S3Keys.extractAmplifyKey(serviceKey);
-    }
-
-    /**
-     * An attempt to extract an Amplify key from a service key that only has a prefix
-     * should throw an error.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void extractKeyFromIncompleteServiceKey() {
-        final String serviceKey = "private/foo";
-        S3Keys.extractAmplifyKey(serviceKey);
+    @Test
+    public void amplifyKeyIsExtractedFromEmptyPrefix() {
+        final String serviceKey = "bar";
+        assertEquals("bar", S3Keys.extractAmplifyKey(serviceKey, ""));
     }
 }


### PR DESCRIPTION
*Issue #1697*

*Description of changes:*
Updated the logic to strip off the prefix appended to S3 service keys. Previously the string removed from the service keys was based on the accesslevel but with the addition of [custom prefix](https://github.com/aws-amplify/amplify-android/pull/1659) this logic is not always valid. To fix this issue, prefix append is passed to extractAmplifyKey function and removed from the sericeKey. 

*How did you test these changes?*
- Added unit test.
- Integration tests are passing.

*Documentation update required?*
- No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
