### PR TITLE
Suppress belongsto index

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandFactory.java
@@ -49,6 +49,16 @@ interface SQLCommandFactory {
     Set<SqlCommand> createIndexesFor(@NonNull ModelSchema modelSchema);
 
     /**
+     * Generates the set of CREATE INDEX SQL commands for foreign keys from the {@link ModelSchema}.
+     * @param modelSchema the schema of a {@link com.amplifyframework.core.model.Model}
+     *                    for which a CREATE INDEX SQL command needs to be generated.
+     * @return the set of CREATE INDEX SQL commands
+     */
+    @NonNull
+    Set<SqlCommand> createIndexesForForeignKeys(@NonNull ModelSchema modelSchema);
+
+
+    /**
      * Generates the QUERY command in a raw string representation from
      * the {@link ModelSchema}.
      *

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -123,10 +123,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
         Set<SqlCommand> indexCommands = new HashSet<>();
         for (SQLiteColumn foreignKey : table.getForeignKeys()) {
-            String connectedType = foreignKey.getOwnedType();
-            ModelSchema connectedSchema = schemaRegistry.getModelSchemaForModelClass(connectedType);
-            String connectedId = getIdField(connectedSchema.getPrimaryIndexFields(),
-                    connectedSchema.getModelType());
+            String connectedId = foreignKey.getName();
             String fkIndexName = table.getName() + connectedId;
             indexCommands.add(createIndexCommand(table.getName(),
                     fkIndexName, Collections.singletonList(connectedId)));
@@ -638,9 +635,10 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         for (Map.Entry<String, ModelAssociation> associationEntry : associationMap.entrySet()) {
             if (associationEntry.getValue().isOwner()) {
                 for (String targetName : associationEntry.getValue().getTargetNames()) {
-                    return !modelIndex.getIndexFieldNames().contains(targetName);
+                    if (modelIndex.getIndexFieldNames().contains(targetName)) {
+                        return false;
+                    }
                 }
-                return false;
             }
         }
         return true;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -18,6 +18,7 @@ package com.amplifyframework.datastore.storage.sqlite;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelAssociation;
 import com.amplifyframework.core.model.ModelField;
 import com.amplifyframework.core.model.ModelIndex;
 import com.amplifyframework.core.model.ModelSchema;
@@ -42,6 +43,7 @@ import com.amplifyframework.util.Wrap;
 import com.google.gson.Gson;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -108,32 +110,56 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
         Set<SqlCommand> indexCommands = new HashSet<>();
         for (ModelIndex modelIndex : modelSchema.getIndexes().values()) {
-            if (shouldCreateIndex(modelIndex)) {
-                final StringBuilder stringBuilder = new StringBuilder();
-                stringBuilder.append("CREATE INDEX IF NOT EXISTS")
-                        .append(SqlKeyword.DELIMITER)
-                        .append(Wrap.inBackticks(getIndexName(modelIndex.getIndexName(),
-                                modelIndex.getIndexFieldNames())))
-                        .append(SqlKeyword.DELIMITER)
-                        .append(SqlKeyword.ON)
-                        .append(SqlKeyword.DELIMITER)
-                        .append(Wrap.inBackticks(table.getName()))
-                        .append(SqlKeyword.DELIMITER);
-
-                stringBuilder.append("(");
-                Iterator<String> iterator = modelIndex.getIndexFieldNames().iterator();
-                while (iterator.hasNext()) {
-                    final String indexColumnName = iterator.next();
-                    stringBuilder.append(Wrap.inBackticks(indexColumnName));
-                    if (iterator.hasNext()) {
-                        stringBuilder.append(",").append(SqlKeyword.DELIMITER);
-                    }
-                }
-                stringBuilder.append(");");
-                indexCommands.add(new SqlCommand(table.getName(), stringBuilder.toString()));
+            if (shouldCreateIndex(modelIndex, modelSchema.getAssociations())) {
+                indexCommands.add(createIndexCommand(table.getName(), modelIndex.getIndexName(),
+                        modelIndex.getIndexFieldNames()));
             }
         }
         return Immutable.of(indexCommands);
+    }
+
+    @NonNull
+    public Set<SqlCommand> createIndexesForForeignKeys(@NonNull ModelSchema modelSchema) {
+        final SQLiteTable table = SQLiteTable.fromSchema(modelSchema);
+        Set<SqlCommand> indexCommands = new HashSet<>();
+        for (SQLiteColumn foreignKey : table.getForeignKeys()) {
+            String connectedType = foreignKey.getOwnedType();
+            ModelSchema connectedSchema = schemaRegistry.getModelSchemaForModelClass(connectedType);
+            String connectedId = getIdField(connectedSchema.getPrimaryIndexFields(),
+                    connectedSchema.getModelType());
+            String fkIndexName = table.getName() + connectedId;
+            indexCommands.add(createIndexCommand(table.getName(),
+                    fkIndexName, Collections.singletonList(connectedId)));
+        }
+        return Immutable.of(indexCommands);
+    }
+
+    @NonNull
+    private SqlCommand createIndexCommand(String tableName,
+                                          String indexName,
+                                          List<String> indexFieldNames) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("CREATE INDEX IF NOT EXISTS")
+                .append(SqlKeyword.DELIMITER)
+                .append(Wrap.inBackticks(getIndexName(indexName,
+                        indexFieldNames)))
+                .append(SqlKeyword.DELIMITER)
+                .append(SqlKeyword.ON)
+                .append(SqlKeyword.DELIMITER)
+                .append(Wrap.inBackticks(tableName))
+                .append(SqlKeyword.DELIMITER);
+
+        stringBuilder.append("(");
+        Iterator<String> iterator = indexFieldNames.iterator();
+        while (iterator.hasNext()) {
+            final String indexColumnName = iterator.next();
+            stringBuilder.append(Wrap.inBackticks(indexColumnName));
+            if (iterator.hasNext()) {
+                stringBuilder.append(",").append(SqlKeyword.DELIMITER);
+            }
+        }
+        stringBuilder.append(");");
+        return new SqlCommand(tableName, stringBuilder.toString());
     }
 
     @NonNull
@@ -605,9 +631,17 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         return builder;
     }
 
-    private boolean shouldCreateIndex(ModelIndex modelIndex) {
+    private boolean shouldCreateIndex(ModelIndex modelIndex, Map<String, ModelAssociation> associationMap) {
         if (modelIndex.getIndexName().equals(UNDEFINED) && modelIndex.getIndexFieldNames().size() == 1) {
             return false;
+        }
+        for (Map.Entry<String, ModelAssociation> associationEntry : associationMap.entrySet()) {
+            if (associationEntry.getValue().isOwner()) {
+                for (String targetName : associationEntry.getValue().getTargetNames()) {
+                   return !modelIndex.getIndexFieldNames().contains(targetName);
+                }
+                return false;
+            }
         }
         return true;
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -638,7 +638,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
         for (Map.Entry<String, ModelAssociation> associationEntry : associationMap.entrySet()) {
             if (associationEntry.getValue().isOwner()) {
                 for (String targetName : associationEntry.getValue().getTargetNames()) {
-                   return !modelIndex.getIndexFieldNames().contains(targetName);
+                    return !modelIndex.getIndexFieldNames().contains(targetName);
                 }
                 return false;
             }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -747,6 +747,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                 schemaRegistry.getModelSchemaForModelClass(modelName);
             createTableCommands.add(sqlCommandFactory.createTableFor(modelSchema));
             createIndexCommands.addAll(sqlCommandFactory.createIndexesFor(modelSchema));
+            createIndexCommands.addAll(sqlCommandFactory.createIndexesForForeignKeys(modelSchema));
         }
         return new CreateSqlCommands(createTableCommands, createIndexCommands);
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/adapter/SQLiteTable.java
@@ -122,7 +122,7 @@ public final class SQLiteTable {
                             ? association.getAssociatedType()
                             : null)
                     .ownerField(isAssociated
-                            ? association.getAssociatedName()
+                            ? modelField.getName()
                             : null)
                     .isNonNull(modelField.isRequired())
                     .dataType(sqlTypeFromModelField(modelField))

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -143,8 +143,8 @@ final class MutationProcessor {
                                     .andThen(merger.merge(modelWithMetadata))
                                     .andThen(Completable
                                             .fromRunnable(() -> {
-                                                announceMutationProcessed(mutationOutboxItem.getModelSchema().getName()
-                                                        , modelWithMetadata);
+                                                announceMutationProcessed(mutationOutboxItem.getModelSchema().getName(),
+                                                        modelWithMetadata);
                                             }))
                                     .doOnComplete(() -> {
                                         String modelName = mutationOutboxItem.getModelSchema().getName();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -140,16 +140,16 @@ final class MutationProcessor {
                             // This is done before merging, because the merger will refuse to merge
                             // if there are outstanding mutations in the outbox.
                             mutationOutbox.remove(mutationOutboxItem.getMutationId())
-                                    .andThen(merger.merge(modelWithMetadata))
-                                    .andThen(Completable
-                                            .fromRunnable(() -> {
-                                                announceMutationProcessed(mutationOutboxItem.getModelSchema().getName(),
-                                                        modelWithMetadata);
-                                            }))
-                                    .doOnComplete(() -> {
-                                        String modelName = mutationOutboxItem.getModelSchema().getName();
-                                        announceMutationProcessed(modelName, modelWithMetadata);
-                                    })
+                                .andThen(merger.merge(modelWithMetadata))
+                                .andThen(Completable
+                                        .fromRunnable(() -> {
+                                            announceMutationProcessed(mutationOutboxItem.getModelSchema().getName(),
+                                                    modelWithMetadata);
+                                        }))
+                                .doOnComplete(() -> {
+                                    String modelName = mutationOutboxItem.getModelSchema().getName();
+                                    announceMutationProcessed(modelName, modelWithMetadata);
+                                })
                 )
             )
             .doOnComplete(() -> {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -174,8 +175,13 @@ public class SQLCommandProcessorTest {
      */
     @Test
     public void testIndexNotCreatedWhenFieldsInBelongsTo() throws AmplifyException {
-        ModelSchema blogOwnerSchema = ModelSchema.fromModelClass(Comment.class);
-        sqlCommandFactory.createIndexesFor(blogOwnerSchema);
-        assertEquals(1, sqlCommandFactory.createIndexesFor(blogOwnerSchema).size());
+        ModelSchema commentSchema = ModelSchema.fromModelClass(Comment.class);
+        sqlCommandFactory.createIndexesFor(commentSchema);
+        Set<SqlCommand> sqlCommands = sqlCommandFactory.createIndexesFor(commentSchema);
+        assertEquals(1, sqlCommands.size());
+        String sqlCommand = sqlCommands.iterator().next().sqlStatement();
+        assertTrue(sqlCommand.contains("CREATE INDEX IF NOT EXISTS" +
+                " `undefined_title_content_likes` ON `Comment` (`title`, `content`, `likes`);"));
+        assertFalse(sqlCommand.contains("`postCommentsId`, `content`"));
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
@@ -26,6 +26,7 @@ import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
+import com.amplifyframework.testmodels.customprimarykey.Comment;
 import com.amplifyframework.util.GsonFactory;
 
 import com.google.gson.Gson;
@@ -165,5 +166,16 @@ public class SQLCommandProcessorTest {
         QueryPredicate predicate = BlogOwner.ID.eq(abigailMcGregor.getId());
         SqlCommand existsCommand = sqlCommandFactory.existsFor(blogOwnerSchema, predicate);
         assertFalse(sqlCommandProcessor.executeExists(existsCommand));
+    }
+
+    /**
+     * Create a BlogOwner, but don't insert it.  Then verify that executeExists returns false.
+     * @throws AmplifyException on failure to create ModelSchema from class.
+     */
+    @Test
+    public void testIndexNotCreatedWhenFieldsInBelongsTo() throws AmplifyException {
+        ModelSchema blogOwnerSchema = ModelSchema.fromModelClass(Comment.class);
+        sqlCommandFactory.createIndexesFor(blogOwnerSchema);
+        assertEquals(1, sqlCommandFactory.createIndexesFor(blogOwnerSchema).size());
     }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
@@ -184,4 +184,21 @@ public class SQLCommandProcessorTest {
                 " `undefined_title_content_likes` ON `Comment` (`title`, `content`, `likes`);"));
         assertFalse(sqlCommand.contains("`postCommentsId`, `content`"));
     }
+
+
+    /**
+     * Verify that index for foreign key fields is included in the commands.
+     * @throws AmplifyException on failure to create ModelSchema from class.
+     */
+    @Test
+    public void testForeignKeyIndexCreated() throws AmplifyException {
+        ModelSchema commentSchema = ModelSchema.fromModelClass(Comment.class);
+        sqlCommandFactory.createIndexesFor(commentSchema);
+        Set<SqlCommand> sqlCommands = sqlCommandFactory.createIndexesForForeignKeys(commentSchema);
+        assertEquals(1, sqlCommands.size());
+        String sqlCommand = sqlCommands.iterator().next().sqlStatement();
+        assertTrue(sqlCommand.contains("CREATE INDEX IF NOT EXISTS `Comment@@postForeignKey` " +
+                "ON `Comment` (`@@postForeignKey`);"));
+
+    }
 }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/sqlite/SQLCommandProcessorTest.java
@@ -170,7 +170,7 @@ public class SQLCommandProcessorTest {
     }
 
     /**
-     * Create a BlogOwner, but don't insert it.  Then verify that executeExists returns false.
+     * Verify that index for fields included in belongs to is not created for Comments.
      * @throws AmplifyException on failure to create ModelSchema from class.
      */
     @Test

--- a/core/src/main/java/com/amplifyframework/core/model/annotations/ModelConfig.java
+++ b/core/src/main/java/com/amplifyframework/core/model/annotations/ModelConfig.java
@@ -64,7 +64,7 @@ public @interface ModelConfig {
      * Model Type SYSTEM or USER.
      * @return Type of Model.
      */
-    Model.Type type() default Model.Type.SYSTEM;
+    Model.Type type() default Model.Type.USER;
 
     /**
      * Model Version.

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/customprimarykey/Comment.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/customprimarykey/Comment.java
@@ -19,6 +19,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "Comments", type = Model.Type.USER, version = 1)
 @Index(name = "undefined", fields = {"title","content","likes"})
+@Index(name = "byPost", fields = {"postCommentsId", "postCommentTitle"})
+
 public final class Comment implements Model {
   public static final QueryField POST = field("Comment", "postCommentsId");
   public static final QueryField TITLE = field("Comment", "title");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Suppress creation of index based on @index annotation when the index fields occur in belongs to association as there is an index created on foreign key already.
*How did you test these changes?*
(Please add a line here how the changes were tested)

- [X ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
