### PR TITLE
fix(amplify-tools): use projectDir for project.file relative paths

### DIFF
--- a/amplify-tools/amplify-tools-gradle-plugin/src/main/groovy/com/amplifyframework/tools/gradle/plugin/AmplifyTools.groovy
+++ b/amplify-tools/amplify-tools-gradle-plugin/src/main/groovy/com/amplifyframework/tools/gradle/plugin/AmplifyTools.groovy
@@ -19,7 +19,7 @@ class AmplifyTools implements Plugin<Project> {
         project.task('createAmplifyApp') {
             def npx = 'npx'
 
-            if (project.file(gradleConfigFileName).exists()) {
+            if (project.file("${project.projectDir}/$gradleConfigFileName").exists()) {
                 return
             }
 
@@ -29,6 +29,7 @@ class AmplifyTools implements Plugin<Project> {
 
             try {
                 project.exec {
+                    workingDir ${project.projectDir}
                     commandLine npx, 'amplify-app', '--platform', 'android'
                 }
             } catch (commandLineFailure) {
@@ -37,7 +38,7 @@ class AmplifyTools implements Plugin<Project> {
         }
 
         project.task('getConfig') {
-            def inputConfigFile = project.file('amplify-gradle-config.json')
+            def inputConfigFile = project.file("${project.projectDir}/amplify-gradle-config.json")
             if (inputConfigFile.isFile()) {
                 def configText = inputConfigFile.text
                 def jsonSlurper = new JsonSlurper()
@@ -53,9 +54,9 @@ class AmplifyTools implements Plugin<Project> {
         project.getConfig.dependsOn('createAmplifyApp')
 
         project.task('datastoreSync') {
-            def transformConfFile = project.file('amplify/backend/api/amplifyDatasource/transform.conf.json')
-            if (project.file('amplify/backend/api').exists()) {
-                new File('amplify/backend/api').eachFileRecurse(groovy.io.FileType.FILES) {
+            def transformConfFile = project.file("${project.projectDir}/amplify/backend/api/amplifyDatasource/transform.conf.json")
+            if (project.file("${project.projectDir}/amplify/backend/api").exists()) {
+                new File("${project.projectDir}/amplify/backend/api").eachFileRecurse(groovy.io.FileType.FILES) {
                     if (it.name.endsWith('transform.conf.json')) {
                         transformConfFile = project.file(it)
                     }
@@ -95,6 +96,7 @@ class AmplifyTools implements Plugin<Project> {
 
             doLast {
                 project.exec {
+                    workingDir ${project.projectDir}
                     commandLine amplify, 'codegen', 'model'
                 }
             }
@@ -144,12 +146,14 @@ class AmplifyTools implements Plugin<Project> {
                     providersConfig = StringEscapeUtils.escapeJavaScript(providersConfig)
                 }
 
-                if (project.file('./amplify/.config/local-env-info.json').exists()) {
+                if (project.file("${project.projectDir}/amplify/.config/local-env-info.json").exists()) {
+                    workingDir ${project.projectDir}
                     project.exec {
                         commandLine amplify, 'push', '--yes'
                     }
                 } else {
                     project.exec {
+                        workingDir ${project.projectDir}
                         commandLine amplify, 'init',
                                 '--amplify', amplifyConfig,
                                 '--providers', providersConfig,
@@ -162,9 +166,9 @@ class AmplifyTools implements Plugin<Project> {
         project.amplifyPush.dependsOn('datastoreSync')
 
         project.task('addModelgenToWorkspace') {
-            if (project.file('./.idea/workspace.xml').exists()) {
+            if (project.file("${project.projectDir}/.idea/workspace.xml").exists()) {
                 //Open XML file
-                def xml = new XmlParser().parse('./.idea/workspace.xml')
+                def xml = new XmlParser().parse("${project.projectDir}/.idea/workspace.xml")
                 def RunManagerNode = xml.component.find { it.'@name' == 'RunManager' } as Node
                 def configModelgenCheck = null
                 if (RunManagerNode) {
@@ -193,7 +197,7 @@ class AmplifyTools implements Plugin<Project> {
                     RunManagerNode.append(configurationNode)
 
                     //Save File
-                    def writer = new FileWriter('./.idea/workspace.xml')
+                    def writer = new FileWriter("${project.projectDir}/.idea/workspace.xml")
 
                     //Pretty print XML
                     groovy.xml.XmlUtil.serialize(xml, writer)
@@ -202,9 +206,9 @@ class AmplifyTools implements Plugin<Project> {
         }
 
         project.task('addAmplifyPushToWorkspace') {
-            if (project.file('./.idea/workspace.xml').exists()) {
+            if (project.file("${project.projectDir}/.idea/workspace.xml").exists()) {
                 //Open file
-                def xml = new XmlParser().parse('./.idea/workspace.xml')
+                def xml = new XmlParser().parse("${project.projectDir}/.idea/workspace.xml")
                 def RunManagerNode = xml.component.find { it.'@name' == 'RunManager' } as Node
                 def configAmplifyPushCheck = null
                 if (RunManagerNode) {
@@ -233,7 +237,7 @@ class AmplifyTools implements Plugin<Project> {
                     RunManagerNode.append(configurationNode)
 
                     //Save File
-                    def writer = new FileWriter('./.idea/workspace.xml')
+                    def writer = new FileWriter("${project.projectDir}/.idea/workspace.xml")
 
                     //Pretty print XML
                     groovy.xml.XmlUtil.serialize(xml, writer)


### PR DESCRIPTION
 - use [standard project property][1] `projectDir` for plugin

In java11 gradle may not have userDir set correctly leading to the project.file not resolving correctly.

https://github.com/gradle/gradle/issues/5991

Pain source: https://youtrack.jetbrains.com/issue/IDEA-265203/Gradle-run-configuration-might-not-use-project-dir-as-working-directory-for-a-task#focus=Comments-27-4834821.0-0



- [ X] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ X] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[1]: https://docs.gradle.org/current/userguide/writing_build_scripts.html#sec:standard_project_properties 
[2]:https://docs.gradle.org/current/userguide/working_with_files.html#sec:single_file_paths
