### PR TITLE
Fix for adding data back to the delete request if it contains data as that is allowed for the Delete api

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -710,14 +710,19 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             case GET:
             case DELETE:
                 if (options.hasData()) {
-                    throw new ApiException("HTTP method does not support data object! " + type,
-                            "Try sending the request without any data in the options.");
+                    operationRequest = new RestOperationRequest(
+                            type,
+                            options.getPath(),
+                            options.getData(),
+                            options.getHeaders(),
+                            options.getQueryParameters());
+                } else {
+                    operationRequest = new RestOperationRequest(
+                            type,
+                            options.getPath(),
+                            options.getHeaders(),
+                            options.getQueryParameters());
                 }
-                operationRequest = new RestOperationRequest(
-                        type,
-                        options.getPath(),
-                        options.getHeaders(),
-                        options.getQueryParameters());
                 break;
             case PUT:
             case POST:

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -708,6 +708,16 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
             // These ones are special, they don't use any data.
             case HEAD:
             case GET:
+                if (options.hasData()) {
+                    throw new ApiException("HTTP method does not support data object! " + type,
+                            "Try sending the request without any data in the options.");
+                }
+                operationRequest = new RestOperationRequest(
+                        type,
+                        options.getPath(),
+                        options.getHeaders(),
+                        options.getQueryParameters());
+                break;
             case DELETE:
                 if (options.hasData()) {
                     operationRequest = new RestOperationRequest(


### PR DESCRIPTION
*Issue #, if available:* 1729

*Description of changes:*
The Delete api does allow for a request to be passed in and therefore this check was removed to accommodate that.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
