### PR TITLE
fix: callbacks not invoked when attached using getTransfer api

### DIFF
--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadTest.java
@@ -39,13 +39,13 @@ import com.amplifyframework.testutils.random.RandomTempFile;
 import com.amplifyframework.testutils.sync.SynchronousAuth;
 import com.amplifyframework.testutils.sync.SynchronousStorage;
 
-import java.io.FileInputStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -123,6 +123,21 @@ public final class AWSS3StorageUploadTest {
         File uploadFile = new RandomTempFile(SMALL_FILE_SIZE);
         String fileName = uploadFile.getName();
         synchronousStorage.uploadFile(fileName, uploadFile, options);
+    }
+
+    /**
+     * Tests that small file (single-part) uploads using input stream successfully.
+     *
+     * @throws Exception if upload fails
+     */
+    @Test
+    public void testUploadSmallFileStream() throws Exception {
+        File uploadFile = new RandomTempFile(4 * 1024 * 1024);
+        String fileName = uploadFile.getName();
+        StorageUploadInputStreamOptions options = StorageUploadInputStreamOptions.builder()
+            .accessLevel(TESTING_ACCESS_LEVEL)
+            .build();
+        synchronousStorage.uploadInputStream(fileName, new FileInputStream(uploadFile), options);
     }
 
     /**
@@ -266,13 +281,13 @@ public final class AWSS3StorageUploadTest {
                     opContainer.get().clearAllListeners();
                     storageCategory.getTransfer(transferId.get(),
                         operation -> {
-                        StorageUploadFileOperation<?> getOp = (StorageUploadFileOperation<?>) operation;
-                        getOp.resume();
-                        resumed.countDown();
-                        getOp.setOnSuccess( result -> {
-                            completed.countDown();
-                        });
-                    }, errorContainer::set);
+                            StorageUploadFileOperation<?> getOp = (StorageUploadFileOperation<?>) operation;
+                            getOp.resume();
+                            resumed.countDown();
+                            getOp.setOnSuccess(result -> {
+                                completed.countDown();
+                            });
+                        }, errorContainer::set);
                 }
             }
         });
@@ -288,7 +303,7 @@ public final class AWSS3StorageUploadTest {
                     opContainer.get().pause();
                 }
             },
-            result -> {},
+            result -> { },
             errorContainer::set
         );
         opContainer.set(op);
@@ -331,7 +346,7 @@ public final class AWSS3StorageUploadTest {
                             StorageUploadFileOperation<?> getOp = (StorageUploadFileOperation<?>) operation;
                             getOp.resume();
                             resumed.countDown();
-                            getOp.setOnSuccess( result -> {
+                            getOp.setOnSuccess(result -> {
                                 completed.countDown();
                             });
                         }, errorContainer::set);
@@ -352,7 +367,7 @@ public final class AWSS3StorageUploadTest {
                     opContainer.get().pause();
                 }
             },
-            result -> {},
+            result -> { },
             errorContainer::set
         );
         opContainer.set(op);

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadTest.java
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/AWSS3StorageUploadTest.java
@@ -30,13 +30,16 @@ import com.amplifyframework.storage.StorageCategory;
 import com.amplifyframework.storage.StorageChannelEventName;
 import com.amplifyframework.storage.TransferState;
 import com.amplifyframework.storage.operation.StorageUploadFileOperation;
+import com.amplifyframework.storage.operation.StorageUploadInputStreamOperation;
 import com.amplifyframework.storage.options.StorageUploadFileOptions;
+import com.amplifyframework.storage.options.StorageUploadInputStreamOptions;
 import com.amplifyframework.storage.s3.test.R;
 import com.amplifyframework.storage.s3.util.WorkmanagerTestUtils;
 import com.amplifyframework.testutils.random.RandomTempFile;
 import com.amplifyframework.testutils.sync.SynchronousAuth;
 import com.amplifyframework.testutils.sync.SynchronousStorage;
 
+import java.io.FileInputStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -228,6 +231,132 @@ public final class AWSS3StorageUploadTest {
             errorContainer::set
         );
         opContainer.set(op);
+
+        // Assert that all the required conditions have been met
+        assertTrue(resumed.await(EXTENDED_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(completed.await(EXTENDED_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertNull(errorContainer.get());
+    }
+
+    /**
+     * Tests that file upload operation can be paused and resumed
+     * using getTransfer API.
+     *
+     * @throws Exception if upload is not paused, resumed, and
+     *         completed successfully before timeout
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUploadFileGetTransferOnPause() throws Exception {
+        final CountDownLatch completed = new CountDownLatch(1);
+        final CountDownLatch resumed = new CountDownLatch(1);
+        final AtomicReference<String> transferId = new AtomicReference<>();
+        final AtomicReference<StorageUploadFileOperation<?>> opContainer = new AtomicReference<>();
+        final AtomicReference<Throwable> errorContainer = new AtomicReference<>();
+
+        // Create a file large enough that transfer won't finish before being paused
+        File uploadFile = new RandomTempFile(LARGE_FILE_SIZE);
+
+        // Listen to Hub events to resume when operation has been paused
+        SubscriptionToken resumeToken = Amplify.Hub.subscribe(HubChannel.STORAGE, hubEvent -> {
+            if (StorageChannelEventName.UPLOAD_STATE.toString().equals(hubEvent.getName())) {
+                HubEvent<String> stateEvent = (HubEvent<String>) hubEvent;
+                TransferState state = TransferState.getState(stateEvent.getData());
+                if (TransferState.PAUSED.equals(state)) {
+                    opContainer.get().clearAllListeners();
+                    storageCategory.getTransfer(transferId.get(),
+                        operation -> {
+                        StorageUploadFileOperation<?> getOp = (StorageUploadFileOperation<?>) operation;
+                        getOp.resume();
+                        resumed.countDown();
+                        getOp.setOnSuccess( result -> {
+                            completed.countDown();
+                        });
+                    }, errorContainer::set);
+                }
+            }
+        });
+        subscriptions.add(resumeToken);
+
+        // Begin uploading a large file
+        StorageUploadFileOperation<?> op = storageCategory.uploadFile(
+            uploadFile.getName(),
+            uploadFile,
+            options,
+            progress -> {
+                if (progress.getCurrentBytes() > 0 && resumed.getCount() > 0) {
+                    opContainer.get().pause();
+                }
+            },
+            result -> {},
+            errorContainer::set
+        );
+        opContainer.set(op);
+        transferId.set(op.getTransferId());
+
+        // Assert that all the required conditions have been met
+        assertTrue(resumed.await(EXTENDED_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertTrue(completed.await(EXTENDED_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertNull(errorContainer.get());
+    }
+
+    /**
+     * Tests that input stream upload operation can be paused and resumed
+     * using getTransfer API.
+     *
+     * @throws Exception if upload is not paused, resumed, and
+     *         completed successfully before timeout
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUploadInputStreamGetTransferOnPause() throws Exception {
+        final CountDownLatch completed = new CountDownLatch(1);
+        final CountDownLatch resumed = new CountDownLatch(1);
+        final AtomicReference<String> transferId = new AtomicReference<>();
+        final AtomicReference<StorageUploadInputStreamOperation<?>> opContainer = new AtomicReference<>();
+        final AtomicReference<Throwable> errorContainer = new AtomicReference<>();
+
+        // Create a file large enough that transfer won't finish before being paused
+        File uploadFile = new RandomTempFile(LARGE_FILE_SIZE);
+
+        // Listen to Hub events to resume when operation has been paused
+        SubscriptionToken resumeToken = Amplify.Hub.subscribe(HubChannel.STORAGE, hubEvent -> {
+            if (StorageChannelEventName.UPLOAD_STATE.toString().equals(hubEvent.getName())) {
+                HubEvent<String> stateEvent = (HubEvent<String>) hubEvent;
+                TransferState state = TransferState.getState(stateEvent.getData());
+                if (TransferState.PAUSED.equals(state)) {
+                    opContainer.get().clearAllListeners();
+                    storageCategory.getTransfer(transferId.get(),
+                        operation -> {
+                            StorageUploadFileOperation<?> getOp = (StorageUploadFileOperation<?>) operation;
+                            getOp.resume();
+                            resumed.countDown();
+                            getOp.setOnSuccess( result -> {
+                                completed.countDown();
+                            });
+                        }, errorContainer::set);
+                }
+            }
+        });
+        subscriptions.add(resumeToken);
+        StorageUploadInputStreamOptions inputStreamOptions = StorageUploadInputStreamOptions.builder()
+            .accessLevel(TESTING_ACCESS_LEVEL)
+            .build();
+        // Begin uploading a large file
+        StorageUploadInputStreamOperation<?> op = storageCategory.uploadInputStream(
+            uploadFile.getName(),
+            new FileInputStream(uploadFile),
+            inputStreamOptions,
+            progress -> {
+                if (progress.getCurrentBytes() > 0 && resumed.getCount() > 0) {
+                    opContainer.get().pause();
+                }
+            },
+            result -> {},
+            errorContainer::set
+        );
+        opContainer.set(op);
+        transferId.set(op.getTransferId());
 
         // Assert that all the required conditions have been met
         assertTrue(resumed.await(EXTENDED_TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -25,6 +25,7 @@ import com.amplifyframework.core.NoOpConsumer;
 import com.amplifyframework.storage.StorageAccessLevel;
 import com.amplifyframework.storage.StorageException;
 import com.amplifyframework.storage.StoragePlugin;
+import com.amplifyframework.storage.TransferState;
 import com.amplifyframework.storage.operation.StorageDownloadFileOperation;
 import com.amplifyframework.storage.operation.StorageGetUrlOperation;
 import com.amplifyframework.storage.operation.StorageListOperation;
@@ -520,7 +521,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
                             transferRecord.getKey(),
                             transferRecord.getFile(),
                             null,
-                            transferRecord.getState());
+                            transferRecord.getState() != null ? transferRecord.getState() : TransferState.UNKNOWN);
                     TransferType transferType = transferRecord.getType();
                     switch (Objects.requireNonNull(transferType)) {
                         case UPLOAD:

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -509,61 +509,72 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         @NonNull Consumer<StorageTransferOperation<?, ? extends StorageTransferResult>> onReceived,
         @NonNull Consumer<StorageException> onError) {
         executorService.submit(() -> {
-            TransferRecord transferRecord = storageService.getTransfer(transferId);
-            if (transferRecord != null) {
-                TransferObserver transferObserver =
-                    new TransferObserver(
-                        transferRecord.getId(),
-                        storageService.getTransferManager().getTransferStatusUpdater(),
-                        transferRecord.getBucketName(),
-                        transferRecord.getKey(),
-                        transferRecord.getFile(),
-                        null,
-                        transferRecord.getState());
-                TransferType transferType = transferRecord.getType();
-                switch (Objects.requireNonNull(transferType)) {
-                    case UPLOAD:
-                        if (transferRecord.getFile().startsWith(TransferStatusUpdater.TEMP_FILE_PREFIX)) {
-                            AWSS3StorageUploadInputStreamOperation operation =
-                                new AWSS3StorageUploadInputStreamOperation(
-                                    transferId,
-                                    storageService,
-                                    executorService,
-                                    authCredentialsProvider,
-                                    awsS3StoragePluginConfiguration,
-                                    null,
-                                    transferObserver);
-                            onReceived.accept(operation);
-                        } else {
-                            AWSS3StorageUploadFileOperation operation =
-                                new AWSS3StorageUploadFileOperation(
-                                    transferId,
-                                    storageService,
-                                    executorService,
-                                    authCredentialsProvider,
-                                    awsS3StoragePluginConfiguration,
-                                    null,
-                                    transferObserver);
-                            onReceived.accept(operation);
-                        }
-                        break;
-                    case DOWNLOAD:
-                        AWSS3StorageDownloadFileOperation
-                            downloadFileOperation = new AWSS3StorageDownloadFileOperation(
-                            transferId,
-                            new File(transferRecord.getFile()),
-                            storageService,
-                            executorService,
-                            authCredentialsProvider,
-                            awsS3StoragePluginConfiguration,
+            try {
+                TransferRecord transferRecord = storageService.getTransfer(transferId);
+                if (transferRecord != null) {
+                    TransferObserver transferObserver =
+                        new TransferObserver(
+                            transferRecord.getId(),
+                            storageService.getTransferManager().getTransferStatusUpdater(),
+                            transferRecord.getBucketName(),
+                            transferRecord.getKey(),
+                            transferRecord.getFile(),
                             null,
-                            transferObserver);
-                        onReceived.accept(downloadFileOperation);
-                        break;
-                    default:
+                            transferRecord.getState());
+                    TransferType transferType = transferRecord.getType();
+                    switch (Objects.requireNonNull(transferType)) {
+                        case UPLOAD:
+                            if (transferRecord.getFile().startsWith(TransferStatusUpdater.TEMP_FILE_PREFIX)) {
+                                AWSS3StorageUploadRequest<InputStream> request =
+                                    new AWSS3StorageUploadRequest<>(Objects.requireNonNull(transferRecord.getKey()));
+                                AWSS3StorageUploadInputStreamOperation operation =
+                                    new AWSS3StorageUploadInputStreamOperation(
+                                        transferId,
+                                        storageService,
+                                        executorService,
+                                        authCredentialsProvider,
+                                        awsS3StoragePluginConfiguration,
+                                        request,
+                                        transferObserver);
+                                onReceived.accept(operation);
+                            } else {
+                                File file = new File(transferRecord.getFile());
+                                AWSS3StorageUploadRequest<File> request =
+                                    new AWSS3StorageUploadRequest<>(Objects.requireNonNull(transferRecord.getKey()));
+                                AWSS3StorageUploadFileOperation operation =
+                                    new AWSS3StorageUploadFileOperation(
+                                        transferId,
+                                        storageService,
+                                        executorService,
+                                        authCredentialsProvider,
+                                        awsS3StoragePluginConfiguration,
+                                        request,
+                                        transferObserver);
+                                onReceived.accept(operation);
+                            }
+                            break;
+                        case DOWNLOAD:
+                            AWSS3StorageDownloadFileOperation
+                                downloadFileOperation = new AWSS3StorageDownloadFileOperation(
+                                transferId,
+                                new File(transferRecord.getFile()),
+                                storageService,
+                                executorService,
+                                authCredentialsProvider,
+                                awsS3StoragePluginConfiguration,
+                                null,
+                                transferObserver);
+                            onReceived.accept(downloadFileOperation);
+                            break;
+                        default:
+                    }
+                } else {
+                    onError.accept(new StorageException("Get transfer failed",
+                        "Please verify that the transfer id is valid and the transfer is not completed"));
                 }
-            } else {
+            } catch (Exception exception) {
                 onError.accept(new StorageException("Get transfer failed",
+                    exception,
                     "Please verify that the transfer id is valid and the transfer is not completed"));
             }
         });

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -525,8 +525,6 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
                     switch (Objects.requireNonNull(transferType)) {
                         case UPLOAD:
                             if (transferRecord.getFile().startsWith(TransferStatusUpdater.TEMP_FILE_PREFIX)) {
-                                AWSS3StorageUploadRequest<InputStream> request =
-                                    new AWSS3StorageUploadRequest<>(Objects.requireNonNull(transferRecord.getKey()));
                                 AWSS3StorageUploadInputStreamOperation operation =
                                     new AWSS3StorageUploadInputStreamOperation(
                                         transferId,
@@ -534,13 +532,10 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
                                         executorService,
                                         authCredentialsProvider,
                                         awsS3StoragePluginConfiguration,
-                                        request,
+                                        null,
                                         transferObserver);
                                 onReceived.accept(operation);
                             } else {
-                                File file = new File(transferRecord.getFile());
-                                AWSS3StorageUploadRequest<File> request =
-                                    new AWSS3StorageUploadRequest<>(Objects.requireNonNull(transferRecord.getKey()));
                                 AWSS3StorageUploadFileOperation operation =
                                     new AWSS3StorageUploadFileOperation(
                                         transferId,
@@ -548,7 +543,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
                                         executorService,
                                         authCredentialsProvider,
                                         awsS3StoragePluginConfiguration,
-                                        request,
+                                        null,
                                         transferObserver);
                                 onReceived.accept(operation);
                             }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/TransferOperations.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/TransferOperations.kt
@@ -114,10 +114,13 @@ internal object TransferOperations {
         workManager: WorkManager
     ): Boolean {
         if (!TransferState.isInTerminalState(transferRecord.state)) {
-            val nextState: TransferState = TransferState.PENDING_CANCEL
+            var nextState: TransferState = TransferState.PENDING_CANCEL
             if (TransferState.isPaused(transferRecord.state)) {
                 if (transferRecord.isMultipart == 1) {
                     abortMultipartUploadRequest(transferRecord, pluginKey, workManager)
+                } else {
+                    // transfer is paused so directly mark it as canceled
+                    nextState = TransferState.CANCELED
                 }
             } else {
                 workManager.cancelUniqueWork(transferRecord.id.toString())

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.kt
@@ -180,7 +180,7 @@ class AWSS3StorageDownloadFileOperation @JvmOverloads internal constructor(
     }
 
     inner class DownloadTransferListener : TransferListener {
-        override fun onStateChanged(transferId: Int, state: TransferState) {
+        override fun onStateChanged(transferId: Int, state: TransferState, key: String) {
             Amplify.Hub.publish(
                 HubChannel.STORAGE,
                 HubEvent.create(StorageChannelEventName.DOWNLOAD_STATE, state.name)

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.kt
@@ -80,18 +80,19 @@ class AWSS3StorageDownloadFileOperation @JvmOverloads internal constructor(
 
     override fun start() {
         // Only start if it hasn't already been started
-        if (transferObserver != null || request == null) {
+        if (transferObserver != null) {
             return
         }
+        val downloadRequest = request ?: return
         executorService.submit(
             Runnable {
                 awsS3StoragePluginConfiguration.getAWSS3PluginPrefixResolver(authCredentialsProvider).resolvePrefix(
-                    request.accessLevel,
-                    request.targetIdentityId,
+                    downloadRequest.accessLevel,
+                    downloadRequest.targetIdentityId,
                     Consumer { prefix: String ->
                         try {
-                            val serviceKey = prefix + request.key
-                            this.file = request.local
+                            val serviceKey = prefix + downloadRequest.key
+                            this.file = downloadRequest.local
                             transferObserver = storageService.downloadToFile(transferId, serviceKey, file)
                             transferObserver?.setTransferListener(DownloadTransferListener())
                         } catch (exception: Exception) {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageDownloadFileOperation.kt
@@ -14,7 +14,6 @@
  */
 package com.amplifyframework.storage.s3.operation
 
-import android.util.Log
 import com.amplifyframework.auth.AuthCredentialsProvider
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.Consumer
@@ -53,14 +52,7 @@ class AWSS3StorageDownloadFileOperation @JvmOverloads internal constructor(
 ) : StorageDownloadFileOperation<AWSS3StorageDownloadFileRequest>(request, transferId, onProgress, onSuccess, onError) {
 
     init {
-        transferObserver?.let {
-            val listener = DownloadTransferListener()
-            Log.d(
-                "AWSS3StorageDownloadFileOperation",
-                "Setting up new transfer listener ${listener.hashCode()} for operation ${hashCode()}"
-            )
-            it.setTransferListener(listener)
-        }
+        transferObserver?.setTransferListener(DownloadTransferListener())
     }
 
     constructor(

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.kt
@@ -191,14 +191,14 @@ class AWSS3StorageUploadFileOperation @JvmOverloads internal constructor(
     }
 
     private inner class UploadTransferListener : TransferListener {
-        override fun onStateChanged(transferId: Int, state: TransferState) {
+        override fun onStateChanged(transferId: Int, state: TransferState, key: String) {
             Amplify.Hub.publish(
                 HubChannel.STORAGE,
                 HubEvent.create(StorageChannelEventName.UPLOAD_STATE, state.name)
             )
             when (state) {
                 TransferState.COMPLETED -> {
-                    onSuccess?.accept(StorageUploadFileResult.fromKey(request.key))
+                    onSuccess?.accept(StorageUploadFileResult.fromKey(key))
                     return
                 }
                 TransferState.FAILED -> {}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.kt
@@ -74,6 +74,10 @@ class AWSS3StorageUploadFileOperation @JvmOverloads internal constructor(
         onError
     )
 
+    init {
+        transferObserver?.setTransferListener(UploadTransferListener())
+    }
+
     override fun start() {
         // Only start if it hasn't already been started
         if (transferObserver != null || request == null) {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.kt
@@ -204,14 +204,14 @@ class AWSS3StorageUploadInputStreamOperation @JvmOverloads internal constructor(
     }
 
     private inner class UploadTransferListener : TransferListener {
-        override fun onStateChanged(transferId: Int, state: TransferState) {
+        override fun onStateChanged(transferId: Int, state: TransferState, key: String) {
             Amplify.Hub.publish(
                 HubChannel.STORAGE,
                 HubEvent.create(StorageChannelEventName.UPLOAD_STATE, state.name)
             )
             when (state) {
                 TransferState.COMPLETED -> {
-                    onSuccess?.accept(StorageUploadInputStreamResult.fromKey(request.key))
+                    onSuccess?.accept(StorageUploadInputStreamResult.fromKey(key))
                     return
                 }
                 TransferState.FAILED -> {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.kt
@@ -81,6 +81,10 @@ class AWSS3StorageUploadInputStreamOperation @JvmOverloads internal constructor(
         onError
     )
 
+    init {
+        transferObserver?.setTransferListener(UploadTransferListener())
+    }
+
     override fun start() {
         // Only start if it hasn't already been started
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.kt
@@ -87,27 +87,27 @@ class AWSS3StorageUploadInputStreamOperation @JvmOverloads internal constructor(
 
     override fun start() {
         // Only start if it hasn't already been started
-
-        // Only start if it hasn't already been started
-        if (transferObserver != null || request == null) {
+        if (transferObserver != null) {
             return
         }
+
+        val uploadRequest = request ?: return
         executorService.submit(
             Runnable {
                 awsS3StoragePluginConfiguration.getAWSS3PluginPrefixResolver(authCredentialsProvider).resolvePrefix(
-                    request.accessLevel,
-                    request.targetIdentityId,
+                    uploadRequest.accessLevel,
+                    uploadRequest.targetIdentityId,
                     Consumer { prefix: String ->
                         try {
-                            val serviceKey = prefix + request.key
+                            val serviceKey = prefix + uploadRequest.key
                             // Grab the inputStream to upload...
-                            val inputStream = request.local
+                            val inputStream = uploadRequest.local
                             // Set up the metadata
                             val objectMetadata = ObjectMetadata()
-                            objectMetadata.userMetadata = request.metadata
-                            objectMetadata.metaData[ObjectMetadata.CONTENT_TYPE] = request.contentType
+                            objectMetadata.userMetadata = uploadRequest.metadata
+                            objectMetadata.metaData[ObjectMetadata.CONTENT_TYPE] = uploadRequest.contentType
                             val storageServerSideEncryption =
-                                request.serverSideEncryption
+                                uploadRequest.serverSideEncryption
                             if (ServerSideEncryption.NONE != storageServerSideEncryption) {
                                 objectMetadata.metaData[ObjectMetadata.SERVER_SIDE_ENCRYPTION] =
                                     storageServerSideEncryption.getName()
@@ -198,8 +198,10 @@ class AWSS3StorageUploadInputStreamOperation @JvmOverloads internal constructor(
 
     override fun setOnSuccess(onSuccess: Consumer<StorageUploadInputStreamResult>?) {
         super.setOnSuccess(onSuccess)
-        if (transferState == TransferState.COMPLETED) {
-            onSuccess?.accept(StorageUploadInputStreamResult.fromKey(request.key))
+        request?.let {
+            if (transferState == TransferState.COMPLETED) {
+                onSuccess?.accept(StorageUploadInputStreamResult.fromKey(it.key))
+            }
         }
     }
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageDownloadFileRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageDownloadFileRequest.java
@@ -34,6 +34,9 @@ public final class AWSS3StorageDownloadFileRequest {
 
     /**
      * Constructs a new AWSS3StorageDownloadFileRequest.
+     * Although this has public access, it is intended for internal use and should not be used directly by host
+     * applications. The behavior of this may change without warning.
+     *
      * @param key key for item to download
      * @param local Target file for the downloaded file to be saved to
      * @param accessLevel Storage access level

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageGetPresignedUrlRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageGetPresignedUrlRequest.java
@@ -32,6 +32,9 @@ public final class AWSS3StorageGetPresignedUrlRequest {
 
     /**
      * Constructs a new AWSS3StorageGetUrlRequest.
+     * Although this has public access, it is intended for internal use and should not be used directly by host
+     * applications. The behavior of this may change without warning.
+     *
      * @param key key for item to obtain URL for
      * @param accessLevel Storage access level
      * @param targetIdentityId If set, this should override the current user's identity ID.

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageListRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageListRequest.java
@@ -30,6 +30,9 @@ public final class AWSS3StorageListRequest {
 
     /**
      * Constructs a new AWSS3StorageListRequest.
+     * Although this has public access, it is intended for internal use and should not be used directly by host
+     * applications. The behavior of this may change without warning.
+     *
      * @param path the path in S3 to list items from
      * @param accessLevel Storage access level
      * @param targetIdentityId If set, this should override the current user's identity ID.

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageRemoveRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageRemoveRequest.java
@@ -30,6 +30,9 @@ public final class AWSS3StorageRemoveRequest {
 
     /**
      * Constructs a new AWSS3StorageRemoveRequest.
+     * Although this has public access, it is intended for internal use and should not be used directly by host
+     * applications. The behavior of this may change without warning.
+     *
      * @param key key for item to download
      * @param accessLevel Storage access level
      * @param targetIdentityId If set, this should override the current user's identity ID.

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest.java
@@ -39,6 +39,9 @@ public final class AWSS3StorageUploadRequest<L> {
 
     /**
      * Constructs a new AWSS3StorageUploadRequest.
+     * Although this has public access, it is intended for internal use and should not be used directly by host
+     * applications. The behavior of this may change without warning.
+     *
      * @param key key for item to upload
      * @param local object to upload (e.g. File or InputStream)
      * @param accessLevel Storage access level

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest.java
@@ -70,6 +70,20 @@ public final class AWSS3StorageUploadRequest<L> {
     }
 
     /**
+     * Constructs a new AWSS3StorageUploadRequest.
+     * @param key key for item to upload
+     */
+    public AWSS3StorageUploadRequest(@NonNull String key) {
+        this.key = key;
+        this.local = null;
+        this.accessLevel = null;
+        this.targetIdentityId = null;
+        this.contentType = null;
+        this.serverSideEncryption = null;
+        this.metadata = new HashMap<>();
+    }
+
+    /**
      * Gets the storage key.
      * @return key
      */

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest.java
@@ -70,20 +70,6 @@ public final class AWSS3StorageUploadRequest<L> {
     }
 
     /**
-     * Constructs a new AWSS3StorageUploadRequest.
-     * @param key key for item to upload
-     */
-    public AWSS3StorageUploadRequest(@NonNull String key) {
-        this.key = key;
-        this.local = null;
-        this.accessLevel = null;
-        this.targetIdentityId = null;
-        this.contentType = null;
-        this.serverSideEncryption = null;
-        this.metadata = new HashMap<>();
-    }
-
-    /**
      * Gets the storage key.
      * @return key
      */

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferListener.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferListener.kt
@@ -27,8 +27,9 @@ internal interface TransferListener {
      *
      * @param id The id of the transfer record.
      * @param state The new state of the transfer.
+     * @param key The key of the transfer
      */
-    fun onStateChanged(id: Int, state: TransferState)
+    fun onStateChanged(id: Int, state: TransferState, key: String)
 
     /**
      * Called when more bytes are transferred.

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferObserver.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferObserver.kt
@@ -71,7 +71,7 @@ internal data class TransferObserver @JvmOverloads constructor(
             totalBytes = bytesTotal
         }
 
-        override fun onStateChanged(id: Int, state: TransferState) {
+        override fun onStateChanged(id: Int, state: TransferState, key: String) {
             transferState = state
         }
     }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferStatusUpdater.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferStatusUpdater.kt
@@ -110,7 +110,15 @@ internal class TransferStatusUpdater private constructor(
             }
 
             transferStatusListenerMap[transferRecord.id]?.forEach { listener ->
-                mainHandler.post { listener.onStateChanged(transferRecord.id, newState) }
+                mainHandler.post {
+                    transferRecord.key?.let { key ->
+                        listener.onStateChanged(
+                            transferRecord.id,
+                            newState,
+                            key
+                        )
+                    }
+                }
             }
 
             if (TransferState.isInTerminalState(newState)) {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/BaseTransferWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/BaseTransferWorker.kt
@@ -49,6 +49,7 @@ import com.amplifyframework.storage.s3.transfer.TransferRecord
 import com.amplifyframework.storage.s3.transfer.TransferStatusUpdater
 import java.io.File
 import java.lang.Exception
+import java.net.SocketException
 import java.nio.ByteBuffer
 import kotlinx.coroutines.CancellationException
 
@@ -111,7 +112,7 @@ internal abstract class BaseTransferWorker(
             }
             else -> {
                 val ex = result.exceptionOrNull()
-                logger.error("${this.javaClass.simpleName} failed with exception: $ex, stacktrace: ${ex?.stackTrace}")
+                logger.error("${this.javaClass.simpleName} failed with exception: $ex")
                 if (isRetryableError(ex)) {
                     Result.retry()
                 } else {
@@ -151,7 +152,9 @@ internal abstract class BaseTransferWorker(
         return isStopped ||
             !isNetworkAvailable(applicationContext) ||
             runAttemptCount < maxRetryCount ||
-            e is CancellationException
+            e is CancellationException ||
+            // SocketException is thrown when download is terminated due to network disconnection.
+            e is SocketException
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/StorageComponentTest.java
@@ -179,7 +179,7 @@ public final class StorageComponentTest {
         // callback, as part of our "happy path" test.
         doAnswer(invocation -> {
             TransferListener listener = invocation.getArgument(0);
-            listener.onStateChanged(0, TransferState.COMPLETED);
+            listener.onStateChanged(0, TransferState.COMPLETED, fromRemoteKey);
             return null;
         }).when(observer)
                 .setTransferListener(any(TransferListener.class));
@@ -256,7 +256,7 @@ public final class StorageComponentTest {
 
         doAnswer(invocation -> {
             TransferListener listener = invocation.getArgument(0);
-            listener.onStateChanged(0, TransferState.COMPLETED);
+            listener.onStateChanged(0, TransferState.COMPLETED, toRemoteKey);
             return null;
         }).when(observer)
                 .setTransferListener(any(com.amplifyframework.storage.s3.transfer.TransferListener.class));
@@ -297,7 +297,7 @@ public final class StorageComponentTest {
 
         doAnswer(invocation -> {
             TransferListener listener = invocation.getArgument(0);
-            listener.onStateChanged(0, TransferState.COMPLETED);
+            listener.onStateChanged(0, TransferState.COMPLETED, toRemoteKey);
             return null;
         }).when(observer)
                 .setTransferListener(any(TransferListener.class));

--- a/core/src/main/java/com/amplifyframework/core/async/AmplifyOperation.java
+++ b/core/src/main/java/com/amplifyframework/core/async/AmplifyOperation.java
@@ -62,6 +62,9 @@ public abstract class AmplifyOperation<R> {
 
     /**
      * Gets the request object.
+     * Request will be null if the operation is returned by
+     * {@link com.amplifyframework.storage.s3.AWSS3StoragePlugin} getTransfer api
+     *
      * @return the request object
      */
     public R getRequest() {

--- a/core/src/main/java/com/amplifyframework/core/async/AmplifyOperation.java
+++ b/core/src/main/java/com/amplifyframework/core/async/AmplifyOperation.java
@@ -62,8 +62,6 @@ public abstract class AmplifyOperation<R> {
 
     /**
      * Gets the request object.
-     * Request will be null if the operation is returned by
-     * {@link com.amplifyframework.storage.s3.AWSS3StoragePlugin} getTransfer api
      *
      * @return the request object
      */

--- a/core/src/main/java/com/amplifyframework/storage/operation/StorageDownloadFileOperation.java
+++ b/core/src/main/java/com/amplifyframework/storage/operation/StorageDownloadFileOperation.java
@@ -75,6 +75,7 @@ public abstract class StorageDownloadFileOperation<R> extends StorageTransferOpe
      * @return the request object
      */
     @Override
+    @Nullable
     public R getRequest() {
         return super.getRequest();
     }

--- a/core/src/main/java/com/amplifyframework/storage/operation/StorageDownloadFileOperation.java
+++ b/core/src/main/java/com/amplifyframework/storage/operation/StorageDownloadFileOperation.java
@@ -67,5 +67,16 @@ public abstract class StorageDownloadFileOperation<R> extends StorageTransferOpe
     public void setOnSuccess(@Nullable Consumer<StorageDownloadFileResult> onSuccess) {
         super.setOnSuccess(onSuccess);
     }
+
+    /**
+     * Request will be null if the operation is returned by
+     * {@link com.amplifyframework.storage.s3.AWSS3StoragePlugin} getTransfer api.
+     *
+     * @return the request object
+     */
+    @Override
+    public R getRequest() {
+        return super.getRequest();
+    }
 }
 

--- a/core/src/main/java/com/amplifyframework/storage/operation/StorageUploadOperation.java
+++ b/core/src/main/java/com/amplifyframework/storage/operation/StorageUploadOperation.java
@@ -68,5 +68,16 @@ public abstract class StorageUploadOperation<R, T extends StorageUploadResult>
     public void setOnSuccess(@Nullable Consumer<T> onSuccess) {
         super.setOnSuccess(onSuccess);
     }
+
+    /**
+     * Request will be null if the operation is returned by
+     * {@link com.amplifyframework.storage.s3.AWSS3StoragePlugin} getTransfer api.
+     *
+     * @return the request object
+     */
+    @Override
+    public R getRequest() {
+        return super.getRequest();
+    }
 }
 

--- a/core/src/main/java/com/amplifyframework/storage/operation/StorageUploadOperation.java
+++ b/core/src/main/java/com/amplifyframework/storage/operation/StorageUploadOperation.java
@@ -76,6 +76,7 @@ public abstract class StorageUploadOperation<R, T extends StorageUploadResult>
      * @return the request object
      */
     @Override
+    @Nullable
     public R getRequest() {
         return super.getRequest();
     }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- OnProgress, OnSuccess & OnError callbacks for uploads were not invoked when attached using operation returned by GetTransfer API
- TransferState for single part uploads and download was not marked correctly when a paused transfer is cancelled.
- Terminating Download file operation due to network disconnection throws SocketException, marking it as retryable exception since download needs to restart again when network is available.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [x] Added Integration Tests

*Documentation update required?*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
