### PR TITLE
fix(datastore): Propagate error if mutation process failed to drain outbox #1794

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -111,6 +111,7 @@ public final class Orchestrator {
             .appSync(appSync)
             .conflictResolver(conflictResolver)
             .retryHandler(retryHandler)
+            .onFailure(this::onApiSyncFailure)
             .build();
         this.syncProcessor = SyncProcessor.builder()
             .modelProvider(modelProvider)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/1794

*Description of changes:*
- propagate the error to Orchestrator if mutation processor failed to process outbox

*How did you test these changes?*
(Please add a line here how the changes were tested)
- Disable the internet (not the network)
- Do a mutation, wait for mutation exception
- The sync stop process should be triggered

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

closes #1794 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
