### PR TITLE
chore: Update gradle to use latest snapshot release for main

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,15 @@ buildscript {
     }
 }
 
+def useAwsSdkReleaseBuild() {
+    return hasProperty('useAwsSdkReleaseBuild') && project.useAwsSdkReleaseBuild == "true"
+}
+
 allprojects {
     repositories {
+        maven {
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots/"
+        }
         google()
         jcenter()
     }
@@ -56,8 +63,8 @@ ext {
     compileSdkVersion = 30
     minSdkVersion = 16
     targetSdkVersion = 30
-
-    awsSdkVersion = '2.51.0'
+    awsSDKReleaseVersion = "2.51.0"
+    awsSdkVersion = useAwsSdkReleaseBuild() ? awsSDKReleaseVersion : "latest.integration"
     fragmentVersion = '1.3.1'
     navigationVersion = '2.3.4'
     dependency = [

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def useAwsSdkReleaseBuild() {
 allprojects {
     repositories {
         maven {
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots/"
+            url = 'https://aws.oss.sonatype.org/content/repositories/snapshots/'
         }
         google()
         jcenter()
@@ -63,7 +63,7 @@ ext {
     compileSdkVersion = 30
     minSdkVersion = 16
     targetSdkVersion = 30
-    awsSDKReleaseVersion = "2.51.0"
+    awsSDKReleaseVersion = '2.51.0'
     awsSdkVersion = useAwsSdkReleaseBuild() ? awsSDKReleaseVersion : "latest.integration"
     fragmentVersion = '1.3.1'
     navigationVersion = '2.3.4'

--- a/scripts/maven-release-publisher.yml
+++ b/scripts/maven-release-publisher.yml
@@ -1,6 +1,8 @@
 version: 0.2
 env:
   shell: /bin/sh
+  variables:
+    ORG_GRADLE_PROJECT_useAwsSdkReleaseBuild: true
   secrets-manager:
     ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: awsmobilesdk/android/sonatype:username
     ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: awsmobilesdk/android/sonatype:password


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Use latest snapshot build for AWS Sdk from main branch.
- Update release publisher to use explicitly use release AWS sdk.

*How did you test these changes?*
- Tested locally

*Documentation update required?*
- NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
