### PR TITLE
chore(all): dokka multi-module support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,11 @@ allprojects {
     }
 }
 
+apply plugin: 'org.jetbrains.dokka'
+dokkaHtmlCollector {
+    outputDirectory = rootProject.buildDir
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
@@ -166,6 +171,20 @@ subprojects { project ->
     afterEvaluate {
         configureAndroidLibrary(project)
         project.apply from: '../jacoco.gradle'
+    }
+    if (!project.name.contains("test")) {
+        apply plugin: 'org.jetbrains.dokka'
+        dokkaHtml {
+            dokkaSourceSets {
+                configureEach {
+                    includeNonPublic.set(false)
+                    skipEmptyPackages.set(true)
+                    skipDeprecated.set(true)
+                    reportUndocumented.set(true)
+                    jdkVersion.set(8)
+                }
+            }
+        }
     }
 }
 

--- a/core-kotlin/build.gradle
+++ b/core-kotlin/build.gradle
@@ -16,19 +16,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply from: rootProject.file("configuration/publishing.gradle")
-apply plugin: 'org.jetbrains.dokka'
 
-dokkaHtml {
-    dokkaSourceSets {
-        named("main") {
-            includeNonPublic.set(false)
-            skipEmptyPackages.set(true)
-            skipDeprecated.set(true)
-            reportUndocumented.set(true)
-            jdkVersion.set(8)
-        }
-    }
-}
 dependencies {
     implementation dependency.kotlin.stdlib
     implementation dependency.kotlin.coroutines


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Generate multi-module docs with `./gradlew dokkaHtmlMultiModule`
Generated docs currently reside in root build/dokka
Open build/dokka/htmlMultiModule/index.html in browser

Excluded test modules

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
