### PR TITLE
feat: Add flushEvents HubEvent for analytics

### DIFF
--- a/aws-analytics-pinpoint/build.gradle
+++ b/aws-analytics-pinpoint/build.gradle
@@ -16,6 +16,8 @@
 apply plugin: 'com.android.library'
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
+apply plugin: 'kotlin-android'
+apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 dependencies {
     implementation project(path: ':core')

--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
@@ -54,7 +54,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
@@ -168,7 +168,7 @@ public class AnalyticsPinpointInstrumentedTest {
      *
      */
     @Test
-    public void testFlushEvent() {
+    public void testFlushEventHubEvent() {
         HubAccumulator analyticsHubEventAccumulator =
             HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsHubEventNames.FLUSH_EVENTS, 1)
                 .start();
@@ -195,17 +195,16 @@ public class AnalyticsPinpointInstrumentedTest {
         assertEquals(2, analyticsClient.getAllEvents().size());
         Amplify.Analytics.flushEvents();
         waitForAutoFlush(analyticsClient);
+
         HubEvent<?> hubEvent = analyticsHubEventAccumulator.awaitFirst();
         List<?> hubEventData = (List<?>) hubEvent.getData();
-        LOG.debug("Events in database after calling submitEvents() after submitting: " +
-                analyticsClient.getAllEvents().size());
+        assertEquals(AnalyticsHubEventNames.FLUSH_EVENTS.getEventName(), hubEvent.getName());
         assertEquals(eventName1, ((com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent) hubEventData.
             get(0)).
             getEventType());
         assertEquals(eventName2, ((com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent) hubEventData.
             get(1)).
             getEventType());
-        assertEquals(0, analyticsClient.getAllEvents().size());
     }
 
     /**

--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
@@ -170,7 +170,7 @@ public class AnalyticsPinpointInstrumentedTest {
     @Test
     public void testFlushEventHubEvent() {
         HubAccumulator analyticsHubEventAccumulator =
-            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsHubEventNames.FLUSH_EVENTS, 1)
+            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsChannelEventName.FLUSH_EVENTS, 1)
                 .start();
         String eventName1 = "Amplify-event" + UUID.randomUUID().toString();
         AnalyticsEvent event1 = AnalyticsEvent.builder()
@@ -198,7 +198,7 @@ public class AnalyticsPinpointInstrumentedTest {
 
         HubEvent<?> hubEvent = analyticsHubEventAccumulator.awaitFirst();
         List<?> hubEventData = (List<?>) hubEvent.getData();
-        assertEquals(AnalyticsHubEventNames.FLUSH_EVENTS.getEventName(), hubEvent.getName());
+        assertEquals(AnalyticsChannelEventName.FLUSH_EVENTS.getEventName(), hubEvent.getName());
         assertEquals(eventName1, ((com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent) hubEventData.
             get(0)).
             getEventType());

--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/AnalyticsPinpointInstrumentedTest.java
@@ -25,7 +25,10 @@ import com.amplifyframework.analytics.AnalyticsProperties;
 import com.amplifyframework.analytics.UserProfile;
 import com.amplifyframework.analytics.pinpoint.models.AWSPinpointUserProfile;
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.logging.Logger;
+import com.amplifyframework.testutils.HubAccumulator;
 import com.amplifyframework.testutils.Sleep;
 
 import com.amazonaws.mobile.client.AWSMobileClient;
@@ -51,13 +54,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 /**
  * Validates the functionality of the {@link AWSPinpointAnalyticsPlugin}.
  */
+
 public class AnalyticsPinpointInstrumentedTest {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-analytics");
 
@@ -161,16 +165,61 @@ public class AnalyticsPinpointInstrumentedTest {
     }
 
     /**
+     * Record a basic analytics event and test that events are flushed from local database by calling submitEvents.
+     *
+     */
+    @Test
+    public void testFlushEvent() {
+        HubAccumulator analyticsHubEventAccumulator =
+            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsHubEventNames.FLUSH_EVENTS, 1)
+                .start();
+        String eventName1 = "Amplify-event" + UUID.randomUUID().toString();
+        AnalyticsEvent event1 = AnalyticsEvent.builder()
+                .name(eventName1)
+                .addProperty("DemoProperty1", "DemoValue1")
+                .addProperty("DemoDoubleProperty2", 2.0)
+                .build();
+
+        Amplify.Analytics.recordEvent(event1);
+        assertEquals(1, analyticsClient.getAllEvents().size());
+
+        String eventName2 = "Amplify-event" + UUID.randomUUID().toString();
+
+        AnalyticsEvent event2 = AnalyticsEvent.builder()
+                .name(eventName2)
+                .addProperty("DemoProperty1", "DemoValue1")
+                .addProperty("DemoProperty2", 2.0)
+                .build();
+
+        Amplify.Analytics.recordEvent(event2);
+
+        assertEquals(2, analyticsClient.getAllEvents().size());
+        Amplify.Analytics.flushEvents();
+        waitForAutoFlush(analyticsClient);
+        HubEvent<?> hubEvent = analyticsHubEventAccumulator.awaitFirst();
+        List<?> hubEventData = (List<?>) hubEvent.getData();
+        LOG.debug("Events in database after calling submitEvents() after submitting: " +
+                analyticsClient.getAllEvents().size());
+        assertEquals(eventName1, ((com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent) hubEventData.
+            get(0)).
+            getEventType());
+        assertEquals(eventName2, ((com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent) hubEventData.
+            get(1)).
+            getEventType());
+        assertEquals(0, analyticsClient.getAllEvents().size());
+    }
+
+    /**
      * Record a basic analytics event and test that events are flushed from local database periodically.
      *
      */
     @Test
     public void testAutoFlush() {
         AnalyticsEvent event1 = AnalyticsEvent.builder()
-                .name("Amplify-event" + UUID.randomUUID().toString())
-                .addProperty("DemoProperty1", "DemoValue1")
-                .addProperty("DemoDoubleProperty2", 2.0)
-                .build();
+            .name("Amplify-event" + UUID.randomUUID().toString())
+            .addProperty("DemoProperty1", "DemoValue1")
+            .addProperty("DemoDoubleProperty2", 2.0)
+            .build();
 
         Amplify.Analytics.recordEvent(event1);
 
@@ -179,15 +228,15 @@ public class AnalyticsPinpointInstrumentedTest {
         waitForAutoFlush(analyticsClient);
 
         LOG.debug("Events in database after calling submitEvents() after submitting: " +
-                analyticsClient.getAllEvents().size());
+            analyticsClient.getAllEvents().size());
 
         assertEquals(0, analyticsClient.getAllEvents().size());
 
         AnalyticsEvent event2 = AnalyticsEvent.builder()
-                .name("Amplify-event" + UUID.randomUUID().toString())
-                .addProperty("DemoProperty1", "DemoValue1")
-                .addProperty("DemoProperty2", 2.0)
-                .build();
+            .name("Amplify-event" + UUID.randomUUID().toString())
+            .addProperty("DemoProperty1", "DemoValue1")
+            .addProperty("DemoProperty2", 2.0)
+            .build();
 
         Amplify.Analytics.recordEvent(event2);
 
@@ -196,10 +245,11 @@ public class AnalyticsPinpointInstrumentedTest {
         waitForAutoFlush(analyticsClient);
 
         LOG.debug("Events in database after calling submitEvents() after submitting: " +
-                analyticsClient.getAllEvents().size());
+            analyticsClient.getAllEvents().size());
 
         assertEquals(0, analyticsClient.getAllEvents().size());
     }
+
 
     /**
      * Registers a global property and ensures that all recorded events have the global property.

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
@@ -331,7 +331,7 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
     public void flushEvents() {
         analyticsClient.submitEvents(analyticsEvents ->
                 Amplify.Hub.publish(HubChannel.ANALYTICS, HubEvent
-                    .create(AnalyticsHubEventNames.FLUSH_EVENTS, analyticsEvents)),
+                    .create(AnalyticsChannelEventName.FLUSH_EVENTS, analyticsEvents)),
             e -> {
                 LOG.error("Failed to flush events", e);
             }
@@ -419,8 +419,7 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
         this.targetingClient = pinpointManager.getTargetingClient();
 
         // Initiate the logic to automatically submit events periodically
-        autoEventSubmitter = new AutoEventSubmitter(analyticsClient,
-                pinpointAnalyticsPluginConfiguration.getAutoFlushEventsInterval());
+        autoEventSubmitter = new AutoEventSubmitter(pinpointAnalyticsPluginConfiguration.getAutoFlushEventsInterval());
         autoEventSubmitter.start();
 
         // Instantiate the logic to automatically track app session

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
@@ -36,6 +36,7 @@ import com.amplifyframework.analytics.pinpoint.models.AWSPinpointUserProfile;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
+import com.amplifyframework.logging.Logger;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.mobile.client.AWSMobileClient;
@@ -59,6 +60,12 @@ import java.util.Objects;
  * The plugin implementation for Amazon Pinpoint in Analytics category.
  */
 public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
+
+    /**
+     * logger for Analytics category.
+     */
+    protected static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-analytics");
+
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
             USER_NAME,
@@ -325,7 +332,9 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
         analyticsClient.submitEvents(analyticsEvents ->
                 Amplify.Hub.publish(HubChannel.ANALYTICS, HubEvent
                     .create(AnalyticsHubEventNames.FLUSH_EVENTS, analyticsEvents)),
-            e -> { }
+            e -> {
+                LOG.error("Failed to flush events", e);
+            }
         );
     }
 

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.java
@@ -34,6 +34,8 @@ import com.amplifyframework.analytics.AnalyticsStringProperty;
 import com.amplifyframework.analytics.UserProfile;
 import com.amplifyframework.analytics.pinpoint.models.AWSPinpointUserProfile;
 import com.amplifyframework.core.Amplify;
+import com.amplifyframework.hub.HubChannel;
+import com.amplifyframework.hub.HubEvent;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.mobile.client.AWSMobileClient;
@@ -320,7 +322,11 @@ public final class AWSPinpointAnalyticsPlugin extends AnalyticsPlugin<Object> {
 
     @Override
     public void flushEvents() {
-        analyticsClient.submitEvents();
+        analyticsClient.submitEvents(analyticsEvents ->
+                Amplify.Hub.publish(HubChannel.ANALYTICS, HubEvent
+                    .create(AnalyticsHubEventNames.FLUSH_EVENTS, analyticsEvents)),
+            e -> { }
+        );
     }
 
     @NonNull

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AnalyticsChannelEventName.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AnalyticsChannelEventName.kt
@@ -19,7 +19,7 @@ package com.amplifyframework.analytics.pinpoint
  * that are published via {@link HubCategory#publish(HubChannel, HubEvent)} on the
  * {@link HubChannel#ANALYTICS} channel.
  */
-enum class AnalyticsHubEventNames(val eventName: String) {
+enum class AnalyticsChannelEventName(val eventName: String) {
     /**
      * Event sent out on submitEventWithResults with the list of all the event
      * successfully submitted

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AnalyticsHubEventNames.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AnalyticsHubEventNames.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.analytics.pinpoint
+
+/**
+ * An enumeration of the names of events relating the {@link AnalyticsCategory},
+ * that are published via {@link HubCategory#publish(HubChannel, HubEvent)} on the
+ * {@link HubChannel#ANALYTICS} channel.
+ */
+enum class AnalyticsHubEventNames(val eventName: String) {
+    /**
+     * Event sent out on submitEventWithResults with the list of all the event
+     * successfully submitted
+     */
+    FLUSH_EVENTS("flushEvents");
+
+    override fun toString(): String {
+        return eventName
+    }
+}

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AutoEventSubmitter.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AutoEventSubmitter.java
@@ -20,8 +20,6 @@ import android.os.HandlerThread;
 
 import com.amplifyframework.core.Amplify;
 
-import com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsClient;
-
 import java.util.Locale;
 
 /**
@@ -33,7 +31,7 @@ final class AutoEventSubmitter {
     private Runnable submitRunnable;
     private final long autoFlushInterval;
 
-    AutoEventSubmitter(final AnalyticsClient analyticsClient, final long autoFlushInterval) {
+    AutoEventSubmitter(final long autoFlushInterval) {
         HandlerThread handlerThread = new HandlerThread("AutoEventSubmitter");
         handlerThread.start();
         this.handler = new Handler(handlerThread.getLooper());

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AutoEventSubmitter.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AutoEventSubmitter.java
@@ -42,7 +42,7 @@ final class AutoEventSubmitter {
         this.autoFlushInterval = autoFlushInterval;
         this.submitRunnable = () -> {
             LOG.debug(String.format(Locale.US, "Auto submitting events after %d seconds", autoFlushInterval));
-            analyticsClient.submitEvents();
+            Amplify.Analytics.flushEvents();
             handler.postDelayed(this.submitRunnable, autoFlushInterval);
         };
     }

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AutoEventSubmitter.java
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AutoEventSubmitter.java
@@ -19,7 +19,6 @@ import android.os.Handler;
 import android.os.HandlerThread;
 
 import com.amplifyframework.core.Amplify;
-import com.amplifyframework.logging.Logger;
 
 import com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsClient;
 
@@ -29,7 +28,6 @@ import java.util.Locale;
  * Submits all the recorded event periodically.
  */
 final class AutoEventSubmitter {
-    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-analytics");
 
     private final Handler handler;
     private Runnable submitRunnable;
@@ -41,7 +39,10 @@ final class AutoEventSubmitter {
         this.handler = new Handler(handlerThread.getLooper());
         this.autoFlushInterval = autoFlushInterval;
         this.submitRunnable = () -> {
-            LOG.debug(String.format(Locale.US, "Auto submitting events after %d seconds", autoFlushInterval));
+            AWSPinpointAnalyticsPlugin.LOG.debug(
+                String.format(Locale.US, "Auto submitting events after %d seconds",
+                    autoFlushInterval)
+            );
             Amplify.Analytics.flushEvents();
             handler.postDelayed(this.submitRunnable, autoFlushInterval);
         };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Send hub events with all the successfully submitted events on flushEvents.
- [PR](https://github.com/aws-amplify/aws-sdk-android/pull/2934) with AWS SDK Changes

*How did you test these changes?*
- Added instrumentation test to assert hub event is send after calling flush events.
- Testing using sample app.

*Documentation update required?*
- [ ] Yes (tbd)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
