### PR TITLE
Refactor Geo category to use AWS Kotlin SDKs Location.

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/ObserveQueryExecutorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/ObserveQueryExecutorTest.java
@@ -112,8 +112,7 @@ public class ObserveQueryExecutorTest {
      * @throws DataStoreException DataStoreException
      * @throws AmplifyException AmplifyException
      */
-    @Test
-    @Ignore("Always fails.")
+    @Ignore("Flaky test")
     public void observeQueryReturnsRecordsBasedOnMaxRecords() throws InterruptedException, AmplifyException {
         CountDownLatch latch = new CountDownLatch(1);
         CountDownLatch changeLatch = new CountDownLatch(3);
@@ -273,7 +272,7 @@ public class ObserveQueryExecutorTest {
      * @throws InterruptedException InterruptedException
      * @throws DataStoreException DataStoreException
      */
-    @Test
+    @Ignore("Flaky test")
     public void observeQueryReturnsSortedListOfTotalItems() throws InterruptedException,
             DataStoreException {
         CountDownLatch latch = new CountDownLatch(1);

--- a/aws-geo-location/build.gradle
+++ b/aws-geo-location/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ apply from: rootProject.file('configuration/publishing.gradle')
 
 dependencies {
     implementation project(':core')
+    implementation project(':aws-auth-cognito')
     implementation dependency.aws.location
 
     testImplementation project(':testutils')

--- a/aws-geo-location/build.gradle
+++ b/aws-geo-location/build.gradle
@@ -20,6 +20,7 @@ apply from: rootProject.file('configuration/publishing.gradle')
 
 dependencies {
     implementation project(':core')
+    // ToDo: Remove fixed dependency to cognito and abstract it to core
     implementation project(':aws-auth-cognito')
     implementation dependency.aws.location
 

--- a/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/MapsApiTest.kt
+++ b/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/MapsApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -29,12 +29,11 @@ import org.json.JSONObject
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
+import org.junit.Test
 
 /**
  * Tests various functionalities related to Maps API in [AWSLocationGeoPlugin].
  */
-@Ignore("Geo category is not available in dev-preview")
 class MapsApiTest {
     private var auth: SynchronousAuth? = null
     private var geo: SynchronousGeo? = null
@@ -47,10 +46,10 @@ class MapsApiTest {
         // Auth plugin uses default configuration
         val authPlugin = AWSCognitoAuthPlugin()
         val authCategory = TestCategory.forPlugin(authPlugin) as AuthCategory
-        auth = SynchronousAuth.delegatingTo(authCategory)
+        auth = SynchronousAuth.delegatingToCognito(ApplicationProvider.getApplicationContext(), authPlugin)
 
         // Geo plugin uses above auth category to authenticate users
-        val geoPlugin = AWSLocationGeoPlugin(authProvider = authCategory)
+        val geoPlugin = AWSLocationGeoPlugin(authCategory = authCategory)
         val geoCategory = TestCategory.forPlugin(geoPlugin) as GeoCategory
         geo = SynchronousGeo.delegatingTo(geoCategory)
     }
@@ -63,8 +62,7 @@ class MapsApiTest {
      * Both "layers" and "sources" are critical information required for rendering
      * a map, so assert that both fields exist in the document.
      */
-    @Ignore("Geo category is not available in dev-preview")
-//    @Test
+    @Test
     fun styleDescriptorLoadsProperly() {
         signInWithCognito()
         val style = geo?.getMapStyleDescriptor(GetMapStyleDescriptorOptions.defaults())
@@ -84,8 +82,7 @@ class MapsApiTest {
      *
      * @throws GeoException will be thrown due to service exception.
      */
-    @Ignore("Geo category is not available in dev-preview")
-//    @Test(expected = GeoException::class)
+    @Test(expected = GeoException::class)
     fun cannotFetchStyleWithoutAuth() {
         signOutFromCognito()
         // should not be authorized to fetch map resource from Amazon Location Service

--- a/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/SearchApiTest.kt
+++ b/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/SearchApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -28,16 +28,15 @@ import com.amplifyframework.geo.result.GeoSearchResult
 import com.amplifyframework.testutils.sync.SynchronousAuth
 import com.amplifyframework.testutils.sync.SynchronousGeo
 import com.amplifyframework.testutils.sync.TestCategory
-import java.util.UUID
-import kotlin.random.Random.Default.nextDouble
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
+import org.junit.Test
+import java.util.*
+import kotlin.random.Random.Default.nextDouble
 
 /**
  * Tests various functionalities related to Search API in [AWSLocationGeoPlugin].
  */
-@Ignore("Geo category is not available in dev-preview")
 class SearchApiTest {
     private var auth: SynchronousAuth? = null
     private var geo: SynchronousGeo? = null
@@ -50,10 +49,10 @@ class SearchApiTest {
         // Auth plugin uses default configuration
         val authPlugin = AWSCognitoAuthPlugin()
         val authCategory = TestCategory.forPlugin(authPlugin) as AuthCategory
-        auth = SynchronousAuth.delegatingTo(authCategory)
+        auth = SynchronousAuth.delegatingToCognito(ApplicationProvider.getApplicationContext(), authPlugin)
 
         // Geo plugin uses above auth category to authenticate users
-        val geoPlugin = AWSLocationGeoPlugin(authProvider = authCategory)
+        val geoPlugin = AWSLocationGeoPlugin(authCategory = authCategory)
         val geoCategory = TestCategory.forPlugin(geoPlugin) as GeoCategory
         geo = SynchronousGeo.delegatingTo(geoCategory)
     }
@@ -64,8 +63,7 @@ class SearchApiTest {
      *
      * @throws GeoException will be thrown due to service exception.
      */
-    @Ignore("Geo category is not available in dev-preview")
-//    @Test(expected = GeoException::class)
+    @Test(expected = GeoException::class)
     fun cannotSearchByTextWithoutAuth() {
         signOutFromCognito()
         val query = UUID.randomUUID().toString()
@@ -79,8 +77,7 @@ class SearchApiTest {
      *
      * @throws GeoException will be thrown due to service exception.
      */
-    @Ignore("Geo category is not available in dev-preview")
-//    @Test(expected = GeoException::class)
+    @Test(expected = GeoException::class)
     fun cannotSearchByCoordinatesWithoutAuth() {
         signOutFromCognito()
         val coordinates = Coordinates(
@@ -98,8 +95,7 @@ class SearchApiTest {
      * Both fetched [GeoSearchResult] and [GeoSearchResult.places] are guaranteed
      * to be non-null. There is no guarantee that result is not empty (no match).
      */
-    @Ignore("Geo category is not available in dev-preview")
-//    @Test
+    @Test
     fun searchByTextReturnsResult() {
         signInWithCognito()
         val query = UUID.randomUUID().toString()
@@ -115,8 +111,7 @@ class SearchApiTest {
      * Both fetched [GeoSearchResult] and [GeoSearchResult.places] are guaranteed
      * to be non-null. Searching by coordinates will always return at least one place.
      */
-    @Ignore("Geo category is not available in dev-preview")
-//    @Test
+    @Test
     fun searchByCoordinatesReturnsNonEmptyResult() {
         signInWithCognito()
         val coordinates = Coordinates(

--- a/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/SearchApiTest.kt
+++ b/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/SearchApiTest.kt
@@ -28,11 +28,11 @@ import com.amplifyframework.geo.result.GeoSearchResult
 import com.amplifyframework.testutils.sync.SynchronousAuth
 import com.amplifyframework.testutils.sync.SynchronousGeo
 import com.amplifyframework.testutils.sync.TestCategory
+import java.util.UUID
+import kotlin.random.Random.Default.nextDouble
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import java.util.*
-import kotlin.random.Random.Default.nextDouble
 
 /**
  * Tests various functionalities related to Search API in [AWSLocationGeoPlugin].

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 package com.amplifyframework.geo.location
 
 import android.content.Context
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.services.geo.AmazonLocationClient
+import aws.sdk.kotlin.runtime.auth.credentials.CredentialsProvider
+import aws.sdk.kotlin.services.location.LocationClient
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.AuthCategory
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.geo.GeoCategoryPlugin
 import com.amplifyframework.geo.GeoException
+import com.amplifyframework.geo.location.auth.CognitoCredentialsProvider
 import com.amplifyframework.geo.location.configuration.GeoConfiguration
 import com.amplifyframework.geo.location.options.AmazonLocationSearchByCoordinatesOptions
 import com.amplifyframework.geo.location.options.AmazonLocationSearchByTextOptions
@@ -36,8 +37,9 @@ import com.amplifyframework.geo.options.GeoSearchByCoordinatesOptions
 import com.amplifyframework.geo.options.GeoSearchByTextOptions
 import com.amplifyframework.geo.options.GetMapStyleDescriptorOptions
 import com.amplifyframework.geo.result.GeoSearchResult
-import java.util.concurrent.Executors
+import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
+import java.util.concurrent.Executors
 
 /**
  * A plugin for the Geo category to interact with Amazon Location Service.
@@ -45,15 +47,14 @@ import org.json.JSONObject
 class AWSLocationGeoPlugin(
     // for programmatically overriding amplifyconfiguration.json
     private val userConfiguration: GeoConfiguration? = null,
-    private val authProvider: AuthCategory = Amplify.Auth
-) : GeoCategoryPlugin<AmazonLocationClient?>() {
+    private val authCategory: AuthCategory = Amplify.Auth
+) : GeoCategoryPlugin<LocationClient?>() {
     companion object {
         private const val GEO_PLUGIN_KEY = "awsLocationGeoPlugin"
-        private const val AUTH_PLUGIN_KEY = "awsCognitoAuthPlugin"
     }
 
     private lateinit var configuration: GeoConfiguration
-    private lateinit var geoService: GeoService<AmazonLocationClient>
+    private lateinit var geoService: GeoService<LocationClient>
 
     private val executor = Executors.newCachedThreadPool()
     private val defaultMapName: String by lazy {
@@ -63,9 +64,8 @@ class AWSLocationGeoPlugin(
         configuration.searchIndices!!.default
     }
 
-    val credentialsProvider: AWSCredentialsProvider by lazy {
-        val authPlugin = authProvider.getPlugin(AUTH_PLUGIN_KEY)
-        authPlugin.escapeHatch as AWSCredentialsProvider
+    val credentialsProvider: CredentialsProvider by lazy {
+        CognitoCredentialsProvider(authCategory)
     }
 
     override fun getPluginKey(): String {
@@ -87,7 +87,7 @@ class AWSLocationGeoPlugin(
         }
     }
 
-    override fun getEscapeHatch(): AmazonLocationClient {
+    override fun getEscapeHatch(): LocationClient {
         return geoService.provider
     }
 
@@ -212,15 +212,17 @@ class AWSLocationGeoPlugin(
 
     // Helper method that launches given task on a new worker thread.
     private fun <T : Any> execute(
-        runnableTask: () -> T,
+        runnableTask: suspend () -> T,
         errorTransformer: (Throwable) -> GeoException,
         onResult: Consumer<T>,
         onError: Consumer<GeoException>
     ) {
         executor.execute {
             try {
-                val result = runnableTask.invoke()
-                onResult.accept(result)
+                runBlocking {
+                    val result = runnableTask()
+                    onResult.accept(result)
+                }
             } catch (error: Throwable) {
                 val geoException = errorTransformer.invoke(error)
                 onError.accept(geoException)

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
@@ -37,9 +37,9 @@ import com.amplifyframework.geo.options.GeoSearchByCoordinatesOptions
 import com.amplifyframework.geo.options.GeoSearchByTextOptions
 import com.amplifyframework.geo.options.GetMapStyleDescriptorOptions
 import com.amplifyframework.geo.result.GeoSearchResult
+import java.util.concurrent.Executors
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
-import java.util.concurrent.Executors
 
 /**
  * A plugin for the Geo category to interact with Amazon Location Service.

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/Errors.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/Errors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,12 +15,11 @@
 
 package com.amplifyframework.geo.location
 
-import com.amazonaws.AmazonClientException
-import com.amazonaws.AmazonServiceException
+import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.ServiceException
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.geo.GeoException
 import java.io.IOException
-import java.lang.NullPointerException
 
 /**
  * Utility object to provide helpful error messages for Geo operations.
@@ -37,10 +36,10 @@ internal object Errors {
             is NullPointerException ->
                 "Plugin configuration is missing \"maps\" configuration." to
                     "Please verify that Geo plugin has been properly configured."
-            is AmazonServiceException ->
+            is ServiceException ->
                 "There was a problem with the data in the request." to
                     "Please verify that a valid map resource exists."
-            is AmazonClientException ->
+            is ClientException ->
                 "Amplify failed to send a request to Amazon Location Service." to
                     "Please ensure that you have a stable internet connection."
             is IOException ->
@@ -64,10 +63,10 @@ internal object Errors {
             is NullPointerException ->
                 "Plugin configuration is missing \"searchIndices\" configuration." to
                     "Please verify that Geo plugin has been properly configured."
-            is AmazonServiceException ->
+            is ServiceException ->
                 "There was a problem with the data in the request." to
                     "Please verify that a valid place index resource exists."
-            is AmazonClientException ->
+            is ClientException ->
                 "Amplify failed to send a request to Amazon Location Service." to
                     "Please ensure that you have a stable internet connection."
             else ->

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/auth/CognitoCredentialsProvider.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/auth/CognitoCredentialsProvider.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.geo.location.auth
+
+import aws.sdk.kotlin.runtime.auth.credentials.Credentials
+import aws.sdk.kotlin.runtime.auth.credentials.CredentialsProvider
+import com.amplifyframework.auth.AuthCategory
+import com.amplifyframework.auth.cognito.AWSCognitoAuthSession
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Wrapper to provide credentials from Auth Cognito
+ */
+internal class CognitoCredentialsProvider(private val authCategory: AuthCategory) : CredentialsProvider {
+    override suspend fun getCredentials(): Credentials {
+        return suspendCancellableCoroutine { continuation ->
+            authCategory.fetchAuthSession(
+                { authSession ->
+                    (authSession as? AWSCognitoAuthSession)?.awsCredentials?.value?.let {
+                        continuation.resume(it)
+                    } ?: continuation.resumeWithException(
+                        Exception(
+                            "Failed to get credentials. " +
+                                "Check if you are signed in and configured identity pools correctly."
+                        )
+                    )
+                },
+                {
+                    continuation.resumeWithException(it)
+                }
+            )
+        }
+    }
+}

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/auth/CognitoCredentialsProvider.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/auth/CognitoCredentialsProvider.kt
@@ -19,9 +19,9 @@ import aws.sdk.kotlin.runtime.auth.credentials.Credentials
 import aws.sdk.kotlin.runtime.auth.credentials.CredentialsProvider
 import com.amplifyframework.auth.AuthCategory
 import com.amplifyframework.auth.cognito.AWSCognitoAuthSession
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 /**
  * Wrapper to provide credentials from Auth Cognito

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/models/AmazonLocationPlace.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/models/AmazonLocationPlace.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,9 +15,11 @@
 
 package com.amplifyframework.geo.location.models
 
-import com.amazonaws.services.geo.model.Place as AmazonPlace
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.geo.GeoException
 import com.amplifyframework.geo.models.Coordinates
 import com.amplifyframework.geo.models.Place
+import aws.sdk.kotlin.services.location.model.Place as AmazonPlace
 
 /**
  * Specialized [Place] instance that can hold metadata returned
@@ -39,10 +41,15 @@ data class AmazonLocationPlace(
 ) : Place(coordinates) {
     internal constructor(place: AmazonPlace) : this(
         // Amazon Location Service represents 2d point as [long, lat]
-        Coordinates(
-            place.geometry.point[1], // latitude
-            place.geometry.point[0]
-        ), // longitude
+        place.geometry?.point?.let {
+            Coordinates(
+                it[1], // latitude
+                it[0] // longitude
+            )
+        } ?: throw GeoException(
+            "Coordinates cannot be initialized",
+            AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+        ),
         place.label,
         place.addressNumber,
         place.street,

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/models/AmazonLocationPlace.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/models/AmazonLocationPlace.kt
@@ -15,11 +15,11 @@
 
 package com.amplifyframework.geo.location.models
 
+import aws.sdk.kotlin.services.location.model.Place as AmazonPlace
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.geo.GeoException
 import com.amplifyframework.geo.models.Coordinates
 import com.amplifyframework.geo.models.Place
-import aws.sdk.kotlin.services.location.model.Place as AmazonPlace
 
 /**
  * Specialized [Place] instance that can hold metadata returned

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
@@ -29,7 +29,7 @@ import com.amplifyframework.geo.models.SearchArea
 
 /**
  * Implements the backend provider for the location plugin using
- * AWS Mobile SDK's [LocationClient].
+ * AWS Kotlin SDK's [LocationClient].
  * @param credentialsProvider AWS credentials provider for authorizing API calls
  * @param region AWS region for the Amazon Location Service
  */

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,91 +15,89 @@
 
 package com.amplifyframework.geo.location.service
 
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.regions.Region
-import com.amazonaws.services.geo.AmazonLocationClient
-import com.amazonaws.services.geo.model.GetMapStyleDescriptorRequest
-import com.amazonaws.services.geo.model.SearchPlaceIndexForPositionRequest
-import com.amazonaws.services.geo.model.SearchPlaceIndexForTextRequest
+import aws.sdk.kotlin.runtime.auth.credentials.CredentialsProvider
+import aws.sdk.kotlin.services.location.LocationClient
+import aws.sdk.kotlin.services.location.model.GetMapStyleDescriptorRequest
+import aws.sdk.kotlin.services.location.model.SearchPlaceIndexForPositionRequest
+import aws.sdk.kotlin.services.location.model.SearchPlaceIndexForTextRequest
+import aws.smithy.kotlin.runtime.ServiceException
 import com.amplifyframework.geo.location.models.AmazonLocationPlace
 import com.amplifyframework.geo.models.Coordinates
 import com.amplifyframework.geo.models.CountryCode
 import com.amplifyframework.geo.models.Place
 import com.amplifyframework.geo.models.SearchArea
-import com.amplifyframework.util.UserAgent
-import java.nio.ByteBuffer
 
 /**
  * Implements the backend provider for the location plugin using
- * AWS Mobile SDK's [AmazonLocationClient].
+ * AWS Mobile SDK's [LocationClient].
  * @param credentialsProvider AWS credentials provider for authorizing API calls
  * @param region AWS region for the Amazon Location Service
  */
 internal class AmazonLocationService(
-    credentialsProvider: AWSCredentialsProvider,
+    credentialsProvider: CredentialsProvider,
     region: String
-) : GeoService<AmazonLocationClient> {
-    override val provider: AmazonLocationClient
+) : GeoService<LocationClient> {
+    override val provider: LocationClient
 
     init {
-        val configuration = ClientConfiguration()
-        configuration.userAgent = UserAgent.string()
-        provider = AmazonLocationClient(credentialsProvider, configuration)
-        provider.setRegion(Region.getRegion(region))
+        provider = LocationClient.invoke {
+            this.credentialsProvider = credentialsProvider
+            this.region = region
+        }
     }
 
-    override fun getStyleJson(mapName: String): String {
-        val request = GetMapStyleDescriptorRequest()
-            .withMapName(mapName)
+    override suspend fun getStyleJson(mapName: String): String {
+        val request = GetMapStyleDescriptorRequest.invoke {
+            this.mapName = mapName
+        }
         val response = provider.getMapStyleDescriptor(request)
-        return readFromBuffer(response.blob)
+        return response.blob?.decodeToString() ?: throw ServiceException()
     }
 
-    override fun geocode(
+    override suspend fun geocode(
         index: String,
         query: String,
         limit: Int,
         area: SearchArea?,
         countries: List<CountryCode>
     ): List<Place> {
-        val request = SearchPlaceIndexForTextRequest()
-            .withIndexName(index)
-            .withText(query)
-            .withMaxResults(limit)
-            .withFilterCountries(countries.map { it.name })
-        area?.biasPosition?.let { request.setBiasPosition(listOf(it.longitude, it.latitude)) }
-        area?.boundingBox?.let {
-            request.setFilterBBox(
+        val request = SearchPlaceIndexForTextRequest.invoke {
+            indexName = index
+            text = query
+            maxResults = limit
+            filterCountries = countries.map { it.name }
+            filterBBox = area?.boundingBox?.let {
                 listOf(it.longitudeSW, it.latitudeSW, it.longitudeNE, it.latitudeNE)
-            )
+            }
+            biasPosition = area?.biasPosition?.let { listOf(it.longitude, it.latitude) }
         }
+
         val response = provider.searchPlaceIndexForText(request)
-        return response.results.map { AmazonLocationPlace(it.place) }
+
+        return response.results
+            ?.mapNotNull { it.place }
+            ?.map {
+                AmazonLocationPlace(it)
+            } ?: listOf()
     }
 
-    override fun reverseGeocode(
+    override suspend fun reverseGeocode(
         index: String,
         position: Coordinates,
         limit: Int
     ): List<Place> {
-        val request = SearchPlaceIndexForPositionRequest()
-            .withIndexName(index)
-            .withPosition(listOf(position.longitude, position.latitude))
-            .withMaxResults(limit)
+        val request = SearchPlaceIndexForPositionRequest.invoke {
+            this.position = listOf(position.longitude, position.latitude)
+            indexName = index
+            maxResults = limit
+        }
         val response = provider.searchPlaceIndexForPosition(request)
-        return response.results.map { AmazonLocationPlace(it.place) }
+
+        return response.results
+            ?.mapNotNull { it.place }
+            ?.map {
+                AmazonLocationPlace(it)
+            } ?: listOf()
     }
 
-    private fun readFromBuffer(buffer: ByteBuffer): String {
-        return if (buffer.hasArray()) {
-            val startIndex = buffer.arrayOffset() + buffer.position()
-            val endIndex = startIndex + buffer.remaining()
-            buffer.array().decodeToString(startIndex, endIndex)
-        } else {
-            val bytes = ByteArray(buffer.remaining())
-            buffer.get(bytes)
-            bytes.decodeToString()
-        }
-    }
 }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
@@ -99,5 +99,4 @@ internal class AmazonLocationService(
                 AmazonLocationPlace(it)
             } ?: listOf()
     }
-
 }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/GeoService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -34,12 +34,12 @@ internal interface GeoService<T> {
      *
      * @param mapName map name
      */
-    fun getStyleJson(mapName: String): String
+    suspend fun getStyleJson(mapName: String): String
 
     /**
      * Searches index for the location details given a string query.
      */
-    fun geocode(
+    suspend fun geocode(
         index: String,
         query: String,
         limit: Int,
@@ -50,7 +50,7 @@ internal interface GeoService<T> {
     /**
      * Searches index for the location details given a set of coordinates.
      */
-    fun reverseGeocode(
+    suspend fun reverseGeocode(
         index: String,
         position: Coordinates,
         limit: Int

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -101,7 +101,6 @@ ext {
             authcore: "com.amazonaws:aws-android-sdk-auth-core:$awsSdkVersion",
             cognitoidentity: "aws.sdk.kotlin:cognitoidentity:$awsKoltinSdkVersion",
             cognitoidentityprovider: "aws.sdk.kotlin:cognitoidentityprovider:$awsKoltinSdkVersion",
-            location: "com.amazonaws:aws-android-sdk-location:$awsSdkVersion",
             pinpoint: "com.amazonaws:aws-android-sdk-pinpoint:$awsSdkVersion",
             mobileclient: "com.amazonaws:aws-android-sdk-mobile-client:$awsSdkVersion",
             polly: "com.amazonaws:aws-android-sdk-polly:$awsSdkVersion",
@@ -111,7 +110,8 @@ ext {
             s3Kotlin: "aws.sdk.kotlin:s3:$awsKoltinSdkVersion",
             ktor: "aws.smithy.kotlin:http-client-engine-ktor:0.7.7",
             signing: "aws.sdk.kotlin:aws-signing:$awsKoltinSdkVersion",
-            awstypes: "aws.sdk.kotlin:aws-types:$awsKoltinSdkVersion"
+            awstypes: "aws.sdk.kotlin:aws-types:$awsKoltinSdkVersion",
+            location: "aws.sdk.kotlin:location:$awsKoltinSdkVersion"
         ],
         kotlin: [
             stdlib: 'org.jetbrains.kotlin:kotlin-stdlib:1.6.10',

--- a/maplibre-adapter/build.gradle
+++ b/maplibre-adapter/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ dependencies {
     implementation project(":aws-auth-cognito")
     implementation project(":aws-geo-location")
     implementation project(":core")
-    implementation dependency.aws.core
+    implementation dependency.aws.signing
     implementation dependency.maplibre.sdk
     implementation dependency.maplibre.annotations
     implementation dependency.okhttp

--- a/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/MapViewTestActivity.kt
+++ b/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/MapViewTestActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -32,9 +32,10 @@ class MapViewTestActivity : AppCompatActivity() {
     internal var auth: SynchronousAuth? = null
 
     private val geo: GeoCategory by lazy {
-        val authCategory = TestCategory.forPlugin(AWSCognitoAuthPlugin()) as AuthCategory
-        auth = SynchronousAuth.delegatingTo(authCategory)
-        TestCategory.forPlugin(AWSLocationGeoPlugin(authProvider = authCategory)) as GeoCategory
+        val awsCognitoAuthPlugin = AWSCognitoAuthPlugin()
+        val authCategory = TestCategory.forPlugin(awsCognitoAuthPlugin) as AuthCategory
+        auth = SynchronousAuth.delegatingToCognito(this, awsCognitoAuthPlugin)
+        TestCategory.forPlugin(AWSLocationGeoPlugin(authCategory = authCategory)) as GeoCategory
     }
 
     internal val mapView: MapLibreView by lazy {

--- a/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/MapViewTestActivityTest.kt
+++ b/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/MapViewTestActivityTest.kt
@@ -24,15 +24,15 @@ import com.amplifyframework.geo.maplibre.view.MapLibreView
 import com.amplifyframework.testutils.sync.SynchronousAuth
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 
 class MapViewTestActivityTest {
 

--- a/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/MapViewTestActivityTest.kt
+++ b/maplibre-adapter/src/androidTest/java/com/amplifyframework/geo/maplibre/MapViewTestActivityTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -24,24 +24,22 @@ import com.amplifyframework.geo.maplibre.view.MapLibreView
 import com.amplifyframework.testutils.sync.SynchronousAuth
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Ignore
+import org.junit.Test
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
-@Ignore("Geo category is not available in dev-preview")
 class MapViewTestActivityTest {
 
     /**
      * Tests that activity can successfully load a map instance.
      */
-//    @Test
-    @Ignore("Geo category is not available in dev-preview")
+    @Test
     fun loadsMapSuccessfully() = runBlocking {
         val scenario = launchActivity<MapViewTestActivity>()
         val map = suspendCoroutine<MapboxMap> { continuation ->
@@ -60,8 +58,7 @@ class MapViewTestActivityTest {
     /**
      * Tests that clustering is enabled by default when setting the style for a map.
      */
-//    @Test
-    @Ignore("Geo category is not available in dev-preview")
+    @Test
     fun enablesClusteringByDefault() = runBlocking {
         val scenario = launchActivity<MapViewTestActivity>()
         val mapStyle = suspendCoroutine<Style> { continuation ->
@@ -83,8 +80,7 @@ class MapViewTestActivityTest {
     /**
      * Tests that clustering can be enabled and clustering options passed in for the map.
      */
-//    @Test
-    @Ignore("Geo category is not available in dev-preview")
+    @Test
     fun clusteringCanBeEnabledWithOptions() = runBlocking {
         val clusteringOptions = ClusteringOptions.builder().clusterColor(Color.RED).build()
         val scenario = launchActivity<MapViewTestActivity>()
@@ -109,8 +105,7 @@ class MapViewTestActivityTest {
     /**
      * Tests that clustering can be enabled for the map without passing in clustering options.
      */
-//    @Test
-    @Ignore("Geo category is not available in dev-preview")
+    @Test
     fun clusteringCanBeEnabledWithoutOptions() = runBlocking {
         val scenario = launchActivity<MapViewTestActivity>()
         val mapStyle = suspendCoroutine<Style> { continuation ->
@@ -134,8 +129,7 @@ class MapViewTestActivityTest {
     /**
      * Tests that clustering can be disabled for the map.
      */
-//    @Test
-    @Ignore("Geo category is not available in dev-preview")
+    @Test
     fun clusteringCanBeDisabled(): Unit = runBlocking {
         val scenario = launchActivity<MapViewTestActivity>()
         val mapStyle = suspendCoroutine<Style> { continuation ->

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/http/AWSRequestSignerInterceptor.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/http/AWSRequestSignerInterceptor.kt
@@ -17,11 +17,14 @@ package com.amplifyframework.geo.maplibre.http
 
 import aws.sdk.kotlin.runtime.auth.signing.AwsSigningConfig
 import aws.sdk.kotlin.runtime.auth.signing.sign
+import aws.smithy.kotlin.runtime.http.Headers as AwsHeaders
 import aws.smithy.kotlin.runtime.http.HttpMethod
 import aws.smithy.kotlin.runtime.http.Url
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import com.amplifyframework.geo.location.AWSLocationGeoPlugin
+import java.io.ByteArrayOutputStream
+import java.io.IOException
 import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
@@ -29,9 +32,6 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
 import okio.Buffer
-import java.io.ByteArrayOutputStream
-import java.io.IOException
-import aws.smithy.kotlin.runtime.http.Headers as AwsHeaders
 
 const val AMAZON_HOST = "amazonaws.com"
 
@@ -80,8 +80,8 @@ internal class AWSRequestSignerInterceptor(
     private fun signRequest(request: Request): HttpRequest {
         val url = request.url
         val headers: AwsHeaders = AwsHeaders.invoke {
-            request.headers.names().forEach { headerName ->
-                request.header(headerName)?.let { set(headerName, it) }
+            request.headers.forEach { (name, value) ->
+                setMissing(name, value)
             }
             set("Host", request.url.host)
         }

--- a/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/http/AWSRequestSignerInterceptor.kt
+++ b/maplibre-adapter/src/main/java/com/amplifyframework/geo/maplibre/http/AWSRequestSignerInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,34 +15,23 @@
 
 package com.amplifyframework.geo.maplibre.http
 
-import com.amazonaws.DefaultRequest
-import com.amazonaws.http.HttpMethodName
-import com.amazonaws.util.IOUtils
+import aws.sdk.kotlin.runtime.auth.signing.AwsSigningConfig
+import aws.sdk.kotlin.runtime.auth.signing.sign
+import aws.smithy.kotlin.runtime.http.HttpMethod
+import aws.smithy.kotlin.runtime.http.Url
+import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import com.amplifyframework.geo.location.AWSLocationGeoPlugin
-import java.io.ByteArrayInputStream
-import java.net.URI
+import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import okio.Buffer
-
-private typealias AWSRequest = com.amazonaws.Request<Any>
-
-private fun Request.Builder.copyFrom(request: AWSRequest): Request.Builder {
-    val urlBuilder = HttpUrl.Builder()
-        .host(request.endpoint.host)
-        .scheme(request.endpoint.scheme)
-        .encodedPath(request.encodedUriResourcePath)
-
-    request.parameters.forEach { (name, value) ->
-        urlBuilder.setQueryParameter(name, value)
-    }
-    request.headers.forEach { (name, value) ->
-        this.header(name, value)
-    }
-    return this.url(urlBuilder.build())
-}
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import aws.smithy.kotlin.runtime.http.Headers as AwsHeaders
 
 const val AMAZON_HOST = "amazonaws.com"
 
@@ -69,27 +58,76 @@ internal class AWSRequestSignerInterceptor(
         return chain.proceed(signedRequest)
     }
 
-    private fun signRequest(request: Request): DefaultRequest<Any> {
-        // read request content
-        val body = request.body?.let {
-            val buffer = Buffer()
-            it.writeTo(buffer)
-            IOUtils.toByteArray(buffer.inputStream())
-        } ?: ByteArray(0)
+    private fun Request.Builder.copyFrom(request: HttpRequest): Request.Builder {
+        val urlBuilder = HttpUrl.Builder()
+            .host(request.url.host)
+            .scheme(request.url.scheme.protocolName)
+            .encodedPath(request.url.encodedPath)
+
+        request.url.parameters.forEach { name, parameters ->
+            parameters.forEach {
+                urlBuilder.setQueryParameter(name, it)
+            }
+        }
+        request.headers.forEach { name, values ->
+            values.forEach {
+                this.header(name, it)
+            }
+        }
+        return this.url(urlBuilder.build())
+    }
+
+    private fun signRequest(request: Request): HttpRequest {
+        val url = request.url
+        val headers: AwsHeaders = AwsHeaders.invoke {
+            request.headers.names().forEach { headerName ->
+                request.header(headerName)?.let { set(headerName, it) }
+            }
+            set("Host", request.url.host)
+        }
 
         val client = plugin.escapeHatch
-        val url = request.url
-        val awsRequest = DefaultRequest<Any>(client.serviceName)
-        awsRequest.setEncodedResourcePath(request.url.encodedPath)
-        awsRequest.parameters = url.queryParameterNames.associateWith { url.queryParameter(it) }
-        awsRequest.endpoint = URI.create("${url.scheme}://${url.host}")
-        awsRequest.httpMethod = HttpMethodName.valueOf(request.method.uppercase())
-        awsRequest.content = ByteArrayInputStream(body)
-        awsRequest.headers = request.headers.associate { (name, value) -> name to value }
+        val signingConfig = AwsSigningConfig.invoke {
+            region = client.config.region
+            service = client.serviceName
+            credentialsProvider = plugin.credentialsProvider
+        }
 
-        // sign request with AWS Signer for the underlying service
-        val signer = client.getSignerByURI(awsRequest.endpoint)
-        signer.sign(awsRequest, plugin.credentialsProvider.credentials)
+        // set the request body
+        val bodyBytes: ByteArray = getBytes(request.body)
+        val body2 = ByteArrayContent(bodyBytes)
+        val method = HttpMethod.parse(request.method)
+        val awsRequest = HttpRequest(method, Url.parse(url.toString()), headers, body2)
+
+        runBlocking {
+            // sign request with AWS Signer for the underlying service
+            sign(awsRequest, signingConfig)
+        }
         return awsRequest
+    }
+
+    private fun getBytes(body: RequestBody?): ByteArray {
+        if (body == null) {
+            return "".toByteArray()
+        }
+        val BUFFER_SIZE = 1024 * 4
+        try {
+            ByteArrayOutputStream().use { output ->
+                // write the body to a byte array.
+                val buffer = Buffer()
+                body.writeTo(buffer)
+                val bytes = ByteArray(BUFFER_SIZE)
+                var n: Int
+                while (buffer.inputStream().read(bytes).also { n = it } != -1) {
+                    output.write(bytes, 0, n)
+                }
+                return output.toByteArray()
+            }
+        } catch (exception: IOException) {
+            throw Exception(
+                "Unable to calculate SigV4 signature for the request",
+                exception
+            )
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replace `aws-android-sdk-location` with `aws.sdk.kotlin:location` as a dependency for `Geo` category and `maplibre-adapter` module.

Note: These changes are just refactoring of existing code to migrate from Java based dependencies to Kotlin. The existing API's and behaviors are left intact.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [x] Enabled previously ignored Instrumentation tests.
- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
