### PR TITLE
chore: replace jcenter with mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -40,7 +40,7 @@ allprojects {
             url = 'https://aws.oss.sonatype.org/content/repositories/snapshots/'
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 
     gradle.projectsEvaluated {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Jcenter no longer receives updates. If gradle cache does not contain the dependencies, it may fail to be downloaded from jcenter. Replaced with mavenCentral.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
