### PR TITLE
fix(auth): Auth hub events fired from api calls instead of SM

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -454,6 +454,7 @@ internal class RealAWSCognitoAuthPlugin(
                             AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null)
                         )
                         onSuccess.accept(authSignInResult)
+                        sendHubEvent(AuthChannelEventName.SIGNED_IN.toString())
                     }
                     else -> Unit
                 }
@@ -525,6 +526,7 @@ internal class RealAWSCognitoAuthPlugin(
                             AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null)
                         )
                         onSuccess.accept(authSignInResult)
+                        sendHubEvent(AuthChannelEventName.SIGNED_IN.toString())
                     }
                     signInState is SignInState.Error -> {
                         token?.let(authStateMachine::cancel)
@@ -670,6 +672,7 @@ internal class RealAWSCognitoAuthPlugin(
                                 AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null)
                             )
                         onSuccess.accept(authSignInResult)
+                        sendHubEvent(AuthChannelEventName.SIGNED_IN.toString())
                     }
                     else -> Unit
                 }
@@ -828,6 +831,7 @@ internal class RealAWSCognitoAuthPlugin(
                                     }
                                     is SessionExpiredException -> {
                                         onSuccess.accept(AmplifyCredential.Empty.getCognitoSession(error.exception))
+                                        sendHubEvent(AuthChannelEventName.SESSION_EXPIRED.toString())
                                     }
                                     else -> {
                                         val errorResult = UnknownException("Fetch auth session failed.", error)
@@ -1425,7 +1429,7 @@ internal class RealAWSCognitoAuthPlugin(
                         )
                     )
                     authStateMachine.send(event)
-                    _signOut(onComplete)
+                    _signOut(onComplete = onComplete)
                 }
                 is AuthenticationState.FederatedToIdentityPool -> {
                     onComplete.accept(
@@ -1444,7 +1448,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    private fun _signOut(onComplete: Consumer<AuthSignOutResult>) {
+    private fun _signOut(sendHubEvent: Boolean = true, onComplete: Consumer<AuthSignOutResult>) {
         var token: StateChangeListenerToken? = null
         token = authStateMachine.listen(
             { authState ->
@@ -1468,8 +1472,14 @@ internal class RealAWSCognitoAuthPlugin(
                                         }
                                     )
                                 )
+                                if (sendHubEvent) {
+                                    sendHubEvent(AuthChannelEventName.SIGNED_OUT.toString())
+                                }
                             } else {
                                 onComplete.accept(AWSCognitoAuthSignOutResult.CompleteSignOut)
+                                if (sendHubEvent) {
+                                    sendHubEvent(AuthChannelEventName.SIGNED_OUT.toString())
+                                }
                             }
                         }
                         authNState is AuthenticationState.Error -> {
@@ -1533,6 +1543,7 @@ internal class RealAWSCognitoAuthPlugin(
                 when (val deleteUserState = authZState?.deleteUserState) {
                     is DeleteUserState.UserDeleted -> {
                         onSuccess.call()
+                        sendHubEvent(AuthChannelEventName.USER_DELETED.toString())
                         listenerToken?.let(authStateMachine::cancel)
                     }
                     is DeleteUserState.Error -> {
@@ -1557,47 +1568,7 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     private fun addAuthStateChangeListener() {
-        authStateMachine.listen(
-            { authState ->
-                logger.verbose("Auth State Change: $authState")
-
-                when (authState) {
-                    is AuthState.Configured -> {
-                        val (authNState, authZState) = authState
-                        val deleteUserAuthZState = authZState as? AuthorizationState.DeletingUser
-                        val hubEvent = when {
-                            authNState is AuthenticationState.SignedOut &&
-                                authZState is AuthorizationState.Configured -> {
-                                AuthChannelEventName.SIGNED_OUT.toString()
-                            }
-                            authNState is AuthenticationState.SignedIn &&
-                                authZState is AuthorizationState.SessionEstablished -> {
-                                AuthChannelEventName.SIGNED_IN.toString()
-                            }
-                            authNState is AuthenticationState.FederatedToIdentityPool &&
-                                authZState is AuthorizationState.SessionEstablished -> {
-                                AWSCognitoAuthChannelEventName.FEDERATED_TO_IDENTITY_POOL.toString()
-                            }
-                            deleteUserAuthZState?.deleteUserState is DeleteUserState.UserDeleted -> {
-                                AuthChannelEventName.USER_DELETED.toString()
-                            }
-                            authNState is AuthenticationState.SignedIn && authZState is AuthorizationState.Error &&
-                                authZState.exception is SessionError &&
-                                authZState.exception.exception is SessionExpiredException -> {
-                                AuthChannelEventName.SESSION_EXPIRED.toString()
-                            }
-                            else -> lastPublishedHubEventName.get()
-                        }
-                        if (lastPublishedHubEventName.get() != hubEvent) {
-                            lastPublishedHubEventName.set(hubEvent)
-                            Amplify.Hub.publish(HubChannel.AUTH, HubEvent.create(hubEvent))
-                        }
-                    }
-                    else -> Unit
-                }
-            },
-            null
-        )
+        authStateMachine.listen({ authState -> logger.verbose("Auth State Change: $authState") }, null)
     }
 
     private fun configureAuthStates() {
@@ -1699,6 +1670,7 @@ internal class RealAWSCognitoAuthPlugin(
                                 identityId = identityId
                             )
                             onSuccess.accept(result)
+                            sendHubEvent(AWSCognitoAuthChannelEventName.FEDERATED_TO_IDENTITY_POOL.toString())
                         } else {
                             onError.accept(
                                 UnknownException(
@@ -1753,19 +1725,23 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     private fun _clearFederationToIdentityPool(onSuccess: Action, onError: Consumer<AuthException>) {
-        _signOut {
+        _signOut(sendHubEvent = false) {
             when (it) {
                 is AWSCognitoAuthSignOutResult.FailedSignOut -> {
                     onError.accept(it.error)
                 }
                 else -> {
                     onSuccess.call()
-                    Amplify.Hub.publish(
-                        HubChannel.AUTH,
-                        HubEvent.create(AWSCognitoAuthChannelEventName.FEDERATION_TO_IDENTITY_POOL_CLEARED)
-                    )
+                    sendHubEvent(AWSCognitoAuthChannelEventName.FEDERATION_TO_IDENTITY_POOL_CLEARED.toString())
                 }
             }
+        }
+    }
+
+    private fun sendHubEvent(eventName: String) {
+        if (lastPublishedHubEventName.get() != eventName) {
+            lastPublishedHubEventName.set(eventName)
+            Amplify.Hub.publish(HubChannel.AUTH, HubEvent.create(eventName))
         }
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
@@ -237,9 +237,10 @@ internal sealed class AuthorizationState : State {
                 }
                 is SessionEstablished -> when {
                     authenticationEvent is AuthenticationEvent.EventType.SignInRequested -> StateResolution(SigningIn())
-                    authenticationEvent is AuthenticationEvent.EventType.SignOutRequested -> StateResolution(
-                        SigningOut(oldState.amplifyCredential)
-                    )
+                    authenticationEvent is AuthenticationEvent.EventType.SignOutRequested ||
+                        authenticationEvent is AuthenticationEvent.EventType.ClearFederationToIdentityPool -> {
+                        StateResolution(SigningOut(oldState.amplifyCredential))
+                    }
                     deleteUserEvent is DeleteUserEvent.EventType.DeleteUser -> StateResolution(
                         DeletingUser(DeleteUserState.NotStarted()),
                         listOf(authorizationActions.initiateDeleteUser(deleteUserEvent))


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Auth Hub events fired on API calls, not SM changes
Fix clear federation

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
