### PR TITLE
chore(ci): add cloudwatch monitoring for getting started smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,19 @@ orbs:
   getting-started-smoke-test:
     orbs:
       android: circleci/android@2.0.0
+      aws-cli: circleci/aws-cli@3.1.1
 
+    commands:
+      send-metric-on-fail:
+        description: Send failure datapoint to cloudwatch
+        steps:
+          - run:
+              name: Send failure datapoint to cloudwatch
+              command: |
+                payload="{\"jobName\": \"${CIRCLE_JOB}\", \"projectRepoName\": \"${CIRCLE_PROJECT_REPONAME}\"}"
+                echo $payload
+                aws lambda invoke --function-name CircleCIWorkflowFailureHandler --payload "$payload" --cli-binary-format raw-in-base64-out response.json
+              when: on_fail
     jobs:
       android:
         working_directory: ~/android-canaries/canaries/example
@@ -17,6 +29,10 @@ orbs:
         steps:
           - checkout:
               path: ~/android-canaries
+          - aws-cli/setup:
+                role-session-name: ${CIRCLE_WORKFLOW_JOB_ID}
+                role-arn: ${AWS_ROLE_ARN}
+                session-duration: '2000'
           - android/create-avd:
               avd-name: myavd
               install: true
@@ -24,6 +40,7 @@ orbs:
           - android/start-emulator:
               avd-name: myavd
           - android/run-tests
+          - send-metric-on-fail
 
 
 
@@ -34,4 +51,6 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "Canaries", << pipeline.schedule.name >> ]
     jobs:
-      - getting-started-smoke-test/android
+      - getting-started-smoke-test/android:
+          context:
+            - cloudwatch-monitoring


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

Enhancement for the getting started workflow in circleCI(https://github.com/aws-amplify/amplify-android/pull/1770). We added cloudwatch monitoring for the workflow, so the devops team could get notified right away if there's any issues with the workflow. The change should not alter any existing behavior. 

*How did you test these changes?*
(Please add a line here how the changes were tested)

Ran in personal circleci project, and ran successfully 
- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
