### PR TITLE
Fix(Auth): Fix for when move to idle state is called twice in the credential store

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/CredentialStoreState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/CredentialStoreState.kt
@@ -64,7 +64,10 @@ internal sealed class CredentialStoreState : State {
                         val action = credentialStoreActions.loadCredentialStoreAction(storeEvent.credentialType)
                         StateResolution(LoadingStoredCredentials(), listOf(action))
                     }
-                    is CredentialStoreEvent.EventType.ThrowError -> StateResolution(Error(storeEvent.error))
+                    is CredentialStoreEvent.EventType.ThrowError -> {
+                        val action = credentialStoreActions.moveToIdleStateAction()
+                        StateResolution(Error(storeEvent.error), listOf(action))
+                    }
                     else -> defaultResolution
                 }
                 is LoadingStoredCredentials, is StoringCredentials, is ClearingCredentials -> when (storeEvent) {
@@ -96,8 +99,7 @@ internal sealed class CredentialStoreState : State {
                 }
                 is Success, is Error -> when (storeEvent) {
                     is CredentialStoreEvent.EventType.MoveToIdleState -> {
-                        val action = credentialStoreActions.moveToIdleStateAction()
-                        StateResolution(Idle(), listOf(action))
+                        StateResolution(Idle(), listOf())
                     }
                     else -> StateResolution(oldState)
                 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
We were seeing failures in our integration tests that showed that Credential Store success in an idle state may potentially be called twice. This PR fixes that issue.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
