### PR TITLE
fix(auth): device key param for refresh tokens and custom auth

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -750,7 +750,7 @@ internal class RealAWSCognitoAuthPlugin(
         val forceRefresh = options.forceRefresh
         authStateMachine.getCurrentState { authState ->
             when (val authZState = authState.authZState) {
-                is AuthorizationState.Configured, is AuthorizationState.Error -> {
+                is AuthorizationState.Configured -> {
                     authStateMachine.send(AuthorizationEvent(AuthorizationEvent.EventType.FetchUnAuthSession))
                     _fetchAuthSession(onSuccess, onError)
                 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -763,6 +763,17 @@ internal class RealAWSCognitoAuthPlugin(
                         _fetchAuthSession(onSuccess, onError)
                     } else onSuccess.accept(credential.getCognitoSession())
                 }
+                is AuthorizationState.Error -> {
+                    val error = authZState.exception
+                    if (error is SessionError) {
+                        authStateMachine.send(
+                            AuthorizationEvent(AuthorizationEvent.EventType.RefreshSession(error.amplifyCredential))
+                        )
+                        _fetchAuthSession(onSuccess, onError)
+                    } else {
+                        onError.accept(InvalidStateException())
+                    }
+                }
                 else -> onError.accept(InvalidStateException())
             }
         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
@@ -47,7 +47,7 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
     private const val KEY_DEVICE_KEY = "DEVICE_KEY"
 
     override fun refreshUserPoolTokensAction(signedInData: SignedInData) =
-        Action<AuthEnvironment>("InitiateRefreshSession") { id, dispatcher ->
+        Action<AuthEnvironment>("RefreshUserPoolTokens") { id, dispatcher ->
             logger.verbose("$id Starting execution")
             val evt = try {
                 val username = signedInData.username
@@ -110,7 +110,7 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
         }
 
     override fun refreshHostedUIUserPoolTokensAction(signedInData: SignedInData) =
-        Action<AuthEnvironment>("InitiateRefreshHostedUITokens") { id, dispatcher ->
+        Action<AuthEnvironment>("RefreshHostedUITokens") { id, dispatcher ->
             logger.verbose("$id Starting execution")
             val evt = try {
                 val username = signedInData.username

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
@@ -17,7 +17,6 @@ package com.amplifyframework.auth.cognito.actions
 
 import aws.sdk.kotlin.services.cognitoidentity.model.GetCredentialsForIdentityRequest
 import aws.sdk.kotlin.services.cognitoidentity.model.GetIdRequest
-import aws.sdk.kotlin.services.cognitoidentity.model.NotAuthorizedException
 import aws.sdk.kotlin.services.cognitoidentityprovider.initiateAuth
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType
 import aws.smithy.kotlin.runtime.time.Instant
@@ -33,6 +32,8 @@ import com.amplifyframework.statemachine.codegen.actions.FetchAuthSessionActions
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
+import com.amplifyframework.statemachine.codegen.data.CredentialType
+import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.LoginsMapProvider
 import com.amplifyframework.statemachine.codegen.data.SignedInData
 import com.amplifyframework.statemachine.codegen.events.AuthorizationEvent
@@ -43,22 +44,29 @@ import kotlin.time.Duration.Companion.seconds
 object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_REFRESH_TOKEN = "REFRESH_TOKEN"
+    private const val KEY_DEVICE_KEY = "DEVICE_KEY"
 
     override fun refreshUserPoolTokensAction(signedInData: SignedInData) =
         Action<AuthEnvironment>("InitiateRefreshSession") { id, dispatcher ->
             logger.verbose("$id Starting execution")
             val evt = try {
+                val username = signedInData.username
                 val tokens = signedInData.cognitoUserPoolTokens
 
                 val authParameters = mutableMapOf<String, String>()
                 val secretHash = AuthHelper.getSecretHash(
-                    signedInData.username,
+                    username,
                     configuration.userPool?.appClient,
                     configuration.userPool?.appClientSecret
                 )
                 tokens.refreshToken?.let { authParameters[KEY_REFRESH_TOKEN] = it }
                 secretHash?.let { authParameters[KEY_SECRET_HASH] = it }
-                val encodedContextData = userContextDataProvider?.getEncodedContextData(signedInData.username)
+                val encodedContextData = userContextDataProvider?.getEncodedContextData(username)
+
+                val deviceCredentials = credentialStoreClient.loadCredentials(CredentialType.Device(username))
+                val deviceMetadata = (deviceCredentials as AmplifyCredential.DeviceData)
+                    .deviceMetadata as? DeviceMetadata.Metadata
+                deviceMetadata?.let { authParameters[KEY_DEVICE_KEY] = it.deviceKey }
 
                 val response = cognitoAuthService.cognitoIdentityProviderClient?.initiateAuth {
                     authFlow = AuthFlowType.RefreshToken
@@ -68,7 +76,7 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                 }
 
                 val expiresIn = response?.authenticationResult?.expiresIn?.toLong() ?: 0
-                val cognitoUserPoolTokens = CognitoUserPoolTokens(
+                val refreshedUserPoolTokens = CognitoUserPoolTokens(
                     idToken = response?.authenticationResult?.idToken,
                     accessToken = response?.authenticationResult?.accessToken,
                     refreshToken = tokens.refreshToken,
@@ -76,23 +84,22 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                 )
 
                 val updatedSignedInData = signedInData.copy(
-                    userId = cognitoUserPoolTokens.accessToken?.let(SessionHelper::getUserSub) ?: signedInData.userId,
-                    username = cognitoUserPoolTokens.accessToken?.let(SessionHelper::getUsername)
-                        ?: signedInData.username,
-                    cognitoUserPoolTokens = cognitoUserPoolTokens
+                    userId = refreshedUserPoolTokens.accessToken?.let(SessionHelper::getUserSub) ?: signedInData.userId,
+                    username = refreshedUserPoolTokens.accessToken?.let(SessionHelper::getUsername) ?: username,
+                    cognitoUserPoolTokens = refreshedUserPoolTokens
                 )
 
                 if (configuration.identityPool != null) {
                     val logins = LoginsMapProvider.CognitoUserPoolLogins(
                         configuration.userPool?.region,
                         configuration.userPool?.poolId,
-                        cognitoUserPoolTokens.idToken!!
+                        refreshedUserPoolTokens.idToken!!
                     )
                     RefreshSessionEvent(RefreshSessionEvent.EventType.RefreshAuthSession(updatedSignedInData, logins))
                 } else {
                     RefreshSessionEvent(RefreshSessionEvent.EventType.Refreshed(updatedSignedInData))
                 }
-            } catch (notAuthorized: NotAuthorizedException) {
+            } catch (notAuthorized: aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException) {
                 val error = SessionExpiredException(cause = notAuthorized)
                 AuthorizationEvent(AuthorizationEvent.EventType.ThrowError(error))
             } catch (e: Exception) {
@@ -106,6 +113,7 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
         Action<AuthEnvironment>("InitiateRefreshHostedUITokens") { id, dispatcher ->
             logger.verbose("$id Starting execution")
             val evt = try {
+                val username = signedInData.username
                 val refreshToken = signedInData.cognitoUserPoolTokens.refreshToken
                 if (hostedUIClient == null) throw InvalidOauthConfigurationException()
                 if (refreshToken == null) throw UnknownException("Unable to refresh token due to missing refreshToken.")
@@ -118,7 +126,11 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                     refreshToken = signedInData.cognitoUserPoolTokens.refreshToken
                 )
 
-                val updatedSignedInData = signedInData.copy(cognitoUserPoolTokens = refreshedUserPoolTokens)
+                val updatedSignedInData = signedInData.copy(
+                    userId = refreshedUserPoolTokens.accessToken?.let(SessionHelper::getUserSub) ?: signedInData.userId,
+                    username = refreshedUserPoolTokens.accessToken?.let(SessionHelper::getUsername) ?: username,
+                    cognitoUserPoolTokens = refreshedUserPoolTokens
+                )
 
                 if (configuration.identityPool != null) {
                     val logins = LoginsMapProvider.CognitoUserPoolLogins(
@@ -130,7 +142,8 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                 } else {
                     RefreshSessionEvent(RefreshSessionEvent.EventType.Refreshed(updatedSignedInData))
                 }
-            } catch (notAuthorized: NotAuthorizedException) {
+            } catch (notAuthorized: aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException) {
+                // TODO: identity not authorized exception from response
                 val error = SessionExpiredException(cause = notAuthorized)
                 AuthorizationEvent(AuthorizationEvent.EventType.ThrowError(error))
             } catch (e: Exception) {
@@ -162,7 +175,7 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                 response?.identityId?.let {
                     FetchAuthSessionEvent(FetchAuthSessionEvent.EventType.FetchAwsCredentials(it, loginsMap))
                 } ?: throw Exception("Fetching identity id failed.")
-            } catch (notAuthorized: NotAuthorizedException) {
+            } catch (notAuthorized: aws.sdk.kotlin.services.cognitoidentity.model.NotAuthorizedException) {
                 val exception = SignedOutException(
                     recoverySuggestion = SignedOutException.RECOVERY_SUGGESTION_GUEST_ACCESS_DISABLED,
                     cause = notAuthorized
@@ -199,7 +212,7 @@ object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                     )
                     FetchAuthSessionEvent(FetchAuthSessionEvent.EventType.Fetched(identityId, credentials))
                 } ?: throw Exception("Fetching AWS credentials failed.")
-            } catch (notAuthorized: NotAuthorizedException) {
+            } catch (notAuthorized: aws.sdk.kotlin.services.cognitoidentity.model.NotAuthorizedException) {
                 val exception = SignedOutException(
                     recoverySuggestion = SignedOutException.RECOVERY_SUGGESTION_GUEST_ACCESS_DISABLED,
                     cause = notAuthorized

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomActions.kt
@@ -24,6 +24,9 @@ import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
 import com.amplifyframework.auth.exceptions.ServiceException
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.CustomSignInActions
+import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
+import com.amplifyframework.statemachine.codegen.data.CredentialType
+import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
 import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.CustomSignInEvent
@@ -47,8 +50,10 @@ object SignInCustomActions : CustomSignInActions {
                 secretHash?.let { authParams[KEY_SECRET_HASH] = it }
                 val encodedContextData = userContextDataProvider?.getEncodedContextData(event.username)
 
-                val deviceKey = event.metadata[KEY_DEVICE_KEY]
-                deviceKey?.let { authParams[KEY_DEVICE_KEY] = it }
+                val deviceCredentials = credentialStoreClient.loadCredentials(CredentialType.Device(event.username))
+                val deviceMetadata = (deviceCredentials as AmplifyCredential.DeviceData)
+                    .deviceMetadata as? DeviceMetadata.Metadata
+                deviceMetadata?.let { authParams[KEY_DEVICE_KEY] = it.deviceKey }
 
                 val initiateAuthResponse = cognitoAuthService.cognitoIdentityProviderClient?.initiateAuth {
                     authFlow = AuthFlowType.CustomAuth


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- use stored device key for refresh tokens and custom auth
- use namespaced imports for NotAuthorized exception
- update username for hosted UI signed in data

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
