### PR TITLE
fix(test): fix geo and datastore integration tests

### DIFF
--- a/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/MapsApiTest.kt
+++ b/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/MapsApiTest.kt
@@ -17,7 +17,6 @@ package com.amplifyframework.geo.location
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import com.amplifyframework.auth.AuthCategory
 import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
 import com.amplifyframework.geo.GeoCategory
 import com.amplifyframework.geo.GeoException
@@ -29,7 +28,6 @@ import org.json.JSONObject
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -45,12 +43,10 @@ class MapsApiTest {
     @Before
     fun setUp() {
         // Auth plugin uses default configuration
-        val authPlugin = AWSCognitoAuthPlugin()
-        val authCategory = TestCategory.forPlugin(authPlugin) as AuthCategory
-        auth = SynchronousAuth.delegatingToCognito(ApplicationProvider.getApplicationContext(), authPlugin)
+        auth = SynchronousAuth.delegatingToCognito(ApplicationProvider.getApplicationContext(), AWSCognitoAuthPlugin())
 
         // Geo plugin uses above auth category to authenticate users
-        val geoPlugin = AWSLocationGeoPlugin(authCategory = authCategory)
+        val geoPlugin = AWSLocationGeoPlugin()
         val geoCategory = TestCategory.forPlugin(geoPlugin) as GeoCategory
         geo = SynchronousGeo.delegatingTo(geoCategory)
     }
@@ -83,7 +79,6 @@ class MapsApiTest {
      *
      * @throws GeoException will be thrown due to service exception.
      */
-    @Ignore("Fails randomly in build server, needs investigation")
     @Test(expected = GeoException::class)
     fun cannotFetchStyleWithoutAuth() {
         signOutFromCognito()

--- a/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/SearchApiTest.kt
+++ b/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/SearchApiTest.kt
@@ -17,7 +17,6 @@ package com.amplifyframework.geo.location
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import com.amplifyframework.auth.AuthCategory
 import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
 import com.amplifyframework.geo.GeoCategory
 import com.amplifyframework.geo.GeoException
@@ -47,12 +46,10 @@ class SearchApiTest {
     @Before
     fun setUp() {
         // Auth plugin uses default configuration
-        val authPlugin = AWSCognitoAuthPlugin()
-        val authCategory = TestCategory.forPlugin(authPlugin) as AuthCategory
-        auth = SynchronousAuth.delegatingToCognito(ApplicationProvider.getApplicationContext(), authPlugin)
+        auth = SynchronousAuth.delegatingToCognito(ApplicationProvider.getApplicationContext(), AWSCognitoAuthPlugin())
 
         // Geo plugin uses above auth category to authenticate users
-        val geoPlugin = AWSLocationGeoPlugin(authCategory = authCategory)
+        val geoPlugin = AWSLocationGeoPlugin()
         val geoCategory = TestCategory.forPlugin(geoPlugin) as GeoCategory
         geo = SynchronousGeo.delegatingTo(geoCategory)
     }

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -20,10 +20,8 @@ import android.content.Context;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RawRes;
 
 import com.amplifyframework.AmplifyException;
-import com.amplifyframework.auth.AuthCategory;
 import com.amplifyframework.auth.AuthCategoryBehavior;
 import com.amplifyframework.auth.AuthCodeDeliveryDetails;
 import com.amplifyframework.auth.AuthDevice;
@@ -50,12 +48,8 @@ import com.amplifyframework.auth.result.AuthSignInResult;
 import com.amplifyframework.auth.result.AuthSignUpResult;
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult;
 import com.amplifyframework.core.Amplify;
-import com.amplifyframework.core.AmplifyConfiguration;
-import com.amplifyframework.core.category.CategoryConfiguration;
-import com.amplifyframework.core.category.CategoryType;
 import com.amplifyframework.core.plugin.Plugin;
 import com.amplifyframework.testutils.Await;
-import com.amplifyframework.testutils.Resources;
 import com.amplifyframework.testutils.VoidResult;
 
 import java.util.List;
@@ -111,12 +105,6 @@ public final class SynchronousAuth {
      */
     public static SynchronousAuth delegatingToCognito(Context context, Plugin<?> authPlugin)
         throws AmplifyException, InterruptedException {
-        @RawRes int configResourceId = Resources.getRawResourceId(context, "amplifyconfiguration");
-        AmplifyConfiguration amplifyConfiguration = AmplifyConfiguration.fromConfigFile(context, configResourceId);
-        CategoryConfiguration authCategoryConfiguration = amplifyConfiguration.forCategoryType(CategoryType.AUTH);
-        AuthCategory authCategory = new AuthCategory();
-        authCategory.addPlugin((AuthPlugin<?>) authPlugin);
-        authCategory.configure(authCategoryConfiguration, context);
         try {
             Amplify.Auth.addPlugin((AuthPlugin<?>) authPlugin);
             Amplify.configure(context);
@@ -125,7 +113,7 @@ public final class SynchronousAuth {
         }
         //TODO: make authCategory confiuration synchronous
         Thread.sleep(AUTH_OPERATION_TIMEOUT_MS);
-        return SynchronousAuth.delegatingTo(authCategory);
+        return SynchronousAuth.delegatingTo(Amplify.Auth);
     }
 
     /**


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- remove multiple plugin configures to prevent attaching multiple auth state listeners
- calling plugin configure multiple times, initializes the auth state machine multiple times which results in inconsistent final state.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
