### PR TITLE
Change device farm script to exit on FAIL only

### DIFF
--- a/scripts/run_test_in_devicefarm.sh
+++ b/scripts/run_test_in_devicefarm.sh
@@ -76,10 +76,10 @@ done
 echo "Status = $status Result = $result"
 
 ./scripts/generate_df_testrun_report --run_arn="$run_arn" --module_name="$module_name" --pr="$CODEBUILD_SOURCE_VERSION" --output_path="build/allTests/$module_name/"
-# If the result is PASSED, then exit with a return code 0
-if [ "$result" = "PASSED" ]
+# If the result is FAILED, then exit with a non-zero return
+if [ "$result" = "FAILED" ]
 then
-  exit 0
+  exit 1
 fi
-# Otherwise, exit with a non-zero.
-exit 1
+# Otherwise, exit with a zero.
+exit 0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Current script fails in case when the test result is anything other than `PASSED`. Changed to exit to non-zero on `FAILED` as `SKIPPED` is also one of the potential cases

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
