### PR TITLE
feat(auth):Make Current user an Asynchronous call (Breaking change)

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/CognitoUserPoolsAuthProvider.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/CognitoUserPoolsAuthProvider.java
@@ -33,6 +33,8 @@ public interface CognitoUserPoolsAuthProvider {
     /**
      * Returns the currently logged in user's name from local cache.
      * @return the currently logged in user's name or null if not available
+     * @throws ApiException in case the operation was interrupted by a different thread
+     * or there is a problem retrieving the username
      */
     String getUsername() throws ApiException;
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/CognitoUserPoolsAuthProvider.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/CognitoUserPoolsAuthProvider.java
@@ -34,5 +34,5 @@ public interface CognitoUserPoolsAuthProvider {
      * Returns the currently logged in user's name from local cache.
      * @return the currently logged in user's name or null if not available
      */
-    String getUsername();
+    String getUsername() throws ApiException;
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/DefaultCognitoUserPoolsAuthProvider.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/DefaultCognitoUserPoolsAuthProvider.java
@@ -15,16 +15,12 @@
 
 package com.amplifyframework.api.aws.sigv4;
 
-import androidx.annotation.NonNull;
-
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiException.ApiAuthException;
 import com.amplifyframework.api.aws.auth.CognitoCredentialsProvider;
-import com.amplifyframework.auth.AuthException;
 import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.core.Amplify;
-import com.amplifyframework.core.Consumer;
 
 import java.util.concurrent.Semaphore;
 
@@ -96,7 +92,7 @@ public final class DefaultCognitoUserPoolsAuthProvider implements CognitoUserPoo
     @Override
     public String getUsername() throws ApiException {
         fetchUser();
-        return currentUser != null ? currentUser.getUsername() : "";
+        return currentUser != null ? currentUser.getUsername() : null;
     }
 
     private synchronized void fetchUser() throws ApiException {
@@ -105,7 +101,7 @@ public final class DefaultCognitoUserPoolsAuthProvider implements CognitoUserPoo
             currentUser = value;
             semaphore.release();
         }, value -> {
-            currentUser = new AuthUser("", "");
+            currentUser = null;
             currentUserRetrievalFailureMessage = value.getLocalizedMessage();
             semaphore.release();
         });

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/DefaultCognitoUserPoolsAuthProvider.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/sigv4/DefaultCognitoUserPoolsAuthProvider.java
@@ -60,13 +60,12 @@ public final class DefaultCognitoUserPoolsAuthProvider implements CognitoUserPoo
         final Semaphore semaphore = new Semaphore(0);
         lastTokenRetrievalFailureMessage = null;
         credentialsProvider.getAccessToken(value -> {
-                    token = value;
-                    semaphore.release();
-                }, error -> {
-                    lastTokenRetrievalFailureMessage = error.getLocalizedMessage();
-                    semaphore.release();
-                }
-        );
+            token = value;
+            semaphore.release();
+        }, error -> {
+                lastTokenRetrievalFailureMessage = error.getLocalizedMessage();
+                semaphore.release();
+            });
 
         try {
             semaphore.acquire();
@@ -101,10 +100,10 @@ public final class DefaultCognitoUserPoolsAuthProvider implements CognitoUserPoo
             currentUser = value;
             semaphore.release();
         }, value -> {
-            currentUser = null;
-            currentUserRetrievalFailureMessage = value.getLocalizedMessage();
-            semaphore.release();
-        });
+                currentUser = null;
+                currentUserRetrievalFailureMessage = value.getLocalizedMessage();
+                semaphore.release();
+            });
 
         try {
             semaphore.acquire();

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -66,7 +66,6 @@ import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.SignedInData
 import com.amplifyframework.statemachine.codegen.data.SignedOutData
-import com.amplifyframework.statemachine.codegen.data.UserSignedInData
 import com.amplifyframework.statemachine.codegen.events.AuthEvent
 import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.AuthorizationEvent
@@ -414,8 +413,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
                             AmplifyCredential(
                                 signedInData.cognitoUserPoolTokens,
                                 null,
-                                null,
-                                UserSignedInData(userid = signedInData.userId, username = signedInData.username)
+                                null
                             )
                         )
                     )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -772,11 +772,14 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
                             when (it) {
                                 is CredentialStoreState.Success -> {
                                     val accessToken = it.storedCredentials?.cognitoUserPoolTokens?.accessToken ?: ""
+                                    if (accessToken.isEmpty()) {
+                                        onError.accept(AuthException.InvalidUserPoolConfigurationException())
+                                    }
                                     val userid = JWTParser.getClaim(accessToken, "sub") ?: ""
                                     val username = JWTParser.getClaim(accessToken, "username") ?: ""
 
                                     if (userid.isEmpty() && username.isEmpty()) {
-                                        onError.accept(AuthException.InvalidStateException())
+                                        onError.accept(AuthException.InvalidUserPoolConfigurationException())
                                     } else {
                                         onSuccess.accept(
                                             AuthUser(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -771,8 +771,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
                         {
                             when (it) {
                                 is CredentialStoreState.Success -> {
-                                    val userSignedInData = it.storedCredentials
-                                    val accessToken = userSignedInData?.cognitoUserPoolTokens?.accessToken ?: ""
+                                    val accessToken = it.storedCredentials?.cognitoUserPoolTokens?.accessToken ?: ""
                                     val userid = JWTParser.getClaim(accessToken, "sub") ?: ""
                                     val username = JWTParser.getClaim(accessToken, "username") ?: ""
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -879,8 +879,8 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
         var token: StateChangeListenerToken? = null
         token = credentialStoreStateMachine.listen(
             {
-                when {
-                    it is CredentialStoreState.Success -> {
+                when (it) {
+                    is CredentialStoreState.Success -> {
                         token?.let(credentialStoreStateMachine::cancel)
                         authStateMachine.send(
                             AuthenticationEvent(
@@ -888,7 +888,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
                             )
                         )
                     }
-                    it is CredentialStoreState.Error -> {
+                    is CredentialStoreState.Error -> {
                         token?.let(credentialStoreStateMachine::cancel)
                         authStateMachine.send(
                             SignOutEvent(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -81,7 +81,6 @@ import com.amplifyframework.statemachine.codegen.states.SRPSignInState
 import com.amplifyframework.statemachine.codegen.states.SignOutState
 import com.amplifyframework.statemachine.codegen.states.SignUpState
 import com.amplifyframework.util.UserAgent
-import java.util.concurrent.Semaphore
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -761,6 +760,9 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
         authStateMachine.getCurrentState { authState ->
             when (val authorizationState = authState.authNState) {
                 is AuthenticationState.SignedIn -> {
+                    if (authorizationState.signedInData.userId.isEmpty() && authorizationState.signedInData.username.isEmpty()) {
+                        onError.accept(AuthException.InvalidStateException())
+                    }
                     onSuccess.accept(
                         AuthUser(
                             authorizationState.signedInData.userId,
@@ -769,7 +771,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
                     )
                 }
                 else -> {
-                    onError.accept(AuthException.InvalidStateException())
+                    onError.accept(AuthException.SignedOutException())
                 }
             }
         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthenticationCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthenticationCognitoActions.kt
@@ -17,6 +17,7 @@ package com.amplifyframework.auth.cognito.actions
 
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.helpers.JWTParser
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.AuthenticationActions
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
@@ -34,7 +35,7 @@ object AuthenticationCognitoActions : AuthenticationActions {
             logger?.verbose("$id Starting execution")
             val userPoolTokens = event.storedCredentials?.cognitoUserPoolTokens
             val evt = userPoolTokens?.let {
-                val signedInData = SignedInData("", "", Date(), SignInMethod.SRP, it)
+                val signedInData = SignedInData(JWTParser.getClaim(it.accessToken?:"", "sub")?:"", JWTParser.getClaim(it.accessToken?:"", "username")?:"", Date(), SignInMethod.SRP, it)
                 AuthenticationEvent(AuthenticationEvent.EventType.InitializedSignedIn(signedInData))
             } ?: AuthenticationEvent(AuthenticationEvent.EventType.InitializedSignedOut(SignedOutData()))
             logger?.verbose("$id Sending event ${evt.type}")

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthenticationCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthenticationCognitoActions.kt
@@ -17,7 +17,6 @@ package com.amplifyframework.auth.cognito.actions
 
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.cognito.AuthEnvironment
-import com.amplifyframework.auth.cognito.helpers.JWTParser
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.AuthenticationActions
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
@@ -38,11 +37,8 @@ object AuthenticationCognitoActions : AuthenticationActions {
                 AuthenticationEvent(
                     AuthenticationEvent.EventType.InitializedSignedIn(
                         SignedInData(
-                            JWTParser.getClaim(
-                                userPoolTokens.accessToken,
-                                "sub"
-                            ) ?: "",
-                            JWTParser.getClaim(userPoolTokens.accessToken, "username") ?: "",
+                            "",
+                            "",
                             Date(),
                             SignInMethod.SRP,
                             userPoolTokens

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/JWTParser.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/JWTParser.kt
@@ -90,6 +90,9 @@ object JWTParser {
      * @return claim from the JWT as a String.
      */
     fun getClaim(jwt: String, claim: String?): String? {
+        if (jwt.isEmpty()) {
+            return jwt
+        }
         return try {
             val payload = getPayload(jwt)
             val claimValue = claim?.let { payload[claim] }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AmplifyCredential.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AmplifyCredential.kt
@@ -22,6 +22,7 @@ data class AmplifyCredential(
     val cognitoUserPoolTokens: CognitoUserPoolTokens?,
     val identityId: String?,
     val awsCredentials: AWSCredentials?,
+    val userSignedInData: UserSignedInData? = null
 )
 
 @Serializable
@@ -54,6 +55,12 @@ data class CognitoUserPoolTokens(
             ")"
     }
 }
+
+@Serializable
+data class UserSignedInData(
+    val userid: String,
+    val username: String
+)
 
 @Serializable
 data class AWSCredentials(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AmplifyCredential.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AmplifyCredential.kt
@@ -21,8 +21,7 @@ import kotlinx.serialization.Serializable
 data class AmplifyCredential(
     val cognitoUserPoolTokens: CognitoUserPoolTokens?,
     val identityId: String?,
-    val awsCredentials: AWSCredentials?,
-    val userSignedInData: UserSignedInData? = null
+    val awsCredentials: AWSCredentials?
 )
 
 @Serializable
@@ -55,12 +54,6 @@ data class CognitoUserPoolTokens(
             ")"
     }
 }
-
-@Serializable
-data class UserSignedInData(
-    val userid: String,
-    val username: String
-)
 
 @Serializable
 data class AWSCredentials(

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStoreTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStoreTest.kt
@@ -22,7 +22,6 @@ import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.IdentityPoolConfiguration
 import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
-import com.amplifyframework.statemachine.codegen.data.UserSignedInData
 import kotlin.test.assertEquals
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -206,8 +205,7 @@ class AWSCognitoAuthCredentialStoreTest {
                 "secretAccessKey",
                 "sessionToken",
                 expiration
-            ),
-            UserSignedInData(userid = "userid", username = "username")
+            )
         )
     }
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStoreTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStoreTest.kt
@@ -22,6 +22,7 @@ import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.IdentityPoolConfiguration
 import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
+import com.amplifyframework.statemachine.codegen.data.UserSignedInData
 import kotlin.test.assertEquals
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -205,7 +206,8 @@ class AWSCognitoAuthCredentialStoreTest {
                 "secretAccessKey",
                 "sessionToken",
                 expiration
-            )
+            ),
+            UserSignedInData(userid = "userid", username = "username")
         )
     }
 

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -41,7 +41,6 @@ import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult
-import com.amplifyframework.core.Consumer
 
 /**
  * Defines Authentication behaviors available from Kotlin.

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -41,6 +41,7 @@ import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult
+import com.amplifyframework.core.Consumer
 
 /**
  * Defines Authentication behaviors available from Kotlin.
@@ -306,7 +307,7 @@ interface Auth {
      * @return the currently logged in user with basic info and methods for fetching/updating user attributes
      * @return Information about the current user
      */
-    fun getCurrentUser(): AuthUser?
+    suspend fun getCurrentUser(): AuthUser
 
     /**
      * Sign out with advanced options.

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -308,8 +308,13 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
         }
     }
 
-    override fun getCurrentUser(): AuthUser? {
-        return delegate.currentUser
+    override suspend fun getCurrentUser(): AuthUser {
+        return suspendCoroutine { continuation ->
+            delegate.getCurrentUser(
+                { continuation.resume(it) },
+                { continuation.resumeWithException(it) }
+            )
+        }
     }
 
     override suspend fun signOut(options: AuthSignOutOptions) {

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -679,7 +679,7 @@ class KotlinAuthFacadeTest {
         } answers {
             val indexOfResultConsumer = 2
             val onResult = it.invocation.args[indexOfResultConsumer]
-                as Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>
+                    as Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>
             onResult.accept(affirmed)
         }
         assertEquals(affirmed, auth.updateUserAttributes(genderAffirmation))
@@ -792,10 +792,16 @@ class KotlinAuthFacadeTest {
      * have any suspending functions, this is a straight pass through verification.
      */
     @Test
-    fun getCurrentUserSucceeds() {
-        val expectedAuthUser = AuthUser("userId", "username")
-        every { delegate.currentUser } returns expectedAuthUser
-        assertEquals(expectedAuthUser, auth.getCurrentUser())
+    fun getCurrentUserSucceeds(): Unit = runBlocking {
+        val authUser = AuthUser("testUserID", "testUsername")
+        every {
+            delegate.getCurrentUser(any(), any())
+        } answers {
+            val indexOfResultConsumer = 0
+            val onResult = it.invocation.args[indexOfResultConsumer] as Consumer<AuthUser>
+            onResult.accept(authUser)
+        }
+        auth.getCurrentUser()
     }
 
     /**
@@ -803,10 +809,16 @@ class KotlinAuthFacadeTest {
      * Kotlin facade should, too.  Essentially, the AuthUser returned is nullable.
      */
     @Test
-    fun getCurrentUserSucceedsWhenSignedOut() {
-        val expectedAuthUser = null
-        every { delegate.currentUser } returns expectedAuthUser
-        assertEquals(expectedAuthUser, auth.getCurrentUser())
+    fun getCurrentUserSucceedsWhenSignedOut(): Unit = runBlocking {
+        val authUser = AuthUser("", "")
+        every {
+            delegate.getCurrentUser(any(), any())
+        } answers {
+            val indexOfResultConsumer = 0
+            val onResult = it.invocation.args[indexOfResultConsumer] as Consumer<AuthUser>
+            onResult.accept(authUser)
+        }
+        auth.getCurrentUser()
     }
 
     /**
@@ -815,9 +827,15 @@ class KotlinAuthFacadeTest {
      * have any suspending functions, this is a straight pass through verification.
      */
     @Test(expected = AuthException::class)
-    fun getCurrentUserThrows() {
+    fun getCurrentUserThrows(): Unit = runBlocking {
         val expectedException = AuthException("uh", "oh")
-        every { delegate.currentUser } throws expectedException
+        every {
+            delegate.getCurrentUser(any(), any())
+        } answers {
+            val indexOfErrorConsumer = 1
+            val onResult = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
+            onResult.accept(expectedException)
+        }
         auth.getCurrentUser()
     }
 

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -679,7 +679,7 @@ class KotlinAuthFacadeTest {
         } answers {
             val indexOfResultConsumer = 2
             val onResult = it.invocation.args[indexOfResultConsumer]
-                    as Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>
+                as Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>
             onResult.accept(affirmed)
         }
         assertEquals(affirmed, auth.updateUserAttributes(genderAffirmation))

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -840,6 +840,24 @@ class KotlinAuthFacadeTest {
     }
 
     /**
+     * When the getCurrentUser() delegate throws an error, the proxy
+     * API in the Kotlin facade should, too. Note that this API doesn't
+     * have any suspending functions, this is a straight pass through verification.
+     */
+    @Test(expected = AuthException::class)
+    fun getCurrentUserWhenUserNameIsEmpty(): Unit = runBlocking {
+        val expectedException = AuthException.InvalidUserPoolConfigurationException()
+        every {
+            delegate.getCurrentUser(any(), any())
+        } answers {
+            val indexOfErrorConsumer = 1
+            val onResult = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
+            onResult.accept(expectedException)
+        }
+        auth.getCurrentUser()
+    }
+
+    /**
      * Signing out calls through to the delegate. If no error is thrown from
      * the delegate, none is rendered by the coroutine.
      */

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -805,18 +805,18 @@ class KotlinAuthFacadeTest {
     }
 
     /**
-     * When the getCurrentUser() delegate return null, the proxy API in the
-     * Kotlin facade should, too.  Essentially, the AuthUser returned is nullable.
+     * When the getCurrentUser() has null values an Auth Exception should be sent in the onError
+     * which should be captured in the Kotlin facade too
      */
-    @Test
-    fun getCurrentUserSucceedsWhenSignedOut(): Unit = runBlocking {
-        val authUser = AuthUser("", "")
+    @Test(expected = AuthException.SignedOutException::class)
+    fun getCurrentUserThrowsWhenSignedOut(): Unit = runBlocking {
+        val expectedException = AuthException.SignedOutException()
         every {
             delegate.getCurrentUser(any(), any())
         } answers {
-            val indexOfResultConsumer = 0
-            val onResult = it.invocation.args[indexOfResultConsumer] as Consumer<AuthUser>
-            onResult.accept(authUser)
+            val indexOfResultConsumer = 1
+            val onResult = it.invocation.args[indexOfResultConsumer] as Consumer<AuthException>
+            onResult.accept(expectedException)
         }
         auth.getCurrentUser()
     }

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -360,8 +360,8 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     }
 
     @Override
-    public AuthUser getCurrentUser() {
-        return getSelectedPlugin().getCurrentUser();
+    public void getCurrentUser(@NonNull Consumer<AuthUser> onSuccess, @NonNull Consumer<AuthException> onError) {
+        getSelectedPlugin().getCurrentUser(onSuccess, onError);
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -462,7 +462,10 @@ public interface AuthCategoryBehavior {
      * Gets the currently logged in User.
      * @return the currently logged in user with basic info and methods for fetching/updating user attributes
      */
-    AuthUser getCurrentUser();
+    void getCurrentUser(
+            @NonNull Consumer<AuthUser> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    );
 
     /**
      * Sign out of the current device.

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -460,7 +460,8 @@ public interface AuthCategoryBehavior {
 
     /**
      * Gets the currently logged in User.
-     * @return the currently logged in user with basic info and methods for fetching/updating user attributes
+     * @param onSuccess Success callback
+     * @param onError Error callback
      */
     void getCurrentUser(
             @NonNull Consumer<AuthUser> onSuccess,

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -443,6 +443,9 @@ public class AuthException extends AmplifyException {
             super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
 
+        /**
+         * Default message/recovery suggestion without a cause.
+         */
         public InvalidUserPoolConfigurationException() {
             super(MESSAGE, RECOVERY_SUGGESTION);
         }

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -442,6 +442,10 @@ public class AuthException extends AmplifyException {
         public InvalidUserPoolConfigurationException(Throwable cause) {
             super(MESSAGE, cause, RECOVERY_SUGGESTION);
         }
+
+        public InvalidUserPoolConfigurationException() {
+            super(MESSAGE, RECOVERY_SUGGESTION);
+        }
     }
 
     /**

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -273,8 +273,8 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
     }
 
     @Override
-    public AuthUser getCurrentUser() {
-        return delegate.getCurrentUser();
+    public Single<AuthUser> getCurrentUser() {
+        return toSingle(delegate::getCurrentUser);
     }
 
     @Override

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -398,7 +398,7 @@ public interface RxAuthCategoryBehavior {
      * Gets the currently logged in User.
      * @return the currently logged in user with basic info and methods for fetching/updating user attributes
      */
-    AuthUser getCurrentUser();
+    Single<AuthUser> getCurrentUser();
 
     /**
      * Sign out of the current device.

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -988,8 +988,23 @@ public final class RxAuthBindingTest {
      * it would.
      */
     @Test
-    public void testGetCurrentUser() {
-        //TODO: Implement this
+    public void testGetCurrentUser() throws InterruptedException {
+        AuthUser authUser = new AuthUser("testUserId", "testUsername");
+        doAnswer(invocation -> {
+            // 0 = onComplete, 1 = onFailure
+            int positionOfCompletionAction = 0;
+            Consumer<AuthUser> onResult = invocation.getArgument(positionOfCompletionAction);
+            onResult.accept(authUser);
+            return null;
+        }).when(delegate).getCurrentUser(anyConsumer(), anyConsumer());
+
+        // Act: call the binding
+        TestObserver<AuthUser> observer = auth.getCurrentUser().test();
+
+        // Assert: Completable completes successfully
+        observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        observer.assertNoErrors()
+                .assertComplete();
     }
 
     /**

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -989,9 +989,7 @@ public final class RxAuthBindingTest {
      */
     @Test
     public void testGetCurrentUser() {
-        AuthUser expected = new AuthUser(RandomString.string(), RandomString.string());
-        when(delegate.getCurrentUser()).thenReturn(expected);
-        assertEquals(expected, auth.getCurrentUser());
+        //TODO: Implement this
     }
 
     /**

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -59,13 +59,11 @@ import io.reactivex.rxjava3.observers.TestObserver;
 
 import static com.amplifyframework.rx.Matchers.anyAction;
 import static com.amplifyframework.rx.Matchers.anyConsumer;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests the {@link RxAuthBinding}.
@@ -986,6 +984,7 @@ public final class RxAuthBindingTest {
     /**
      * Getting the current user should just pass through to the delegate, to return whatever
      * it would.
+     * @throws InterruptedException If test observer is interrupted while awaiting terminal event
      */
     @Test
     public void testGetCurrentUser() throws InterruptedException {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
This change will make Auth.getCurrentUser an asynchronous call using our state machines that way it should be.
*Note* the documentation change will happen once this PR is merged in
*How did you test these changes?*
This change was tested both from a unit test perspective and from the sample app perspective. Sample app change will come once this is released.

- [ x] Added Unit Tests
- [ x] Tested on frontend (Add Screenshots) 
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
