### PR TITLE
chore(auth): add a username param to confirm reset password api.

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -269,22 +269,24 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
     }
 
     override fun confirmResetPassword(
+        username: String,
         newPassword: String,
         confirmationCode: String,
         options: AuthConfirmResetPasswordOptions,
         onSuccess: Action,
         onError: Consumer<AuthException>
     ) {
-        realPlugin.confirmResetPassword(newPassword, confirmationCode, options, onSuccess, onError)
+        realPlugin.confirmResetPassword(username, newPassword, confirmationCode, options, onSuccess, onError)
     }
 
     override fun confirmResetPassword(
+        username: String,
         newPassword: String,
         confirmationCode: String,
         onSuccess: Action,
         onError: Consumer<AuthException>
     ) {
-        realPlugin.confirmResetPassword(newPassword, confirmationCode, onSuccess, onError)
+        realPlugin.confirmResetPassword(username, newPassword, confirmationCode, onSuccess, onError)
     }
 
     override fun updatePassword(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -855,6 +855,7 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     override fun confirmResetPassword(
+        username: String,
         newPassword: String,
         confirmationCode: String,
         options: AuthConfirmResetPasswordOptions,
@@ -865,6 +866,7 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     override fun confirmResetPassword(
+        username: String,
         newPassword: String,
         confirmationCode: String,
         onSuccess: Action,

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -357,18 +357,34 @@ class AWSCognitoAuthPluginTest {
 
     @Test
     fun verifyConfirmResetPassword() {
+        val expectedUsername = "user1"
         val expectedPassword = "p1234"
         val expectedCode = "4723j"
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
 
-        authPlugin.confirmResetPassword(expectedPassword, expectedCode, expectedOnSuccess, expectedOnError)
+        authPlugin.confirmResetPassword(
+            expectedUsername,
+            expectedPassword,
+            expectedCode,
+            expectedOnSuccess,
+            expectedOnError
+        )
 
-        verify { realPlugin.confirmResetPassword(expectedPassword, expectedCode, expectedOnSuccess, expectedOnError) }
+        verify {
+            realPlugin.confirmResetPassword(
+                expectedUsername,
+                expectedPassword,
+                expectedCode,
+                expectedOnSuccess,
+                expectedOnError
+            )
+        }
     }
 
     @Test
     fun verifyOverloadedConfirmResetPassword() {
+        val expectedUsername = "user1"
         val expectedPassword = "p1234"
         val expectedCode = "4723j"
         val expectedOptions = AuthConfirmResetPasswordOptions.defaults()
@@ -376,6 +392,7 @@ class AWSCognitoAuthPluginTest {
         val expectedOnError = Consumer<AuthException> { }
 
         authPlugin.confirmResetPassword(
+            expectedUsername,
             expectedPassword,
             expectedCode,
             expectedOptions,
@@ -385,6 +402,7 @@ class AWSCognitoAuthPluginTest {
 
         verify {
             realPlugin.confirmResetPassword(
+                expectedUsername,
                 expectedPassword,
                 expectedCode,
                 expectedOptions,

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -225,6 +225,7 @@ interface Auth {
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param newPassword The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
      * @param options Advanced options such as a map of auth information for custom auth,
@@ -232,6 +233,7 @@ interface Auth {
      */
     @Throws(AuthException::class)
     suspend fun confirmResetPassword(
+        username: String,
         newPassword: String,
         confirmationCode: String,
         options: AuthConfirmResetPasswordOptions = AuthConfirmResetPasswordOptions.defaults()

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -217,12 +217,14 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
     }
 
     override suspend fun confirmResetPassword(
+        username: String,
         newPassword: String,
         confirmationCode: String,
         options: AuthConfirmResetPasswordOptions
     ) {
         return suspendCoroutine { continuation ->
             delegate.confirmResetPassword(
+                username,
                 newPassword,
                 confirmationCode,
                 options,

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -514,10 +514,12 @@ class KotlinAuthFacadeTest {
      */
     @Test
     fun confirmResetPasswordSucceeds(): Unit = runBlocking {
+        val username = "TonyDaniels6989"
         val newPassword = "VerySecurePassword=VSPBaby"
         val confirmationCode = "LegitConfirmation"
         every {
             delegate.confirmResetPassword(
+                eq(username),
                 eq(newPassword),
                 eq(confirmationCode),
                 any(),
@@ -525,13 +527,14 @@ class KotlinAuthFacadeTest {
                 any()
             )
         } answers {
-            val indexOfCompletionAction = 3
+            val indexOfCompletionAction = 4
             val onComplete = it.invocation.args[indexOfCompletionAction] as Action
             onComplete.call()
         }
-        auth.confirmResetPassword(newPassword, confirmationCode)
+        auth.confirmResetPassword(username, newPassword, confirmationCode)
         verify {
             delegate.confirmResetPassword(
+                eq(username),
                 eq(newPassword),
                 eq(confirmationCode),
                 any(),
@@ -546,11 +549,13 @@ class KotlinAuthFacadeTest {
      */
     @Test(expected = AuthException::class)
     fun confirmResetPasswordThrows(): Unit = runBlocking {
+        val username = "TonyDaniels6989"
         val newPassword = "SuperSecurePass911"
         val confirmationCode = "ConfirmationCode4u"
         val error = AuthException("uh", "oh")
         every {
             delegate.confirmResetPassword(
+                eq(username),
                 eq(newPassword),
                 eq(confirmationCode),
                 any(),
@@ -558,11 +563,11 @@ class KotlinAuthFacadeTest {
                 any()
             )
         } answers {
-            val indexOfErrorConsumer = 4
+            val indexOfErrorConsumer = 5
             val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
             onError.accept(error)
         }
-        auth.confirmResetPassword(newPassword, confirmationCode)
+        auth.confirmResetPassword(username, newPassword, confirmationCode)
     }
 
     @Test

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -255,23 +255,24 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
 
     @Override
     public void confirmResetPassword(
+            @NonNull String username,
             @NonNull String newPassword,
             @NonNull String confirmationCode,
             @NonNull AuthConfirmResetPasswordOptions options,
             @NonNull Action onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
-        getSelectedPlugin().confirmResetPassword(newPassword, confirmationCode, options, onSuccess, onError);
+        getSelectedPlugin().confirmResetPassword(username, newPassword, confirmationCode, options, onSuccess, onError);
     }
 
     @Override
     public void confirmResetPassword(
-            @NonNull String newPassword,
+            String username, @NonNull String newPassword,
             @NonNull String confirmationCode,
             @NonNull Action onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
-        getSelectedPlugin().confirmResetPassword(newPassword, confirmationCode, onSuccess, onError);
+        getSelectedPlugin().confirmResetPassword(username, newPassword, confirmationCode, onSuccess, onError);
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -315,6 +315,7 @@ public interface AuthCategoryBehavior {
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param newPassword The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
      * @param options Advanced options such as a map of auth information for custom auth
@@ -322,6 +323,7 @@ public interface AuthCategoryBehavior {
      * @param onError Error callback
      */
     void confirmResetPassword(
+            @NonNull String username,
             @NonNull String newPassword,
             @NonNull String confirmationCode,
             @NonNull AuthConfirmResetPasswordOptions options,
@@ -330,12 +332,14 @@ public interface AuthCategoryBehavior {
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param newPassword The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
      * @param onSuccess Success callback
      * @param onError Error callback
      */
     void confirmResetPassword(
+            @NonNull String username,
             @NonNull String newPassword,
             @NonNull String confirmationCode,
             @NonNull Action onSuccess,

--- a/core/src/main/java/com/amplifyframework/auth/result/step/AuthResetPasswordStep.java
+++ b/core/src/main/java/com/amplifyframework/auth/result/step/AuthResetPasswordStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.auth.result.step;
 
+import com.amplifyframework.auth.AuthCategoryBehavior;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
 
@@ -24,7 +25,7 @@ import com.amplifyframework.core.Consumer;
 public enum AuthResetPasswordStep {
     /**
      * A code was sent to enable the user to change their password. Submit this code using
-     * {@link com.amplifyframework.auth.AuthCategoryBehavior#confirmResetPassword(String, String, Action, Consumer)}
+     * {@link AuthCategoryBehavior#confirmResetPassword(String, String, String, Action, Consumer)}
      * with the user's chosen new password.
      */
     CONFIRM_RESET_PASSWORD_WITH_CODE,

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -197,18 +197,32 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
 
     @Override
     public Completable confirmResetPassword(
+            @NonNull String username,
             @NonNull String newPassword,
             @NonNull String confirmationCode,
             @NonNull AuthConfirmResetPasswordOptions options
     ) {
         return toCompletable((onComplete, onError) ->
-            delegate.confirmResetPassword(newPassword, confirmationCode, options, onComplete, onError));
+            delegate.confirmResetPassword(
+                username, newPassword, confirmationCode, options, onComplete, onError
+            )
+        );
     }
 
     @Override
-    public Completable confirmResetPassword(@NonNull String newPassword, @NonNull String confirmationCode) {
+    public Completable confirmResetPassword(
+            @NonNull String username,
+            @NonNull String newPassword,
+            @NonNull String confirmationCode) {
         return toCompletable((onComplete, onError) ->
-            delegate.confirmResetPassword(newPassword, confirmationCode, onComplete, onError));
+            delegate.confirmResetPassword(
+                    username,
+                    newPassword,
+                    confirmationCode,
+                    onComplete,
+                    onError
+            )
+        );
     }
 
     @Override

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -285,6 +285,7 @@ public interface RxAuthCategoryBehavior {
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param newPassword The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
      * @param options Advanced options such as a map of auth information for custom auth
@@ -292,6 +293,7 @@ public interface RxAuthCategoryBehavior {
      *         emits an {@link AuthException} otherwise
      */
     Completable confirmResetPassword(
+            @NonNull String username,
             @NonNull String newPassword,
             @NonNull String confirmationCode,
             @NonNull AuthConfirmResetPasswordOptions options
@@ -299,12 +301,13 @@ public interface RxAuthCategoryBehavior {
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param newPassword The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
      * @return An Rx {@link Completable} which completes successfully if password reset is confirmed,
      *         emits an {@link AuthException} otherwise
      */
-    Completable confirmResetPassword(@NonNull String newPassword, @NonNull String confirmationCode);
+    Completable confirmResetPassword(String username, @NonNull String newPassword, @NonNull String confirmationCode);
 
     /**
      * Update the password of an existing user - must be signed in to perform this action.

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -597,21 +597,24 @@ public final class RxAuthBindingTest {
      */
     @Test
     public void testConfirmResetPasswordSucceeds() throws InterruptedException {
+        String username = RandomString.string();
         String newPassword = RandomString.string();
         String confirmationCode = RandomString.string();
 
         // Arrange completion callback to be invoked
         doAnswer(invocation -> {
-            // 0 = new pass, 1 = confirmation code, 2 = onComplete, 3 = onFailure
-            int positionOfCompletionAction = 2;
+            // 0 = username, 1 = new pass, 2 = confirmation code, 3 = onComplete, 4 = onFailure
+            int positionOfCompletionAction = 3;
             Action onComplete = invocation.getArgument(positionOfCompletionAction);
             onComplete.call();
             return null;
-        }).when(delegate).confirmResetPassword(eq(newPassword), eq(confirmationCode), anyAction(), anyConsumer());
+        }).when(delegate).confirmResetPassword(
+                eq(username), eq(newPassword), eq(confirmationCode), anyAction(), anyConsumer()
+        );
 
         // Act: call the binding
         TestObserver<Void> observer =
-            auth.confirmResetPassword(newPassword, confirmationCode).test();
+            auth.confirmResetPassword(username, newPassword, confirmationCode).test();
 
         // Assert: Completable was completed successfully
         observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -627,22 +630,25 @@ public final class RxAuthBindingTest {
      */
     @Test
     public void testConfirmResetPasswordFails() throws InterruptedException {
+        String username = RandomString.string();
         String newPassword = RandomString.string();
         String confirmationCode = RandomString.string();
 
         // Arrange delegate to furnish a failure
         AuthException failure = new AuthException("Confirm password reset ", " has failed.");
         doAnswer(invocation -> {
-            // 0 = new pass, 1 = confirmation code, 2 = onComplete, 3 = onFailure
-            int positionOfFailureConsumer = 3;
+            // 0 = username, 1 = new pass, 2 = confirmation code, 3 = onComplete, 4 = onFailure
+            int positionOfFailureConsumer = 4;
             Consumer<AuthException> onFailure = invocation.getArgument(positionOfFailureConsumer);
             onFailure.accept(failure);
             return null;
-        }).when(delegate).confirmResetPassword(eq(newPassword), eq(confirmationCode), anyAction(), anyConsumer());
+        }).when(delegate).confirmResetPassword(
+                eq(username), eq(newPassword), eq(confirmationCode), anyAction(), anyConsumer()
+        );
 
         // Act: call the binding
         TestObserver<Void> observer =
-            auth.confirmResetPassword(newPassword, confirmationCode).test();
+            auth.confirmResetPassword(username, newPassword, confirmationCode).test();
 
         // Assert: Completable terminated with failure
         observer.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -351,44 +351,50 @@ public final class SynchronousAuth {
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param newPassword The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
      * @param options Advanced options such as a map of auth information for custom auth
      * @throws AuthException exception
      */
     public void confirmResetPassword(
+            @NonNull String username,
             @NonNull String newPassword,
             @NonNull String confirmationCode,
             @NonNull AuthConfirmResetPasswordOptions options
     ) throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.confirmResetPassword(
-                    newPassword,
-                    confirmationCode,
-                    options,
-                    () -> onResult.accept(VoidResult.instance()),
-                    onError
-                )
+            asyncDelegate.confirmResetPassword(
+                username,
+                newPassword,
+                confirmationCode,
+                options,
+                () -> onResult.accept(VoidResult.instance()),
+                onError
+            )
         );
     }
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
+     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param newPassword The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
      * @throws AuthException exception
      */
     public void confirmResetPassword(
+            @NonNull String username,
             @NonNull String newPassword,
             @NonNull String confirmationCode
     ) throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.confirmResetPassword(
-                    newPassword,
-                    confirmationCode,
-                    () -> onResult.accept(VoidResult.instance()),
-                    onError
-                )
+            asyncDelegate.confirmResetPassword(
+                username,
+                newPassword,
+                confirmationCode,
+                () -> onResult.accept(VoidResult.instance()),
+                onError
+            )
         );
     }
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Add username as a parameter to `confirmResetPasswordAPI`

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
