### PR TITLE
fix(auth): fix auth states when invoking signup related APIs

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthExceptions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthExceptions.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito
+
+import com.amplifyframework.auth.AuthException
+
+sealed class AWSCognitoAuthExceptions(message: String, recoverySuggestion: String) : AuthException(
+    message,
+    recoverySuggestion
+) {
+
+    /**
+     * Auth exception caused by auth state being in a not configured state.
+     */
+    class NotConfiguredException : AWSCognitoAuthExceptions(MESSAGE, RECOVERY_SUGGESTION) {
+        companion object {
+            private const val MESSAGE = "Auth not configured, cannot process the request."
+            private const val RECOVERY_SUGGESTION = "Cognito User Pool not configured. " +
+                "Please check amplifyconfiguration.json file."
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -131,19 +131,14 @@ internal class RealAWSCognitoAuthPlugin(
         onError: Consumer<AuthException>
     ) {
         authStateMachine.getCurrentState { authState ->
-            if (authState.authNState is AuthenticationState.Configured ||
-                authState.authNState is AuthenticationState.SignedOut
-            ) {
-                GlobalScope.launch {
+            when (authState.authNState) {
+                is AuthenticationState.NotConfigured -> onError.accept(
+                    AWSCognitoAuthExceptions.NotConfiguredException()
+                )
+                is AuthenticationState.SignedIn, is AuthenticationState.SignedOut -> GlobalScope.launch {
                     _signUp(username, password, options, onSuccess, onError)
                 }
-            } else {
-                onError.accept(
-                    AuthException(
-                        "Sign up failed.",
-                        "Cognito User Pool not configured. Please check amplifyconfiguration.json file."
-                    )
-                )
+                else -> onError.accept(AuthException.InvalidStateException())
             }
         }
     }
@@ -223,19 +218,14 @@ internal class RealAWSCognitoAuthPlugin(
         onError: Consumer<AuthException>
     ) {
         authStateMachine.getCurrentState { authState ->
-            if (authState.authNState is AuthenticationState.Configured ||
-                authState.authNState is AuthenticationState.SignedOut
-            ) {
-                GlobalScope.launch {
+            when (authState.authNState) {
+                is AuthenticationState.NotConfigured -> onError.accept(
+                    AWSCognitoAuthExceptions.NotConfiguredException()
+                )
+                is AuthenticationState.SignedIn, is AuthenticationState.SignedOut -> GlobalScope.launch {
                     _confirmSignUp(username, confirmationCode, options, onSuccess, onError)
                 }
-            } else {
-                onError.accept(
-                    AuthException(
-                        "Confirm sign up failed.",
-                        "Cognito User Pool not configured. Please check amplifyconfiguration.json file."
-                    )
-                )
+                else -> onError.accept(AuthException.InvalidStateException())
             }
         }
     }
@@ -289,19 +279,14 @@ internal class RealAWSCognitoAuthPlugin(
         onError: Consumer<AuthException>
     ) {
         authStateMachine.getCurrentState { authState ->
-            if (authState.authNState is AuthenticationState.Configured ||
-                authState.authNState is AuthenticationState.SignedOut
-            ) {
-                GlobalScope.launch {
+            when (authState.authNState) {
+                is AuthenticationState.NotConfigured -> onError.accept(
+                    AWSCognitoAuthExceptions.NotConfiguredException()
+                )
+                is AuthenticationState.SignedIn, is AuthenticationState.SignedOut -> GlobalScope.launch {
                     _resendSignUpCode(username, options, onSuccess, onError)
                 }
-            } else {
-                onError.accept(
-                    AuthException(
-                        "Resend sign up code failed.",
-                        "Cognito User Pool not configured. Please check amplifyconfiguration.json file."
-                    )
-                )
+                else -> onError.accept(AuthException.InvalidStateException())
             }
         }
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -127,7 +127,9 @@ internal class RealAWSCognitoAuthPlugin(
         onError: Consumer<AuthException>
     ) {
         authStateMachine.getCurrentState { authState ->
-            if (authState.authNState is AuthenticationState.Configured) {
+            if (authState.authNState is AuthenticationState.Configured ||
+                authState.authNState is AuthenticationState.SignedOut
+            ) {
                 GlobalScope.launch {
                     _signUp(username, password, options, onSuccess, onError)
                 }
@@ -217,7 +219,9 @@ internal class RealAWSCognitoAuthPlugin(
         onError: Consumer<AuthException>
     ) {
         authStateMachine.getCurrentState { authState ->
-            if (authState.authNState is AuthenticationState.Configured) {
+            if (authState.authNState is AuthenticationState.Configured ||
+                authState.authNState is AuthenticationState.SignedOut
+            ) {
                 GlobalScope.launch {
                     _confirmSignUp(username, confirmationCode, options, onSuccess, onError)
                 }
@@ -281,7 +285,9 @@ internal class RealAWSCognitoAuthPlugin(
         onError: Consumer<AuthException>
     ) {
         authStateMachine.getCurrentState { authState ->
-            if (authState.authNState is AuthenticationState.Configured) {
+            if (authState.authNState is AuthenticationState.Configured ||
+                authState.authNState is AuthenticationState.SignedOut
+            ) {
                 GlobalScope.launch {
                     _resendSignUpCode(username, options, onSuccess, onError)
                 }
@@ -372,7 +378,13 @@ internal class RealAWSCognitoAuthPlugin(
                     )
                 )
                 // Continue sign in
-                is AuthenticationState.SignedOut -> _signIn(username, password, options, onSuccess, onError)
+                is AuthenticationState.SignedOut, is AuthenticationState.Configured -> _signIn(
+                    username,
+                    password,
+                    options,
+                    onSuccess,
+                    onError
+                )
                 is AuthenticationState.SignedIn -> onSuccess.accept(
                     AuthSignInResult(true, AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null))
                 )

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
@@ -302,13 +302,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         token = stateMachine.listen(
             {
                 val authState =
-                    it.takeIf {
-                        it is AuthState.Configured &&
-                            (
-                                it.authNState is AuthenticationState.SignedOut ||
-                                    it.authNState is AuthenticationState.Configured
-                                )
-                    }
+                    it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedOut }
                 authState?.run {
                     configureLatch.countDown()
                     stateMachine.send(
@@ -378,13 +372,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         token = stateMachine.listen(
             {
                 val authState =
-                    it.takeIf {
-                        it is AuthState.Configured &&
-                            (
-                                it.authNState is AuthenticationState.SignedOut ||
-                                    it.authNState is AuthenticationState.Configured
-                                )
-                    }
+                    it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedOut }
                 authState?.run {
                     configureLatch.countDown()
                     stateMachine.send(

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
@@ -299,7 +299,13 @@ class StateTransitionTests : StateTransitionTestBase() {
         token = stateMachine.listen(
             {
                 val authState =
-                    it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedOut }
+                    it.takeIf {
+                        it is AuthState.Configured &&
+                            (
+                                it.authNState is AuthenticationState.SignedOut ||
+                                    it.authNState is AuthenticationState.Configured
+                                )
+                    }
                 authState?.run {
                     configureLatch.countDown()
                     stateMachine.send(
@@ -369,7 +375,13 @@ class StateTransitionTests : StateTransitionTestBase() {
         token = stateMachine.listen(
             {
                 val authState =
-                    it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedOut }
+                    it.takeIf {
+                        it is AuthState.Configured &&
+                            (
+                                it.authNState is AuthenticationState.SignedOut ||
+                                    it.authNState is AuthenticationState.Configured
+                                )
+                    }
                 authState?.run {
                     configureLatch.countDown()
                     stateMachine.send(

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -60,8 +60,8 @@ public class AuthException extends AmplifyException {
      */
     public static class InvalidStateException extends AuthException {
         private static final long serialVersionUID = 1L;
-        private static final String MESSAGE = "Auth state reached an invalid state.";
-        private static final String RECOVERY_SUGGESTION = "Please reset auth plugin and reattempt the operation.";
+        private static final String MESSAGE = "Auth state is an invalid state, cannot process the request.";
+        private static final String RECOVERY_SUGGESTION = "Please reset auth plugin or reattempt the operation later.";
 
         /**
          * Default message/recovery suggestion without a cause.


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Allowed for signup, signin, confirmsignup, resendsignupcode to be able to function if authentication state is in signedout state.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [x] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
