### PR TITLE
fix(datastore): Expand a catch to catch a null pointer error

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -190,8 +190,8 @@ final class PersistentMutationOutbox implements MutationOutbox {
                         try {
                             PendingMutation.PersistentRecord persistentRecord = results.next();
                             mutationQueue.add(converter.fromRecord(persistentRecord));
-                        } catch (DataStoreException conversionFailure) {
-                            emitter.onError(conversionFailure);
+                        } catch (Throwable throwable) {
+                            emitter.onError(throwable);
                             return;
                         }
                     }


### PR DESCRIPTION
This was throwing a null pointer which got
silently eaten up by RxJava.

- [x ] PR title and description conform to [Pull 
Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

Expanded a catch clause that was swallowing a null pointer error.  RxJava will silently eat unchecked 
exceptions 😱

*How did you test these changes?*
(Please add a line here how the changes were tested)

Manual testing in debugger confirmed we could see the NPE

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [x ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
