### PR TITLE
fix(auth): Prevent attempting to read backed up EncryptedSharedPreferences

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/EncryptedKeyValueRepository.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/EncryptedKeyValueRepository.kt
@@ -22,36 +22,81 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV
 import androidx.security.crypto.EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
 import androidx.security.crypto.MasterKeys
+import java.io.File
+import java.util.UUID
 
 internal class EncryptedKeyValueRepository(
     private val context: Context,
     private val sharedPreferencesName: String,
 ) : KeyValueRepository {
 
-    override fun put(dataKey: String, value: String?) {
-        with(getSharedPreferences().edit()) {
-            putString(dataKey, value)
-            apply()
-        }
-    }
-
-    override fun get(dataKey: String): String? = getSharedPreferences().getString(dataKey, null)
-
-    override fun remove(dataKey: String) {
-        with(getSharedPreferences().edit()) {
-            remove(dataKey)
-            apply()
-        }
-    }
-
     @VisibleForTesting
-    fun getSharedPreferences(): SharedPreferences {
-        return EncryptedSharedPreferences.create(
-            sharedPreferencesName,
+    internal val sharedPreferences: SharedPreferences by lazy {
+        EncryptedSharedPreferences.create(
+            "$sharedPreferencesName.${getInstallationIdentifier(context, sharedPreferencesName)}",
             MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
             context,
             AES256_SIV,
             AES256_GCM
         )
+    }
+
+    @VisibleForTesting
+    internal val editor: SharedPreferences.Editor by lazy {
+        sharedPreferences.edit()
+    }
+
+    override fun put(dataKey: String, value: String?) {
+        with(editor) {
+            putString(dataKey, value)
+            apply()
+        }
+    }
+
+    override fun get(dataKey: String): String? = sharedPreferences.getString(dataKey, null)
+
+    override fun remove(dataKey: String) {
+        with(editor) {
+            remove(dataKey)
+            apply()
+        }
+    }
+
+    /**
+     * EncryptedSharedPreferences may have been backed up by the application, but will be unreadable due to the
+     * KeyStore record being lost. To prevent an unreadable EncryptedSharedPreferences, we append a suffix to the name
+     * with a UUID created in the noBackupFilesDir
+     */
+    @Synchronized
+    private fun getInstallationIdentifier(context: Context, keyValueRepoID: String): String {
+        val identifierFile = File(context.noBackupFilesDir, "$keyValueRepoID.installationIdentifier")
+        val previousIdentifier = getExistingInstallationIdentifier(identifierFile)
+
+        return previousIdentifier ?: createInstallationIdentifier(identifierFile)
+    }
+
+    /**
+     * Gets the existing installation identifier (if exists)
+     */
+    private fun getExistingInstallationIdentifier(identifierFile: File): String? {
+        return if (identifierFile.exists()) {
+            val identifier = identifierFile.readText()
+            identifier.ifBlank { null }
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Creates a new installation identifier for the install
+     */
+    private fun createInstallationIdentifier(identifierFile: File): String {
+        val newIdentifier = UUID.randomUUID().toString()
+        try {
+            identifierFile.writeText(newIdentifier)
+        } catch (e: Exception) {
+            // Failed to write identifier to file, session will be forced to be in memory
+        }
+        return newIdentifier
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/EncryptedKeyValueRepositoryTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/EncryptedKeyValueRepositoryTest.kt
@@ -49,8 +49,8 @@ class EncryptedKeyValueRepositoryTest {
 
     @Before
     fun setup() {
-        Mockito.`when`(repository.getSharedPreferences()).thenReturn(mockPrefs)
-        Mockito.`when`(mockPrefs.edit()).thenReturn(mockPrefsEditor)
+        Mockito.`when`(repository.sharedPreferences).thenReturn(mockPrefs)
+        Mockito.`when`(repository.editor).thenReturn(mockPrefsEditor)
     }
 
     @Test


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
EncryptedSharedPreferences are backed up with the rest of SharedPreferences files depending on app backup settings. As a library, we can't control backup configurations as it would conflict with app developers config.

As a workaround, we create a UUID installationIdentifier in noBackupDir to add as a suffix to our EncryptedSharedPreferences, ensuring that file we are attempting to read was not created from a backup.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
