### PR TITLE
fix(auth): Fix for when loading credentials the success/error is fired twice

### DIFF
--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsInstrumentationTest.kt
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsInstrumentationTest.kt
@@ -34,18 +34,20 @@ import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.hub.HubChannel
 import com.amplifyframework.hub.HubEvent
+import com.amplifyframework.logging.AndroidLoggingPlugin
+import com.amplifyframework.logging.LogLevel
 import com.amplifyframework.testutils.HubAccumulator
 import com.amplifyframework.testutils.Resources
 import com.amplifyframework.testutils.Sleep
 import com.amplifyframework.testutils.sync.SynchronousAuth
-import java.util.UUID
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
 import org.json.JSONException
 import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
+import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 class PinpointAnalyticsInstrumentationTest {
     @Before
@@ -388,9 +390,11 @@ class PinpointAnalyticsInstrumentationTest {
             setUniqueId()
             Amplify.Auth.addPlugin(AWSCognitoAuthPlugin() as AuthPlugin<*>)
             Amplify.addPlugin(AWSPinpointAnalyticsPlugin())
+            Amplify.Logging.addPlugin(AndroidLoggingPlugin(LogLevel.DEBUG))
             Amplify.configure(context)
             Sleep.milliseconds(COGNITO_CONFIGURATION_TIMEOUT)
             synchronousAuth = SynchronousAuth.delegatingTo(Amplify.Auth)
+
         }
 
         private fun setUniqueId() {

--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsInstrumentationTest.kt
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsInstrumentationTest.kt
@@ -40,14 +40,14 @@ import com.amplifyframework.testutils.HubAccumulator
 import com.amplifyframework.testutils.Resources
 import com.amplifyframework.testutils.Sleep
 import com.amplifyframework.testutils.sync.SynchronousAuth
+import java.util.UUID
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
 import org.json.JSONException
 import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 class PinpointAnalyticsInstrumentationTest {
     @Before
@@ -394,7 +394,6 @@ class PinpointAnalyticsInstrumentationTest {
             Amplify.configure(context)
             Sleep.milliseconds(COGNITO_CONFIGURATION_TIMEOUT)
             synchronousAuth = SynchronousAuth.delegatingTo(Amplify.Auth)
-
         }
 
         private fun setUniqueId() {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
@@ -56,9 +56,9 @@ internal class CredentialStoreClient(configuration: AuthConfiguration, context: 
     ) {
         var capturedSuccess: Result<AmplifyCredential>? = null
         var capturedError: Exception? = null
-        val token = StateChangeListenerToken()
+        var token: StateChangeListenerToken? = StateChangeListenerToken()
         credentialStoreStateMachine.listen(
-            token,
+            token as StateChangeListenerToken,
             { storeState ->
                 logger.verbose("Credential Store State Change: $storeState")
 
@@ -72,11 +72,12 @@ internal class CredentialStoreClient(configuration: AuthConfiguration, context: 
                     is CredentialStoreState.Idle -> {
                         val success = capturedSuccess
                         val error = capturedError
-                        if (success != null) {
-                            credentialStoreStateMachine.cancel(token)
+                        if (success != null && token != null) {
+                            credentialStoreStateMachine.cancel(token as StateChangeListenerToken)
+                            token = null
                             onSuccess(success)
-                        } else if (error != null) {
-                            credentialStoreStateMachine.cancel(token)
+                        } else if (error != null && token != null) {
+                            credentialStoreStateMachine.cancel(token as StateChangeListenerToken)
                             onError(error)
                         }
                     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
@@ -61,7 +61,6 @@ internal class CredentialStoreClient(configuration: AuthConfiguration, context: 
             token as StateChangeListenerToken,
             { storeState ->
                 logger.verbose("Credential Store State Change: $storeState")
-
                 when (storeState) {
                     is CredentialStoreState.Success -> {
                         capturedSuccess = Result.success(storeState.storedCredentials)
@@ -73,11 +72,12 @@ internal class CredentialStoreClient(configuration: AuthConfiguration, context: 
                         val success = capturedSuccess
                         val error = capturedError
                         if (success != null && token != null) {
-                            credentialStoreStateMachine.cancel(token as StateChangeListenerToken)
+                            credentialStoreStateMachine.cancel(token!!)
                             token = null
                             onSuccess(success)
                         } else if (error != null && token != null) {
-                            credentialStoreStateMachine.cancel(token as StateChangeListenerToken)
+                            credentialStoreStateMachine.cancel(token!!)
+                            token = null
                             onError(error)
                         }
                     }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:* Fix for when loading credentials the success/error is fired twice it returns an already resumed error in the continuation

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
