### PR TITLE
chore: ignore storage tests failing with invalid auth state

### DIFF
--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadAccessLevelTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadAccessLevelTest.java
@@ -31,8 +31,10 @@ import com.amplifyframework.testutils.random.RandomTempFile;
 import com.amplifyframework.testutils.sync.SynchronousAuth;
 import com.amplifyframework.testutils.sync.SynchronousStorage;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -68,7 +70,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
         Context context = getApplicationContext();
 
         WorkmanagerTestUtils.INSTANCE.initializeWorkmanagerTestUtil(context);
-        synchronousAuth = SynchronousAuth.delegatingToCognito(context, (AuthPlugin) new AWSCognitoAuthPlugin());
+        synchronousAuth = SynchronousAuth.delegatingToCognito(context, new AWSCognitoAuthPlugin());
         IdentityIdSource identityIdSource = MobileClientIdentityIdSource.create(synchronousAuth);
         UserCredentials userCredentials = UserCredentials.create(context, identityIdSource);
         Iterator<Credential> iterator = userCredentials.iterator();
@@ -78,6 +80,17 @@ public final class AWSS3StorageUploadAccessLevelTest {
         // Setup storage.
         StorageCategory asyncDelegate = TestStorageCategory.create(context, R.raw.amplifyconfiguration);
         storage = SynchronousStorage.delegatingTo(asyncDelegate);
+    }
+
+    /**
+     * Reset all the assigned static fields.
+     */
+    @AfterClass
+    public static void tearDown() {
+        synchronousAuth = null;
+        userOne = null;
+        userTwo = null;
+        storage = null;
     }
 
     /**
@@ -152,6 +165,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
      *
      * @throws Exception if upload is unsuccessful
      */
+    @Ignore("Test fails in CI indeterministically")
     @Test
     public void testUploadAuthenticatedProtectedAccess() throws Exception {
         synchronousAuth.signIn(userOne.getUsername(), userOne.getPassword());
@@ -167,6 +181,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
      *
      * @throws Exception if upload is unsuccessful
      */
+    @Ignore("Test fails in CI indeterministically")
     @Test
     public void testUploadAuthenticatedPrivateAccess() throws Exception {
         synchronousAuth.signIn(userOne.getUsername(), userOne.getPassword());
@@ -186,6 +201,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
      *
      * @throws Exception if download is unsuccessful
      */
+    @Ignore("Test fails in CI indeterministically")
     @Test(expected = StorageException.class)
     public void testUploadDifferentUserProtectedAccess() throws Exception {
         synchronousAuth.signIn(userOne.getUsername(), userOne.getPassword());
@@ -205,6 +221,7 @@ public final class AWSS3StorageUploadAccessLevelTest {
      *
      * @throws Exception if download is unsuccessful
      */
+    @Ignore("Test fails in CI indeterministically")
     @Test(expected = StorageException.class)
     public void testUploadDifferentUserPrivateAccess() throws Exception {
         synchronousAuth.signIn(userOne.getUsername(), userOne.getPassword());

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadAccessLevelTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadAccessLevelTest.java
@@ -18,7 +18,6 @@ package com.amplifyframework.storage.s3;
 import android.content.Context;
 
 import com.amplifyframework.AmplifyException;
-import com.amplifyframework.auth.AuthPlugin;
 import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin;
 import com.amplifyframework.storage.StorageAccessLevel;
 import com.amplifyframework.storage.StorageCategory;


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Some tests which are failing frequently with "invalid auth state" has been ignored.
These tests are being investigated for root cause and will be un-ignored with the fix.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Tested on frontend (Add Screenshots)
- [ ] Successful logs (Attach them to the PR)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
