### PR TITLE
catch exceptions from processOutboxItem

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -113,9 +113,15 @@ final class MutationProcessor {
             if (next == null) {
                 return Completable.complete();
             }
-            boolean itemFailedToProcess = !processOutboxItem(next)
-                .blockingAwait(ITEM_PROCESSING_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-            if (itemFailedToProcess) {
+            try {
+                boolean itemFailedToProcess = !processOutboxItem(next)
+                    .blockingAwait(ITEM_PROCESSING_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                if (itemFailedToProcess) {
+                    return Completable.error(new DataStoreException(
+                        "Timeout processing " + next, "Check your internet connection."
+                    ));
+                }
+            } catch (RuntimeException e) {
                 return Completable.error(new DataStoreException(
                     "Failed to process " + next, "Check your internet connection."
                 ));

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -121,9 +121,9 @@ final class MutationProcessor {
                         "Timeout processing " + next, "Check your internet connection."
                     ));
                 }
-            } catch (RuntimeException e) {
+            } catch (RuntimeException error) {
                 return Completable.error(new DataStoreException(
-                    "Failed to process " + next, "Check your internet connection."
+                        "Failed to process " + error, "Check your internet connection."
                 ));
             }
         } while (true);


### PR DESCRIPTION
processOutBoxItem should be wrapped to catch exceptions from the method as the blocking await only catches the timeout and returns false. otherwise the exception ends up uncaught

https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling

*Issue #, if available:*
N/A

*Description of changes:*
Catch pending mutation exceptions while draining the outbox.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [x] Successful logs (Attach them to the PR)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
