### PR TITLE
Fix(Auth): Fix for error propagation when sign in fails inside Sign In Custom Auth Action

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomActions.kt
@@ -25,6 +25,7 @@ import com.amplifyframework.auth.exceptions.ServiceException
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.CustomSignInActions
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
+import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.CustomSignInEvent
 import com.amplifyframework.statemachine.codegen.events.SignInEvent
 
@@ -74,7 +75,11 @@ object SignInCustomActions : CustomSignInActions {
                     )
                 }
             } catch (e: Exception) {
-                SignInEvent(SignInEvent.EventType.ThrowError(e))
+                val errorEvent = SignInEvent(SignInEvent.EventType.ThrowError(e))
+                logger.verbose("$id Sending event ${errorEvent.type}")
+                dispatcher.send(errorEvent)
+
+                AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
             }
             logger.verbose("$id Sending event ${evt.type}")
             dispatcher.send(evt)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomActions.kt
@@ -25,8 +25,8 @@ import com.amplifyframework.auth.exceptions.ServiceException
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.CustomSignInActions
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
-import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.CustomSignInEvent
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
 
 object SignInCustomActions : CustomSignInActions {
     private const val KEY_SECRET_HASH = "SECRET_HASH"
@@ -74,7 +74,7 @@ object SignInCustomActions : CustomSignInActions {
                     )
                 }
             } catch (e: Exception) {
-                AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn(error = e))
+                SignInEvent(SignInEvent.EventType.ThrowError(e))
             }
             logger.verbose("$id Sending event ${evt.type}")
             dispatcher.send(evt)


### PR DESCRIPTION
- [ x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*: When there is an error inside Custom Auth we currently fail silently without telling the sign in state that an error has occurred. This PR fixes that.

*How did you test these changes?*
(Please add a line here how the changes were tested)
Tested Manually
- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
