### PR TITLE
feat(datastore): Add recoverability improvements

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
@@ -133,7 +133,10 @@ public final class AppSyncGraphQLOperation<R> extends GraphQLOperation<R> {
             if (responseBody != null) {
                 try {
                     jsonResponse = responseBody.string();
+
+                    LOG.debug(String.format("Response: %s", jsonResponse));
                 } catch (IOException exception) {
+                    LOG.warn("Error retrieving JSON from response.", exception);
                     onFailure.accept(new ApiException(
                         "Could not retrieve the response body from the returned JSON",
                         exception, AmplifyException.TODO_RECOVERY_SUGGESTION

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLOperation.java
@@ -133,8 +133,6 @@ public final class AppSyncGraphQLOperation<R> extends GraphQLOperation<R> {
             if (responseBody != null) {
                 try {
                     jsonResponse = responseBody.string();
-
-                    LOG.debug(String.format("Response: %s", jsonResponse));
                 } catch (IOException exception) {
                     LOG.warn("Error retrieving JSON from response.", exception);
                     onFailure.accept(new ApiException(

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
@@ -32,7 +32,6 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -63,11 +62,11 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
                 .registerTypeHierarchyAdapter(Iterable.class, new IterableDeserializer<>(request))
                 .create();
             return responseGson.fromJson(responseJson, responseType);
-        } catch (JsonSyntaxException jsonSyntaxException) {
+        } catch (JsonParseException jsonParseException) {
             throw new ApiException(
-                "Amplify encountered an error while deserializing an object.",
-                jsonSyntaxException,
-                AmplifyException.TODO_RECOVERY_SUGGESTION
+                    "Amplify encountered an error while deserializing an object.",
+                    jsonParseException,
+                    AmplifyException.TODO_RECOVERY_SUGGESTION
             );
         }
     }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthAppSyncGraphQLOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthAppSyncGraphQLOperation.java
@@ -55,7 +55,6 @@ import okhttp3.ResponseBody;
 public final class MultiAuthAppSyncGraphQLOperation<R> extends GraphQLOperation<R> {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-api");
     private static final String CONTENT_TYPE = "application/json";
-    private static final String UNAUTHORIZED_EXCEPTION = "UnauthorizedException";
 
     private final String endpoint;
     private final OkHttpClient client;

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -157,8 +157,6 @@ final class SubscriptionEndpoint {
                 .put("authorization", authorizer.createHeadersForSubscription(request, authType))))
                 .toString();
 
-            LOG.verbose(String.format("Outgoing WebSocket message: %s", jsonMessage));
-
             webSocket.send(jsonMessage);
         } catch (JSONException | ApiException exception) {
             // If the subscriptionId was still pending, then we can call the onSubscriptionError
@@ -273,8 +271,6 @@ final class SubscriptionEndpoint {
                     .put("type", "stop")
                     .put("id", subscriptionId)
                     .toString();
-
-                LOG.verbose(String.format("Outgoing WebSocket message: %s", jsonMessage));
 
                 webSocket.send(jsonMessage);
             } catch (JSONException jsonException) {
@@ -568,8 +564,6 @@ final class SubscriptionEndpoint {
                     .put("type", "connection_init")
                     .toString();
 
-                LOG.verbose(String.format("Outgoing WebSocket message: %s", jsonMessage));
-
                 webSocket.send(jsonMessage);
             } catch (JSONException jsonException) {
                 notifyError(jsonException);
@@ -581,8 +575,6 @@ final class SubscriptionEndpoint {
                 final JSONObject jsonMessage = new JSONObject(message);
                 final SubscriptionMessageType subscriptionMessageType =
                     SubscriptionMessageType.from(jsonMessage.getString("type"));
-
-                LOG.verbose(String.format("Incoming WebSocket message: %s", jsonMessage));
 
                 switch (subscriptionMessageType) {
                     case CONNECTION_ACK:

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -571,12 +571,18 @@ final class SubscriptionEndpoint {
                 final SubscriptionMessageType subscriptionMessageType =
                     SubscriptionMessageType.from(jsonMessage.getString("type"));
 
+                LOG.verbose(String.format("WebSocket message: %s", jsonMessage));
+
                 switch (subscriptionMessageType) {
                     case CONNECTION_ACK:
-                        timeoutWatchdog.start(() -> webSocket.close(
-                                NORMAL_CLOSURE_STATUS,
-                                "WebSocket closed due to timeout."
-                            ),
+                        timeoutWatchdog.start(() -> {
+                                    LOG.warn("WebSocket closed due to timeout.");
+
+                                    webSocket.close(
+                                            NORMAL_CLOSURE_STATUS,
+                                            "WebSocket closed due to timeout."
+                                    );
+                                },
                             Integer.parseInt(
                                 jsonMessage.getJSONObject("payload").getString("connectionTimeoutMs")
                             )

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -148,15 +148,18 @@ final class SubscriptionEndpoint {
         }
 
         try {
-            webSocket.send(new JSONObject()
+            String jsonMessage = new JSONObject()
                 .put("id", subscriptionId)
                 .put("type", "start")
                 .put("payload", new JSONObject()
                 .put("data", request.getContent())
                 .put("extensions", new JSONObject()
                 .put("authorization", authorizer.createHeadersForSubscription(request, authType))))
-                .toString()
-            );
+                .toString();
+
+            LOG.verbose(String.format("Outgoing WebSocket message: %s", jsonMessage));
+
+            webSocket.send(jsonMessage);
         } catch (JSONException | ApiException exception) {
             // If the subscriptionId was still pending, then we can call the onSubscriptionError
             if (pendingSubscriptionIds.remove(subscriptionId)) {
@@ -266,10 +269,14 @@ final class SubscriptionEndpoint {
 
         if (!wasSubscriptionPending && !webSocketListener.isDisconnectedState()) {
             try {
-                webSocket.send(new JSONObject()
+                String jsonMessage = new JSONObject()
                     .put("type", "stop")
                     .put("id", subscriptionId)
-                    .toString());
+                    .toString();
+
+                LOG.verbose(String.format("Outgoing WebSocket message: %s", jsonMessage));
+
+                webSocket.send(jsonMessage);
             } catch (JSONException jsonException) {
                 throw new ApiException(
                     "Failed to construct subscription release message.",
@@ -557,9 +564,13 @@ final class SubscriptionEndpoint {
 
         private void sendConnectionInit(WebSocket webSocket) {
             try {
-                webSocket.send(new JSONObject()
+                String jsonMessage = new JSONObject()
                     .put("type", "connection_init")
-                    .toString());
+                    .toString();
+
+                LOG.verbose(String.format("Outgoing WebSocket message: %s", jsonMessage));
+
+                webSocket.send(jsonMessage);
             } catch (JSONException jsonException) {
                 notifyError(jsonException);
             }
@@ -571,7 +582,7 @@ final class SubscriptionEndpoint {
                 final SubscriptionMessageType subscriptionMessageType =
                     SubscriptionMessageType.from(jsonMessage.getString("type"));
 
-                LOG.verbose(String.format("WebSocket message: %s", jsonMessage));
+                LOG.verbose(String.format("Incoming WebSocket message: %s", jsonMessage));
 
                 switch (subscriptionMessageType) {
                     case CONNECTION_ACK:

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -576,13 +576,13 @@ final class SubscriptionEndpoint {
                 switch (subscriptionMessageType) {
                     case CONNECTION_ACK:
                         timeoutWatchdog.start(() -> {
-                                    LOG.warn("WebSocket closed due to timeout.");
+                            LOG.warn("WebSocket closed due to timeout.");
 
-                                    webSocket.close(
-                                            NORMAL_CLOSURE_STATUS,
-                                            "WebSocket closed due to timeout."
-                                    );
-                                },
+                            webSocket.close(
+                                    NORMAL_CLOSURE_STATUS,
+                                    "WebSocket closed due to timeout."
+                            );
+                        },
                             Integer.parseInt(
                                 jsonMessage.getJSONObject("payload").getString("connectionTimeoutMs")
                             )

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/auth/ApiKeyRequestDecorator.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/auth/ApiKeyRequestDecorator.java
@@ -36,10 +36,8 @@ public final class ApiKeyRequestDecorator implements RequestDecorator {
 
     @Override
     public okhttp3.Request decorate(okhttp3.Request request) {
-        String apiKey = apiKeyProvider.getAPIKey();
-
         return request.newBuilder()
-                      .addHeader(X_API_KEY, apiKey)
+                      .addHeader(X_API_KEY, apiKeyProvider.getAPIKey())
                       .build();
     }
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/auth/ApiKeyRequestDecorator.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/auth/ApiKeyRequestDecorator.java
@@ -36,8 +36,10 @@ public final class ApiKeyRequestDecorator implements RequestDecorator {
 
     @Override
     public okhttp3.Request decorate(okhttp3.Request request) {
+        String apiKey = apiKeyProvider.getAPIKey();
+
         return request.newBuilder()
-                      .addHeader(X_API_KEY, apiKeyProvider.getAPIKey())
+                      .addHeader(X_API_KEY, apiKey)
                       .build();
     }
 }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
@@ -115,6 +115,26 @@ public final class GsonGraphQLResponseFactoryTest {
     }
 
     /**
+     * Validates that an empty response throws an
+     * ApiException instead of returning a null reference.
+     * @throws ApiException From API configuration
+     */
+    @Test
+    public void emptyResponseThrowsApiException() throws ApiException {
+        // Arrange some empty string from a "server"
+        final String emptyResponse = "";
+
+        // Act! Parse it into a model.
+        Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Todo.class);
+        GraphQLRequest<PaginatedResult<Todo>> request = buildDummyRequest(responseType);
+
+        // Assert that the appropriate exception is thrown
+        assertThrows(ApiException.class, () -> {
+            responseFactory.buildResponse(request, emptyResponse);
+        });
+    }
+
+    /**
      * Validates that the converter is able to parse a partial GraphQL
      * response into a result. In this case, the result contains some
      * data, but also a list of errors.

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactoryTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Unit test for implementation of ResponseFactory.
@@ -90,6 +91,27 @@ public final class GsonGraphQLResponseFactoryTest {
         assertFalse(response.hasData());
         assertFalse(response.hasErrors());
         assertEquals(new ArrayList<>(), response.getErrors());
+    }
+
+    /**
+     * Validates that a response with non-Json content throws an
+     * ApiException instead of a RuntimeException.
+     * @throws ApiException From API configuration
+     */
+    @Test
+    public void nonJsonResponseThrowsApiException() throws ApiException {
+        // Arrange some non-JSON string from a "server"
+        final String nonJsonResponse =
+            Resources.readAsString("non-json-gql-response.json");
+
+        // Act! Parse it into a model.
+        Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, Todo.class);
+        GraphQLRequest<PaginatedResult<Todo>> request = buildDummyRequest(responseType);
+
+        // Assert that the appropriate exception is thrown
+        assertThrows(ApiException.class, () -> {
+            responseFactory.buildResponse(request, nonJsonResponse);
+        });
     }
 
     /**

--- a/aws-api/src/test/resources/non-json-gql-response.json
+++ b/aws-api/src/test/resources/non-json-gql-response.json
@@ -1,0 +1,1 @@
+Not a JSON response

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -89,8 +89,6 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
 
     private final AuthModeStrategyType authModeStrategy;
 
-    private final boolean isSyncRetryEnabled;
-
     private final ReachabilityMonitor reachabilityMonitor;
 
     private AWSDataStorePlugin(
@@ -102,7 +100,6 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         this.categoryInitializationsPending = new CountDownLatch(1);
         this.authModeStrategy = AuthModeStrategyType.DEFAULT;
         this.userProvidedConfiguration = userProvidedConfiguration;
-        this.isSyncRetryEnabled = userProvidedConfiguration != null && userProvidedConfiguration.getDoSyncRetry();
         this.reachabilityMonitor = ReachabilityMonitor.Companion.create();
         // Used to interrogate plugins, to understand if sync should be automatically turned on
         this.orchestrator = new Orchestrator(
@@ -111,8 +108,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             sqliteStorageAdapter,
             AppSyncClient.via(api),
             () -> pluginConfiguration,
-            () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API,
-                isSyncRetryEnabled
+            () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API
         );
 
     }
@@ -127,7 +123,6 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         this.authModeStrategy = builder.authModeStrategy == null ?
             AuthModeStrategyType.DEFAULT :
             builder.authModeStrategy;
-        this.isSyncRetryEnabled = builder.isSyncRetryEnabled;
         ApiCategory api = builder.apiCategory == null ? Amplify.API : builder.apiCategory;
         this.userProvidedConfiguration = builder.dataStoreConfiguration;
         this.sqliteStorageAdapter = builder.storageAdapter == null ?
@@ -145,8 +140,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             sqliteStorageAdapter,
             AppSyncClient.via(api, this.authModeStrategy),
             () -> pluginConfiguration,
-            () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API,
-            isSyncRetryEnabled
+            () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API
         );
     }
 
@@ -693,7 +687,6 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         private AuthModeStrategyType authModeStrategy;
         private LocalStorageAdapter storageAdapter;
         private ReachabilityMonitor reachabilityMonitor;
-        private boolean isSyncRetryEnabled;
 
         private Builder() {}
 
@@ -769,16 +762,6 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
          */
         public Builder authModeStrategy(AuthModeStrategyType authModeStrategy) {
             this.authModeStrategy = authModeStrategy;
-            return this;
-        }
-
-        /**
-         * Enables Retry on DataStore sync engine.
-         * @param isSyncRetryEnabled is sync retry enabled.
-         * @return An implementation of the {@link ModelProvider} interface.
-         */
-        public Builder isSyncRetryEnabled(Boolean isSyncRetryEnabled) {
-            this.isSyncRetryEnabled = isSyncRetryEnabled;
             return this;
         }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -774,6 +774,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
 
         /**
          * Enables Retry on DataStore sync engine.
+         * @deprecated This configuration will be deprecated in a future version.
          * @param isSyncRetryEnabled is sync retry enabled.
          * @return An implementation of the {@link ModelProvider} interface.
          */

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -322,6 +322,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         return Completable.fromAction(() -> categoryInitializationsPending.await())
             .timeout(LIFECYCLE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
             .subscribeOn(Schedulers.io())
+            .doOnComplete(() -> LOG.info("DataStore plugin initialized."))
             .doOnError(error -> LOG.error("DataStore initialization timed out.", error));
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
@@ -38,19 +38,19 @@ import java.util.concurrent.TimeUnit;
  * Configuration options for {@link AWSDataStorePlugin}.
  */
 public final class DataStoreConfiguration {
-    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
-
     static final String PLUGIN_CONFIG_KEY = "awsDataStorePlugin";
     @VisibleForTesting
     static final long DEFAULT_SYNC_INTERVAL_MINUTES = TimeUnit.DAYS.toMinutes(1);
     @VisibleForTesting
     static final int DEFAULT_SYNC_MAX_RECORDS = 10_000;
-    @VisibleForTesting 
+    @VisibleForTesting
     static final int DEFAULT_SYNC_PAGE_SIZE = 1_000;
     @VisibleForTesting
     static final boolean DEFAULT_DO_SYNC_RETRY = false;
     static final int MAX_RECORDS = 1000;
     static final long MAX_TIME_SEC = 2;
+
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
 
     private final DataStoreErrorHandler errorHandler;
     private final DataStoreConflictHandler conflictHandler;
@@ -403,6 +403,8 @@ public final class DataStoreConfiguration {
 
         /**
          * Sets the retry enabled on datastore sync.
+         *
+         * @deprecated This configuration will be deprecated in a future version.
          * @param doSyncRetry Is retry enabled on datastore sync
          * @return Current builder instance
          */

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/DataStoreConfiguration.java
@@ -52,7 +52,6 @@ public final class DataStoreConfiguration {
     private final DataStoreConflictHandler conflictHandler;
     private final Integer syncMaxRecords;
     private final Integer syncPageSize;
-    private final boolean doSyncRetry;
     private final Map<String, DataStoreSyncExpression> syncExpressions;
     private final Long syncIntervalInMinutes;
     private final Long maxTimeLapseForObserveQuery;
@@ -65,7 +64,6 @@ public final class DataStoreConfiguration {
         this.syncPageSize = builder.syncPageSize;
         this.syncIntervalInMinutes = builder.syncIntervalInMinutes;
         this.syncExpressions = builder.syncExpressions;
-        this.doSyncRetry = builder.doSyncRetry;
         this.maxTimeLapseForObserveQuery = builder.maxTimeLapseForObserveQuery;
         this.observeQueryMaxRecords = builder.observeQueryMaxRecords;
     }
@@ -121,7 +119,6 @@ public final class DataStoreConfiguration {
             .syncInterval(DEFAULT_SYNC_INTERVAL_MINUTES, TimeUnit.MINUTES)
             .syncPageSize(DEFAULT_SYNC_PAGE_SIZE)
             .syncMaxRecords(DEFAULT_SYNC_MAX_RECORDS)
-                .doSyncRetry(DEFAULT_DO_SYNC_RETRY)
                 .observeQueryMaxTime(MAX_TIME_SEC)
                 .observeQueryMaxRecords(MAX_RECORDS)
             .build();
@@ -188,15 +185,6 @@ public final class DataStoreConfiguration {
     }
 
     /**
-     * Gets the boolean for enabling retry on sync failure
-     * a sync operation.
-     * @return Desired size of a page of results from an AppSync sync response
-     */
-    public Boolean getDoSyncRetry() {
-        return this.doSyncRetry;
-    }
-
-    /**
      * Returns the Map of all {@link DataStoreSyncExpression}s used to filter data received from AppSync, either during
      * a sync or over the real-time subscription.
      * @return the Map of all {@link DataStoreSyncExpression}s.
@@ -233,9 +221,6 @@ public final class DataStoreConfiguration {
         if (!ObjectsCompat.equals(getSyncExpressions(), that.getSyncExpressions())) {
             return false;
         }
-        if (!ObjectsCompat.equals(getDoSyncRetry(), that.getDoSyncRetry())) {
-            return false;
-        }
         if (!ObjectsCompat.equals(getMaxTimeLapseForObserveQuery(), that.getMaxTimeLapseForObserveQuery())) {
             return false;
         }
@@ -253,7 +238,6 @@ public final class DataStoreConfiguration {
         result = 31 * result + (getSyncPageSize() != null ? getSyncPageSize().hashCode() : 0);
         result = 31 * result + (getSyncIntervalInMinutes() != null ? getSyncIntervalInMinutes().hashCode() : 0);
         result = 31 * result + (getSyncExpressions() != null ? getSyncExpressions().hashCode() : 0);
-        result = 31 * result + getDoSyncRetry().hashCode();
         result = 31 * result + (getObserveQueryMaxRecords() != null ? getObserveQueryMaxRecords().hashCode() : 0);
         result = 31 * result + getMaxTimeLapseForObserveQuery().hashCode();
         return result;
@@ -268,7 +252,6 @@ public final class DataStoreConfiguration {
             ", syncPageSize=" + syncPageSize +
             ", syncIntervalInMinutes=" + syncIntervalInMinutes +
             ", syncExpressions=" + syncExpressions +
-                ", doSyncRetry=" + doSyncRetry +
                 ", maxTimeRelapseForObserveQuery=" + maxTimeLapseForObserveQuery +
                 ", observeQueryMaxRecords=" + observeQueryMaxRecords +
             '}';
@@ -303,7 +286,6 @@ public final class DataStoreConfiguration {
         private Long syncIntervalInMinutes;
         private Integer syncMaxRecords;
         private Integer syncPageSize;
-        private boolean doSyncRetry;
         private Map<String, DataStoreSyncExpression> syncExpressions;
         private boolean ensureDefaults;
         private JSONObject pluginJson;
@@ -394,17 +376,6 @@ public final class DataStoreConfiguration {
         @NonNull
         public Builder syncMaxRecords(@IntRange(from = 0) Integer syncMaxRecords) {
             this.syncMaxRecords = syncMaxRecords;
-            return Builder.this;
-        }
-
-        /**
-         * Sets the retry enabled on datastore sync.
-         * @param doSyncRetry Is retry enabled on datastore sync
-         * @return Current builder instance
-         */
-        @NonNull
-        public Builder doSyncRetry(boolean doSyncRetry) {
-            this.doSyncRetry = doSyncRetry;
             return Builder.this;
         }
 
@@ -507,7 +478,6 @@ public final class DataStoreConfiguration {
             syncMaxRecords = getValueOrDefault(userProvidedConfiguration.getSyncMaxRecords(), syncMaxRecords);
             syncPageSize = getValueOrDefault(userProvidedConfiguration.getSyncPageSize(), syncPageSize);
             syncExpressions = userProvidedConfiguration.getSyncExpressions();
-            doSyncRetry = getValueOrDefault(userProvidedConfiguration.getDoSyncRetry(), doSyncRetry);
             observeQueryMaxRecords = getValueOrDefault(userProvidedConfiguration.getObserveQueryMaxRecords(),
                     observeQueryMaxRecords);
             maxTimeLapseForObserveQuery = userProvidedConfiguration.getMaxTimeLapseForObserveQuery()

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -25,6 +25,7 @@ import com.amplifyframework.api.graphql.MutationType;
 import com.amplifyframework.api.graphql.PaginatedResult;
 import com.amplifyframework.api.graphql.QueryType;
 import com.amplifyframework.api.graphql.SubscriptionType;
+import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.AuthRule;
 import com.amplifyframework.core.model.AuthStrategy;
 import com.amplifyframework.core.model.Model;
@@ -50,6 +51,7 @@ import com.amplifyframework.core.model.query.predicate.QueryPredicateGroup;
 import com.amplifyframework.core.model.query.predicate.QueryPredicateOperation;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
+import com.amplifyframework.logging.Logger;
 import com.amplifyframework.util.Casing;
 import com.amplifyframework.util.TypeMaker;
 
@@ -75,6 +77,8 @@ import java.util.Map;
  * and AppSync-specific field names (`_version`, `_deleted`, etc.)
  */
 final class AppSyncRequestFactory {
+    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore");
+
     private AppSyncRequestFactory() {}
 
     /**
@@ -485,6 +489,8 @@ final class AppSyncRequestFactory {
         } else if (modelField.isModel() && fieldValue instanceof Map) {
             return ((Map<?, ?>) fieldValue).get("id");
         } else {
+            LOG.warn(String.format("Can't extract identifier: modelField=%s, isModel=%s, fieldValue=%s",
+                    modelField.getName(), modelField.isModel(), fieldValue));
             throw new IllegalStateException("Associated data is not Model or Map.");
         }
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -339,7 +339,6 @@ final class MutationProcessor {
             @NonNull PendingMutation<T> mutation) {
         List<Class<? extends Throwable>> skipException = new ArrayList<>();
         skipException.add(DataStoreException.GraphQLResponseException.class);
-        skipException.add(ApiException.NonRetryableException.class);
         LOG.info("Started Publish with retry: " + mutation);
         return retryHandler.retry(publishToNetwork(mutation), skipException);
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -80,7 +80,6 @@ public final class Orchestrator {
      *        The reference to the variable returned by the provider only get set after the plugin's
      *        {@link AWSDataStorePlugin#configure(JSONObject, Context)} is invoked by Amplify.
      * @param targetState The desired state of operation - online, or offline
-     * @param isSyncRetryEnabled enable or disable the SyncProcessor retry
      */
     public Orchestrator(
             @NonNull final ModelProvider modelProvider,
@@ -88,8 +87,7 @@ public final class Orchestrator {
             @NonNull final LocalStorageAdapter localStorageAdapter,
             @NonNull final AppSync appSync,
             @NonNull final DataStoreConfigurationProvider dataStoreConfigurationProvider,
-            @NonNull final Supplier<State> targetState,
-            final boolean isSyncRetryEnabled) {
+            @NonNull final Supplier<State> targetState) {
         Objects.requireNonNull(schemaRegistry);
         Objects.requireNonNull(modelProvider);
         Objects.requireNonNull(appSync);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -101,7 +101,6 @@ public final class Orchestrator {
         SyncTimeRegistry syncTimeRegistry = new SyncTimeRegistry(localStorageAdapter);
         ConflictResolver conflictResolver = new ConflictResolver(dataStoreConfigurationProvider, appSync);
         this.queryPredicateProvider = new QueryPredicateProvider(dataStoreConfigurationProvider);
-        RetryHandler retryHandler = new RetryHandler();
 
         this.mutationProcessor = MutationProcessor.builder()
             .merger(merger)
@@ -110,7 +109,7 @@ public final class Orchestrator {
             .mutationOutbox(mutationOutbox)
             .appSync(appSync)
             .conflictResolver(conflictResolver)
-            .retryHandler(retryHandler)
+            .retryHandler(new RetryHandler())
             .build();
         this.syncProcessor = SyncProcessor.builder()
             .modelProvider(modelProvider)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -97,7 +97,6 @@ public final class Orchestrator {
         VersionRepository versionRepository = new VersionRepository(localStorageAdapter);
         Merger merger = new Merger(mutationOutbox, versionRepository, localStorageAdapter);
         SyncTimeRegistry syncTimeRegistry = new SyncTimeRegistry(localStorageAdapter);
-        ConflictResolver conflictResolver = new ConflictResolver(dataStoreConfigurationProvider, appSync);
         this.queryPredicateProvider = new QueryPredicateProvider(dataStoreConfigurationProvider);
 
         this.mutationProcessor = MutationProcessor.builder()
@@ -106,7 +105,7 @@ public final class Orchestrator {
             .schemaRegistry(schemaRegistry)
             .mutationOutbox(mutationOutbox)
             .appSync(appSync)
-            .conflictResolver(conflictResolver)
+            .dataStoreConfigurationProvider(dataStoreConfigurationProvider)
             .retryHandler(new RetryHandler())
             .build();
         this.syncProcessor = SyncProcessor.builder()

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -121,7 +121,6 @@ public final class Orchestrator {
             .dataStoreConfigurationProvider(dataStoreConfigurationProvider)
             .queryPredicateProvider(queryPredicateProvider)
             .retryHandler(new RetryHandler())
-                .isSyncRetryEnabled(isSyncRetryEnabled)
             .build();
         this.subscriptionProcessor = SubscriptionProcessor.builder()
                 .appSync(appSync)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -80,6 +80,7 @@ public final class Orchestrator {
      *        The reference to the variable returned by the provider only get set after the plugin's
      *        {@link AWSDataStorePlugin#configure(JSONObject, Context)} is invoked by Amplify.
      * @param targetState The desired state of operation - online, or offline
+     * @param isSyncRetryEnabled enable or disable the SyncProcessor retry
      */
     public Orchestrator(
             @NonNull final ModelProvider modelProvider,
@@ -87,7 +88,8 @@ public final class Orchestrator {
             @NonNull final LocalStorageAdapter localStorageAdapter,
             @NonNull final AppSync appSync,
             @NonNull final DataStoreConfigurationProvider dataStoreConfigurationProvider,
-            @NonNull final Supplier<State> targetState) {
+            @NonNull final Supplier<State> targetState,
+            final boolean isSyncRetryEnabled) {
         Objects.requireNonNull(schemaRegistry);
         Objects.requireNonNull(modelProvider);
         Objects.requireNonNull(appSync);
@@ -117,6 +119,7 @@ public final class Orchestrator {
             .dataStoreConfigurationProvider(dataStoreConfigurationProvider)
             .queryPredicateProvider(queryPredicateProvider)
             .retryHandler(new RetryHandler())
+                .isSyncRetryEnabled(isSyncRetryEnabled)
             .build();
         this.subscriptionProcessor = SubscriptionProcessor.builder()
                 .appSync(appSync)

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RetryHandler.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RetryHandler.java
@@ -130,7 +130,7 @@ public class RetryHandler {
 
 
     /**
-     * Method returns jittered delay time in milliseconds.
+     * Method returns a jittered 2^numAttempt delay time in milliseconds.
      *
      * @param numAttempt Attempt number.
      * @return delay in milliseconds.

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RetryHandler.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RetryHandler.java
@@ -104,6 +104,11 @@ public class RetryHandler {
 
                     LOG.warn("Attempt #" + (numAttempt.get() + 1) + " failed.", error);
 
+                    if (delay > maxDelayMs) {
+                        LOG.warn("No more attempts left.");
+                        return Observable.error(error);
+                    }
+
                     return Observable.timer(delay, TimeUnit.MILLISECONDS, scheduler).doOnSubscribe(ignore -> {
                         LOG.debug("Retrying in " + delay + " milliseconds.");
 
@@ -131,10 +136,7 @@ public class RetryHandler {
      * @return delay in milliseconds.
      */
     long jitteredDelayMillis(int numAttempt) {
-        return (long) Math.min(
-                maxDelayMs,
-                Duration.ofSeconds((long) Math.pow(2, numAttempt)).toMillis() + (jitterMs * Math.random())
-        );
+        return (long) (Duration.ofSeconds((long) Math.pow(2, numAttempt)).toMillis() + (jitterMs * Math.random()));
     }
 
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RetryHandler.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/RetryHandler.java
@@ -105,7 +105,7 @@ public class RetryHandler {
                     LOG.warn("Attempt #" + (numAttempt.get() + 1) + " failed.", error);
 
                     return Observable.timer(delay, TimeUnit.MILLISECONDS, scheduler).doOnSubscribe(ignore -> {
-                        LOG.info("Retrying in " + delay + " milliseconds.");
+                        LOG.debug("Retrying in " + delay + " milliseconds.");
 
                         numAttempt.getAndIncrement();
                     });

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -273,7 +273,6 @@ final class SyncProcessor {
 
         // We don't want to treat DataStoreException.GraphQLResponseException as non retryable here because we want to
         // support merging the applicable data if any.
-        // TODO: Merge applicable data if any, and log errors
         List<Class<? extends Throwable>> nonRetryableExceptions = new ArrayList<>();
         nonRetryableExceptions.add(DataStoreException.IrRecoverableException.class);
         nonRetryableExceptions.add(ApiException.NonRetryableException.class);
@@ -281,9 +280,6 @@ final class SyncProcessor {
         return requestRetry.retry(Single.create(emitter -> {
             Cancelable cancelable = appSync.sync(request, result -> {
                 if (result.hasErrors()) {
-                    // TODO: Check if there is applicable data, if so, emit it but also log the errors.
-                    //  For now, we treat any error as irrecoverable
-
                     emitter.onError(new DataStoreException.IrRecoverableException(
                             String.format("A model sync failed: %s", result.getErrors()),
                             "Check your schema."

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -270,9 +270,9 @@ final class SyncProcessor {
      */
     private <T extends Model> Single<PaginatedResult<ModelWithMetadata<T>>> syncPage(
             GraphQLRequest<PaginatedResult<ModelWithMetadata<T>>> request) {
-        List<Class<? extends Throwable>> skipException = new ArrayList<>();
-        skipException.add(DataStoreException.GraphQLResponseException.class);
-        skipException.add(ApiException.NonRetryableException.class);
+        List<Class<? extends Throwable>> nonRetryableExceptions = new ArrayList<>();
+        nonRetryableExceptions.add(DataStoreException.IrRecoverableException.class);
+        nonRetryableExceptions.add(ApiException.NonRetryableException.class);
 
         return requestRetry.retry(Single.create(emitter -> {
             Cancelable cancelable = appSync.sync(request, result -> {
@@ -290,7 +290,7 @@ final class SyncProcessor {
                 }
             }, emitter::onError);
             emitter.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
-        }), skipException);
+        }), nonRetryableExceptions);
     }
 
     /**

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -77,7 +77,7 @@ final class SyncProcessor {
 
     /**
      * The `isSyncRetryEnabled` value is being passed down all the way from the `AWSDataStorePlugin` or the
-     * `DataStoreConfiguration` where it's named `doSyncRetry`
+     * `DataStoreConfiguration` where it's named `doSyncRetry`.
      */
     private final boolean isSyncRetryEnabled;
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
@@ -112,6 +112,8 @@ public final class DataStoreConfigurationTest {
 
         DataStoreSyncExpression ownerSyncExpression = () -> BlogOwner.ID.beginsWith(RandomString.string());
         DataStoreSyncExpression postSyncExpression = () -> Post.ID.beginsWith(RandomString.string());
+
+        @SuppressWarnings("deprecation")
         DataStoreConfiguration configObject = DataStoreConfiguration
             .builder()
             .syncMaxRecords(expectedSyncMaxRecords)

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -65,6 +66,7 @@ public final class DataStoreConfigurationTest {
         assertTrue(dataStoreConfiguration.getConflictHandler() instanceof AlwaysApplyRemoteHandler);
         assertTrue(dataStoreConfiguration.getErrorHandler() instanceof DefaultDataStoreErrorHandler);
         assertEquals(Collections.emptyMap(), dataStoreConfiguration.getSyncExpressions());
+        assertFalse(dataStoreConfiguration.getDoSyncRetry());
     }
 
     /**
@@ -117,6 +119,7 @@ public final class DataStoreConfigurationTest {
             .errorHandler(errorHandler)
             .syncExpression(BlogOwner.class, ownerSyncExpression)
             .syncExpression("Post", postSyncExpression)
+                .doSyncRetry(true)
             .build();
 
         JSONObject jsonConfigFromFile = new JSONObject()
@@ -129,6 +132,7 @@ public final class DataStoreConfigurationTest {
         assertEquals(expectedSyncMaxRecords, dataStoreConfiguration.getSyncMaxRecords());
         assertEquals(DataStoreConfiguration.DEFAULT_SYNC_PAGE_SIZE,
             dataStoreConfiguration.getSyncPageSize().longValue());
+        assertTrue(dataStoreConfiguration.getDoSyncRetry());
 
         assertEquals(dummyConflictHandler, dataStoreConfiguration.getConflictHandler());
         assertEquals(errorHandler, dataStoreConfiguration.getErrorHandler());

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/DataStoreConfigurationTest.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -66,7 +65,6 @@ public final class DataStoreConfigurationTest {
         assertTrue(dataStoreConfiguration.getConflictHandler() instanceof AlwaysApplyRemoteHandler);
         assertTrue(dataStoreConfiguration.getErrorHandler() instanceof DefaultDataStoreErrorHandler);
         assertEquals(Collections.emptyMap(), dataStoreConfiguration.getSyncExpressions());
-        assertFalse(dataStoreConfiguration.getDoSyncRetry());
     }
 
     /**
@@ -119,7 +117,6 @@ public final class DataStoreConfigurationTest {
             .errorHandler(errorHandler)
             .syncExpression(BlogOwner.class, ownerSyncExpression)
             .syncExpression("Post", postSyncExpression)
-                .doSyncRetry(true)
             .build();
 
         JSONObject jsonConfigFromFile = new JSONObject()
@@ -132,7 +129,6 @@ public final class DataStoreConfigurationTest {
         assertEquals(expectedSyncMaxRecords, dataStoreConfiguration.getSyncMaxRecords());
         assertEquals(DataStoreConfiguration.DEFAULT_SYNC_PAGE_SIZE,
             dataStoreConfiguration.getSyncPageSize().longValue());
-        assertTrue(dataStoreConfiguration.getDoSyncRetry());
 
         assertEquals(dummyConflictHandler, dataStoreConfiguration.getConflictHandler());
         assertEquals(errorHandler, dataStoreConfiguration.getErrorHandler());

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/MutationProcessorRetryTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/MutationProcessorRetryTest.java
@@ -85,7 +85,6 @@ public final class MutationProcessorRetryTest {
     @Before
     public void setup() throws AmplifyException {
         this.context = getApplicationContext();
-        modelProvider = spy(AmplifyCliGeneratedModelProvider.singletonInstance());
         this.modelProvider = spy(AmplifyCliGeneratedModelProvider.singletonInstance());
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -99,7 +99,7 @@ public final class MutationProcessorTest {
         this.appSync = mock(AppSync.class);
         this.configurationProvider = mock(DataStoreConfigurationProvider.class);
         ConflictResolver conflictResolver = new ConflictResolver(configurationProvider, appSync);
-        RetryHandler retryHandler = new RetryHandler(1, 1, 2, 1);
+        RetryHandler retryHandler = new RetryHandler(1, 2, 1);
         schemaRegistry = SchemaRegistry.instance();
         schemaRegistry.register(Collections.singleton(BlogOwner.class));
         this.mutationProcessor = MutationProcessor.builder()
@@ -359,18 +359,19 @@ public final class MutationProcessorTest {
                     invocation.getArgument(indexOfResponseConsumer);
             ModelMetadata modelMetadata = new ModelMetadata(model.getId(), false, 1,
                     Temporal.Timestamp.now());
-            ModelWithMetadata<BlogOwner> modelWithMetadata = new ModelWithMetadata<BlogOwner>(model,
+
+            ModelWithMetadata<BlogOwner> modelWithMetadata = new ModelWithMetadata<>(model,
                     modelMetadata);
             retryHandlerInvocationCount.countDown();
             onResponse.accept(new GraphQLResponse<>(modelWithMetadata, Collections.emptyList()));
             // latch makes sure success response is returned.
             return mock(GraphQLOperation.class);
-        }).when(appSync).update(ArgumentMatchers.<BlogOwner>any(),
+        }).when(appSync).update(ArgumentMatchers.any(),
                 any(ModelSchema.class),
                 anyInt(),
                 any(QueryPredicate.class),
                 ArgumentMatchers.<Consumer<GraphQLResponse<ModelWithMetadata<BlogOwner>>>>any(),
-                ArgumentMatchers.<Consumer<DataStoreException>>any());
+                ArgumentMatchers.any());
 
         ModelSchema schema = schemaRegistry.getModelSchemaForModelClass(BlogOwner.class);
         LastSyncMetadata lastSyncMetadata = LastSyncMetadata.baseSyncedAt(schema.getName(),

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -99,7 +99,6 @@ public final class MutationProcessorTest {
         Merger merger = new Merger(mutationOutbox, versionRepository, localStorageAdapter);
         this.appSync = mock(AppSync.class);
         this.configurationProvider = mock(DataStoreConfigurationProvider.class);
-        ConflictResolver conflictResolver = new ConflictResolver(configurationProvider, appSync);
         RetryHandler retryHandler = new RetryHandler(0, Duration.ofMinutes(1).toMillis());
         schemaRegistry = SchemaRegistry.instance();
         schemaRegistry.register(Collections.singleton(BlogOwner.class));
@@ -109,7 +108,7 @@ public final class MutationProcessorTest {
                 .schemaRegistry(schemaRegistry)
                 .mutationOutbox(mutationOutbox)
                 .appSync(appSync)
-                .conflictResolver(conflictResolver)
+                .dataStoreConfigurationProvider(configurationProvider)
                 .retryHandler(retryHandler)
                 .build();
     }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -48,6 +48,7 @@ import org.mockito.ArgumentMatchers;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.shadows.ShadowLog;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -99,7 +100,7 @@ public final class MutationProcessorTest {
         this.appSync = mock(AppSync.class);
         this.configurationProvider = mock(DataStoreConfigurationProvider.class);
         ConflictResolver conflictResolver = new ConflictResolver(configurationProvider, appSync);
-        RetryHandler retryHandler = new RetryHandler(0, 1);
+        RetryHandler retryHandler = new RetryHandler(0, Duration.ofMinutes(1).toMillis());
         schemaRegistry = SchemaRegistry.instance();
         schemaRegistry.register(Collections.singleton(BlogOwner.class));
         this.mutationProcessor = MutationProcessor.builder()

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationProcessorTest.java
@@ -99,7 +99,7 @@ public final class MutationProcessorTest {
         this.appSync = mock(AppSync.class);
         this.configurationProvider = mock(DataStoreConfigurationProvider.class);
         ConflictResolver conflictResolver = new ConflictResolver(configurationProvider, appSync);
-        RetryHandler retryHandler = new RetryHandler(1, 2, 1);
+        RetryHandler retryHandler = new RetryHandler(0, 1);
         schemaRegistry = SchemaRegistry.instance();
         schemaRegistry.register(Collections.singleton(BlogOwner.class));
         this.mutationProcessor = MutationProcessor.builder()

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -110,7 +110,8 @@ public final class OrchestratorTest {
                 localStorageAdapter,
                 appSync,
                 DataStoreConfiguration::defaults,
-                () -> Orchestrator.State.SYNC_VIA_API
+                () -> Orchestrator.State.SYNC_VIA_API,
+                    true
             );
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -110,8 +110,7 @@ public final class OrchestratorTest {
                 localStorageAdapter,
                 appSync,
                 DataStoreConfiguration::defaults,
-                () -> Orchestrator.State.SYNC_VIA_API,
-                    true
+                () -> Orchestrator.State.SYNC_VIA_API
             );
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/RetryHandlerTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/RetryHandlerTest.java
@@ -123,7 +123,7 @@ public class RetryHandlerTest {
     @Test
     public void testRetryOnRecoverableError() {
         //arrange
-        RetryHandler subject = new RetryHandler(0, 1);
+        RetryHandler subject = new RetryHandler(0, Duration.ofMinutes(1).toMillis());
         DataStoreException expectedException =
                 new DataStoreException("PaginatedResult<ModelWithMetadata<BlogOwner>>", "");
         AtomicInteger count = new AtomicInteger(0);
@@ -192,7 +192,7 @@ public class RetryHandlerTest {
     @Test
     public void testJitteredDelaySecReturnsNoMoreThanMaxValue() {
         //arrange
-        long maxDelayMs = Duration.ofSeconds(1).toMillis();
+        long maxDelayMs = Duration.ofSeconds(4).toMillis();
         RetryHandler subject = new RetryHandler(0, maxDelayMs);
         //act
         long delay = subject.jitteredDelayMillis(2);

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -111,8 +111,6 @@ public final class SyncProcessorTest {
     private int errorHandlerCallCount;
     private int modelCount;
     private RetryHandler requestRetry;
-    private boolean isSyncRetryEnabled = true;
-
 
     /**
      * Wire up dependencies for the SyncProcessor, and build one for testing.
@@ -168,7 +166,6 @@ public final class SyncProcessorTest {
             .dataStoreConfigurationProvider(dataStoreConfigurationProvider)
             .queryPredicateProvider(queryPredicateProvider)
             .retryHandler(requestRetry)
-            .isSyncRetryEnabled(isSyncRetryEnabled)
             .build();
     }
 
@@ -632,31 +629,6 @@ public final class SyncProcessorTest {
                 .test(false)
                 .assertNotComplete();
         verify(requestRetry, times(1)).retry(any(), any());
-
-    }
-
-    /**
-     * Verify that retry is called on appsync failure when syncRetry is set to true.
-     *
-     * @throws AmplifyException On failure to build GraphQLRequest for sync query.
-     */
-    @Test
-    public void shouldNotRetryOnAppSyncFailureWhenSynRetryIsSetToFalse() throws AmplifyException {
-        // Arrange: mock failure when invoking hydrate on the mock object.
-        requestRetry = mock(RetryHandler.class);
-        isSyncRetryEnabled = false;
-        when(requestRetry.retry(any(), any())).thenReturn(Single.error(
-                new DataStoreException("PaginatedResult<ModelWithMetadata<BlogOwner>>", "")));
-
-        initSyncProcessor(10_000);
-        AppSyncMocking.sync(appSync)
-                .mockFailure(new DataStoreException("Something timed out during sync.", ""));
-
-        // Act: call hydrate.
-        syncProcessor.hydrate()
-                .test(false)
-                .assertNotComplete();
-        verify(requestRetry, times(0)).retry(any(), any());
 
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -110,6 +110,7 @@ public final class SyncProcessorTest {
     private int errorHandlerCallCount;
     private int modelCount;
     private RetryHandler requestRetry;
+    private boolean isSyncRetryEnabled = true;
 
     /**
      * Wire up dependencies for the SyncProcessor, and build one for testing.
@@ -165,6 +166,7 @@ public final class SyncProcessorTest {
             .dataStoreConfigurationProvider(dataStoreConfigurationProvider)
             .queryPredicateProvider(queryPredicateProvider)
             .retryHandler(requestRetry)
+            .isSyncRetryEnabled(isSyncRetryEnabled)
             .build();
     }
 
@@ -627,6 +629,31 @@ public final class SyncProcessorTest {
                 .test(false)
                 .assertNotComplete();
         verify(requestRetry, times(1)).retry(any(), any());
+
+    }
+
+    /**
+     * Verify that retry is called on appsync failure when syncRetry is set to true.
+     *
+     * @throws AmplifyException On failure to build GraphQLRequest for sync query.
+     */
+    @Test
+    public void shouldNotRetryOnAppSyncFailureWhenSynRetryIsSetToFalse() throws AmplifyException {
+        // Arrange: mock failure when invoking hydrate on the mock object.
+        requestRetry = mock(RetryHandler.class);
+        isSyncRetryEnabled = false;
+        when(requestRetry.retry(any(), any())).thenReturn(Single.error(
+                new DataStoreException("PaginatedResult<ModelWithMetadata<BlogOwner>>", "")));
+
+        initSyncProcessor(10_000);
+        AppSyncMocking.sync(appSync)
+                .mockFailure(new DataStoreException("Something timed out during sync.", ""));
+
+        // Act: call hydrate.
+        syncProcessor.hydrate()
+                .test(false)
+                .assertNotComplete();
+        verify(requestRetry, times(0)).retry(any(), any());
 
     }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -19,7 +19,6 @@ import android.util.Range;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.GraphQLRequest;
-import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.PaginatedResult;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
@@ -593,8 +592,7 @@ public final class SyncProcessorTest {
         // Arrange: mock failure when invoking hydrate on the mock object.
         AppSyncMocking.sync(appSync)
             .mockFailure(new DataStoreException
-                    .GraphQLResponseException("Something timed out during sync.",
-                    new ArrayList<GraphQLResponse.Error>()));
+                    .IrRecoverableException("Something timed out during sync.", "This was intentional"));
 
         // Act: call hydrate.
         assertTrue(


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

- Fixes: #1637
- Fixes: #1794
- Fixes: #1865 
- Fixes: #2077 

*Description of changes:*
- Call errorHandler on mutation errors
- ~Log network responses~
- Don't die on non-json responses
- Remove unused constant
- ~Log WebSocket incoming/outgoing messages~
- ~Remove~ Deprecate `isSyncRetryEnabled` from `AWSDataStorePlugin`
-  ~Remove~ Deprecate `doSyncRetry` from `DataStoreConfiguration`
- Log ConflictHandler calls
- Adjust non-retryable errors in `MutationProcessor` and `SyncProcessor`
- Align RetryHandler logic with other platforms
- ~Remove optional retry of errors in sync~ Log a warning when disabling sync retries

*How did you test these changes?*
- Wrote additional unit tests
- Manual testing with emulator
- Simulation of different network conditions via a MITM (e.g. 5XX, 4XX, timeouts, connection resets, etc)

- [x] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update)
  - aws-amplify/docs#4986

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
