### PR TITLE
fix orchestrator failing if emitter is disposed

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -300,9 +300,11 @@ public final class Orchestrator {
                 try {
                     subscriptionProcessor.startSubscriptions();
                 } catch (Throwable failure) {
-                    if (!emitter.tryOnError(new DataStoreException("DataStore subscriptionProcessor failed to start.", failure, "Check your internet.")))
-                    {
-                        LOG.warn("DataStore subscriptionProcessor failed to start after emitter was disposed.", failure);
+                    if (!emitter.tryOnError(
+                            new DataStoreException("DataStore subscriptionProcessor failed to start.",
+                                    failure, "Check your internet."))) {
+                        LOG.warn("DataStore failed to start after emitter was disposed.",
+                                failure);
                         emitter.onComplete();
                     }
                     return;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Let orchestrator fail more gracefully if emitter is disposed

*How did you test these changes?*
(Please add a line here how the changes were tested)
To create the error, I had an online system that was constantly adding new records to 20 different tables. I walk out of wifi range, and then walk back into wifi range. Prior to the fix if the emitter on the orchestrator was already disposed then startSubscription() could leak an async exception event causing the orchestrator to continue accepting records as if the subscriptions were okay.

Combined with #1743 I was able to **finally** have datastore restart sync operations without having to restart the entire application. Please accept these two fixes to make datastore much more resilient during network transitions.

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [x] Successful logs (Attach them to the PR)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
