### PR TITLE
Fix(Auth): Sign up if successful should return DONE instead of Confirm sign up

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -138,16 +138,16 @@ import com.amplifyframework.statemachine.codegen.states.SRPSignInState
 import com.amplifyframework.statemachine.codegen.states.SignInChallengeState
 import com.amplifyframework.statemachine.codegen.states.SignInState
 import com.amplifyframework.statemachine.codegen.states.SignOutState
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 
 internal class RealAWSCognitoAuthPlugin(
     private val configuration: AuthConfiguration,

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/JsonGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/JsonGenerator.kt
@@ -61,6 +61,6 @@ object JsonGenerator {
 }
 
 fun main() {
-    //cleanDirectory()
+    cleanDirectory()
     JsonGenerator.generate()
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/JsonGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/JsonGenerator.kt
@@ -61,6 +61,6 @@ object JsonGenerator {
 }
 
 fun main() {
-    cleanDirectory()
+    //cleanDirectory()
     JsonGenerator.generate()
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignUpTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignUpTestCaseGenerator.kt
@@ -106,7 +106,7 @@ object SignUpTestCaseGenerator : SerializableProvider {
 
     val signupSuccessCase = baseCase.copy(
         description = "Sign up finishes if user is confirmed in the first step",
-        preConditions = baseCase.preConditions.copy (
+        preConditions = baseCase.preConditions.copy(
             mockedResponses = listOf(
                 MockResponse(
                     CognitoType.CognitoIdentityProvider,
@@ -131,15 +131,15 @@ object SignUpTestCaseGenerator : SerializableProvider {
                 apiName = AuthAPI.signUp,
                 responseType = ResponseType.Success,
                 response =
-                AuthSignUpResult(
-                    true,
-                    AuthNextSignUpStep(
-                        AuthSignUpStep.DONE,
-                        emptyMap(),
+                    AuthSignUpResult(
+                        true,
+                        AuthNextSignUpStep(
+                            AuthSignUpStep.DONE,
+                            emptyMap(),
+                            null
+                        ),
                         null
-                    ),
-                    null
-                ).toJsonElement()
+                    ).toJsonElement()
             )
         )
     )

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignUpTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignUpTestCaseGenerator.kt
@@ -42,6 +42,12 @@ object SignUpTestCaseGenerator : SerializableProvider {
         "attributeName" to "attributeName"
     )
 
+    private val emptyCodeDeliveryDetails = mapOf(
+        "destination" to "",
+        "deliveryMedium" to "",
+        "attributeName" to ""
+    )
+
     val baseCase = FeatureTestCase(
         description = "Test that signup invokes proper cognito request and returns success",
         preConditions = PreConditions(
@@ -98,5 +104,45 @@ object SignUpTestCaseGenerator : SerializableProvider {
         )
     )
 
-    override val serializables: List<Any> = listOf(baseCase)
+    val signupSuccessCase = baseCase.copy(
+        description = "Sign up finishes if user is confirmed in the first step",
+        preConditions = baseCase.preConditions.copy (
+            mockedResponses = listOf(
+                MockResponse(
+                    CognitoType.CognitoIdentityProvider,
+                    "signUp",
+                    ResponseType.Success,
+                    mapOf("codeDeliveryDetails" to emptyCodeDeliveryDetails, "userConfirmed" to true).toJsonElement()
+                )
+            )
+        ),
+        validations = listOf(
+            ExpectationShapes.Cognito.CognitoIdentityProvider(
+                apiName = "signUp",
+                // see [https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignUp.html]
+                request = mapOf(
+                    "clientId" to "testAppClientId", // This should be pulled from configuration
+                    "username" to username,
+                    "password" to password,
+                    "userAttributes" to listOf(mapOf("name" to "email", "value" to email))
+                ).toJsonElement()
+            ),
+            ExpectationShapes.Amplify(
+                apiName = AuthAPI.signUp,
+                responseType = ResponseType.Success,
+                response =
+                AuthSignUpResult(
+                    true,
+                    AuthNextSignUpStep(
+                        AuthSignUpStep.DONE,
+                        emptyMap(),
+                        null
+                    ),
+                    null
+                ).toJsonElement()
+            )
+        )
+    )
+
+    override val serializables: List<Any> = listOf(baseCase, signupSuccessCase)
 }

--- a/aws-auth-cognito/src/test/java/featureTest/utilities/CognitoMockFactory.kt
+++ b/aws-auth-cognito/src/test/java/featureTest/utilities/CognitoMockFactory.kt
@@ -68,7 +68,9 @@ class CognitoMockFactory(
                     setupError(mockResponse, responseObject)
                     SignUpResponse.invoke {
                         this.codeDeliveryDetails = parseCodeDeliveryDetails(responseObject)
-                        this.userConfirmed = if(responseObject.containsKey("userConfirmed")){(responseObject["userConfirmed"] as JsonPrimitive).boolean} else false
+                        this.userConfirmed = if (responseObject.containsKey("userConfirmed")) {
+                            (responseObject["userConfirmed"] as? JsonPrimitive)?.boolean ?: false
+                        } else false
                     }
                 }
             }

--- a/aws-auth-cognito/src/test/java/featureTest/utilities/CognitoMockFactory.kt
+++ b/aws-auth-cognito/src/test/java/featureTest/utilities/CognitoMockFactory.kt
@@ -42,6 +42,7 @@ import io.mockk.coEvery
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
 
 /**
  * Factory to mock aws sdk's cognito API calls and responses.
@@ -67,6 +68,7 @@ class CognitoMockFactory(
                     setupError(mockResponse, responseObject)
                     SignUpResponse.invoke {
                         this.codeDeliveryDetails = parseCodeDeliveryDetails(responseObject)
+                        this.userConfirmed = if(responseObject.containsKey("userConfirmed")){(responseObject["userConfirmed"] as JsonPrimitive).boolean} else false
                     }
                 }
             }

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_after_refresh.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_after_refresh.json
@@ -1,0 +1,53 @@
+{
+    "description": "AuthSession object is successfully returned after refresh",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration.json",
+        "state": "SignedIn_SessionEstablished.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "authenticationResult": {
+                        "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiresIn": 300
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "fetchAuthSession",
+        "params": {
+        },
+        "options": {
+            "forceRefresh": true
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "fetchAuthSession",
+            "responseType": "success",
+            "response": {
+                "awsCredentialsResult": {
+                    "accessKeyId": "someAccessKey",
+                    "expiration": 2342134,
+                    "secretAccessKey": "someSecretKey",
+                    "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU"
+                },
+                "identityIdResult": "someIdentityId",
+                "isSignedIn": true,
+                "userPoolTokensResult": {
+                    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU"
+                },
+                "userSubResult": "userId"
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_for_Identity_Pool.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_for_Identity_Pool.json
@@ -1,0 +1,45 @@
+{
+    "description": "AuthSession object is successfully returned for Identity Pool",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration.json",
+        "state": "SignedOut_IdentityPoolConfigured.json",
+        "mockedResponses": [
+        ]
+    },
+    "api": {
+        "name": "fetchAuthSession",
+        "params": {
+        },
+        "options": {
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "fetchAuthSession",
+            "responseType": "success",
+            "response": {
+                "awsCredentialsResult": {
+                    "accessKeyId": "someAccessKey",
+                    "expiration": 2342134,
+                    "secretAccessKey": "someSecretKey",
+                    "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU"
+                },
+                "identityIdResult": "someIdentityId",
+                "isSignedIn": false,
+                "userPoolTokensResult": {
+                    "errorType": "SignedOutException",
+                    "errorMessage": "You are currently signed out.",
+                    "recoverySuggestion": "Please sign in and reattempt the operation.",
+                    "cause": null
+                },
+                "userSubResult": {
+                    "errorType": "SignedOutException",
+                    "errorMessage": "You are currently signed out.",
+                    "recoverySuggestion": "Please sign in and reattempt the operation.",
+                    "cause": null
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_for_UserAndIdentity_Pool.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_for_UserAndIdentity_Pool.json
@@ -1,0 +1,39 @@
+{
+    "description": "AuthSession object is successfully returned for UserAndIdentity Pool",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration.json",
+        "state": "SignedIn_SessionEstablished.json",
+        "mockedResponses": [
+        ]
+    },
+    "api": {
+        "name": "fetchAuthSession",
+        "params": {
+        },
+        "options": {
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "fetchAuthSession",
+            "responseType": "success",
+            "response": {
+                "awsCredentialsResult": {
+                    "accessKeyId": "someAccessKey",
+                    "expiration": 2342134,
+                    "secretAccessKey": "someSecretKey",
+                    "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU"
+                },
+                "identityIdResult": "someIdentityId",
+                "isSignedIn": true,
+                "userPoolTokensResult": {
+                    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU"
+                },
+                "userSubResult": "userId"
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_for_User_Pool.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_for_User_Pool.json
@@ -1,0 +1,44 @@
+{
+    "description": "AuthSession object is successfully returned for User Pool",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration.json",
+        "state": "SignedIn_UserPoolSessionEstablished.json",
+        "mockedResponses": [
+        ]
+    },
+    "api": {
+        "name": "fetchAuthSession",
+        "params": {
+        },
+        "options": {
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "fetchAuthSession",
+            "responseType": "success",
+            "response": {
+                "awsCredentialsResult": {
+                    "errorType": "ConfigurationException",
+                    "errorMessage": "Could not fetch AWS Cognito credentials",
+                    "recoverySuggestion": "Cognito Identity not configured. Please check amplifyconfiguration.json file.",
+                    "cause": null
+                },
+                "identityIdResult": {
+                    "errorType": "ConfigurationException",
+                    "errorMessage": "Could not retrieve Identity ID",
+                    "recoverySuggestion": "Cognito Identity not configured. Please check amplifyconfiguration.json file.",
+                    "cause": null
+                },
+                "isSignedIn": true,
+                "userPoolTokensResult": {
+                    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU"
+                },
+                "userSubResult": "userId"
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Sign_up_finishes_if_user_is_confirmed_in_the_first_step.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Sign_up_finishes_if_user_is_confirmed_in_the_first_step.json
@@ -1,0 +1,64 @@
+{
+    "description": "Sign up finishes if user is confirmed in the first step",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "signUp",
+                "responseType": "success",
+                "response": {
+                    "codeDeliveryDetails": {
+                        "destination": "",
+                        "deliveryMedium": "",
+                        "attributeName": ""
+                    },
+                    "userConfirmed": true
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signUp",
+        "params": {
+            "username": "user",
+            "password": "password"
+        },
+        "options": {
+            "userAttributes": {
+                "email": "user@domain.com"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "signUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "user",
+                "password": "password",
+                "userAttributes": [
+                    {
+                        "name": "email",
+                        "value": "user@domain.com"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "signUp",
+            "responseType": "success",
+            "response": {
+                "isSignUpComplete": true,
+                "nextStep": {
+                    "signUpStep": "DONE",
+                    "additionalInfo": {
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Sign up if successful should return DONE instead of Confirm sign up

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [x] Added Unit Tests
- [x] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
