### PR TITLE
fix(api): catch exceptions when making rest request

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/RestApiInstrumentationTest.java
@@ -153,4 +153,21 @@ public final class RestApiInstrumentationTest {
         assertNotNull("Should return non-null data", response.getData());
         assertFalse("Response should be unsuccessful", response.getCode().isSuccessful());
     }
+
+    /**
+     * Test whether an exception that occurs when making a request and that is not
+     * an IOException can be caught in a try/catch.
+     * @throws Exception On failure to catch the exception that occurs when making a request.
+     */
+    @Test
+    public void getRequestNonIOExceptionCanBeCaught() throws Exception {
+        final RestOptions options = RestOptions.builder()
+                .addPath("/invalidPath")
+                .build();
+        try {
+            final RestResponse response = api.get("iamAuthApi", options);
+        } catch (ApiException apiException) {
+            // Expected to enter catch block
+        }
+    }
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -161,6 +161,8 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
                             return chain.proceed(decorator.decorate(chain.request()));
                         } catch (ApiException.ApiAuthException apiAuthException) {
                             throw new IOException("Failed to decorate request for authorization.", apiAuthException);
+                        } catch (Exception exception) {
+                            throw new IOException("An error occurred while making the request.", exception);
                         }
                     });
                 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/operation/AWSRestOperation.java
@@ -27,6 +27,8 @@ import com.amplifyframework.api.rest.RestOperationRequest;
 import com.amplifyframework.api.rest.RestResponse;
 import com.amplifyframework.core.Consumer;
 
+import com.amazonaws.AmazonClientException;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
@@ -146,11 +148,19 @@ public final class AWSRestOperation extends RestOperation {
             if (ongoingCall != null && ongoingCall.isCanceled()) {
                 return;
             }
-
-            onFailure.accept(new ApiException(
-                "Received an IO exception while making the request.",
-                ioe, "Retry the request."
-            ));
+            
+            ApiException apiException;
+            if (ioe.getCause() != null && ioe.getCause() instanceof AmazonClientException) {
+                apiException = new ApiException(
+                        "Received an exception while making the request.",
+                        ioe.getCause(), "See attached exception for more details.");
+            } else {
+                apiException = new ApiException(
+                        "Received an IO exception while making the request.",
+                        ioe, "Retry the request."
+                );
+            }
+            onFailure.accept(apiException);
         }
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #1818

*Description of changes:* When an exception occurs in the process of making a REST API request that isn't an IOException (e.g., user needs to be signed in to make the request but isn't signed in), the exception will be uncatchable and crashes the app. This PR adds an additional catch block to the interceptor used for REST API requests in order to catch those exceptions and propagate them back to the client, without crashing the app.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [x] Added Unit Tests
- [x] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
