### PR TITLE
fix: Errors across storage and analytics category

### DIFF
--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/EventRecorder.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/EventRecorder.kt
@@ -115,7 +115,7 @@ internal class EventRecorder(
                     }
                 }
                 currentSubmissions++
-            } while (currentSubmissions < maxSubmissionsAllowed && cursor.moveToNext())
+            } while (currentSubmissions < maxSubmissionsAllowed && !cursor.isClosed && cursor.moveToNext())
         }
         syncedPinpointEvents.forEach { pinpointEvent ->
             syncedAnalyticsEvents.add(convertPinpointEventToAnalyticsEvent(pinpointEvent))

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/result/AWSCognitoAuthSignOutResult.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/result/AWSCognitoAuthSignOutResult.kt
@@ -110,7 +110,7 @@ class GlobalSignOutError internal constructor(globalSignOutErrorData: GlobalSign
 
 /**
  * Revoke Token Error
- * @param revokeTokenErrorData Information about failed global sign out.
+ * @param revokeTokenErrorData Information about failed token revocation.
  */
 class RevokeTokenError internal constructor(revokeTokenErrorData: RevokeTokenErrorData) {
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferDB.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferDB.kt
@@ -639,7 +639,7 @@ internal class TransferDB private constructor(context: Context) {
             null,
             selection = TransferTable.COLUMN_STATE + "!=?",
             arrayOf(
-                TransferState.COMPLETED.toString()
+                TransferState.PART_COMPLETED.toString()
             ),
             null
         )

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/transfer/worker/DownloadWorkerTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/transfer/worker/DownloadWorkerTest.kt
@@ -87,12 +87,13 @@ internal class DownloadWorkerTest {
             )
         }.coAnswers { secondArg<suspend (GetObjectResponse) -> ListenableWorker.Result>().invoke(response) }
         every { transferDB.getTransferRecordById(any()) }.answers { transferRecord }
-        every { transferStatusUpdater.updateProgress(1, any(), any(), true) }.answers { }
+        every { transferStatusUpdater.updateProgress(1, any(), any(), true, false) }.answers { }
+        every { transferStatusUpdater.updateProgress(1, any(), any(), true, true) }.answers { }
 
         val worker = DownloadWorker(s3Client, transferDB, transferStatusUpdater, context, workerParameters)
         val result = worker.doWork()
 
-        verify(atLeast = 1) { transferStatusUpdater.updateProgress(1, 1000, 1000, true) }
+        verify(atLeast = 1) { transferStatusUpdater.updateProgress(1, 1000, 1000, true, true) }
         val expectedResult =
             ListenableWorker.Result.success(workDataOf(BaseTransferWorker.OUTPUT_TRANSFER_RECORD_ID to 1))
         assertEquals(expectedResult, result)


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Fix for cursor is closed exception
```
java.lang.IllegalStateException: attempt to re-open an already-closed object: SQLiteQuery: SELECT * FROM pinpointevent1
2022-11-08 09:41:14.583  5426-5452  System.err              com...ework.analytics.pinpoint.test  W  	at android.database.sqlite.SQLiteClosable.acquireReference(SQLiteClosable.java:58)
2022-11-08 09:41:14.583  5426-5452  System.err              com...ework.analytics.pinpoint.test  W  	at android.database.sqlite.SQLiteQuery.fillWindow(SQLiteQuery.java:58)
2022-11-08 09:41:14.583  5426-5452  System.err              com...ework.analytics.pinpoint.test  W  	at android.database.sqlite.SQLiteCursor.fillWindow(SQLiteCursor.java:153)
2022-11-08 09:41:14.583  5426-5452  System.err              com...ework.analytics.pinpoint.test  W  	at android.database.sqlite.SQLiteCursor.onMove(SQLiteCursor.java:123)
2022-11-08 09:41:14.583  5426-5452  System.err              com...ework.analytics.pinpoint.test  W  	at android.database.AbstractCursor.moveToPosition(AbstractCursor.java:255)
2022-11-08 09:41:14.583  5426-5452  System.err              com...ework.analytics.pinpoint.test  W  	at android.database.AbstractCursor.moveToNext(AbstractCursor.java:287)
2022-11-08 09:41:14.584  5426-5452  System.err              com...ework.analytics.pinpoint.test  W  	at com.amplifyframework.analytics.pinpoint.EventRecorder.processEvents(EventRecorder.kt:129)
2022-11-08 09:41:14.584  5426-5452  System.err              com...ework.analytics.pinpoint.test  W  	at 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
