### PR TITLE
feat(auth): add sign in support w/o identity pool

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -399,9 +399,7 @@ internal class RealAWSCognitoAuthPlugin(
                     onSuccess,
                     onError
                 )
-                is AuthenticationState.SignedIn -> {
-                    onError.accept(AuthException.SignedInException())
-                }
+                is AuthenticationState.SignedIn -> onError.accept(AuthException.SignedInException())
                 else -> onError.accept(AuthException.InvalidStateException())
             }
         }
@@ -445,9 +443,7 @@ internal class RealAWSCognitoAuthPlugin(
                         )
                         onSuccess.accept(authSignInResult)
                     }
-                    else -> {
-                        // no-op
-                    }
+                    else -> Unit
                 }
             },
             {
@@ -674,8 +670,7 @@ internal class RealAWSCognitoAuthPlugin(
                 }
             },
             {
-                val hostedUIOptions =
-                    HostedUIHelper.createHostedUIOptions(callingActivity, provider, options)
+                val hostedUIOptions = HostedUIHelper.createHostedUIOptions(callingActivity, provider, options)
                 authStateMachine.send(
                     AuthenticationEvent(
                         AuthenticationEvent.EventType.SignInRequested(
@@ -752,7 +747,7 @@ internal class RealAWSCognitoAuthPlugin(
         val forceRefresh = options.forceRefresh
         authStateMachine.getCurrentState { authState ->
             when (val authZState = authState.authZState) {
-                is AuthorizationState.Configured -> {
+                is AuthorizationState.Configured, is AuthorizationState.Error -> {
                     authStateMachine.send(AuthorizationEvent(AuthorizationEvent.EventType.FetchUnAuthSession))
                     _fetchAuthSession(onSuccess, onError)
                 }
@@ -769,9 +764,7 @@ internal class RealAWSCognitoAuthPlugin(
                         _fetchAuthSession(onSuccess, onError)
                     } else onSuccess.accept(credential.getCognitoSession())
                 }
-                else -> {
-                    // no-op
-                }
+                else -> Unit
             }
         }
     }
@@ -797,9 +790,7 @@ internal class RealAWSCognitoAuthPlugin(
                             )
                         )
                     }
-                    else -> {
-                        // no-op
-                    }
+                    else -> Unit
                 }
             },
             null

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
@@ -167,7 +167,10 @@ sealed class AuthorizationState : State {
                         )
                         StateResolution(StoringCredentials(amplifyCredential))
                     }
-                    is AuthorizationEvent.EventType.ThrowError -> StateResolution(Error(authorizationEvent.exception))
+                    is AuthorizationEvent.EventType.ThrowError -> {
+                        val amplifyCredential = AmplifyCredential.UserPool(oldState.signedInData)
+                        StateResolution(StoringCredentials(amplifyCredential))
+                    }
                     else -> {
                         val resolution = fetchAuthSessionResolver.resolve(oldState.fetchAuthSessionState, event)
                         StateResolution(

--- a/core/src/main/java/com/amplifyframework/auth/AuthException.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthException.java
@@ -93,9 +93,9 @@ public class AuthException extends AmplifyException {
      */
     public static class SignedInException extends AuthException {
         private static final long serialVersionUID = 1L;
-        private static final String MESSAGE = "There is already a user in signedIn state";
+        private static final String MESSAGE = "There is already a user signed in.";
         private static final String RECOVERY_SUGGESTION =
-                "SignOut the user first before calling signIn";
+                "Sign out the user first before signing in again.";
 
         /**
          * Default message/recovery suggestion without a cause.


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Add sign in support and store user pool only credentials when identity pool is not present in config 

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
