### PR TITLE
feat(api): graphql selection set customization

### DIFF
--- a/aws-api-appsync/build.gradle
+++ b/aws-api-appsync/build.gradle
@@ -16,6 +16,7 @@
 apply plugin: 'com.android.library'
 apply from: rootProject.file('configuration/checkstyle.gradle')
 apply from: rootProject.file('configuration/publishing.gradle')
+apply plugin: 'kotlin-android'
 
 dependencies {
     implementation project(':core')
@@ -29,4 +30,5 @@ dependencies {
     testImplementation dependency.jsonassert
     testImplementation project(path: ':testmodels')
     testImplementation project(path: ':testutils')
+    testImplementation project(path: ':aws-api-appsync')
 }

--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSetDepth.kt
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSetDepth.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.api.aws
+
+/**
+ * GraphQL request options that allows for configurable depth.
+ */
+class SelectionSetDepth(private val maxDepth: Int = 2) : GraphQLRequestOptions {
+
+    override fun paginationFields(): List<String> {
+        return listOf(NEXT_TOKEN_KEY)
+    }
+
+    override fun modelMetaFields(): List<String> {
+        return emptyList()
+    }
+
+    override fun listField(): String {
+        return ITEMS_KEY
+    }
+
+    override fun maxDepth(): Int {
+        return maxDepth
+    }
+
+    override fun leafSerializationBehavior(): LeafSerializationBehavior {
+        return LeafSerializationBehavior.ALL_FIELDS
+    }
+
+    companion object {
+        private const val NEXT_TOKEN_KEY = "nextToken"
+        private const val ITEMS_KEY = "items"
+
+        @JvmStatic
+        fun defaultDepth() = SelectionSetDepth()
+
+        @JvmStatic
+        fun onlyIncluded() = SelectionSetDepth(maxDepth = 0)
+
+    }
+}

--- a/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSetExtensions.kt
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/api/aws/SelectionSetExtensions.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+@file:JvmName("SelectionSetUtils")
+
+package com.amplifyframework.api.aws
+
+import com.amplifyframework.api.aws.SelectionSetDepth.Companion.onlyIncluded
+import com.amplifyframework.api.graphql.QueryType
+import com.amplifyframework.core.model.ModelSchema
+import com.amplifyframework.core.model.PropertyContainerPath
+
+/**
+ * Find a child in the tree matching its `value`.
+ *
+ * @param name: the name to match the child node of type `SelectionSetField`
+ * @return the matched `SelectionSet` or `nil` if there's no child with the specified name.
+ */
+fun SelectionSet.findChildByName(name: String) = nodes.find { it.value == name }
+
+/**
+ * Replaces or adds a new child to the selection set tree. When a child node exists
+ * with a matching `value` property of the `SelectionSet` the node will be replaced
+ * while retaining its position in the children list. Otherwise the call is
+ * delegated to `nodes.add()`.
+ *
+ * @param selectionSet: the child node to be replaced.
+ */
+fun SelectionSet.replaceChild(selectionSet: SelectionSet) {
+    this.nodes.removeIf { it.value == selectionSet.value }
+    this.nodes.add(selectionSet)
+}
+
+/**
+ * Transforms the entire property path (walking up the tree) into a `SelectionSet`.
+ */
+fun PropertyContainerPath.asSelectionSet(includeRoot: Boolean = true): SelectionSet {
+    val metadata = getMetadata()
+    val name = if (metadata.isCollection) "items" else metadata.name
+    var selectionSet = SelectionSet.builder()
+        .operation(QueryType.GET)
+        .value(name)
+        .requestOptions(onlyIncluded())
+        .modelClass(getModelType())
+        .build()
+
+    if (metadata.isCollection) {
+        selectionSet = SelectionSet(metadata.name, setOf(selectionSet))
+    }
+
+    val parent = metadata.parent as? PropertyContainerPath
+    if (parent != null && (parent.getMetadata().parent != null || includeRoot)) {
+        val parentSelectionSet = parent.asSelectionSet(includeRoot)
+        parentSelectionSet.replaceChild(selectionSet)
+        selectionSet = parentSelectionSet
+    }
+
+    return selectionSet
+}
+
+/**
+ * Merges a subtree into the this `SelectionSet`. The subtree position will be determined
+ * by the value of the node's `name`. When an existing node is found the algorithm will
+ * merge its children to ensure no values are lost or incorrectly overwritten.
+ *
+ * @param selectionSet the subtree to be merged into the current tree.
+ *
+ * @see findChildByName
+ * @see replaceChild
+ */
+@JvmName("merge")
+fun SelectionSet.mergeWith(selectionSet: SelectionSet) {
+    val name = selectionSet.value ?: ""
+    val existingField = findChildByName(name)
+
+    if (existingField != null) {
+        val replaceFields = mutableListOf<SelectionSet>()
+        selectionSet.nodes.forEach { child ->
+            val childName = child.value
+            if (child.nodes.isNotEmpty() && childName != null) {
+                if (existingField.findChildByName(childName) != null) {
+                    existingField.mergeWith(child)
+                } else {
+                    replaceFields.add(child)
+                }
+            } else {
+                replaceFields.add(child)
+            }
+        }
+        replaceFields.forEach(existingField::replaceChild)
+    } else {
+        nodes.add(selectionSet)
+    }
+}

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/ModelPathTest.kt
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/ModelPathTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws
+
+import com.amplifyframework.core.model.ModelException
+import com.amplifyframework.core.model.getRootPath
+import com.amplifyframework.testmodels.modelv2.Post
+import com.amplifyframework.testmodels.todo.Todo
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+@RunWith(RobolectricTestRunner::class)
+class ModelPathTest {
+
+    /**
+     * - Given:
+     *     - a model with a generated `rootPath` static property
+     * - When:
+     *     - the extension method `getRootPath()` is called
+     * - Then:
+     *     - the method should successfully return the reference to the `rootPath`
+     */
+    @Test fun `it should get a reference to the rootPath successfully`() {
+        assertEquals(Post.rootPath, Post::class.java.getRootPath())
+    }
+
+    /**
+     * - Given:
+     *     - a model v1 _without_ the generated `rootPath` static property
+     * - When:
+     *     - the extension method `getRootPath()` is called
+     * - Then:
+     *     - the method should throw a `ModelException.PropertyPathNotFound`
+     *     indicating the `rootPath` is not present.
+     */
+    @Test fun `it should thrown an exception when the rootPath is missing`() {
+        assertThrows(ModelException.PropertyPathNotFound::class.java) {
+            Todo::class.java.getRootPath()
+        }
+    }
+
+    /**
+     * - Given:
+     *     - A property path from `Post`, `post.comments.id`
+     * - When:
+     *     - The `getKeyPath()` method is called with no arguments
+     * - Then:
+     *     - The output should be `comments.id`
+     */
+    @Test fun `it should return the path as a string successfully`() {
+        val post = Post.rootPath
+        assertEquals("comments.id", post.comments.id.getKeyPath())
+    }
+
+    /**
+     * - Given:
+     *   - A property path from `Post`, `post.comments.id`
+     * - When:
+     *   - The `getKeyPath()` method is called with `includesRoot = true`
+     * - Then:
+     *   - The output should be `root.comments.id`
+     */
+    @Test fun `it should return the path with the root node as a string successfully`() {
+        val post = Post.rootPath
+        assertEquals("root.comments.id", post.comments.id.getKeyPath(includesRoot = true))
+    }
+
+}

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetIncludesTest.kt
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetIncludesTest.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws
+
+import com.amplifyframework.api.aws.SelectionSetDepth.Companion.onlyIncluded
+import com.amplifyframework.api.graphql.QueryType
+import com.amplifyframework.testmodels.modelv2.Comment
+import com.amplifyframework.testmodels.modelv2.Post
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+private fun assertSelectionSetEquals(expected: String, actual: SelectionSet) {
+    assertEquals(expected.trimIndent(), actual.toString("").trim())
+}
+
+@RunWith(RobolectricTestRunner::class)
+class SelectionSetIncludesTest {
+
+    /**
+     * - Given:
+     *     - a `Model` schema
+     * - When:
+     *     - the model schema comes from the type `Comment`
+     *     - the belongTo `post` association is present in the schema
+     *     but not included in the selection set
+     * - Then:
+     *     - check if the generated selection set includes only the
+     *     `post` primary keys (i.e. the foreign key needed to associate both models)
+     */
+    @Test
+    fun `it should create a selection set of a comment with default options`() {
+        val selectionSet = SelectionSet.builder()
+            .operation(QueryType.GET)
+            .modelClass(Comment::class.java)
+            .requestOptions(onlyIncluded())
+            .build()
+
+        assertSelectionSetEquals(
+            """
+            {
+              content
+              id
+              post {
+                id
+              }
+            }
+            """,
+            selectionSet
+        )
+    }
+
+    /**
+     * - Given:
+     *     - a `Model` schema
+     * - When:
+     *     - the model schema comes from the type `Post`
+     *     - the belongTo `author` association is present in the schema
+     *     but not included in the selection set
+     *     - the belongTo `blog` association is present in the schema
+     *     but not included in the selection set
+     * - Then:
+     *     - check if the generated selection set includes only the
+     *     `post` and `authors` primary keys (i.e. the foreign key needed to associate both models)
+     */
+    @Test fun `it should create a selection set of a post`() {
+        val post = Post.rootPath
+        val selectionSet = SelectionSet.builder()
+            .operation(QueryType.GET)
+            .modelClass(Post::class.java)
+            .requestOptions(onlyIncluded())
+            .build()
+
+        assertSelectionSetEquals(
+            """
+            {
+              author {
+                id
+              }
+              blog {
+                id
+              }
+              id
+              title
+            }
+            """,
+            selectionSet
+        )
+    }
+
+    /**
+     * - Given:
+     *     - a `Model` schema
+     * - When:
+     *     - the model schema comes from the type `Post`
+     *     - the belongTo `author` association is present in the schema
+     *     but not included in the selection set
+     *     - the belongTo `blog` association is present in the schema
+     *     but not included in the selection set
+     *     - the hasMany `comments` association is included
+     * - Then:
+     *     - check if the comments selection set is added to the schema
+     *     - check if the generated selection set includes only the
+     *     `post` and `authors` primary keys (i.e. the foreign key needed to associate both models)
+     */
+    @Test fun `it should create a selection set of a post including its comments`() {
+        val post = Post.rootPath
+        val selectionSet = SelectionSet.builder()
+            .operation(QueryType.GET)
+            .modelClass(Post::class.java)
+            .requestOptions(onlyIncluded())
+            .includeAssociations(post.comments)
+            .build()
+
+        assertSelectionSetEquals(
+            """
+            {
+              author {
+                id
+              }
+              blog {
+                id
+              }
+              comments {
+                items {
+                  content
+                  id
+                  post {
+                    id
+                  }
+                }
+              }
+              id
+              title
+            }
+            """,
+            selectionSet
+        )
+    }
+
+
+    /**
+     * - Given:
+     *     - a `Model` schema
+     * - When:
+     *     - the model schema comes from the type `Post`
+     *     - the belongTo `author` association is included
+     *     - the hasMany `comments` association is included
+     *     - the belongTo `blog` association is present in the schema
+     *     but not included in the selection set
+     * - Then:
+     *     - check if the comments selection set is added to the schema
+     *     - check if the generated selection set includes only the
+     *     `post` and `authors` primary keys (i.e. the foreign key needed to associate both models)
+     */
+    @Test fun `it should create a selection set of a post including its comments and author`() {
+        val post = Post.rootPath
+        val selectionSet = SelectionSet.builder()
+            .operation(QueryType.GET)
+            .modelClass(Post::class.java)
+            .requestOptions(onlyIncluded())
+            .includeAssociations(post.author, post.comments)
+            .build()
+
+        assertSelectionSetEquals(
+            """
+            {
+              author {
+                id
+                name
+              }
+              blog {
+                id
+              }
+              comments {
+                items {
+                  content
+                  id
+                  post {
+                    id
+                  }
+                }
+              }
+              id
+              title
+            }
+            """,
+            selectionSet
+        )
+    }
+}

--- a/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/api/aws/SelectionSetTest.java
@@ -15,6 +15,9 @@
 
 package com.amplifyframework.api.aws;
 
+import static com.amplifyframework.api.aws.SelectionSetDepth.defaultDepth;
+import static org.junit.Assert.assertEquals;
+
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.QueryType;
 import com.amplifyframework.core.model.AuthRule;
@@ -42,8 +45,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-
 @RunWith(RobolectricTestRunner.class)
 public class SelectionSetTest {
     /**
@@ -55,7 +56,7 @@ public class SelectionSetTest {
         SelectionSet selectionSet = SelectionSet.builder()
                 .modelClass(Post.class)
                 .operation(QueryType.GET)
-                .requestOptions(new DefaultGraphQLRequestOptions())
+                .requestOptions(defaultDepth())
                 .build();
         assertEquals(Resources.readAsString("selection-set-post.txt"), selectionSet.toString() + "\n");
     }
@@ -69,7 +70,7 @@ public class SelectionSetTest {
         SelectionSet selectionSet = SelectionSet.builder()
                 .modelClass(Parent.class)
                 .operation(QueryType.GET)
-                .requestOptions(new DefaultGraphQLRequestOptions())
+                .requestOptions(defaultDepth())
                 .build();
         assertEquals(Resources.readAsString("selection-set-parent.txt"), selectionSet.toString() + "\n");
     }
@@ -83,7 +84,7 @@ public class SelectionSetTest {
         SelectionSet selectionSet = SelectionSet.builder()
                 .modelClass(OwnerAuth.class)
                 .operation(QueryType.GET)
-                .requestOptions(new DefaultGraphQLRequestOptions())
+                .requestOptions(defaultDepth())
                 .build();
         assertEquals(Resources.readAsString("selection-set-ownerauth.txt"), selectionSet.toString() + "\n");
     }
@@ -134,7 +135,7 @@ public class SelectionSetTest {
             .modelClass(SerializedModel.class) // Note: this is different from the above test.
             .modelSchema(schema) // Note: this test passes an explicit schema, instead of relying on modelClass().
             .operation(QueryType.GET)
-            .requestOptions(new DefaultGraphQLRequestOptions())
+            .requestOptions(defaultDepth())
             .build();
         assertEquals(Resources.readAsString("selection-set-ownerauth.txt"), selectionSet.toString() + "\n");
     }
@@ -148,7 +149,7 @@ public class SelectionSetTest {
         SelectionSet selectionSet = SelectionSet.builder()
                 .modelClass(OwnerAuthExplicit.class)
                 .operation(QueryType.GET)
-                .requestOptions(new DefaultGraphQLRequestOptions())
+                .requestOptions(defaultDepth())
                 .build();
         assertEquals(Resources.readAsString("selection-set-ownerauth.txt"), selectionSet.toString() + "\n");
     }
@@ -262,7 +263,7 @@ public class SelectionSetTest {
                 .modelClass(SerializedModel.class)
                 .modelSchema(personSchema)
                 .operation(QueryType.GET)
-                .requestOptions(new DefaultGraphQLRequestOptions())
+                .requestOptions(defaultDepth())
                 .build();
         String result = selectionSet.toString();
         assertEquals(Resources.readAsString("selection-set-nested-serialized-model-serialized-custom-type.txt"),

--- a/core/src/main/java/com/amplifyframework/core/model/ModelException.kt
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelException.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model
+
+import com.amplifyframework.AmplifyException
+
+sealed class ModelException(
+    message: String,
+    recoverySuggestion: String,
+    cause: Exception? = null
+) : AmplifyException(message, cause, recoverySuggestion) {
+
+    class PropertyPathNotFound(
+        val modelName: String,
+        cause: Exception? = null
+    ) : ModelException(
+        "The root property path for the model $modelName could not be found",
+        "Check if the model types were generated with the latest Amplify CLI and try again",
+        cause
+    )
+
+}

--- a/core/src/main/java/com/amplifyframework/core/model/ModelPropertyPath.kt
+++ b/core/src/main/java/com/amplifyframework/core/model/ModelPropertyPath.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.core.model
+
+/**
+ * Represents a property of a `Model`. PropertyPath is a way of representing the
+ * structure of a model with static typing, so developers can reference model
+ * properties in queries and other functionality that require them.
+ */
+interface PropertyPath {
+
+    /**
+     * Access the property metadata.
+     *
+     * **Implementation note:** this function is in place over an implicit accessor over
+     * a property named `metadata` in order to avoid name conflict with the actual property
+     * names that will get generate from the `Model`.
+     *
+     * @return the property metadata, that contains the name and a reference to its parent.
+     */
+    fun getMetadata(): PropertyPathMetadata
+
+    /**
+     * Returns the full path of the property, e.g. `"post.author.name"`.
+     *
+     * @param includesRoot whether it should include the root name or not. It's `false` by default.
+     * @return path as a string
+     */
+    fun getKeyPath(includesRoot: Boolean = false): String {
+        var metadata = getMetadata()
+        val path = mutableListOf<String>()
+        while (metadata.parent != null) {
+            path.add(index = 0, element = metadata.name)
+            metadata = metadata.parent!!.getMetadata()
+        }
+        if (includesRoot) {
+            path.add(index = 0, metadata.name)
+        }
+        return path.joinToString(separator = ".")
+    }
+}
+
+/**
+ * Runtime information about a property. Its `name` and `parent` property reference,
+ * as well as whether the property represents a collection of the type or not.
+ */
+data class PropertyPathMetadata(
+    val name: String,
+    val isCollection: Boolean = false,
+    val parent: PropertyPath? = null
+)
+
+/**
+ * This interface is used to mark a property path as being a container
+ * for other properties.
+ *
+ * @see ModelPath for a more concrete representation of a property container
+ */
+interface PropertyContainerPath : PropertyPath {
+
+    /**
+     *
+     */
+    fun getModelType(): Class<Model>
+
+}
+
+/**
+ * Represents the `Model` structure itself, a container of property references.
+ *
+ * ```kotlin
+ * class Path(name: String = "root", isCollection: Boolean = false, parent: PropertyPath? = null)
+*    : ModelPath<Post>(name, isCollection, modelType = Post::class.java, parent = parent) {
+*
+*    val id = string("id")
+*    val title = string("title")
+*    val blog by lazy { Blog.Path("blog", parent = this) }
+*    val comments by lazy { Comment.Path("comments", isCollection = true, parent = this) }
+*  }
+*
+*  companion object {
+*    val rootPath = Path()
+*  }
+ * ```
+ */
+open class ModelPath<ModelType : Model>(
+    private val name: String,
+    private val isCollection: Boolean = false,
+    private val parent: PropertyPath? = null,
+    private val modelType: Class<ModelType>
+) : PropertyContainerPath {
+
+    override fun getMetadata() = PropertyPathMetadata(
+        name = name,
+        isCollection = isCollection,
+        parent = parent
+    )
+
+    override fun getModelType(): Class<Model> = modelType as Class<Model>
+
+    protected fun <T : Any> field(name: String, type: Class<T>) = FieldPath(
+        name = name,
+        parent = this,
+        propertyType = type
+    )
+
+    protected inline fun <reified T : Any> field(name: String) = FieldPath(
+        name = name,
+        parent = this,
+        propertyType = T::class.java
+    )
+
+    protected inline fun string(name: String) = field<String>(name)
+
+    protected inline fun integer(name: String) = field<Int>(name)
+
+    protected inline fun double(name: String) = field<Double>(name)
+
+    protected inline fun boolean(name: String) = field<Boolean>(name)
+
+    protected inline fun <reified E : Enum<*>> enumeration(name: String) = FieldPath(
+        name = name,
+        parent = this,
+        propertyType = E::class.java
+    )
+
+}
+
+/**
+ * Represents a scalar (i.e. data type) of a model property.
+ */
+class FieldPath<Type : Any>(
+    private val name: String,
+    private val parent: PropertyPath? = null,
+    val propertyType: Class<Type>
+) : PropertyPath {
+
+    override fun getMetadata() = PropertyPathMetadata(
+        name = name,
+        parent = parent
+    )
+
+}
+
+/**
+ * Function used to define which associations are included in the selection set
+ * in an idiomatic manner. It's a simple delegation to `arrayOf` with the main
+ * goal of improved code readability.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * getById<Post>("id") { includes(it.comments) }
+ * ```
+ *
+ * @param associations the associations that should be included
+ * @return the passed associations as an array
+ */
+fun includes(vararg associations: PropertyContainerPath) = arrayOf(*associations)
+
+/**
+ * Attempts to get a reference to the root property path of a given model
+ * of type `M`. This uses reflection to allow models created before the
+ * `PropertyPath` type was added to continue working without disruption
+ * of the development workflow.
+ *
+ * @return the `ModelPath<M>`
+ * @throws ModelException.PropertyPathNotFound in case the path could not be read or found.
+ */
+@Throws(ModelException.PropertyPathNotFound::class)
+fun <M : Model> Class<M>.getRootPath(): ModelPath<M> {
+    println(fields.map { it.name }.joinToString("\n"))
+    val field = try {
+        this.getDeclaredField("rootPath")
+    } catch (e: NoSuchFieldException) {
+        throw ModelException.PropertyPathNotFound(this.simpleName)
+    }
+    field.isAccessible = true
+    val path = field.get(null) as? ModelPath<M>
+    return path ?: throw ModelException.PropertyPathNotFound(this.simpleName)
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/modelv2/Author.kt
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/modelv2/Author.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.testmodels.modelv2
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelPath
+import com.amplifyframework.core.model.PropertyPath
+import com.amplifyframework.core.model.annotations.HasMany
+import com.amplifyframework.core.model.annotations.ModelConfig
+import com.amplifyframework.core.model.annotations.ModelField
+
+@ModelConfig(pluralName = "Authors")
+data class Author(
+    @ModelField(targetType = "ID")
+    val id: String,
+
+    @ModelField(isRequired = true)
+    val name: String,
+
+    @ModelField(targetType = "Post")
+    @HasMany(associatedWith = "author", type = Post::class)
+    val posts: List<Post>
+) : Model {
+
+    class Path(name: String = "root", isCollection: Boolean = false, parent: PropertyPath? = null) :
+        ModelPath<Author>(name, isCollection, modelType = Author::class.java, parent = parent) {
+
+        val id = string("id")
+        val name = string("name")
+        val posts by lazy { Post.Path("posts", isCollection = true, parent = this) }
+    }
+
+    companion object {
+        val rootPath = Path()
+    }
+
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/modelv2/Blog.kt
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/modelv2/Blog.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.testmodels.modelv2
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelPath
+import com.amplifyframework.core.model.PropertyPath
+import com.amplifyframework.core.model.annotations.HasMany
+import com.amplifyframework.core.model.annotations.ModelConfig
+import com.amplifyframework.core.model.annotations.ModelField
+
+@ModelConfig(pluralName = "Blogs")
+data class Blog(
+    @ModelField(targetType = "ID")
+    val id: String,
+
+    @ModelField(targetType = "Post")
+    @HasMany(associatedWith = "blog", type = Post::class)
+    val posts: List<Post>
+) : Model {
+
+    class Path(name: String = "root", isCollection: Boolean = false, parent: PropertyPath? = null) :
+        ModelPath<Blog>(name, isCollection, modelType = Blog::class.java, parent = parent) {
+
+        val id = string("id")
+        val title = string("title")
+        val posts by lazy { Post.Path("posts", isCollection = true, parent = this) }
+    }
+
+    companion object {
+        val rootPath = Path()
+    }
+
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/modelv2/Comment.kt
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/modelv2/Comment.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.testmodels.modelv2
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelPath
+import com.amplifyframework.core.model.PropertyPath
+import com.amplifyframework.core.model.annotations.BelongsTo
+import com.amplifyframework.core.model.annotations.ModelConfig
+import com.amplifyframework.core.model.annotations.ModelField
+
+@ModelConfig(pluralName = "Comments")
+data class Comment(
+    @ModelField(targetType = "ID")
+    val id: String,
+
+    @ModelField(isRequired = true)
+    val content: String,
+
+    @ModelField(targetType = "Post", isRequired = true)
+    @BelongsTo(targetName = "comments", type = Post::class)
+    val post: Post
+) : Model {
+
+    class Path(name: String = "root", isCollection: Boolean = false, parent: PropertyPath? = null) :
+        ModelPath<Comment>(name, isCollection, modelType = Comment::class.java, parent = parent) {
+
+        val id = string("id")
+        val content = string("content")
+        val post by lazy { Post.Path("posts", parent = this) }
+    }
+
+    companion object {
+        val rootPath = Path()
+    }
+}

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/modelv2/Post.kt
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/modelv2/Post.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.testmodels.modelv2
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelPath
+import com.amplifyframework.core.model.PropertyPath
+import com.amplifyframework.core.model.annotations.BelongsTo
+import com.amplifyframework.core.model.annotations.HasMany
+import com.amplifyframework.core.model.annotations.ModelConfig
+import com.amplifyframework.core.model.annotations.ModelField
+
+@ModelConfig(pluralName = "Posts")
+data class Post(
+    @ModelField(targetType = "ID", isRequired = true) val id: String,
+    @ModelField(isRequired = true) val title: String,
+
+    @ModelField(targetType = "Blog", isRequired = true)
+    @BelongsTo(targetName = "posts", type = Blog::class)
+    val blog: Blog,
+
+    @ModelField(targetType = "Author", isRequired = true)
+    @BelongsTo(targetName = "posts", type = Author::class)
+    val author: Author,
+
+    @ModelField(targetType = "Comment")
+    @HasMany(associatedWith = "author", type = Comment::class)
+    val comments: List<Comment> = emptyList()
+) : Model {
+
+    class Path(name: String = "root", isCollection: Boolean = false, parent: PropertyPath? = null) :
+        ModelPath<Post>(name, isCollection, modelType = Post::class.java, parent = parent) {
+
+        val id = string("id")
+        val title = string("title")
+        val blog by lazy { Blog.Path("blog", parent = this) }
+        val author by lazy { Author.Path("author", parent = this) }
+        val comments by lazy { Comment.Path("comments", isCollection = true, parent = this) }
+    }
+
+    companion object {
+        val rootPath = Path()
+    }
+
+}


### PR DESCRIPTION
## Custom selection set for GraphQL queries in the API category

This feature will enable customers to define which associations will be included in selection set when querying data using the static typed models. Previously developers had no control over that and had to fallback to untyped/string-based GraphQL queries when they needed more control. This feature enables fine control with full type information of which associations should be included in a query.

A quick example of the added capability is represented in the following code snippet:

```kotlin
val postsWithComments = Amplify.API.query(Post.getById("id")) { post ->
  includes(post.comments)
}
```

Developers can go as deep as needed and/or add multiple associations.

### Noteworthy changes

- Models v2 are now defined in Kotlin instead of Java. This is a significant change that makes modelgen Kotlin-first and much more lightweight
- The Kotlin models allow `by lazy` references to circular references, see the added models
- The selection set always adds by default the foreign key, this enables lazy loading to always fetch the required data on demand


---

- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [x] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
