### PR TITLE
Analytics API visibility

### DIFF
--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/internal/core/util/DateUtil.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/internal/core/util/DateUtil.kt
@@ -19,10 +19,10 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-val outFormatter: DateTimeFormatter = DateTimeFormatter
+internal val outFormatter: DateTimeFormatter = DateTimeFormatter
     .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // millisecond precision
     .withZone(ZoneId.of("UTC"))
 
-fun Long.millisToIsoDate(): String {
+internal fun Long.millisToIsoDate(): String {
     return outFormatter.format(Instant.ofEpochMilli(this))
 }

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/internal/core/util/SharedPreferencesUtil.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/internal/core/util/SharedPreferencesUtil.kt
@@ -20,7 +20,7 @@ import android.content.SharedPreferences
 import com.amplifyframework.core.Amplify
 
 private val LOG = Amplify.Logging.forNamespace("amplify:aws-analytics-pinpoint")
-fun SharedPreferences.putString(key: String, value: String) {
+internal fun SharedPreferences.putString(key: String, value: String) {
     try {
         val editor = this.edit()
         editor.putString(key, value)

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/models/LocaleSerializer.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/models/LocaleSerializer.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 @Serializer(forClass = LocaleSerializer::class)
-object LocaleSerializer : KSerializer<Locale> {
+internal object LocaleSerializer : KSerializer<Locale> {
     override fun deserialize(decoder: Decoder): Locale {
         return Locale.forLanguageTag(decoder.decodeString())
     }

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/targeting/endpointProfile/EndpointProfileDemographic.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/targeting/endpointProfile/EndpointProfileDemographic.kt
@@ -22,7 +22,7 @@ import java.util.TimeZone
 import kotlinx.serialization.Serializable
 
 @Serializable
-class EndpointProfileDemographic {
+internal class EndpointProfileDemographic {
     internal constructor(versionName: String?, make: String, locale: String) {
         this.appVersion = versionName
         this.make = make

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/targeting/endpointProfile/EndpointProfileLocation.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/targeting/endpointProfile/EndpointProfileLocation.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.Serializable
  * @param context the Android context, which we use to get the locale
  */
 @Serializable
-data class EndpointProfileLocation internal constructor(internal var country: String) {
+internal data class EndpointProfileLocation internal constructor(internal var country: String) {
     internal var latitude: Double? = null
     fun getLatitude() = latitude
     fun setLatitude(latitude: Double) = latitude.also { this.latitude = it }

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/targeting/endpointProfile/EndpointProfileUser.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/targeting/endpointProfile/EndpointProfileUser.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
 
 @Serializable
-class EndpointProfileUser {
+internal class EndpointProfileUser {
     private var userId: String? = null
     private var userAttributes: MutableMap<String, List<String>> = ConcurrentHashMap()
     fun getUserId(): String? {


### PR DESCRIPTION
ran unit/integration tests locally; remaining public classes are the plugin itself, Hub channel/event, and AWSPinpointUserProfile if users want to include additional attributes when calling `IdentifyUser()`
![image](https://user-images.githubusercontent.com/9170787/199781818-4cf41653-785d-4566-a14c-db2ebc2b35a8.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
