### PR TITLE
fix(datastore): handler for mutation processor timeout

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -109,6 +109,7 @@ public final class Orchestrator {
             .mutationOutbox(mutationOutbox)
             .appSync(appSync)
             .conflictResolver(conflictResolver)
+            .onFailure(this::onApiSyncFailure)
             .build();
         this.syncProcessor = SyncProcessor.builder()
             .modelProvider(modelProvider)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -100,6 +100,7 @@ public final class MutationProcessorTest {
             .mutationOutbox(mutationOutbox)
             .appSync(appSync)
             .conflictResolver(conflictResolver)
+            .onFailure(throwable -> { })
             .build();
     }
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
fixes #1794 

*Description of changes:*
Prior to this commit, The MutationProcessor did not perform an action upon
encountering the 10 second network timeout. The MutationProcessor would
effectively be dormant until the orchestrator recycles due to losing its
socket connection. This commit addresses that by applying the same handler that
recycles the orchestrator to the timeout.

*How did you test these changes?*
(Please add a line here how the changes were tested)
1. Fire up Amplify Android's emulator.
2. Copy emulator console auth token:
    ```shell
      $: cat $HOME/.emulator_console_auth_token
    ```
3. Note port for emulator:
    ```shell
      $: adb devices
      List of devices attached
      emulator-5554 device
    ```
4. Connect to emulator console via telnet:
    ```shell
      $: telnet localhost 5554
      Trying 127.0.0.1...
      Connected to localhost.
      Escape character is '^]'.
      Android Console: Authentication required
      Android Console: type 'auth <auth_token>' to authenticate
      Android Console: you can find your <auth_token> in
      '/Users/whoami/.emulator_console_auth_token'
      OK
    ```
5. Authenticate with emulator console:
    ```telnet
      > auth <token>
      Android Console: type 'help' for a list of commands
      OK
    ```
6. Check network status:
    ```telnet
      > network status
      Current network status:
      download speed:          0 bits/s (0.0 KB/s)
      upload speed:            0 bits/s (0.0 KB/s)
      minimum latency:  0 ms
      maximum latency:  0 ms
      OK
    ```
7. Slow the network connection down to induce timeout:
    ```telnet
      > network speed 1.6 1.6
      OK
      > network status
      Current network status:
        download speed:       1600 bits/s (0.2 KB/s)
        upload speed:         1600 bits/s (0.2 KB/s)
        minimum latency:  0 ms
        maximum latency:  0 ms
      OK
    ```
8. Save records to DataStore and [observe exception and orchestrator recycle](https://gist.github.com/sbaxter/d3242e4e61857379624a1fdf76312690).
9. Verify Pending Mutation count is > 0.
10. Increase the network connection speed.
    ```telnet
      > network speed full
      OK
      > network status
      Current network status:
        download speed:          0 bits/s (0.0 KB/s)
        upload speed:            0 bits/s (0.0 KB/s)
        minimum latency:  0 ms
        maximum latency:  0 ms
      OK
    ```
12. Verified resumption of draining and pending mutation count = 0.

Note: prior to this commit, step 10 and 11 were only successful with a network change that induced `netd` to destroy App Sync's socket connection (e.g. toggling WiFi or connecting to another network). 

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [x] Successful logs (Attach them to the PR)

[Here](https://gist.github.com/sbaxter/d3242e4e61857379624a1fdf76312690) is the log of the handler working. (Versus [no handler](https://gist.github.com/sbaxter/17094ccdc40e0ee6e26c3faebfe77931).)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
