### PR TITLE
fix: Cancel multi-part upload integration test.

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferStatusUpdater.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferStatusUpdater.kt
@@ -100,11 +100,8 @@ internal class TransferStatusUpdater private constructor(
             if (transferRecord.state == newState || TransferState.isInTerminalState(transferRecord.state)) {
                 return
             }
-
-            transferDB.updateState(transferRecord.id, newState)
-
             transferRecord.state = newState
-
+            transferDB.updateState(transferRecord.id, newState)
             if (TransferState.COMPLETED == newState) {
                 removeTransferRecord(transferRecord.id)
             }


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- While canceling a transfer, transferState is first persisted to db before updating the local cache, which results in TransferWorkerObersver not reading the updated state, which causes it not to abort the S3 multi-part upload. Fix is to change the order where the state is first persisted locally before updating the DB.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ x] Added Integration Tests

*Documentation update required?*
- [ x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
