### PR TITLE
fix(datastore): memory issues, add disableSync and disableSubscription

### DIFF
--- a/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
@@ -123,7 +123,7 @@ public final class AWSRestOperationTest {
         RestOperationRequest request =
             new RestOperationRequest(HttpMethod.GET, baseUrl.uri().getPath(), emptyMap(), emptyMap());
         assertTimedOut(() ->
-            Await.<RestResponse, ApiException>result(timeToWaitForResponse, (onResult, onError) -> {
+            Await.<RestResponse, ApiException>result((onResult, onError) -> {
                 AWSRestOperation operation =
                     new AWSRestOperation(request, baseUrl.url().toString(), client, onResult, onError);
                 operation.start();

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/AppSyncClientInstrumentationTest.java
@@ -327,7 +327,7 @@ public final class AppSyncClientInstrumentationTest {
     private <T> T awaitResponseData(
             Await.ResultErrorEmitter<GraphQLResponse<T>, DataStoreException> resultErrorEmitter)
             throws DataStoreException {
-        final GraphQLResponse<T> response = Await.result(TimeUnit.SECONDS.toMillis(20), resultErrorEmitter);
+        final GraphQLResponse<T> response = Await.result(resultErrorEmitter);
         if (response.hasErrors()) {
             String firstErrorMessage = response.getErrors().get(0).getMessage();
             throw new DataStoreException("Response contained errors: " + firstErrorMessage, "Check request.");

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -97,7 +97,6 @@ public final class SynchronousStorageAdapter {
     @SuppressWarnings("UnusedReturnValue")
     public List<ModelSchema> initialize(@NonNull Context context) throws DataStoreException {
         return Await.result(
-            operationTimeoutMs,
             (Consumer<List<ModelSchema>> onResult, Consumer<DataStoreException> onError) -> {
                 try {
                     asyncDelegate.initialize(context,
@@ -144,7 +143,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> void save(@NonNull T model, @NonNull QueryPredicate predicate)
             throws DataStoreException {
         Await.result(
-            operationTimeoutMs,
             (Consumer<StorageItemChange<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.save(
                     model,
@@ -177,7 +175,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> DataStoreException saveExpectingError(
             @NonNull T model, @NonNull QueryPredicate predicate) {
         return Await.error(
-            operationTimeoutMs,
             (Consumer<StorageItemChange<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.save(
                     model,
@@ -212,7 +209,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> List<T> query(@NonNull Class<T> modelClass, @NonNull QueryOptions options)
             throws DataStoreException {
         Iterator<T> resultIterator = Await.result(
-            operationTimeoutMs,
             (Consumer<Iterator<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.query(modelClass, options, onResult, onError)
         );
@@ -268,7 +264,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> void delete(@NonNull T model, @NonNull QueryPredicate predicate)
             throws DataStoreException {
         Await.result(
-            operationTimeoutMs,
             (Consumer<StorageItemChange<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.delete(
                     model,
@@ -290,7 +285,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> void delete(@NonNull Class<T> modelType, @NonNull QueryPredicate predicate)
             throws DataStoreException {
         Await.result(
-            operationTimeoutMs,
             (Consumer<Object> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.delete(
                     modelType,
@@ -328,7 +322,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> DataStoreException deleteExpectingError(
             @NonNull T model, @NonNull QueryPredicate predicate) {
         return Await.error(
-            operationTimeoutMs,
             (Consumer<StorageItemChange<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.delete(
                     model,

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/ModelUpgradeSQLiteInstrumentedTest.java
@@ -106,7 +106,6 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
         // Initialize StorageAdapter with models
         sqliteStorageAdapter = SQLiteStorageAdapter.forModels(schemaRegistry, modelProvider);
         List<ModelSchema> firstResults = Await.result(
-            SQLITE_OPERATION_TIMEOUT_MS,
             (Consumer<List<ModelSchema>> onResult, Consumer<DataStoreException> onError) -> {
                 try {
                     sqliteStorageAdapter.initialize(context, onResult, onError,
@@ -144,7 +143,6 @@ public final class ModelUpgradeSQLiteInstrumentedTest {
 
         // Now, initialize storage adapter with the new models
         List<ModelSchema> secondResults = Await.result(
-            SQLITE_OPERATION_TIMEOUT_MS,
             (Consumer<List<ModelSchema>> onResult, Consumer<DataStoreException> onError) -> {
                 try {
                     sqliteStorageAdapter.initialize(context, onResult, onError,

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/NonAbortingCountDownLatch.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/NonAbortingCountDownLatch.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+/**
+ * A NonAbortingCountDownLatch doesn't respond to the abort, just a latch to allow tests to throw
+ * errors.
+ * @param <E> the type of Throwable to be handled.
+ */
+class NonAbortingCountDownLatch<E extends Throwable> extends AbortableCountDownLatch<E> {
+
+    NonAbortingCountDownLatch(int count) {
+        super(count);
+    }
+
+    public boolean abortableAwait() throws InterruptedException, E {
+        this.await();
+        return true;
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -24,7 +24,9 @@ import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.SerializedModel;
+import com.amplifyframework.core.model.query.Page;
 import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
@@ -125,7 +127,8 @@ final class PersistentMutationOutbox implements MutationOutbox {
                 // to get identically the thing that was saved. But we know the save succeeded.
                 // So, let's skip the unwrapping, and use the thing that was enqueued,
                 // the pendingMutation, directly.
-                mutationQueue.updateExistingQueueItemOrAppendNew(pendingMutation.getMutationId(), pendingMutation);
+                mutationQueue.updateExistingQueueItemOrAppendNewIfWithinLimit(
+                    pendingMutation.getMutationId(), pendingMutation);
                 LOG.info("Successfully enqueued " + pendingMutation);
                 announceEventEnqueued(pendingMutation);
                 publishCurrentOutboxStatus();
@@ -184,7 +187,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
         return Completable.create(emitter -> {
             inFlightMutations.clear();
             mutationQueue.clear();
-            storage.query(PendingMutation.PersistentRecord.class, Where.matchesAll(),
+            storage.query(PendingMutation.PersistentRecord.class, Where.matchesAll().paginated(Page.firstPage()),
                 results -> {
                     while (results.hasNext()) {
                         try {
@@ -195,13 +198,44 @@ final class PersistentMutationOutbox implements MutationOutbox {
                             return;
                         }
                     }
-                    // Publish outbox status upon loading
-                    publishCurrentOutboxStatus();
                     emitter.onComplete();
                 },
                 emitter::onError
             );
-        })
+        }).andThen(Observable.fromIterable(mutationQueue.iterator())
+            .flatMapCompletable((timeBasedUuid) -> {
+                return Completable.create(emitter -> {
+                    PendingMutation<? extends Model> pendingMutation = mutationQueue.getMutationById(timeBasedUuid);
+                    if (pendingMutation != null) {
+                        QueryPredicate hasOtherPendingModelMutations = QueryField
+                            // find other PendingModelMutations
+                            .field("containedModelId")
+                            .eq(pendingMutation.getMutationId().toString())
+                            .and(QueryPredicate.not(
+                                // but not _this_ pending mutation
+                                QueryField.field("id")
+                                    .eq(timeBasedUuid)
+                            ));
+                        storage.query(PendingMutation.PersistentRecord.class,
+                            Where.matches(hasOtherPendingModelMutations),
+                            results -> {
+                                while (results.hasNext()) {
+                                    try {
+                                        PendingMutation.PersistentRecord persistentRecord = results.next();
+                                        mutationQueue.add(converter.fromRecord(persistentRecord));
+                                    } catch (Throwable throwable) {
+                                        emitter.onError(throwable);
+                                        return;
+                                    }
+                                }
+                                emitter.onComplete();
+                            },
+                            emitter::onError
+                        );
+                    }
+                });
+            })
+        ).andThen(Completable.fromAction(this::publishCurrentOutboxStatus))
         .doOnSubscribe(disposable -> semaphore.acquire())
         .doOnTerminate(semaphore::release);
     }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -178,7 +178,8 @@ public final class AWSDataStorePluginTest {
                 .start();
         ApiCategory mockApiCategory = mockApiCategoryWithGraphQlApi();
         JSONObject dataStorePluginJson = new JSONObject()
-            .put("syncIntervalInMinutes", 60);
+            .put("syncIntervalInMinutes", 60)
+            .put("outboxErrorRestartDelay", 0);
         AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
                                                                   .modelProvider(modelProvider)
                                                                   .apiCategory(mockApiCategory)
@@ -215,7 +216,8 @@ public final class AWSDataStorePluginTest {
     public void configureAndInitializeInApiModeWithoutApi() throws JSONException, AmplifyException {
         ApiCategory mockApiCategory = mockApiPluginWithExceptions();
         JSONObject dataStorePluginJson = new JSONObject()
-            .put("syncIntervalInMinutes", 60);
+            .put("syncIntervalInMinutes", 60)
+            .put("outboxErrorRestartDelay", 0);
         AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
                                                                   .modelProvider(modelProvider)
                                                                   .apiCategory(mockApiCategory)
@@ -247,7 +249,8 @@ public final class AWSDataStorePluginTest {
         ApiCategory mockApiCategory = mockApiCategoryWithGraphQlApi();
         ApiPlugin<?> mockApiPlugin = mockApiCategory.getPlugin(MOCK_API_PLUGIN_NAME);
         JSONObject dataStorePluginJson = new JSONObject()
-            .put("syncIntervalInMinutes", 60);
+            .put("syncIntervalInMinutes", 60)
+            .put("outboxErrorRestartDelay", 0);
         AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
                                                                   .modelProvider(modelProvider)
                                                                   .apiCategory(mockApiCategory)
@@ -340,7 +343,8 @@ public final class AWSDataStorePluginTest {
         ApiCategory mockApiCategory = mockApiCategoryWithGraphQlApi();
         ApiPlugin<?> mockApiPlugin = mockApiCategory.getPlugin(MOCK_API_PLUGIN_NAME);
         JSONObject dataStorePluginJson = new JSONObject()
-                .put("syncIntervalInMinutes", 60);
+                .put("syncIntervalInMinutes", 60)
+                .put("outboxErrorRestartDelay", 0);
         AWSDataStorePlugin awsDataStorePlugin = AWSDataStorePlugin.builder()
                                                                   .modelProvider(modelProvider)
                                                                   .apiCategory(mockApiCategory)
@@ -565,7 +569,8 @@ public final class AWSDataStorePluginTest {
                 .modelProvider(modelProvider)
                 .build();
         JSONObject dataStorePluginJson = new JSONObject()
-                .put("syncIntervalInMinutes", 60);
+                .put("syncIntervalInMinutes", 60)
+                .put("outboxErrorRestartDelay", 0);
         awsDataStorePlugin.configure(dataStorePluginJson, context);
         awsDataStorePlugin.initialize(context);
         Amplify.Hub.publish(HubChannel.DATASTORE, HubEvent.create(InitializationStatus.SUCCEEDED));
@@ -608,7 +613,8 @@ public final class AWSDataStorePluginTest {
                 .modelProvider(modelProvider)
                 .build();
         JSONObject dataStorePluginJson = new JSONObject()
-                .put("syncIntervalInMinutes", 60);
+                .put("syncIntervalInMinutes", 60)
+                .put("outboxErrorRestartDelay", 0);
         awsDataStorePlugin.configure(dataStorePluginJson, context);
         awsDataStorePlugin.initialize(context);
         Amplify.Hub.publish(HubChannel.DATASTORE, HubEvent.create(InitializationStatus.SUCCEEDED));

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/storage/SynchronousStorageAdapter.java
@@ -101,7 +101,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> void save(@NonNull T model, @NonNull QueryPredicate predicate)
         throws DataStoreException {
         Await.result(
-            operationTimeoutMs,
             (Consumer<StorageItemChange<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.save(
                     model,
@@ -166,7 +165,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> List<T> query(@NonNull Class<T> modelClass, @NonNull QueryOptions options)
         throws DataStoreException {
         Iterator<T> resultIterator = Await.result(
-            operationTimeoutMs,
             (Consumer<Iterator<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.query(modelClass, options, onResult, onError)
         );
@@ -197,7 +195,6 @@ public final class SynchronousStorageAdapter {
     public <T extends Model> void delete(@NonNull T model, @NonNull QueryPredicate predicate)
         throws DataStoreException {
         Await.result(
-            operationTimeoutMs,
             (Consumer<StorageItemChange<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.delete(
                     model,
@@ -220,7 +217,6 @@ public final class SynchronousStorageAdapter {
     @SuppressWarnings("unused")
     public <T extends Model> DataStoreException deleteExpectingError(@NonNull T model) {
         return Await.error(
-            operationTimeoutMs,
             (Consumer<StorageItemChange<T>> onResult, Consumer<DataStoreException> onError) ->
                 asyncDelegate.delete(
                     model,

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -100,6 +100,7 @@ public final class MutationProcessorTest {
             .mutationOutbox(mutationOutbox)
             .appSync(appSync)
             .conflictResolver(conflictResolver)
+            .dataStoreConfigurationProvider(configurationProvider)
             .build();
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
@@ -46,6 +46,7 @@ import org.robolectric.RobolectricTestRunner;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -96,6 +97,7 @@ public final class SubscriptionProcessorTest {
                 .modelProvider(modelProvider)
                 .schemaRegistry(schemaRegistry)
                 .merger(merger)
+                .dataStoreConfigurationProvider(() -> dataStoreConfiguration)
                 .queryPredicateProvider(queryPredicateProvider)
                 .onFailure(throwable -> { })
                 .build();
@@ -136,7 +138,9 @@ public final class SubscriptionProcessorTest {
 
         // Act: start some subscriptions.
         try {
-            subscriptionProcessor.startSubscriptions();
+            subscriptionProcessor.startSubscriptions(
+                    new TimedAbortableCountDownLatch<DataStoreException>(this.modelSchemas.size(),
+                    OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS), new HashSet<Class<? extends Model>>());
         } catch (DataStoreException exception) {
             // startSubscriptions throws this exception if it doesn't receive the start_ack messages after a time out.
             // This test doesn't mock those start_ack messages, so this expection is expected.  That's okay though -

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TimedAbortableCountDownLatch.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/TimedAbortableCountDownLatch.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.syncengine;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A TimedAbortableCountDownLatch with the ability to handle errors. This is really just for tests.
+ * @param <E> the type of Throwable to be handled.
+ */
+final class TimedAbortableCountDownLatch<E extends Throwable> extends AbortableCountDownLatch<E> {
+    private final long timeout;
+    private final TimeUnit unit;
+
+    TimedAbortableCountDownLatch(int count, long timeout, TimeUnit unit) {
+        super(count);
+        this.timeout = timeout;
+        this.unit = unit;
+    }
+
+    public boolean abortableAwait() throws InterruptedException, E {
+        final boolean success = super.await(timeout, unit);
+        E error = getError();
+        if (error != null) {
+            throw error;
+        }
+        return success;
+    }
+}

--- a/core/src/main/java/com/amplifyframework/core/model/ModelProvider.java
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelProvider.java
@@ -89,6 +89,24 @@ public interface ModelProvider {
     }
 
     /**
+     * A default helper method to return all the model names except those excluded.
+     * @param excluded models that should not be the result set
+     * @return a set of all model names.
+     */
+    default Set<String> modelNames(Set<Class<? extends Model>> excluded) {
+        final Set<String> modelNames = new HashSet<>();
+        if (models() == null) {
+            return modelNames;
+        }
+        for (Class<? extends Model> modelClass : models()) {
+            if (!excluded.contains(modelClass)) {
+                modelNames.add(modelClass.getSimpleName());
+            }
+        }
+        return modelNames;
+    }
+
+    /**
      * A default helper method to return all the custom type names.
      * This method returns an empty map for non-flutter use cases.
      * @return an empty map.

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousApi.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousApi.java
@@ -310,7 +310,7 @@ public final class SynchronousApi {
     @NonNull
     public <T extends Model> Observable<GraphQLResponse<T>> onCreate(@NonNull String apiName, @NonNull Class<T> clazz) {
         return Observable.create(emitter -> {
-            Await.<String, ApiException>result(OPERATION_TIMEOUT_MS,
+            Await.<String, ApiException>result(
                 (onSubscriptionStarted, onError) -> {
                     Cancelable cancelable = asyncDelegate.subscribe(
                             apiName,
@@ -340,7 +340,6 @@ public final class SynchronousApi {
             CompositeDisposable disposable = new CompositeDisposable();
             emitter.setDisposable(disposable);
             Await.<String, ApiException>result(
-                OPERATION_TIMEOUT_MS,
                 (onSubscriptionStarted, onError) -> {
                     Cancelable cancelable = asyncDelegate.subscribe(
                             apiName,
@@ -362,7 +361,7 @@ public final class SynchronousApi {
     private <T> T awaitResponseData(
             Await.ResultErrorEmitter<GraphQLResponse<T>, ApiException> resultErrorEmitter)
             throws ApiException {
-        final GraphQLResponse<T> response = Await.result(OPERATION_TIMEOUT_MS, resultErrorEmitter);
+        final GraphQLResponse<T> response = Await.result(resultErrorEmitter);
         if (response.hasErrors()) {
             String firstErrorMessage = response.getErrors().get(0).getMessage();
             throw new RuntimeException("Response has error:" + firstErrorMessage);
@@ -376,7 +375,7 @@ public final class SynchronousApi {
     private <T> List<GraphQLResponse.Error> awaitResponseErrors(
             Await.ResultErrorEmitter<GraphQLResponse<T>, ApiException> resultErrorEmitter)
             throws ApiException {
-        final GraphQLResponse<T> response = Await.result(OPERATION_TIMEOUT_MS, resultErrorEmitter);
+        final GraphQLResponse<T> response = Await.result(resultErrorEmitter);
         if (!response.hasErrors()) {
             throw new RuntimeException("No errors in response.");
         }
@@ -387,6 +386,6 @@ public final class SynchronousApi {
     private RestResponse awaitRestResponse(
             Await.ResultErrorEmitter<RestResponse, ApiException> resultErrorEmitter)
             throws ApiException {
-        return Await.result(OPERATION_TIMEOUT_MS, resultErrorEmitter);
+        return Await.result(resultErrorEmitter);
     }
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -103,7 +103,7 @@ public final class SynchronousAuth {
             @NonNull String password,
             @NonNull AuthSignUpOptions options
     ) throws AuthException {
-        return Await.<AuthSignUpResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignUpResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.signUp(username, password, options, onResult, onError)
         );
     }
@@ -122,7 +122,7 @@ public final class SynchronousAuth {
             @NonNull String confirmationCode,
             @NonNull AuthConfirmSignUpOptions options
     ) throws AuthException {
-        return Await.<AuthSignUpResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignUpResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.confirmSignUp(username, confirmationCode, options, onResult, onError)
         );
     }
@@ -139,7 +139,7 @@ public final class SynchronousAuth {
             @NonNull String username,
             @NonNull String confirmationCode
     ) throws AuthException {
-        return Await.<AuthSignUpResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignUpResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.confirmSignUp(username, confirmationCode, onResult, onError)
         );
     }
@@ -156,7 +156,7 @@ public final class SynchronousAuth {
             @NonNull String username,
             @NonNull AuthResendSignUpCodeOptions options
     ) throws AuthException {
-        return Await.<AuthSignUpResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignUpResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.resendSignUpCode(username, options, onResult, onError)
         );
     }
@@ -171,7 +171,7 @@ public final class SynchronousAuth {
     public AuthSignUpResult resendSignUpCode(
             @NonNull String username
     ) throws AuthException {
-        return Await.<AuthSignUpResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignUpResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.resendSignUpCode(username, onResult, onError)
         );
     }
@@ -190,7 +190,7 @@ public final class SynchronousAuth {
             @Nullable String password,
             @NonNull AuthSignInOptions options
     ) throws AuthException {
-        return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignInResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.signIn(username, password, options, onResult, onError)
         );
     }
@@ -207,7 +207,7 @@ public final class SynchronousAuth {
             @Nullable String username,
             @Nullable String password
     ) throws AuthException {
-        return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignInResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.signIn(username, password, onResult, onError)
         );
     }
@@ -224,7 +224,7 @@ public final class SynchronousAuth {
             @NonNull String confirmationCode,
             @NonNull AuthConfirmSignInOptions options
     ) throws AuthException {
-        return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignInResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.confirmSignIn(confirmationCode, options, onResult, onError)
         );
     }
@@ -239,7 +239,7 @@ public final class SynchronousAuth {
     public AuthSignInResult confirmSignIn(
             @NonNull String confirmationCode
     ) throws AuthException {
-        return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignInResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.confirmSignIn(confirmationCode, onResult, onError)
         );
     }
@@ -256,7 +256,7 @@ public final class SynchronousAuth {
             @NonNull AuthProvider provider,
             @NonNull Activity callingActivity
     ) throws AuthException {
-        return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignInResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.signInWithSocialWebUI(provider, callingActivity, onResult, onError)
         );
     }
@@ -273,7 +273,7 @@ public final class SynchronousAuth {
             @NonNull Activity callingActivity,
             @NonNull AuthWebUISignInOptions options
     ) throws AuthException {
-        return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthSignInResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.signInWithWebUI(callingActivity, options, onResult, onError)
         );
     }
@@ -290,7 +290,7 @@ public final class SynchronousAuth {
             @NonNull String username,
             @NonNull AuthResetPasswordOptions options
     ) throws AuthException {
-        return Await.<AuthResetPasswordResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthResetPasswordResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.resetPassword(username, options, onResult, onError)
         );
     }
@@ -305,7 +305,7 @@ public final class SynchronousAuth {
     public AuthResetPasswordResult resetPassword(
             @NonNull String username
     ) throws AuthException {
-        return Await.<AuthResetPasswordResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        return Await.<AuthResetPasswordResult, AuthException>result((onResult, onError) ->
                 asyncDelegate.resetPassword(username, onResult, onError)
         );
     }
@@ -322,7 +322,7 @@ public final class SynchronousAuth {
             @NonNull String confirmationCode,
             @NonNull AuthConfirmResetPasswordOptions options
     ) throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.confirmResetPassword(
                     newPassword,
                     confirmationCode,
@@ -343,7 +343,7 @@ public final class SynchronousAuth {
             @NonNull String newPassword,
             @NonNull String confirmationCode
     ) throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.confirmResetPassword(
                     newPassword,
                     confirmationCode,
@@ -360,7 +360,7 @@ public final class SynchronousAuth {
      */
     @NonNull
     public AuthSession fetchAuthSession() throws AuthException {
-        return Await.result(AUTH_OPERATION_TIMEOUT_MS, asyncDelegate::fetchAuthSession);
+        return Await.result(asyncDelegate::fetchAuthSession);
     }
 
     /**
@@ -368,7 +368,7 @@ public final class SynchronousAuth {
      * @throws AuthException exception
      */
     public void rememberDevice() throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.rememberDevice(() -> onResult.accept(VoidResult.instance()), onError)
         );
     }
@@ -378,7 +378,7 @@ public final class SynchronousAuth {
      * @throws AuthException exception
      */
     public void forgetDevice() throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.forgetDevice(() -> onResult.accept(VoidResult.instance()), onError)
         );
     }
@@ -389,7 +389,7 @@ public final class SynchronousAuth {
      * @throws AuthException exception
      */
     public void forgetDevice(@NonNull AuthDevice device) throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.forgetDevice(device, () -> onResult.accept(VoidResult.instance()), onError)
         );
     }
@@ -400,7 +400,7 @@ public final class SynchronousAuth {
      * @throws AuthException exception
      */
     public List<AuthDevice> fetchDevices() throws AuthException {
-        return Await.result(AUTH_OPERATION_TIMEOUT_MS, asyncDelegate::fetchDevices);
+        return Await.result(asyncDelegate::fetchDevices);
     }
 
     /**
@@ -413,7 +413,7 @@ public final class SynchronousAuth {
             @NonNull String oldPassword,
             @NonNull String newPassword
     ) throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.updatePassword(oldPassword, newPassword,
                     () -> onResult.accept(VoidResult.instance()), onError)
         );
@@ -526,7 +526,7 @@ public final class SynchronousAuth {
      */
     public void confirmUserAttribute(@NonNull AuthUserAttributeKey attributeKey,
                                      @NonNull String confirmationCode) throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) -> {
+        Await.<Object, AuthException>result((onResult, onError) -> {
             asyncDelegate.confirmUserAttribute(
                     attributeKey, confirmationCode, () -> onResult.accept(VoidResult.instance()), onError
             );
@@ -538,7 +538,7 @@ public final class SynchronousAuth {
      * @throws AuthException exception
      */
     public void signOut() throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.signOut(
                     () -> onResult.accept(VoidResult.instance()),
                     onError
@@ -552,7 +552,7 @@ public final class SynchronousAuth {
      * @throws AuthException exception
      */
     public void signOut(AuthSignOutOptions options) throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.signOut(
                     options,
                     () -> onResult.accept(VoidResult.instance()),
@@ -566,7 +566,7 @@ public final class SynchronousAuth {
      * @throws AuthException exception
      */
     public void deleteUser() throws AuthException {
-        Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
+        Await.<Object, AuthException>result((onResult, onError) ->
                 asyncDelegate.deleteUser(() -> onResult.accept(VoidResult.instance()), onError)
         );
     }

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousPredictions.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousPredictions.java
@@ -91,7 +91,6 @@ public final class SynchronousPredictions {
             @NonNull TextToSpeechOptions options
     ) throws PredictionsException {
         return Await.<TextToSpeechResult, PredictionsException>result(
-            PREDICTIONS_OPERATION_TIMEOUT_MS,
             (onResult, onError) -> asyncDelegate.convertTextToSpeech(
                     text,
                     options,
@@ -130,7 +129,6 @@ public final class SynchronousPredictions {
             @NonNull TranslateTextOptions options
     ) throws PredictionsException {
         return Await.<TranslateTextResult, PredictionsException>result(
-            PREDICTIONS_OPERATION_TIMEOUT_MS,
             (onResult, onError) -> asyncDelegate.translateText(
                     text,
                     options,
@@ -177,7 +175,6 @@ public final class SynchronousPredictions {
             @NonNull TranslateTextOptions options
     ) throws PredictionsException {
         return Await.<TranslateTextResult, PredictionsException>result(
-            PREDICTIONS_OPERATION_TIMEOUT_MS,
             (onResult, onError) -> asyncDelegate.translateText(
                     text,
                     fromLanguage,
@@ -220,7 +217,6 @@ public final class SynchronousPredictions {
             @NonNull IdentifyOptions options
     ) throws PredictionsException {
         return Await.<IdentifyResult, PredictionsException>result(
-            PREDICTIONS_OPERATION_TIMEOUT_MS,
             (onResult, onError) -> asyncDelegate.identify(
                     actionType,
                     image,
@@ -260,7 +256,6 @@ public final class SynchronousPredictions {
             @NonNull InterpretOptions options
     ) throws PredictionsException {
         return Await.<InterpretResult, PredictionsException>result(
-            PREDICTIONS_OPERATION_TIMEOUT_MS,
             (onResult, onError) -> asyncDelegate.interpret(
                     text,
                     options,

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousStorage.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousStorage.java
@@ -110,7 +110,7 @@ public final class SynchronousStorage {
             @NonNull StorageDownloadFileOptions options,
             long timeoutMs
     ) throws StorageException {
-        return Await.<StorageDownloadFileResult, StorageException>result(timeoutMs, (onResult, onError) ->
+        return Await.<StorageDownloadFileResult, StorageException>result((onResult, onError) ->
                 asyncDelegate.downloadFile(key, local, options, onResult, onError)
         );
     }
@@ -150,7 +150,7 @@ public final class SynchronousStorage {
             @NonNull StorageUploadFileOptions options,
             long timeoutMs
     ) throws StorageException {
-        return Await.<StorageUploadFileResult, StorageException>result(timeoutMs, (onResult, onError) ->
+        return Await.<StorageUploadFileResult, StorageException>result((onResult, onError) ->
                 asyncDelegate.uploadFile(key, local, options, onResult, onError)
         );
     }
@@ -190,7 +190,7 @@ public final class SynchronousStorage {
             @NonNull StorageUploadInputStreamOptions options,
             long timeoutMs
     ) throws StorageException {
-        return Await.<StorageUploadInputStreamResult, StorageException>result(timeoutMs, (onResult, onError) ->
+        return Await.<StorageUploadInputStreamResult, StorageException>result((onResult, onError) ->
                 asyncDelegate.uploadInputStream(key, local, options, onResult, onError)
         );
     }
@@ -226,7 +226,7 @@ public final class SynchronousStorage {
             @NonNull StorageRemoveOptions options,
             long timeoutMs
     ) throws StorageException {
-        return Await.<StorageRemoveResult, StorageException>result(timeoutMs, (onResult, onError) ->
+        return Await.<StorageRemoveResult, StorageException>result((onResult, onError) ->
                 asyncDelegate.remove(key, options, onResult, onError)
         );
     }
@@ -262,7 +262,7 @@ public final class SynchronousStorage {
             @NonNull StorageListOptions options,
             long timeoutMs
     ) throws StorageException {
-        return Await.<StorageListResult, StorageException>result(timeoutMs, (onResult, onError) ->
+        return Await.<StorageListResult, StorageException>result((onResult, onError) ->
                 asyncDelegate.list(path, options, onResult, onError)
         );
     }


### PR DESCRIPTION
- [X] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
Fixes #1869 
Fixes #1849 

*Description of changes:*

## Fix memory management

  - mutation outbox will now allocate 200 slots by default
  - mutation outbox loads only first 100 mutations plus any pending mutations related to first 100 loaded
  - SubscriptionProcessor will now only hold a maximum of 100 subscription events with a max age of 10 minutes

## add options to disable Sync or Subscriptions
Give a "producer only" time series database the sync and subscription systems can be cumbersome or unnecessary.
Sometimes people just want to push data from the datastore and this gives more flexibility to the engine, makes
for faster startup in these conditions, and reduced the need to hack around these features with items such as
having the graphQL endpoint respond with empty lists in the sync or unauthorized for a subscription.

  - use datastore configuration disableSync(Model.class) and disableSubscription(Model.class) to allow toggling if model should sync or receive subscriptions
  - https://docs.amplify.aws/lib/datastore/sync/q/platform/android/ should be updated to reflect new options for Syncing data.
 
## Fix Pending Mutation Engine Halting on Error
Currently the mutation engine will halt on any given error. This update tries to resume reading updates every 30 seconds. Configurable via datastore option outboxErrorRestartDelay.

## Remove timeouts
There are various timeouts that are effectively CPU or network bound. Removing the timeouts makes the system more
likely to work on a diversity of client.

  - remove restart delay for tests as they were CPU bound and caused predicable failure when a thread goes slow
  - remove Orchestrator semaphore timeout
  - remove ITEM_PROCESSING_TIMEOUT_MS from MutationProcessor

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [X] Added Unit Tests
- [X] Tested on frontend (Add Screenshots)
![image](https://user-images.githubusercontent.com/1022919/183271468-aebd8110-d151-49e2-bb4f-c41963a76a1c.png)

- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [X] Yes (Please include a PR link for the documentation update)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
