### PR TITLE
fix(auth): add user context data for cognito ASF

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
@@ -45,6 +45,8 @@ object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
             val evt = try {
                 event.challengeParameters?.let { params ->
                     val username = params.getValue(KEY_USERNAME)
+                    val encodedContextData = userContextDataProvider?.getEncodedContextData(username)
+
                     cognitoAuthService.cognitoIdentityProviderClient?.let {
                         val respondToAuthChallenge = it.respondToAuthChallenge(
                             RespondToAuthChallengeRequest.invoke {
@@ -55,6 +57,7 @@ object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
                                     KEY_DEVICE_KEY to "STUB", // TODO: get this from the device credential store
                                     KEY_SRP_A to srpHelper.getPublicA()
                                 )
+                                encodedContextData?.let { userContextData { encodedData = it } }
                             }
                         )
                         SignInChallengeHelper.evaluateNextStep(
@@ -88,6 +91,7 @@ object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
                     val secretBlock = params.getValue(KEY_SECRET_BLOCK)
                     val srpB = params.getValue(KEY_SRP_B)
                     val username = params.getValue(KEY_USERNAME)
+                    val encodedContextData = userContextDataProvider?.getEncodedContextData(username)
 
                     cognitoAuthService.cognitoIdentityProviderClient?.let {
                         val respondToAuthChallenge = it.respondToAuthChallenge(
@@ -101,6 +105,7 @@ object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
                                     KEY_PASSWORD_CLAIM_SIGNATURE to srpHelper.getSignature(salt, srpB, secretBlock),
                                     KEY_DEVICE_KEY to "STUB", // TODO: get this from the device credential store
                                 )
+                                encodedContextData?.let { userContextData { encodedData = it } }
                             }
                         )
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
@@ -53,11 +53,13 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                 )
                 tokens.refreshToken?.let { authParameters[KEY_REFRESH_TOKEN] = it }
                 secretHash?.let { authParameters[KEY_SECRET_HASH] = it }
+                val encodedContextData = userContextDataProvider?.getEncodedContextData(signedInData.username)
 
                 val response = cognitoAuthService.cognitoIdentityProviderClient?.initiateAuth {
                     authFlow = AuthFlowType.RefreshToken
                     clientId = configuration.userPool?.appClient
                     this.authParameters = authParameters
+                    encodedContextData?.let { userContextData { encodedData = it } }
                 }
 
                 val expiresIn = response?.authenticationResult?.expiresIn?.toLong() ?: 0


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- add user context data for cognito ASF to initiateAuth and respondToAuthChallenge requests

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
