### PR TITLE
Manual release: Amplify Android 1.37.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,7 @@
 ## [Release 1.37.3](https://github.com/aws-amplify/amplify-android/releases/tag/release_v1.37.3)
 
 ### Bug Fixes
-- fix(datastore): pk field list ordering in cascade delete. (#1894)
 - fix(data): disable failing test (#1922)
-
-### Miscellaneous
-- chore: change pull request template (#1892)
-- chore: add device run suffix to test report generator (#1895)
-- chore: Add more devices to integration testing (#1882)
-- chore: Unignore tests (#1900)
-- chore: fix geo and predictions test failures (#1898)
-- chore: remove ignored tests (#1901)
-- chore: Publish Javadocs (Amplify version) (#1897)
-- chore: stop duplicate test runs for same source (#1896) 
 
 [See all changes between 1.37.2 and 1.37.3](https://github.com/aws-amplify/amplify-android/compare/release_v1.37.2...release_v1.37.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [Release 1.37.3](https://github.com/aws-amplify/amplify-android/releases/tag/release_v1.37.3)
+
+### Bug Fixes
+- fix(datastore): pk field list ordering in cascade delete. (#1894)
+- fix(data): disable failing test (#1922)
+
+### Miscellaneous
+- chore: change pull request template (#1892)
+- chore: add device run suffix to test report generator (#1895)
+- chore: Add more devices to integration testing (#1882)
+- chore: Unignore tests (#1900)
+- chore: fix geo and predictions test failures (#1898)
+- chore: remove ignored tests (#1901)
+- chore: Publish Javadocs (Amplify version) (#1897)
+- chore: stop duplicate test runs for same source (#1896) 
+
+[See all changes between 1.37.2 and 1.37.3](https://github.com/aws-amplify/amplify-android/compare/release_v1.37.2...release_v1.37.3)
+
 ## [Release 1.37.2](https://github.com/aws-amplify/amplify-android/releases/tag/release_v1.37.2)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ dependencies section:
 ```groovy
 dependencies {
     // Only specify modules that provide functionality your app will use
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.37.2'
-    implementation 'com.amplifyframework:aws-api:1.37.2'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.37.2'
-    implementation 'com.amplifyframework:aws-datastore:1.37.2'
-    implementation 'com.amplifyframework:aws-predictions:1.37.2'
-    implementation 'com.amplifyframework:aws-storage-s3:1.37.2'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.37.3'
+    implementation 'com.amplifyframework:aws-api:1.37.3'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.37.3'
+    implementation 'com.amplifyframework:aws-datastore:1.37.3'
+    implementation 'com.amplifyframework:aws-predictions:1.37.3'
+    implementation 'com.amplifyframework:aws-storage-s3:1.37.3'
 }
 ```
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -242,10 +242,8 @@ public final class AWSDataStorePluginTest {
      * @throws JSONException on failure to arrange plugin config
      * @throws AmplifyException on failure to arrange API plugin via Amplify facade
      */
-    /** TODO: fix this test! It is believed that this test is flaky, as subsequent 
-     * reruns do not fail.
-     */
-    @Ignore("Ignoring this test to unblock the 8/30/22 release.")
+    @Ignore("Ignoring this test to unblock the 8/30/22 release.  TODO: fix this test! It is believed" +
+            "that this test is flaky, as subsequent reruns do not fail.")
     @Test
     public void clearStopsSyncAndDeletesDatabase() throws AmplifyException, JSONException {
         ApiCategory mockApiCategory = mockApiCategoryWithGraphQlApi();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -242,6 +242,10 @@ public final class AWSDataStorePluginTest {
      * @throws JSONException on failure to arrange plugin config
      * @throws AmplifyException on failure to arrange API plugin via Amplify facade
      */
+    /** TODO: fix this test! It is believed that this test is flaky, as subsequent 
+     * reruns do not fail.
+     */
+    @Ignore("Ignoring this test to unblock the 8/30/22 release.")
     @Test
     public void clearStopsSyncAndDeletesDatabase() throws AmplifyException, JSONException {
         ApiCategory mockApiCategory = mockApiCategoryWithGraphQlApi();

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
     minSdkVersion = 16
     targetSdkVersion = 30
 
-    awsSdkVersion = '2.51.0'
+    awsSdkVersion = '2.51.1'
     fragmentVersion = '1.3.1'
     navigationVersion = '2.3.4'
     dependency = [

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
     minSdkVersion = 16
     targetSdkVersion = 30
 
-    awsSdkVersion = '2.51.1'
+    awsSdkVersion = '2.52.1'
     fragmentVersion = '1.3.1'
     navigationVersion = '2.3.4'
     dependency = [

--- a/core-kotlin/CHANGELOG.md
+++ b/core-kotlin/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [Release 0.21.3](https://github.com/aws-amplify/amplify-android/releases/tag/release-kotlin_v0.21.3)
+
+### Bug Fixes
+- fix(datastore): pk field list ordering in cascade delete. (#1894)
+- fix(data): disable failing test (#1922)
+
+### Miscellaneous
+- chore: change pull request template (#1892)
+- chore: add device run suffix to test report generator (#1895)
+- chore: Add more devices to integration testing (#1882)
+- chore: Unignore tests (#1900)
+- chore: fix geo and predictions test failures (#1898)
+- chore: remove ignored tests (#1901)
+- chore: Publish Javadocs (Amplify version) (#1897)
+- chore: stop duplicate test runs for same source (#1896) 
+
+[See all changes between 0.21.2 and 0.21.3](https://github.com/aws-amplify/amplify-android/compare/release-kotlin_v0.21.2...release-kotlin_v0.21.3)
+
 ## [Release 0.21.2](https://github.com/aws-amplify/amplify-android/releases/tag/release-kotlin_v0.21.2)
 
 ### Bug Fixes

--- a/core-kotlin/CHANGELOG.md
+++ b/core-kotlin/CHANGELOG.md
@@ -1,18 +1,7 @@
 ## [Release 0.21.3](https://github.com/aws-amplify/amplify-android/releases/tag/release-kotlin_v0.21.3)
 
 ### Bug Fixes
-- fix(datastore): pk field list ordering in cascade delete. (#1894)
 - fix(data): disable failing test (#1922)
-
-### Miscellaneous
-- chore: change pull request template (#1892)
-- chore: add device run suffix to test report generator (#1895)
-- chore: Add more devices to integration testing (#1882)
-- chore: Unignore tests (#1900)
-- chore: fix geo and predictions test failures (#1898)
-- chore: remove ignored tests (#1901)
-- chore: Publish Javadocs (Amplify version) (#1897)
-- chore: stop duplicate test runs for same source (#1896) 
 
 [See all changes between 0.21.2 and 0.21.3](https://github.com/aws-amplify/amplify-android/compare/release-kotlin_v0.21.2...release-kotlin_v0.21.3)
 

--- a/core-kotlin/gradle.properties
+++ b/core-kotlin/gradle.properties
@@ -3,4 +3,4 @@ POM_NAME=Amplify Framework for Android - Kotlin facade for Core library
 POM_DESCRIPTION=Amplify Framework for Android - Kotlin facade for Core library
 POM_PACKAGING=aar
 
-VERSION_NAME=0.21.2
+VERSION_NAME=0.21.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx4g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-VERSION_NAME=1.37.2
+VERSION_NAME=1.37.3
 
 POM_GROUP=com.amplifyframework
 POM_URL=https://github.com/aws-amplify/amplify-android

--- a/rxbindings/README.md
+++ b/rxbindings/README.md
@@ -24,7 +24,7 @@ library. In your module's `build.gradle`:
 ```gradle
 dependencies {
     // Add this line.
-    implementation 'com.amplifyframework:rxbindings:1.37.2'
+    implementation 'com.amplifyframework:rxbindings:1.37.3'
 }
 ```
 


### PR DESCRIPTION
Manual cherry-picked release.  Please check thoroughly, comparing to [1.37.2](https://github.com/aws-amplify/amplify-android/commit/6a38bf92799c4c63e7739a24fce3fa77dca89359).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
