### PR TITLE
[DRAFT] fix(datastore): remove typename from ModelMetadata

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelMetadata.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelMetadata.java
@@ -39,7 +39,6 @@ public final class ModelMetadata implements Model {
     private final @ModelField(targetType = "Boolean") Boolean _deleted;
     private final @ModelField(targetType = "Int") Integer _version;
     private final @ModelField(targetType = "AWSTimestamp") Temporal.Timestamp _lastChangedAt;
-    private final @ModelField(targetType = "String") String __typename;
 
     /**
      * Constructor for this metadata model.
@@ -47,19 +46,16 @@ public final class ModelMetadata implements Model {
      * @param deleted Whether this object was deleted since the last sync time specified
      * @param version What version this object was last seen at
      * @param lastChangedAt When was this object last changed
-     * @param typename The type name of the model.
      */
     public ModelMetadata(
             @NonNull String id,
             @Nullable Boolean deleted,
             @Nullable Integer version,
-            @Nullable Temporal.Timestamp lastChangedAt,
-            @Nullable String typename) {
+            @Nullable Temporal.Timestamp lastChangedAt) {
         this.id = Objects.requireNonNull(id);
         this._deleted = deleted;
         this._version = version;
         this._lastChangedAt = lastChangedAt;
-        this.__typename = typename;
     }
 
     /**
@@ -90,21 +86,21 @@ public final class ModelMetadata implements Model {
     }
 
     /**
-     * Gets the type of the model.
-     * @return Type of the Model.
-     */
-    @Nullable
-    public String getTypename() {
-        return __typename;
-    }
-
-    /**
      * Gets last changed at time.
      * @return last changed at time
      */
     @Nullable
     public Temporal.Timestamp getLastChangedAt() {
         return _lastChangedAt;
+    }
+
+    /**
+     * Gets the model name.
+     * @return modelName
+     */
+    @Nullable
+    public String getModelName() {
+        return id.split("\\|")[0];
     }
 
     @Override
@@ -136,7 +132,6 @@ public final class ModelMetadata implements Model {
         result = 31 * result + (_deleted != null ? _deleted.hashCode() : 0);
         result = 31 * result + (_version != null ? _version.hashCode() : 0);
         result = 31 * result + (_lastChangedAt != null ? _lastChangedAt.hashCode() : 0);
-        result = 31 * result + (__typename != null ? __typename.hashCode() : 0);
         return result;
     }
 
@@ -147,7 +142,6 @@ public final class ModelMetadata implements Model {
             ", _deleted=" + _deleted +
             ", _version=" + _version +
             ", _lastChangedAt=" + _lastChangedAt +
-            ",  __typename=" + __typename +
             '}';
     }
 }

--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelWithMetadata.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelWithMetadata.java
@@ -42,7 +42,7 @@ public final class ModelWithMetadata<M extends Model> {
         this.syncMetadata = new ModelMetadata(model.getModelName() + "|" + model.getPrimaryKeyString(),
                 syncMetadata.isDeleted(),
                 syncMetadata.getVersion(),
-                syncMetadata.getLastChangedAt(), syncMetadata.getTypename());
+                syncMetadata.getLastChangedAt());
     }
 
     /**

--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelWithMetadataAdapter.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/ModelWithMetadataAdapter.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
@@ -117,10 +118,14 @@ public final class ModelWithMetadataAdapter implements
         // Flatten out the fields of the model and its metadata into a flat key-value map.
         // To do this, serialize each individually, and then add the key/value pairs for each
         // object into a new container.
-        JsonObject serializedMetadata = (JsonObject) context.serialize(src.getSyncMetadata());
+        ModelMetadata modelMetadata = src.getSyncMetadata();
+        JsonObject serializedMetadata = (JsonObject) context.serialize(modelMetadata);
         for (Map.Entry<java.lang.String, JsonElement> entry : serializedMetadata.entrySet()) {
             result.add(entry.getKey(), entry.getValue());
         }
+        // Additionally serialize the stored model name as the typename, mirroring the deserialization process.
+        result.addProperty(TYPE_NAME, modelMetadata.getModelName());
+
         JsonObject serializedModel = (JsonObject) context.serialize(src.getModel());
         for (Map.Entry<java.lang.String, JsonElement> entry : serializedModel.entrySet()) {
             result.add(entry.getKey(), entry.getValue());

--- a/aws-api-appsync/src/test/java/com/amplifyframework/datastore/appsync/ModelWithMetadataAdapterTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/datastore/appsync/ModelWithMetadataAdapterTest.java
@@ -68,7 +68,7 @@ public final class ModelWithMetadataAdapterTest {
     public void adapterCanSerializeMwm() throws JSONException {
         Temporal.Timestamp lastChangedAt = Temporal.Timestamp.now();
         String modelId = UUID.randomUUID().toString();
-        ModelMetadata metadata = new ModelMetadata(modelId, false, 4, lastChangedAt, "BlogOwner");
+        ModelMetadata metadata = new ModelMetadata(modelId, false, 4, lastChangedAt);
         BlogOwner model = BlogOwner.builder()
             .name("Blog Owner")
             .build();
@@ -80,7 +80,7 @@ public final class ModelWithMetadataAdapterTest {
             .put("_lastChangedAt", metadata.getLastChangedAt().getSecondsSinceEpoch())
             .put("_deleted", metadata.isDeleted())
             .put("_version", metadata.getVersion())
-            .put("__typename", metadata.getTypename())
+            .put("__typename", mwm.getSyncMetadata().getModelName())
             .toString();
         String actual = gson.toJson(mwm);
         JSONAssert.assertEquals(expected, actual, true);
@@ -97,7 +97,7 @@ public final class ModelWithMetadataAdapterTest {
             .id("45a5f600-8aa8-41ac-a529-aed75036f5be")
             .build();
         Temporal.Timestamp lastChangedAt = new Temporal.Timestamp(1594858827, TimeUnit.SECONDS);
-        ModelMetadata metadata = new ModelMetadata(model.getId(), false, 3, lastChangedAt, model.getModelName());
+        ModelMetadata metadata = new ModelMetadata(model.getId(), false, 3, lastChangedAt);
         ModelWithMetadata<BlogOwner> expected = new ModelWithMetadata<>(model, metadata);
 
         // Arrange some JSON, and then try to deserialize it
@@ -133,15 +133,14 @@ public final class ModelWithMetadataAdapterTest {
                 .serializedData(postSerializedData)
                 .build();
         Temporal.Timestamp lastChangedAt = new Temporal.Timestamp(1594858827, TimeUnit.SECONDS);
-        ModelMetadata metadata = new ModelMetadata(model.getPrimaryKeyString(), false, 3, lastChangedAt,
-                model.getModelName());
+        ModelMetadata metadata = new ModelMetadata(model.getPrimaryKeyString(), false, 3, lastChangedAt);
         ModelWithMetadata<SerializedModel> expected = new ModelWithMetadata<>(model, metadata);
 
         // Arrange some JSON, and then try to deserialize it
         String json = Resources.readAsString("serialized-model-with-metadata.json");
         Type type = TypeMaker.getParameterizedType(ModelWithMetadata.class, SerializedModel.class);
         ModelWithMetadata<SerializedModel> actual = gson.fromJson(json, type);
-
+        
         // Assert that the deserialized output matches out expected value
         Assert.assertEquals(expected, actual);
     }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -231,8 +231,7 @@ public final class AWSDataStorePluginTest {
             int indexOfResponseConsumer = 1;
             Consumer<GraphQLResponse<ModelWithMetadata<Person>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);
-            ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1, Temporal.Timestamp.now(),
-                    "Person");
+            ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1, Temporal.Timestamp.now());
             ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person1, modelMetadata);
             onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
             return mock(GraphQLOperation.class);
@@ -256,7 +255,7 @@ public final class AWSDataStorePluginTest {
             Consumer<GraphQLResponse<ModelWithMetadata<Person>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);
             ModelMetadata modelMetadata = new ModelMetadata(person2.getId(), false, 1,
-                    Temporal.Timestamp.now(), "Person");
+                    Temporal.Timestamp.now());
             ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person2, modelMetadata);
             onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
             return mock(GraphQLOperation.class);
@@ -325,7 +324,7 @@ public final class AWSDataStorePluginTest {
             Consumer<GraphQLResponse<ModelWithMetadata<Person>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);
             ModelMetadata modelMetadata = new ModelMetadata(person1.getPrimaryKeyString(), false, 1,
-                    Temporal.Timestamp.now(), "Person");
+                    Temporal.Timestamp.now());
             ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person1, modelMetadata);
             onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
             return mock(GraphQLOperation.class);
@@ -349,7 +348,7 @@ public final class AWSDataStorePluginTest {
             Consumer<GraphQLResponse<ModelWithMetadata<Person>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);
             ModelMetadata modelMetadata = new ModelMetadata(person2.getPrimaryKeyString(), false, 1,
-                    Temporal.Timestamp.now(), "Person");
+                    Temporal.Timestamp.now());
             ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person2, modelMetadata);
             onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
             return mock(GraphQLOperation.class);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/ConflictResolverIntegrationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/ConflictResolverIntegrationTest.java
@@ -191,8 +191,7 @@ public final class ConflictResolverIntegrationTest {
             int indexOfResponseConsumer = 1;
             Consumer<GraphQLResponse<ModelWithMetadata<Person>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);
-            ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1, Temporal.Timestamp.now(),
-                    "Person");
+            ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1, Temporal.Timestamp.now());
             ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person1, modelMetadata);
             onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
             verify(mockApiCategory, atLeast(2)).mutate(argThat(getMatcherFor(person1)),
@@ -207,7 +206,7 @@ public final class ConflictResolverIntegrationTest {
         doAnswer(invocation -> {
             int indexOfResponseConsumer = 1;
             ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1,
-                    Temporal.Timestamp.now(), "Person");
+                    Temporal.Timestamp.now());
             ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person1, modelMetadata);
             // Mock the API emitting an ApiEndpointStatusChangeEvent event.
             Consumer<GraphQLResponse<PaginatedResult<ModelWithMetadata<Person>>>> onResponse =
@@ -221,7 +220,7 @@ public final class ConflictResolverIntegrationTest {
         }).doAnswer(invocation -> {
             int indexOfResponseConsumer = 1;
             Car car = Car.builder().build();
-            ModelMetadata modelMetadata = new ModelMetadata(car.getId(), false, 1, Temporal.Timestamp.now(), "Person");
+            ModelMetadata modelMetadata = new ModelMetadata(car.getId(), false, 1, Temporal.Timestamp.now());
             ModelWithMetadata<Car> modelWithMetadata = new ModelWithMetadata<>(car, modelMetadata);
             Consumer<GraphQLResponse<PaginatedResult<ModelWithMetadata<Car>>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/MutationProcessorRetryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/MutationProcessorRetryTest.java
@@ -167,8 +167,7 @@ public final class MutationProcessorRetryTest {
             int indexOfResponseConsumer = 1;
             Consumer<GraphQLResponse<ModelWithMetadata<Person>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);
-            ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1, Temporal.Timestamp.now(),
-                    "Person");
+            ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1, Temporal.Timestamp.now());
             ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person1, modelMetadata);
             onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
             verify(mockApiCategory, atLeast(2)).mutate(argThat(getMatcherFor(person1)),
@@ -183,7 +182,7 @@ public final class MutationProcessorRetryTest {
         doAnswer(invocation -> {
             int indexOfResponseConsumer = 1;
             ModelMetadata modelMetadata = new ModelMetadata(person1.getId(), false, 1,
-                    Temporal.Timestamp.now(), "Person");
+                    Temporal.Timestamp.now());
             ModelWithMetadata<Person> modelWithMetadata = new ModelWithMetadata<>(person1, modelMetadata);
             // Mock the API emitting an ApiEndpointStatusChangeEvent event.
             Consumer<GraphQLResponse<PaginatedResult<ModelWithMetadata<Person>>>> onResponse =
@@ -197,7 +196,7 @@ public final class MutationProcessorRetryTest {
         }).doAnswer(invocation -> {
             int indexOfResponseConsumer = 1;
             Car car = Car.builder().build();
-            ModelMetadata modelMetadata = new ModelMetadata(car.getId(), false, 1, Temporal.Timestamp.now(), "Person");
+            ModelMetadata modelMetadata = new ModelMetadata(car.getId(), false, 1, Temporal.Timestamp.now());
             ModelWithMetadata<Car> modelWithMetadata = new ModelWithMetadata<>(car, modelMetadata);
             Consumer<GraphQLResponse<PaginatedResult<ModelWithMetadata<Car>>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncConflictUnhandledErrorFactoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncConflictUnhandledErrorFactoryTest.java
@@ -38,7 +38,7 @@ public final class AppSyncConflictUnhandledErrorFactoryTest {
             .name("Blogger Tony")
             .build();
         Temporal.Timestamp lastChangedAt = new Temporal.Timestamp(1602732606L, TimeUnit.SECONDS);
-        ModelMetadata metadata = new ModelMetadata(model.getPrimaryKeyString(), true, 6, lastChangedAt, "BlogOwner");
+        ModelMetadata metadata = new ModelMetadata(model.getPrimaryKeyString(), true, 6, lastChangedAt);
         ModelWithMetadata<BlogOwner> serverData = new ModelWithMetadata<>(model, metadata);
         AppSyncConflictUnhandledError<BlogOwner> error =
             AppSyncConflictUnhandledErrorFactory.createUnhandledConflictError(serverData);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncConflictUnhandledErrorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncConflictUnhandledErrorTest.java
@@ -124,7 +124,7 @@ public final class AppSyncConflictUnhandledErrorTest {
         assertEquals(
             new ModelWithMetadata<>(
                 new Note("KoolId22", "Resurecting the dataz"),
-                new ModelMetadata("KoolId22", true, 7, lastChangedAt, "Note")
+                new ModelMetadata("KoolId22", true, 7, lastChangedAt)
             ),
             conflictUnhandledError.getServerVersion()
         );

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMocking.java
@@ -204,8 +204,7 @@ public final class AppSyncMocking {
          */
         @NonNull
         public <T extends Model> CreateConfigurator mockSuccessResponse(@NonNull T model) {
-            ModelMetadata metadata = new ModelMetadata(model.getPrimaryKeyString(), false, 1, Temporal.Timestamp.now(),
-                    model.getModelName());
+            ModelMetadata metadata = new ModelMetadata(model.getPrimaryKeyString(), false, 1, Temporal.Timestamp.now());
             ModelWithMetadata<T> modelWithMetadata = new ModelWithMetadata<>(model, metadata);
             return mockSuccessResponse(model, modelWithMetadata);
         }
@@ -313,7 +312,7 @@ public final class AppSyncMocking {
         public <T extends Model> UpdateConfigurator mockSuccessResponse(@NonNull T model, int version) {
             Temporal.Timestamp lastChangedAt = Temporal.Timestamp.now();
             ModelMetadata metadata = new ModelMetadata(model.getPrimaryKeyString(), false, version + 1,
-                    lastChangedAt, model.getModelName());
+                    lastChangedAt);
             ModelWithMetadata<T> modelWithMetadata = new ModelWithMetadata<>(model, metadata);
             return mockSuccessResponse(model, version, modelWithMetadata);
         }
@@ -426,7 +425,7 @@ public final class AppSyncMocking {
         public <T extends Model> DeleteConfigurator mockSuccessResponse(@NonNull T model, int version) {
             Temporal.Timestamp lastChangedAt = Temporal.Timestamp.now();
             ModelMetadata metadata = new ModelMetadata(model.getPrimaryKeyString(), true, version + 1,
-                    lastChangedAt, model.getModelName());
+                    lastChangedAt);
             ModelWithMetadata<T> modelWithMetadata = new ModelWithMetadata<>(model, metadata);
             return mockSuccessResponse(model, version, modelWithMetadata);
         }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMockingTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/AppSyncMockingTest.java
@@ -170,7 +170,7 @@ public final class AppSyncMockingTest {
     public void mockSuccessResponseForUpdate() {
         ModelMetadata updatedMetadata =
             new ModelMetadata(StrawMen.TONY_MODEL.getPrimaryKeyString(), false, 2, StrawMen.JOE_METADATA
-                    .getLastChangedAt(), StrawMen.TONY_MODEL.getModelName());
+                    .getLastChangedAt());
         ModelWithMetadata<BlogOwner> tonyWithUpdatedMetadata =
             new ModelWithMetadata<>(StrawMen.TONY_MODEL, updatedMetadata);
         AppSyncMocking.update(appSync)
@@ -218,7 +218,7 @@ public final class AppSyncMockingTest {
     public void mockSuccessResponseForDelete() {
         ModelMetadata deletedMetadata =
             new ModelMetadata(StrawMen.TONY_MODEL.getPrimaryKeyString(), true, 2,
-                    StrawMen.JOE_METADATA.getLastChangedAt(), StrawMen.TONY_MODEL.getModelName());
+                    StrawMen.JOE_METADATA.getLastChangedAt());
         ModelWithMetadata<BlogOwner> tonyWithDeleteMetadata =
             new ModelWithMetadata<>(StrawMen.TONY_MODEL, deletedMetadata);
         AppSyncMocking.delete(appSync)
@@ -335,8 +335,7 @@ public final class AppSyncMockingTest {
             .name("Joe")
             .build();
         static final ModelMetadata JOE_METADATA =
-            new ModelMetadata(JOE_MODEL.getPrimaryKeyString(), false, 1, Temporal.Timestamp.now(),
-                    JOE_MODEL.getModelName());
+            new ModelMetadata(JOE_MODEL.getPrimaryKeyString(), false, 1, Temporal.Timestamp.now());
         static final ModelWithMetadata<BlogOwner> JOE =
             new ModelWithMetadata<>(JOE_MODEL, JOE_METADATA);
 
@@ -344,8 +343,7 @@ public final class AppSyncMockingTest {
             .name("Tony")
             .build();
         static final ModelMetadata TONY_METADATA =
-            new ModelMetadata(TONY_MODEL.getPrimaryKeyString(), false, 1, Temporal.Timestamp.now(),
-                    TONY_MODEL.getModelName());
+            new ModelMetadata(TONY_MODEL.getPrimaryKeyString(), false, 1, Temporal.Timestamp.now());
         static final ModelWithMetadata<BlogOwner> TONY =
             new ModelWithMetadata<>(TONY_MODEL, TONY_METADATA);
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/TestModelWithMetadataInstances.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/appsync/TestModelWithMetadataInstances.java
@@ -40,7 +40,7 @@ public final class TestModelWithMetadataInstances {
             new ModelMetadata("d5b44350-b8e9-4deb-94c2-7fe986d6a0e1",
                     null,
                     3,
-                    new Temporal.Timestamp(223344L, TimeUnit.SECONDS), "BlogOwner")
+                    new Temporal.Timestamp(223344L, TimeUnit.SECONDS))
         );
     public static final ModelWithMetadata<BlogOwner> BLOGGER_ISLA =
         new ModelWithMetadata<>(
@@ -51,7 +51,7 @@ public final class TestModelWithMetadataInstances {
             new ModelMetadata("c0601168-2931-4bc0-bf13-5963cd31f828",
                     null,
                     11,
-                    new Temporal.Timestamp(998877L, TimeUnit.SECONDS), "BlogOwner")
+                    new Temporal.Timestamp(998877L, TimeUnit.SECONDS))
         );
     public static final ModelWithMetadata<Post> DRUM_POST =
         new ModelWithMetadata<>(
@@ -64,7 +64,7 @@ public final class TestModelWithMetadataInstances {
             new ModelMetadata("83ceb757-c8c8-4b6a-bee0-a43afb53a73a",
                     null,
                     5,
-                    new Temporal.Timestamp(123123L, TimeUnit.SECONDS), "Post")
+                    new Temporal.Timestamp(123123L, TimeUnit.SECONDS))
         );
     public static final ModelWithMetadata<Post> DELETED_DRUM_POST =
         new ModelWithMetadata<>(
@@ -72,7 +72,7 @@ public final class TestModelWithMetadataInstances {
             new ModelMetadata("83ceb757-c8c8-4b6a-bee0-a43afb53a73a",
                     Boolean.TRUE,
                     5,
-                    new Temporal.Timestamp(123123L, TimeUnit.SECONDS), "Post")
+                    new Temporal.Timestamp(123123L, TimeUnit.SECONDS))
         );
 
     private TestModelWithMetadataInstances() {}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/ConflictResolverTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/ConflictResolverTest.java
@@ -104,7 +104,7 @@ public final class ConflictResolverTest {
             .name("Remote Susan")
             .build();
         Temporal.Timestamp now = Temporal.Timestamp.now();
-        ModelMetadata modelMetadata = new ModelMetadata(serverSusan.getId(), false, 2, now, "BlogOwner");
+        ModelMetadata modelMetadata = new ModelMetadata(serverSusan.getId(), false, 2, now);
         ModelWithMetadata<BlogOwner> serverData = new ModelWithMetadata<>(serverSusan, modelMetadata);
 
         // Arrange a conflict error that we could hypothetically get from AppSync
@@ -151,7 +151,7 @@ public final class ConflictResolverTest {
             .name("Server Blogger")
             .build();
         Temporal.Timestamp now = Temporal.Timestamp.now();
-        ModelMetadata metadata = new ModelMetadata(serverModel.getId(), false, 4, now, "BlogOwner");
+        ModelMetadata metadata = new ModelMetadata(serverModel.getId(), false, 4, now);
         ModelWithMetadata<BlogOwner> serverData = new ModelWithMetadata<>(serverModel, metadata);
 
         // Arrange a hypothetical conflict error from AppSync
@@ -212,7 +212,7 @@ public final class ConflictResolverTest {
                 .name("Server Blogger")
                 .build();
         Temporal.Timestamp now = Temporal.Timestamp.now();
-        ModelMetadata metadata = new ModelMetadata(serverModel.getId(), false, 4, now, "BlogOwner");
+        ModelMetadata metadata = new ModelMetadata(serverModel.getId(), false, 4, now);
         ModelWithMetadata<SerializedModel> serverData = new ModelWithMetadata<>(serializedOwner, metadata);
 
         // Arrange a hypothetical conflict error from AppSync
@@ -270,7 +270,7 @@ public final class ConflictResolverTest {
                 .build();
 
         Temporal.Timestamp now = Temporal.Timestamp.now();
-        ModelMetadata metadata = new ModelMetadata(serverModel.getPrimaryKeyString(), false, 4, now, "BlogOwner");
+        ModelMetadata metadata = new ModelMetadata(serverModel.getPrimaryKeyString(), false, 4, now);
         ModelWithMetadata<SerializedModel> serverData = new ModelWithMetadata<>(serializedOwner, metadata);
 
         // Arrange a hypothetical conflict error from AppSync
@@ -312,7 +312,7 @@ public final class ConflictResolverTest {
             .name("Remote model")
             .build();
         Temporal.Timestamp now = Temporal.Timestamp.now();
-        ModelMetadata remoteMetadata = new ModelMetadata(remoteModel.getPrimaryKeyString(), false, 4, now, "BlogOwner");
+        ModelMetadata remoteMetadata = new ModelMetadata(remoteModel.getPrimaryKeyString(), false, 4, now);
         ModelWithMetadata<BlogOwner> remoteData = new ModelWithMetadata<>(remoteModel, remoteMetadata);
         // Arrange an unhandled conflict error based on the server data
         AppSyncConflictUnhandledError<BlogOwner> unhandledConflictError =
@@ -330,7 +330,7 @@ public final class ConflictResolverTest {
 
         // When the AppSync update API is called, return a mock response
         ModelMetadata metadata = new ModelMetadata(customModel.getPrimaryKeyString(), false,
-                remoteMetadata.getVersion(), now, "BlogOwner");
+                remoteMetadata.getVersion(), now);
         ModelWithMetadata<BlogOwner> responseData = new ModelWithMetadata<>(customModel, metadata);
         AppSyncMocking.update(appSync)
             .mockSuccessResponse(customModel, remoteMetadata.getVersion(), responseData);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MergerTest.java
@@ -92,16 +92,14 @@ public final class MergerTest {
             .name("Jameson")
             .build();
         ModelMetadata originalMetadata =
-            new ModelMetadata(blogOwner.getId(), false, 1, Temporal.Timestamp.now(),
-                    blogOwner.getModelName());
+            new ModelMetadata(blogOwner.getId(), false, 1, Temporal.Timestamp.now());
         storageAdapter.save(blogOwner, originalMetadata);
         // Just to be sure, our arrangement worked, and that thing is in there, right? Good.
         assertEquals(Collections.singletonList(blogOwner), storageAdapter.query(BlogOwner.class));
 
         // Act: merge a model deletion.
         ModelMetadata deletionMetadata =
-            new ModelMetadata(blogOwner.getId(), true, 2, Temporal.Timestamp.now(),
-                    blogOwner.getModelName());
+            new ModelMetadata(blogOwner.getId(), true, 2, Temporal.Timestamp.now());
         TestObserver<Void> observer =
             merger.merge(new ModelWithMetadata<>(blogOwner, deletionMetadata)).test();
         assertTrue(observer.await(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
@@ -130,8 +128,7 @@ public final class MergerTest {
 
         // Act: try to merge a deletion that refers to an item not in the store
         ModelMetadata deletionMetadata =
-            new ModelMetadata(blogOwner.getId(), true, 1, Temporal.Timestamp.now(),
-                    blogOwner.getModelName());
+            new ModelMetadata(blogOwner.getId(), true, 1, Temporal.Timestamp.now());
         TestObserver<Void> observer =
             merger.merge(new ModelWithMetadata<>(blogOwner, deletionMetadata)).test();
         assertTrue(observer.await(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
@@ -155,7 +152,7 @@ public final class MergerTest {
             .build();
         ModelMetadata metadata =
             new ModelMetadata(blogOwner.getModelName() + "|" + blogOwner.getId(), false, 1,
-                    Temporal.Timestamp.now(), blogOwner.getModelName());
+                    Temporal.Timestamp.now());
         // Note that storageAdapter.save(...) is NOT called!
         // storageAdapter.save(blogOwner, metadata);
 
@@ -187,8 +184,7 @@ public final class MergerTest {
                 originalModel.getModelName() + "|" + originalModel.getId(),
                 false,
                 1,
-                Temporal.Timestamp.now(),
-                originalModel.getModelName());
+                Temporal.Timestamp.now());
         storageAdapter.save(originalModel, originalMetadata);
 
         // Act: merge a save.
@@ -196,8 +192,7 @@ public final class MergerTest {
             .name("Jameson The New and Improved")
             .build();
         ModelMetadata updatedMetadata =
-            new ModelMetadata(originalMetadata.resolveIdentifier(), false, 2, Temporal.Timestamp.now(),
-                    updatedModel.getModelName());
+            new ModelMetadata(originalMetadata.resolveIdentifier(), false, 2, Temporal.Timestamp.now());
         TestObserver<Void> observer = merger.merge(new ModelWithMetadata<>(updatedModel, updatedMetadata)).test();
         assertTrue(observer.await(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS));
         observer.assertComplete().assertNoErrors();
@@ -225,8 +220,7 @@ public final class MergerTest {
             .id(knownId)
             .build();
         ModelMetadata localMetadata =
-            new ModelMetadata(blogOwner.getId(), false, 1, Temporal.Timestamp.now(),
-                    blogOwner.getModelName());
+            new ModelMetadata(blogOwner.getId(), false, 1, Temporal.Timestamp.now());
         storageAdapter.save(blogOwner, localMetadata);
 
         ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
@@ -240,8 +234,7 @@ public final class MergerTest {
         // Act: now, cloud sync happens, and the sync engine tries to apply an update
         // for the same model ID, into the store. According to the cloud, this same
         // item should be DELETED.
-        ModelMetadata cloudMetadata = new ModelMetadata(knownId, true, 2, Temporal.Timestamp.now(),
-                blogOwner.getModelName());
+        ModelMetadata cloudMetadata = new ModelMetadata(knownId, true, 2, Temporal.Timestamp.now());
         TestObserver<Void> mergeObserver = merger.merge(new ModelWithMetadata<>(blogOwner, cloudMetadata)).test();
         mergeObserver.await(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS);
         mergeObserver.assertNoErrors().assertComplete();
@@ -270,8 +263,7 @@ public final class MergerTest {
                 .id(knownId)
                 .build();
         ModelMetadata localMetadata =
-                new ModelMetadata(blogOwner.getId(), false, 1, Temporal.Timestamp.now(),
-                        blogOwner.getModelName());
+                new ModelMetadata(blogOwner.getId(), false, 1, Temporal.Timestamp.now());
         storageAdapter.save(blogOwner, localMetadata);
 
         ModelSchema schema = ModelSchema.fromModelClass(BlogOwner.class);
@@ -286,8 +278,7 @@ public final class MergerTest {
         // Act: now, cloud sync happens, and the sync engine tries to apply an update
         // for the same model ID, into the store. According to the cloud, this same
         // item should be DELETED.
-        ModelMetadata cloudMetadata = new ModelMetadata(knownId, true, 2, Temporal.Timestamp.now(),
-                blogOwner.getModelName());
+        ModelMetadata cloudMetadata = new ModelMetadata(knownId, true, 2, Temporal.Timestamp.now());
         TestObserver<Void> observer =
             mutationOutbox.remove(pendingMutation.getMutationId())
                 .andThen(merger.merge(new ModelWithMetadata<>(blogOwner, cloudMetadata)))
@@ -315,7 +306,7 @@ public final class MergerTest {
             .name("Cornelius Daniels")
             .build();
         ModelMetadata existingMetadata = new ModelMetadata(existingModel.getId(), false, 55,
-                Temporal.Timestamp.now(), existingModel.getModelName());
+                Temporal.Timestamp.now());
         storageAdapter.save(existingModel, existingMetadata);
 
         // Act: try to merge, but specify a LOWER version.
@@ -323,8 +314,7 @@ public final class MergerTest {
             .name("Cornelius Daniels, but woke af, now.")
             .build();
         ModelMetadata lowerVersionMetadata =
-            new ModelMetadata(incomingModel.getId(), false, 33, Temporal.Timestamp.now(),
-                    incomingModel.getModelName());
+            new ModelMetadata(incomingModel.getId(), false, 33, Temporal.Timestamp.now());
         ModelWithMetadata<BlogOwner> modelWithLowerVersionMetadata =
             new ModelWithMetadata<>(existingModel, lowerVersionMetadata);
         TestObserver<Void> mergeObserver = merger.merge(modelWithLowerVersionMetadata).test();
@@ -361,8 +351,7 @@ public final class MergerTest {
                 existingModel.getModelName() + "|" + existingModel.getId(),
                 false,
                 55,
-                Temporal.Timestamp.now(),
-                    existingModel.getModelName());
+                Temporal.Timestamp.now());
         storageAdapter.save(existingModel, existingMetadata);
 
         // Act: try to merge, but specify a LOWER version.
@@ -370,8 +359,7 @@ public final class MergerTest {
             .name("Cornelius Daniels, but woke af, now.")
             .build();
         ModelMetadata lowerVersionMetadata =
-            new ModelMetadata(incomingModel.getId(), false, 33, Temporal.Timestamp.now(),
-                    incomingModel.getModelName());
+            new ModelMetadata(incomingModel.getId(), false, 33, Temporal.Timestamp.now());
         ModelWithMetadata<BlogOwner> modelWithLowerVersionMetadata =
             new ModelWithMetadata<>(incomingModel, lowerVersionMetadata);
         TestObserver<Void> mergeObserver = merger.merge(modelWithLowerVersionMetadata).test();
@@ -408,7 +396,7 @@ public final class MergerTest {
             .name("Cornelius Daniels")
             .build();
         ModelMetadata existingMetadata = new ModelMetadata(existingModel.getId(), false,
-                1, Temporal.Timestamp.now(), existingModel.getModelName());
+                1, Temporal.Timestamp.now());
         storageAdapter.save(existingModel, existingMetadata);
 
         // Act: try to merge, but don't specify a version in the metadata being used to merge.
@@ -416,7 +404,7 @@ public final class MergerTest {
             .name("Cornelius Daniels, but woke af, now.")
             .build();
         ModelMetadata metadataWithoutVersion = new ModelMetadata(incomingModel.getId(), null, null,
-                null, incomingModel.getModelName());
+                null);
         ModelWithMetadata<BlogOwner> incomingModelWithMetadata =
             new ModelWithMetadata<>(existingModel, metadataWithoutVersion);
         TestObserver<Void> mergeObserver = merger.merge(incomingModelWithMetadata).test();
@@ -452,7 +440,7 @@ public final class MergerTest {
                 .owner(badOwner)
                 .build();
         ModelMetadata metadata = new ModelMetadata(orphanedBlog.getId(), false, 1,
-                Temporal.Timestamp.now(), orphanedBlog.getModelName());
+                Temporal.Timestamp.now());
 
         // Enforce foreign key constraint on in-memory storage adapter
         doThrow(SQLiteConstraintException.class)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -207,7 +207,7 @@ public final class MutationProcessorTest {
             .build();
         ModelMetadata metadata =
             new ModelMetadata(model.getModelName() + "|" + model.getPrimaryKeyString(), false, 1,
-                    Temporal.Timestamp.now(), model.getModelName());
+                    Temporal.Timestamp.now());
         ModelSchema schema = schemaRegistry.getModelSchemaForModelClass(BlogOwner.class);
         LastSyncMetadata lastSyncMetadata = LastSyncMetadata.baseSyncedAt(schema.getName(), 1_000L);
         synchronousStorageAdapter.save(model, metadata, lastSyncMetadata);
@@ -260,7 +260,7 @@ public final class MutationProcessorTest {
                 .build();
         ModelMetadata metadata =
                 new ModelMetadata(model.getModelName() + "|" + model.getPrimaryKeyString(), false, 1,
-                        Temporal.Timestamp.now(), model.getModelName());
+                        Temporal.Timestamp.now());
         ModelSchema schema = schemaRegistry.getModelSchemaForModelClass(BlogOwner.class);
         synchronousStorageAdapter.save(model, metadata);
 
@@ -344,7 +344,7 @@ public final class MutationProcessorTest {
                 .build();
         ModelMetadata metadata =
                 new ModelMetadata(model.getModelName() + "|" + model.getPrimaryKeyString(), false, 1,
-                        Temporal.Timestamp.now(), model.getModelName());
+                        Temporal.Timestamp.now());
         doAnswer(invocation -> {
             int indexOfResponseConsumer = 5;
             Consumer<DataStoreException> onError =
@@ -358,8 +358,7 @@ public final class MutationProcessorTest {
             Consumer<GraphQLResponse<ModelWithMetadata<BlogOwner>>> onResponse =
                     invocation.getArgument(indexOfResponseConsumer);
             ModelMetadata modelMetadata = new ModelMetadata(model.getId(), false, 1,
-                    Temporal.Timestamp.now(),
-                    "BlogOwner");
+                    Temporal.Timestamp.now());
             ModelWithMetadata<BlogOwner> modelWithMetadata = new ModelWithMetadata<BlogOwner>(model,
                     modelMetadata);
             retryHandlerInvocationCount.countDown();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -89,7 +89,7 @@ public final class OrchestratorTest {
         ModelMetadata metadata = new ModelMetadata(susan.getId(),
                                                    false,
                                                    1,
-                                                   Temporal.Timestamp.now(), susan.getModelName());
+                                                   Temporal.Timestamp.now());
         ModelWithMetadata<BlogOwner> modelWithMetadata = new ModelWithMetadata<>(susan, metadata);
         // Mock behaviors from for the API category
         mockApi = mock(GraphQLBehavior.class);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
@@ -191,7 +191,7 @@ public final class SubscriptionProcessorTest {
             .name(name)
             .build();
         ModelMetadata modelMetadata = new ModelMetadata(model.getPrimaryKeyString(), false, 1,
-                Temporal.Timestamp.now(), model.getModelName());
+                Temporal.Timestamp.now());
         ModelWithMetadata<BlogOwner> modelWithMetadata = new ModelWithMetadata<>(model, modelMetadata);
         GraphQLResponse<ModelWithMetadata<BlogOwner>> response = new GraphQLResponse<>(modelWithMetadata, null);
         arrangeDataEmittingSubscription(appSync,

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -819,8 +819,7 @@ public final class SyncProcessorTest {
                 .build();
         Temporal.Timestamp randomTimestamp = new Temporal.Timestamp(new Random().nextLong(), TimeUnit.SECONDS);
         return new ModelWithMetadata<>(blogOwner,
-                new ModelMetadata(blogOwner.getId(), null, new Random().nextInt(), randomTimestamp,
-                        blogOwner.getModelName())
+                new ModelMetadata(blogOwner.getId(), null, new Random().nextInt(), randomTimestamp)
         );
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/VersionRepositoryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/VersionRepositoryTest.java
@@ -105,7 +105,7 @@ public final class VersionRepositoryTest {
             .build();
         ModelMetadata metadata =
                 new ModelMetadata(blogOwner.getModelName() + "|" + blogOwner.getId(), null,
-                        null, null, blogOwner.getModelName());
+                        null, null);
         storageAdapter.save(blogOwner, metadata);
 
         // Act: try to get the version.
@@ -141,8 +141,7 @@ public final class VersionRepositoryTest {
             owner.getModelName() + "|" + owner.getId(),
             false,
             expectedVersion,
-            Temporal.Timestamp.now(),
-                owner.getModelName()));
+            Temporal.Timestamp.now()));
 
         // Act! Try to obtain it via the Versioning Repository.
         TestObserver<Integer> observer = versionRepository.findModelVersion(owner).test();


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/1925
https://github.com/aws-amplify/amplify-android/issues/2066

*Description of changes:*
This PR takes option 2 to remove `__typename` from ModelMetadata table, see https://github.com/aws-amplify/amplify-android/issues/2066#issuecomment-1300680387 . It essentially reverts one of the changes in the [CPK PR](https://github.com/aws-amplify/amplify-android/pull/1650) at the [file](https://github.com/aws-amplify/amplify-android/pull/1650/files#diff-5cdf2885642e1d230ebe77616604dc89e3ed4deb7975f34b69159e0affd9dc27)  (FYI @poojamat)

*How did you test these changes?*


- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
