### PR TITLE
Fix/1485 : Fix for sending the session expired hub event when all credentials are expired

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java
@@ -590,6 +590,10 @@ public final class AWSCognitoAuthPlugin extends AuthPlugin<AWSMobileClient> {
                             break;
                         case SIGNED_OUT_FEDERATED_TOKENS_INVALID:
                         case SIGNED_OUT_USER_POOLS_TOKENS_INVALID:
+                            Amplify.Hub.publish(
+                                    HubChannel.AUTH,
+                                    HubEvent.create(AuthChannelEventName.SESSION_EXPIRED)
+                            );
                             onSuccess.accept(expiredSession());
                             break;
                         default:

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -371,6 +371,23 @@ class KotlinAuthFacadeTest {
     }
 
     /**
+     * When the fetchAuthSession() delegate emits an error, it should
+     * be surfaced by the coroutine API, too.
+     */
+    @Test(expected = AuthException.SessionExpiredException::class)
+    fun fetchAuthSessionThrowsSessionExpired(): Unit = runBlocking {
+        val error = AuthException.SessionExpiredException() as AuthException
+        every {
+            delegate.fetchAuthSession(any(), any())
+        } answers {
+            val indexOfErrorConsumer = 1
+            val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
+            onError.accept(error)
+        }
+        auth.fetchAuthSession()
+    }
+
+    /**
      * When rememberDevice() coroutine is called, it should pass through to the
      * delegate. If the delegate succeeds, so should the coroutine.
      */


### PR DESCRIPTION


*Issue #, if available: 1485*

*Description of changes:*

Added a hub event when the session is expired and user is signed in.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ x] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ x] Successful logs (Attach them to the PR)
`2022-06-15 03:53:44.971 13225-13225/com.example.myapplication I/Tutorial: Initialized Amplify
2022-06-15 03:53:45.081 13225-13264/com.example.myapplication I/Tutorial: Auth session just expired
2022-06-15 03:53:45.082 13225-13287/com.example.myapplication I/Tutorial: Auth session = AWSCognitoAuthSession{isSignedIn=true, awsCredentials=AuthSessionResult{value=null, error=SessionExpiredException{message=Your session has expired., cause=null, recoverySuggestion=Please sign in and reattempt the operation.}, type=FAILURE}, userSub='AuthSessionResult{value=null, error=SessionExpiredException{message=Your session has expired., cause=null, recoverySuggestion=Please sign in and reattempt the operation.}, type=FAILURE}', identityId='AuthSessionResult{value=null, error=SessionExpiredException{message=Your session has expired., cause=null, recoverySuggestion=Please sign in and reattempt the operation.}, type=FAILURE}', userPoolTokens='AuthSessionResult{value=null, error=SessionExpiredException{message=Your session has expired., cause=null, recoverySuggestion=Please sign in and reattempt the operation.}, type=FAILURE}'}
2022-06-15 03:53:45.083 13225-13288/com.example.myapplication I/Tutorial: onResult: SIGNED_IN
2022-06-15 03:53:45.086 13225-13289/com.example.myapplication D/Tutorial1: SIGNED_IN`

*Documentation update required?*
- [x ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
