### PR TITLE
fix(auth): Fix State Machine token race condition

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
@@ -56,8 +56,9 @@ internal class CredentialStoreClient(configuration: AuthConfiguration, context: 
     ) {
         var capturedSuccess: Result<AmplifyCredential>? = null
         var capturedError: Exception? = null
-        var token: StateChangeListenerToken? = null
-        token = credentialStoreStateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        credentialStoreStateMachine.listen(
+            token,
             { storeState ->
                 logger.verbose("Credential Store State Change: $storeState")
 
@@ -72,10 +73,10 @@ internal class CredentialStoreClient(configuration: AuthConfiguration, context: 
                         val success = capturedSuccess
                         val error = capturedError
                         if (success != null) {
-                            token?.let(credentialStoreStateMachine::cancel)
+                            credentialStoreStateMachine.cancel(token)
                             onSuccess(success)
                         } else if (error != null) {
-                            token?.let(credentialStoreStateMachine::cancel)
+                            credentialStoreStateMachine.cancel(token)
                             onError(error)
                         }
                     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
@@ -56,7 +56,7 @@ internal class CredentialStoreClient(configuration: AuthConfiguration, context: 
     ) {
         var capturedSuccess: Result<AmplifyCredential>? = null
         var capturedError: Exception? = null
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         credentialStoreStateMachine.listen(
             token,
             { storeState ->

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -168,7 +168,7 @@ internal class RealAWSCognitoAuthPlugin(
     @WorkerThread
     @Throws(AmplifyException::class)
     fun initialize() {
-        val token= StateChangeListenerToken.create()
+        val token= StateChangeListenerToken()
         val latch = CountDownLatch(1)
         authStateMachine.listen(
             token,
@@ -477,7 +477,7 @@ internal class RealAWSCognitoAuthPlugin(
         onSuccess: Consumer<AuthSignInResult>,
         onError: Consumer<AuthException>
     ) {
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         authStateMachine.listen(
             token,
             { authState ->
@@ -573,7 +573,7 @@ internal class RealAWSCognitoAuthPlugin(
         onSuccess: Consumer<AuthSignInResult>,
         onError: Consumer<AuthException>
     ) {
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         authStateMachine.listen(
             token,
             { authState ->
@@ -706,7 +706,7 @@ internal class RealAWSCognitoAuthPlugin(
         onError: Consumer<AuthException>,
         provider: AuthProvider? = null
     ) {
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         authStateMachine.listen(
             token,
             { authState ->
@@ -916,7 +916,7 @@ internal class RealAWSCognitoAuthPlugin(
         onSuccess: Consumer<AuthSession>,
         onError: Consumer<AuthException>
     ) {
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         authStateMachine.listen(
             token,
             { authState ->
@@ -1564,7 +1564,7 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     private fun _signOut(sendHubEvent: Boolean = true, onComplete: Consumer<AuthSignOutResult>) {
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         authStateMachine.listen(
             token,
             { authState ->
@@ -1639,7 +1639,7 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     private fun _deleteUser(token: String, onSuccess: Action, onError: Consumer<AuthException>) {
-        val listenerToken = StateChangeListenerToken.create()
+        val listenerToken = StateChangeListenerToken()
         authStateMachine.listen(
             listenerToken,
             { authState ->
@@ -1686,14 +1686,14 @@ internal class RealAWSCognitoAuthPlugin(
 
     private fun addAuthStateChangeListener() {
         authStateMachine.listen(
-            StateChangeListenerToken.create(),
+            StateChangeListenerToken(),
             { authState -> logger.verbose("Auth State Change: $authState") },
             null
         )
     }
 
     private fun configureAuthStates() {
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         authStateMachine.listen(
             token,
             { authState ->
@@ -1765,7 +1765,7 @@ internal class RealAWSCognitoAuthPlugin(
         onSuccess: Consumer<FederateToIdentityPoolResult>,
         onError: Consumer<AuthException>
     ) {
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         authStateMachine.listen(
             token,
             { authState ->

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -168,7 +168,7 @@ internal class RealAWSCognitoAuthPlugin(
     @WorkerThread
     @Throws(AmplifyException::class)
     fun initialize() {
-        val token= StateChangeListenerToken()
+        val token = StateChangeListenerToken()
         val latch = CountDownLatch(1)
         authStateMachine.listen(
             token,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -1848,7 +1848,7 @@ internal class RealAWSCognitoAuthPlugin(
         _signOut(sendHubEvent = false) {
             when (it) {
                 is AWSCognitoAuthSignOutResult.FailedSignOut -> {
-                    onError.accept(it.error)
+                    onError.accept(it.exception)
                 }
                 else -> {
                     onSuccess.call()

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/result/AWSCognitoAuthSignOutResult.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/result/AWSCognitoAuthSignOutResult.kt
@@ -46,9 +46,9 @@ sealed class AWSCognitoAuthSignOutResult : AuthSignOutResult() {
 
     /**
      * Indicates a failed sign out that did not complete. The user will remain signed in
-     * @param error that occurred during sign out
+     * @param exception that occurred during sign out
      */
-    data class FailedSignOut internal constructor(val error: AuthException) : AWSCognitoAuthSignOutResult() {
+    data class FailedSignOut internal constructor(val exception: AuthException) : AWSCognitoAuthSignOutResult() {
 
         /**
          * Indicates if credentials have been cleared from local device
@@ -89,7 +89,7 @@ class HostedUIError internal constructor(hostedUIErrorData: HostedUIErrorData) {
     /**
      * Error containing information about hosted ui sign out failure
      */
-    val error = hostedUIErrorData.error
+    val exception = hostedUIErrorData.error
 }
 
 /**
@@ -105,7 +105,7 @@ class GlobalSignOutError internal constructor(globalSignOutErrorData: GlobalSign
     /**
      * Error containing information about global sign out failure
      */
-    val error = GlobalSignOutException(globalSignOutErrorData.error)
+    val exception = GlobalSignOutException(globalSignOutErrorData.error)
 }
 
 /**
@@ -122,5 +122,5 @@ class RevokeTokenError internal constructor(revokeTokenErrorData: RevokeTokenErr
     /**
      * Error containing information about revoke token failure
      */
-    val error = RevokeTokenException(revokeTokenErrorData.error)
+    val exception = RevokeTokenException(revokeTokenErrorData.error)
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachine.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachine.kt
@@ -26,9 +26,10 @@ import kotlinx.coroutines.newFixedThreadPoolContext
 
 internal typealias OnSubscribedCallback = () -> Unit
 
-@JvmInline
-internal value class StateChangeListenerToken private constructor(val uuid: UUID) {
-    constructor(): this(UUID.randomUUID())
+internal class StateChangeListenerToken private constructor(val uuid: UUID) {
+    constructor() : this(UUID.randomUUID())
+    override fun equals(other: Any?) = other is StateChangeListenerToken && other.uuid == uuid
+    override fun hashCode() = uuid.hashCode()
 }
 
 /**

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachine.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachine.kt
@@ -15,7 +15,6 @@
 
 package com.amplifyframework.statemachine
 
-import android.util.Log
 import java.util.UUID
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -108,7 +107,6 @@ internal open class StateMachine<StateType : State, EnvironmentType : Environmen
      * @param token identifies the listener to be removed
      */
     fun cancel(token: StateChangeListenerToken) {
-        Log.w("StateMachine", "canceling token: $token")
         pendingCancellations.add(token)
         GlobalScope.launch(stateMachineScope) {
             removeSubscription(token)
@@ -176,7 +174,6 @@ internal open class StateMachine<StateType : State, EnvironmentType : Environmen
     ): Boolean {
         val token = subscriber.key
         if (pendingCancellations.contains(token)) return false
-        Log.w("StateMachine", "notifying token: $token of state $newState")
         subscriber.value(newState)
         return true
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachine.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachine.kt
@@ -28,9 +28,7 @@ internal typealias OnSubscribedCallback = () -> Unit
 
 @JvmInline
 internal value class StateChangeListenerToken private constructor(val uuid: UUID) {
-    companion object {
-        fun create() = StateChangeListenerToken(UUID.randomUUID())
-    }
+    constructor(): this(UUID.randomUUID())
 }
 
 /**

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
@@ -217,14 +217,15 @@ class StateTransitionTests : StateTransitionTestBase() {
         setupConfigureSignedOut()
         val listenLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             {
                 if (it is AuthState.Configured &&
                     it.authNState is AuthenticationState.SignedOut &&
                     it.authZState is AuthorizationState.Configured
                 ) {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     listenLatch.countDown()
                 }
             },
@@ -246,14 +247,15 @@ class StateTransitionTests : StateTransitionTestBase() {
 
         val listenLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             {
                 if (it is AuthState.Configured &&
                     it.authNState is AuthenticationState.SignedIn &&
                     it.authZState is AuthorizationState.SessionEstablished
                 ) {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     listenLatch.countDown()
                 }
             },
@@ -288,8 +290,9 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             {
                 val authState =
                     it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedOut }
@@ -311,7 +314,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                     itN is AuthenticationState.SignedIn && it.authZState is AuthorizationState.SessionEstablished
                 }
                 authNState?.apply {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     testLatch.countDown()
                 }
             },
@@ -353,8 +356,9 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             {
                 val authState =
                     it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedOut }
@@ -389,7 +393,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                         itN is AuthenticationState.SignedIn && it.authZState is AuthorizationState.SessionEstablished
                     }
                 authNState?.apply {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     testLatch.countDown()
                 }
             },
@@ -416,8 +420,8 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(token,
             {
                 val authState =
                     it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedIn }
@@ -434,7 +438,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                     itN is AuthenticationState.SignedOut && it.authZState is AuthorizationState.Configured
                 }
                 authNState?.apply {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     testLatch.countDown()
                 }
             },
@@ -461,8 +465,8 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(token,
             {
                 val authState =
                     it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedIn }
@@ -479,7 +483,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                     itN is AuthenticationState.SignedOut && it.authZState is AuthorizationState.Configured
                 }
                 authNState?.apply {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     testLatch.countDown()
                 }
             },
@@ -505,8 +509,9 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             {
                 val authState =
                     it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedIn }
@@ -523,7 +528,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                     itN is AuthenticationState.SignedOut && it.authZState is AuthorizationState.Configured
                 }
                 authNState?.apply {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     testLatch.countDown()
                 }
             },
@@ -549,8 +554,9 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         configureLatch.countDown()
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             { it ->
                 val authState = it.takeIf {
                     it is AuthState.Configured && it.authNState is AuthenticationState.SignedIn
@@ -564,7 +570,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                     itN is AuthenticationState.SignedIn && it.authZState is AuthorizationState.SessionEstablished
                 }
                 authNState?.run {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     testLatch.countDown()
                 }
             },
@@ -590,8 +596,9 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         configureLatch.countDown()
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             { it ->
                 val authState = it.takeIf {
                     it is AuthState.Configured && it.authNState is AuthenticationState.SignedOut
@@ -605,7 +612,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                     itN is AuthenticationState.SignedOut && it.authZState is AuthorizationState.SessionEstablished
                 }
                 authNState?.run {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     testLatch.countDown()
                 }
             },
@@ -630,8 +637,9 @@ class StateTransitionTests : StateTransitionTestBase() {
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         val testLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             { it ->
                 val authState = it.takeIf {
                     it is AuthState.Configured && it.authNState is AuthenticationState.SignedIn
@@ -642,6 +650,7 @@ class StateTransitionTests : StateTransitionTestBase() {
 
                     stateMachine.send(AuthorizationEvent(AuthorizationEvent.EventType.RefreshSession(credentials)))
                     stateMachine.listen(
+                        StateChangeListenerToken.create(),
                         { it2 ->
                             val authNState = it2.takeIf {
                                 it2 is AuthState.Configured &&
@@ -649,7 +658,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                                     it2.authZState is AuthorizationState.SessionEstablished
                             }
                             authNState?.run {
-                                token?.let(stateMachine::cancel)
+                                stateMachine.cancel(token)
                                 testLatch.countDown()
                             }
                         },
@@ -678,8 +687,9 @@ class StateTransitionTests : StateTransitionTestBase() {
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         val testLatch = CountDownLatch(1)
-        var token: StateChangeListenerToken? = null
-        token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             { it ->
                 val authState =
                     it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedIn }
@@ -705,7 +715,7 @@ class StateTransitionTests : StateTransitionTestBase() {
                 }
 
                 userDeletedSuccess?.run {
-                    token?.let(stateMachine::cancel)
+                    stateMachine.cancel(token)
                     testLatch.countDown()
                 }
             },

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
@@ -217,7 +217,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         setupConfigureSignedOut()
         val listenLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             {
@@ -247,7 +247,7 @@ class StateTransitionTests : StateTransitionTestBase() {
 
         val listenLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             {
@@ -290,7 +290,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             {
@@ -356,7 +356,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             {
@@ -420,7 +420,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(token,
             {
                 val authState =
@@ -465,7 +465,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(token,
             {
                 val authState =
@@ -509,7 +509,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             {
@@ -554,7 +554,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         configureLatch.countDown()
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             { it ->
@@ -596,7 +596,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val testLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         configureLatch.countDown()
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             { it ->
@@ -637,7 +637,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         val testLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             { it ->
@@ -650,7 +650,7 @@ class StateTransitionTests : StateTransitionTestBase() {
 
                     stateMachine.send(AuthorizationEvent(AuthorizationEvent.EventType.RefreshSession(credentials)))
                     stateMachine.listen(
-                        StateChangeListenerToken.create(),
+                        StateChangeListenerToken(),
                         { it2 ->
                             val authNState = it2.takeIf {
                                 it2 is AuthState.Configured &&
@@ -687,7 +687,7 @@ class StateTransitionTests : StateTransitionTestBase() {
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         val testLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             { it ->

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTests.kt
@@ -421,7 +421,8 @@ class StateTransitionTests : StateTransitionTestBase() {
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         val token = StateChangeListenerToken()
-        stateMachine.listen(token,
+        stateMachine.listen(
+            token,
             {
                 val authState =
                     it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedIn }
@@ -466,7 +467,8 @@ class StateTransitionTests : StateTransitionTestBase() {
         val configureLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         val token = StateChangeListenerToken()
-        stateMachine.listen(token,
+        stateMachine.listen(
+            token,
             {
                 val authState =
                     it.takeIf { it is AuthState.Configured && it.authNState is AuthenticationState.SignedIn }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineListenerTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineListenerTests.kt
@@ -55,7 +55,7 @@ class StateMachineListenerTests {
         stateMachine.send(Counter.Event("1", eventType = Increment))
         val testLatch = CountDownLatch(2)
         stateMachine.listen(
-            StateChangeListenerToken.create(),
+            StateChangeListenerToken(),
             {
                 assertEquals(1, it.value)
                 testLatch.countDown()
@@ -73,7 +73,7 @@ class StateMachineListenerTests {
         val listenLatch = CountDownLatch(2)
         val subscribeLatch = CountDownLatch(1)
         stateMachine.listen(
-            StateChangeListenerToken.create(),
+            StateChangeListenerToken(),
             {
                 listenLatch.countDown()
             },
@@ -93,7 +93,7 @@ class StateMachineListenerTests {
         val listenLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         stateMachine.listen(
-            StateChangeListenerToken.create(),
+            StateChangeListenerToken(),
             {
                 listenLatch.countDown()
             },
@@ -112,7 +112,7 @@ class StateMachineListenerTests {
         stateMachine.send(Counter.Event("1", eventType = Increment))
         val listenLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             {
@@ -133,7 +133,7 @@ class StateMachineListenerTests {
     fun testNoNotifyImmediateCancel() {
         stateMachine.send(Counter.Event("1", eventType = Increment))
         val listenLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken.create()
+        val token = StateChangeListenerToken()
         stateMachine.listen(
             token,
             {

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineListenerTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineListenerTests.kt
@@ -55,6 +55,7 @@ class StateMachineListenerTests {
         stateMachine.send(Counter.Event("1", eventType = Increment))
         val testLatch = CountDownLatch(2)
         stateMachine.listen(
+            StateChangeListenerToken.create(),
             {
                 assertEquals(1, it.value)
                 testLatch.countDown()
@@ -72,6 +73,7 @@ class StateMachineListenerTests {
         val listenLatch = CountDownLatch(2)
         val subscribeLatch = CountDownLatch(1)
         stateMachine.listen(
+            StateChangeListenerToken.create(),
             {
                 listenLatch.countDown()
             },
@@ -91,6 +93,7 @@ class StateMachineListenerTests {
         val listenLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
         stateMachine.listen(
+            StateChangeListenerToken.create(),
             {
                 listenLatch.countDown()
             },
@@ -109,7 +112,9 @@ class StateMachineListenerTests {
         stateMachine.send(Counter.Event("1", eventType = Increment))
         val listenLatch = CountDownLatch(1)
         val subscribeLatch = CountDownLatch(1)
-        val token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             {
                 listenLatch.countDown()
             },
@@ -128,7 +133,9 @@ class StateMachineListenerTests {
     fun testNoNotifyImmediateCancel() {
         stateMachine.send(Counter.Event("1", eventType = Increment))
         val listenLatch = CountDownLatch(1)
-        val token = stateMachine.listen(
+        val token = StateChangeListenerToken.create()
+        stateMachine.listen(
+            token,
             {
                 listenLatch.countDown()
             },


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

It is possible for the state machine listener to be invoked on a background thread prior to the token value being returned on the calling thread. Passing the token in resolves this race condition.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
