### PR TITLE
chore: reduce codeowner scope of @aws-amplify/amplify-data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
-*   @aws-amplify/amplify-android @aws-amplify/amplify-data
+*   @aws-amplify/amplify-android
+/aws-api-appsync @aws-amplify/amplify-android @aws-amplify/amplify-data
+/aws-api @aws-amplify/amplify-android @aws-amplify/amplify-data
+/aws-datastore @aws-amplify/amplify-android @aws-amplify/amplify-data
+/aws-core @aws-amplify/amplify-android @aws-amplify/amplify-data
+/.github @aws-amplify/amplify-android @aws-amplify/amplify-data
+/.circleci @aws-amplify/amplify-android @aws-amplify/amplify-data
+/testmodels @aws-amplify/amplify-android @aws-amplify/amplify-data

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 /.github @aws-amplify/amplify-android @aws-amplify/amplify-data
 /.circleci @aws-amplify/amplify-android @aws-amplify/amplify-data
 /testmodels @aws-amplify/amplify-android @aws-amplify/amplify-data
+/testutils @aws-amplify/amplify-android @aws-amplify/amplify-data


### PR DESCRIPTION
- [X] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

N/A

*Description of changes:*

Reduce codeowner scope of @aws-amplify/amplify-data to only packages related to DataStore and API. I followed a similar strategy to the iOS repo: https://github.com/aws-amplify/amplify-ios/blob/main/.github/CODEOWNERS.

*How did you test these changes?*
(Please add a line here how the changes were tested)

N/A

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
