### PR TITLE
chore: add device run suffix to test report generator

### DIFF
--- a/scripts/generate_df_testrun_report
+++ b/scripts/generate_df_testrun_report
@@ -33,6 +33,7 @@ def generate_junit_report(run_arn, output_path):
     jobs = get_test_jobs(run_arn)
     for job in jobs:
         LOGGER.debug(f"Retrieving test suites for job {job['arn']}")
+        device_no = job['arn'].split('/')[-1]
         suites = get_test_suites(job['arn'])
         for suite in suites:
             LOGGER.debug(f"Retrieving tests for suite {suite['arn']}")
@@ -49,12 +50,12 @@ def generate_junit_report(run_arn, output_path):
                 if test['result'] == 'ERROR':
                     tc.add_error_info(message=test['message'])
                 test_cases.append(tc)
-            ts = TestSuite(suite['name'],test_cases=test_cases)
+            ts = TestSuite(suite['name'] + "-" + device_no,test_cases=test_cases)
             ts_output = TestSuite.to_xml_string([ts])
             LOGGER.info(f"Saving test suite {suite['name']} report.")
             if not os.path.exists(output_path):
                 os.makedirs(output_path)
-            f = open(output_path + suite['name'] + ".xml", "w")
+            f = open(output_path + suite['name'] + "-" + device_no + ".xml", "w")
             f.write(ts_output)
             f.close()
 

--- a/scripts/generate_df_testrun_report
+++ b/scripts/generate_df_testrun_report
@@ -31,9 +31,8 @@ def parse_arguments():
 def generate_junit_report(run_arn, output_path):
     LOGGER.debug(f"Retrieving test jobs for run {run_arn}")
     jobs = get_test_jobs(run_arn)
-    for job in jobs:
+    for job_no, job in enumerate(jobs):
         LOGGER.debug(f"Retrieving test suites for job {job['arn']}")
-        device_no = job['arn'].split('/')[-1]
         suites = get_test_suites(job['arn'])
         for suite in suites:
             LOGGER.debug(f"Retrieving tests for suite {suite['arn']}")
@@ -50,12 +49,12 @@ def generate_junit_report(run_arn, output_path):
                 if test['result'] == 'ERROR':
                     tc.add_error_info(message=test['message'])
                 test_cases.append(tc)
-            ts = TestSuite(suite['name'] + "-" + device_no,test_cases=test_cases)
+            ts = TestSuite(suite['name'] + "-" + job_no,test_cases=test_cases)
             ts_output = TestSuite.to_xml_string([ts])
             LOGGER.info(f"Saving test suite {suite['name']} report.")
             if not os.path.exists(output_path):
                 os.makedirs(output_path)
-            f = open(output_path + suite['name'] + "-" + device_no + ".xml", "w")
+            f = open(output_path + suite['name'] + "-" + job_no + ".xml", "w")
             f.write(ts_output)
             f.close()
 

--- a/scripts/generate_df_testrun_report
+++ b/scripts/generate_df_testrun_report
@@ -49,12 +49,12 @@ def generate_junit_report(run_arn, output_path):
                 if test['result'] == 'ERROR':
                     tc.add_error_info(message=test['message'])
                 test_cases.append(tc)
-            ts = TestSuite(suite['name'] + "-" + job_no,test_cases=test_cases)
+            ts = TestSuite(suite['name'] + "-" + str(job_no),test_cases=test_cases)
             ts_output = TestSuite.to_xml_string([ts])
             LOGGER.info(f"Saving test suite {suite['name']} report.")
             if not os.path.exists(output_path):
                 os.makedirs(output_path)
-            f = open(output_path + suite['name'] + "-" + job_no + ".xml", "w")
+            f = open(output_path + suite['name'] + "-" + str(job_no) + ".xml", "w")
             f.write(ts_output)
             f.close()
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Test report generator does not support multiple devices run in same suite. The naming convention being used overrides Testcase and report file generated by another test in same suite. 
This change adds suffix to the test case and report to differentiate.
The suffix being generated uses index of job in jobs array.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
