### PR TITLE
chore: upgrade jmespath to version 1.6.1

### DIFF
--- a/scripts/Gemfile.lock
+++ b/scripts/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    jmespath (1.4.0)
+    jmespath (1.6.1)
     json (2.5.1)
     jwt (2.2.3)
     memoist (0.16.2)


### PR DESCRIPTION
Fix error: Dependabot only supports uninterpolated string arguments to eval_gemfile. Got plugins_path

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
