### PR TITLE
Fix(Auth): Forget Device implementation fix

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -848,10 +848,14 @@ internal class RealAWSCognitoAuthPlugin(
         onError: Consumer<AuthException>
     ) {
         authStateMachine.getCurrentState { authState ->
-            when (authState.authNState) {
+            when (val authState = authState.authNState) {
                 is AuthenticationState.SignedIn -> {
-                    val deviceID = device.id.ifEmpty { null }
-                    updateDevice(deviceID, DeviceRememberedStatusType.NotRemembered, onSuccess, onError)
+                    if (device.id.isEmpty()) {
+                        val deviceKey = (authState.deviceMetadata as? DeviceMetadata.Metadata)?.deviceKey
+                        updateDevice(deviceKey, DeviceRememberedStatusType.NotRemembered, onSuccess, onError)
+                    } else {
+                        updateDevice(device.id, DeviceRememberedStatusType.NotRemembered, onSuccess, onError)
+                    }
                 }
                 else -> {
                     onError.accept(SignedOutException())

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
@@ -157,10 +157,6 @@ object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
                 )
                 logger.verbose("$id Sending event ${errorEvent.type}")
                 dispatcher.send(errorEvent)
-
-                val errorEvent2 = SignInEvent(SignInEvent.EventType.ThrowError(exception))
-                logger.verbose("$id Sending event ${errorEvent.type}")
-                dispatcher.send(errorEvent2)
                 AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
             }
             logger.verbose("$id Sending event ${evt.type}")


### PR DESCRIPTION
- [x ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:* In Forget device API call, device id was still not used from the credential store. Fixed that.

*How did you test these changes?*
(Please add a line here how the changes were tested)
Manually tested

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
