### PR TITLE
fix(datastore): DataStore event networkStatus true when offline #1757

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -282,6 +282,7 @@ public final class Orchestrator {
         storageObserver.stopObservingStorageChanges();
         LOG.info("Setting currentState to STOPPED");
         currentState.set(State.STOPPED);
+        publishNetworkStatusEvent(false);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -148,7 +148,7 @@ final class SubscriptionProcessor {
             subscriptionsStarted = latch.abortableAwait(adjustedTimeoutSeconds, TimeUnit.SECONDS);
         } catch (InterruptedException exception) {
             LOG.warn("Subscription operations were interrupted during setup.");
-            return;
+            throw new DataStoreException("Subscription operations were interrupted during setup.", "Check your internet.");
         }
 
         if (subscriptionsStarted) {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
DataStore event networkStatus true when offline #1757

*Description of changes:*
Throwing Datastore exception from SubscriptionProcessor class when startSubscriptions method is interrupted

*How did you test these changes?*
(Please add a line here how the changes were tested)

- Disable network
- Do some mutation operations
- Network status should always false

*Documentation update required?*
- [x] No 
- [ ] Yes
closes #1757

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
