### PR TITLE
chore: Add more devices to integration testing

### DIFF
--- a/scripts/generate_df_testrun_report
+++ b/scripts/generate_df_testrun_report
@@ -33,6 +33,7 @@ def generate_junit_report(run_arn, output_path):
     jobs = get_test_jobs(run_arn)
     for job in jobs:
         LOGGER.debug(f"Retrieving test suites for job {job['arn']}")
+        device_no = job['arn'].split('/')[-1]
         suites = get_test_suites(job['arn'])
         for suite in suites:
             LOGGER.debug(f"Retrieving tests for suite {suite['arn']}")
@@ -49,12 +50,12 @@ def generate_junit_report(run_arn, output_path):
                 if test['result'] == 'ERROR':
                     tc.add_error_info(message=test['message'])
                 test_cases.append(tc)
-            ts = TestSuite(suite['name'],test_cases=test_cases)
+            ts = TestSuite(suite['name'] + "-" + device_no,test_cases=test_cases)
             ts_output = TestSuite.to_xml_string([ts])
             LOGGER.info(f"Saving test suite {suite['name']} report.")
             if not os.path.exists(output_path):
                 os.makedirs(output_path)
-            f = open(output_path + suite['name'] + ".xml", "w")
+            f = open(output_path + suite['name'] + "-" + device_no + ".xml", "w")
             f.write(ts_output)
             f.close()
 

--- a/scripts/generate_df_testrun_report
+++ b/scripts/generate_df_testrun_report
@@ -33,7 +33,6 @@ def generate_junit_report(run_arn, output_path):
     jobs = get_test_jobs(run_arn)
     for job_no, job in enumerate(jobs):
         LOGGER.debug(f"Retrieving test suites for job {job['arn']}")
-        device_no = job['arn'].split('/')[-1]
         suites = get_test_suites(job['arn'])
         for suite in suites:
             LOGGER.debug(f"Retrieving tests for suite {suite['arn']}")

--- a/scripts/run_test_in_devicefarm.sh
+++ b/scripts/run_test_in_devicefarm.sh
@@ -44,6 +44,7 @@ sleep 10
 
 # Get oldest device we can test against.
 minDevice=$(aws devicefarm list-devices \
+                --region="us-west-2" \
                 --filters '[
                     {"attribute":"AVAILABILITY","operator":"EQUALS","values":["HIGHLY_AVAILABLE"]},
                     {"attribute":"PLATFORM","operator":"EQUALS","values":["ANDROID"]},
@@ -55,6 +56,7 @@ minDevice=$(aws devicefarm list-devices \
 
 # Get middle device we can test against.
 middleDevice=$(aws devicefarm list-devices \
+                --region="us-west-2" \
                 --filters '[
                     {"attribute":"AVAILABILITY","operator":"EQUALS","values":["HIGHLY_AVAILABLE"]},
                     {"attribute":"PLATFORM","operator":"EQUALS","values":["ANDROID"]},
@@ -66,6 +68,7 @@ middleDevice=$(aws devicefarm list-devices \
 
 # Get latest device we can test against.
 latestDevice=$(aws devicefarm list-devices \
+                --region="us-west-2" \
                 --filters '[
                     {"attribute":"AVAILABILITY","operator":"EQUALS","values":["HIGHLY_AVAILABLE"]},
                     {"attribute":"PLATFORM","operator":"EQUALS","values":["ANDROID"]},

--- a/scripts/run_test_in_devicefarm.sh
+++ b/scripts/run_test_in_devicefarm.sh
@@ -112,7 +112,7 @@ while true; do
   then
     break
   fi
-  sleep 5
+  sleep 30
 done
 echo "Status = $status Result = $result"
 

--- a/scripts/run_test_in_devicefarm.sh
+++ b/scripts/run_test_in_devicefarm.sh
@@ -49,7 +49,7 @@ minDevice=$(aws devicefarm list-devices \
                     {"attribute":"AVAILABILITY","operator":"EQUALS","values":["HIGHLY_AVAILABLE"]},
                     {"attribute":"PLATFORM","operator":"EQUALS","values":["ANDROID"]},
                     {"attribute":"OS_VERSION","operator":"GREATER_THAN_OR_EQUALS","values":["7"]},
-                    {"attribute":"OS_VERSION","operator":"LESS_THAN","values":["8"]},
+                    {"attribute":"OS_VERSION","operator":"LESS_THAN","values":["7.1"]},
                     {"attribute":"MANUFACTURER","operator":"IN","values":["Google", "Pixel", "Samsung"]}
                 ]' \
                 | jq -r '.devices[0].arn')
@@ -62,7 +62,7 @@ middleDevice=$(aws devicefarm list-devices \
                     {"attribute":"PLATFORM","operator":"EQUALS","values":["ANDROID"]},
                     {"attribute":"OS_VERSION","operator":"GREATER_THAN_OR_EQUALS","values":["10"]},
                     {"attribute":"OS_VERSION","operator":"LESS_THAN","values":["11"]},
-                    {"attribute":"MANUFACTURER","operator":"IN","values":["Google", "Samsung"]}
+                    {"attribute":"MANUFACTURER","operator":"IN","values":["Samsung"]}
                 ]' \
                 | jq -r '.devices[0].arn')
 


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Testing all PRs on 3 devices (Pixel or Samsung) with different OS versions now, instead of just 1.
Android 7
Android 10
Android 12

Also raised threshold to check every 20 seconds instead of 5. Will probably bump further in future PR.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
