### PR TITLE
chore(auth): fix escape hatch name

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -68,7 +68,7 @@ import org.json.JSONObject
 /**
  * A Cognito implementation of the Auth Plugin.
  */
-class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
+class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     companion object {
         const val AWS_COGNITO_AUTH_LOG_NAMESPACE = "amplify:aws-cognito-auth:%s"
         private const val AWS_COGNITO_AUTH_PLUGIN_KEY = "awsCognitoAuthPlugin"
@@ -111,7 +111,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthServiceBehavior>() {
             val authEnvironment = AuthEnvironment(
                 context,
                 configuration,
-                AWSCognitoAuthServiceBehavior.fromConfiguration(configuration),
+                AWSCognitoAuthService.fromConfiguration(configuration),
                 credentialStoreClient,
                 configuration.userPool?.let { UserContextDataProvider(context, it.poolId!!, it.appClient!!) },
                 HostedUIClient.create(context, configuration.oauth, logger),

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthService.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthService.kt
@@ -20,12 +20,12 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderCl
 import aws.smithy.kotlin.runtime.http.endpoints.Endpoint
 import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 
-interface AWSCognitoAuthServiceBehavior {
+interface AWSCognitoAuthService {
     var cognitoIdentityProviderClient: CognitoIdentityProviderClient?
     var cognitoIdentityClient: CognitoIdentityClient?
 
     companion object {
-        internal fun fromConfiguration(configuration: AuthConfiguration): AWSCognitoAuthServiceBehavior {
+        internal fun fromConfiguration(configuration: AuthConfiguration): AWSCognitoAuthService {
             val cognitoIdentityProviderClient = configuration.userPool?.let { it ->
 
                 CognitoIdentityProviderClient {
@@ -40,7 +40,7 @@ interface AWSCognitoAuthServiceBehavior {
                 CognitoIdentityClient { this.region = it.region }
             }
 
-            return object : AWSCognitoAuthServiceBehavior {
+            return object : AWSCognitoAuthService {
                 override var cognitoIdentityProviderClient = cognitoIdentityProviderClient
                 override var cognitoIdentityClient = cognitoIdentityClient
             }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
@@ -37,7 +37,7 @@ import java.util.UUID
 internal class AuthEnvironment internal constructor(
     val context: Context,
     val configuration: AuthConfiguration,
-    val cognitoAuthService: AWSCognitoAuthServiceBehavior,
+    val cognitoAuthService: AWSCognitoAuthService,
     val credentialStoreClient: StoreClientBehavior,
     private val userContextDataProvider: UserContextDataProvider? = null,
     val hostedUIClient: HostedUIClient?,

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginFeatureTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginFeatureTest.kt
@@ -152,7 +152,7 @@ class AWSCognitoAuthPluginFeatureTest(private val testCase: FeatureTestCase) {
                 .getJSONObject("awsCognitoAuthPlugin")
         val authConfiguration = AuthConfiguration.fromJson(configJSONObject)
 
-        val authService = mockk<AWSCognitoAuthServiceBehavior> {
+        val authService = mockk<AWSCognitoAuthService> {
             every { cognitoIdentityProviderClient } returns mockCognitoIPClient
             every { cognitoIdentityClient } returns mockCognitoIdClient
         }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -516,7 +516,7 @@ class AWSCognitoAuthPluginTest {
 
     @Test
     fun verifyEscapeHatch() {
-        val expectedEscapeHatch = mockk<AWSCognitoAuthServiceBehavior>()
+        val expectedEscapeHatch = mockk<AWSCognitoAuthService>()
         every { realPlugin.escapeHatch() } returns expectedEscapeHatch
 
         assertEquals(expectedEscapeHatch, authPlugin.escapeHatch)

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthServiceTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthServiceTest.kt
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class AWSCognitoAuthServiceBehaviorTest {
+class AWSCognitoAuthServiceTest {
 
     // Robolectric needed due to internals of AWSCognitoAuthServiceBehavior initialization
     @Test
@@ -45,7 +45,7 @@ class AWSCognitoAuthServiceBehaviorTest {
             authFlowType = AuthFlowType.USER_SRP_AUTH
         )
 
-        val testObject = AWSCognitoAuthServiceBehavior.fromConfiguration(config)
+        val testObject = AWSCognitoAuthService.fromConfiguration(config)
 
         assertEquals(expectedIdentityPoolConfigRegion, testObject.cognitoIdentityClient!!.config.region)
         assertEquals(expectedUserPoolRegion, testObject.cognitoIdentityProviderClient!!.config.region)

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
@@ -129,7 +129,7 @@ class RealAWSCognitoAuthPluginTest {
     )
 
     private val mockCognitoIPClient = mockk<CognitoIdentityProviderClient>()
-    private var authService = mockk<AWSCognitoAuthServiceBehavior> {
+    private var authService = mockk<AWSCognitoAuthService> {
         every { cognitoIdentityProviderClient } returns mockCognitoIPClient
     }
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTestBase.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTestBase.kt
@@ -81,7 +81,7 @@ open class StateTransitionTestBase {
     internal lateinit var configuration: AuthConfiguration
 
     @Mock
-    internal lateinit var cognitoAuthService: AWSCognitoAuthServiceBehavior
+    internal lateinit var cognitoAuthService: AWSCognitoAuthService
 
     @Mock
     internal lateinit var mockAuthActions: AuthActions


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Rename SDK escape hatch from `AWSCognitoAuthServiceBehavior` to `AWSCognitoAuthService`.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
