### PR TITLE
fix(datastore): Fix lock contention issue when running DataStore.start() from the callback of DataStore.stop()

### DIFF
--- a/aws-datastore/build.gradle
+++ b/aws-datastore/build.gradle
@@ -38,7 +38,10 @@ dependencies {
     testImplementation dependency.robolectric
     testImplementation dependency.androidx.test.core
     testImplementation dependency.mockk
+    testImplementation project(path: ':aws-datastore')
 
+
+    androidTestImplementation project(path: ':aws-datastore')
     androidTestImplementation dependency.mockito
     androidTestImplementation project(path: ':testmodels')
     androidTestImplementation project(path: ':testutils')

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StartStopInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/StartStopInstrumentationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import android.content.Context;
+
+import androidx.annotation.RawRes;
+
+import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.ApiCategory;
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.logging.AndroidLoggingPlugin;
+import com.amplifyframework.logging.LogLevel;
+import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider;
+import com.amplifyframework.testutils.Resources;
+import com.amplifyframework.testutils.sync.SynchronousDataStore;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests running DataStore.stop() and then calling DataStore.start() from within the stop() callback.
+ * This is the recommended method for resetting sync expressions in the Amplify documentation but
+ * previously it did not work due to a lock contention issue, so this test is added to confirm the
+ * fix.
+ */
+public final class StartStopInstrumentationTest {
+    private static final int TIMEOUT_SECONDS = 60;
+    private static SynchronousDataStore dataStore;
+    private static DataStoreCategory dataStoreCategory;
+
+    @BeforeClass
+    public static void setup() throws AmplifyException {
+        Amplify.addPlugin(new AndroidLoggingPlugin(LogLevel.VERBOSE));
+
+        StrictMode.enable();
+        Context context = getApplicationContext();
+        @RawRes int configResourceId = Resources.getRawResourceId(context, "amplifyconfigurationupdated");
+
+        ApiCategory apiCategory = new ApiCategory();
+
+        dataStoreCategory = DataStoreCategoryConfigurator.begin()
+                .api(apiCategory)
+                .clearDatabase(true)
+                .context(context)
+                .modelProvider(AmplifyModelProvider.getInstance())
+                .resourceId(configResourceId)
+                .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .finish();
+        dataStore = SynchronousDataStore.delegatingTo(dataStoreCategory);
+    }
+
+    @AfterClass
+    public static void teardown() throws DataStoreException {
+        if (dataStore != null) {
+            try {
+                dataStore.clear();
+            } catch (Exception error) {
+                // ok to ignore since problem encountered during tear down of the test.
+            }
+        }
+    }
+
+    @Test
+    public void testStartStop() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(2);
+        dataStoreCategory.stop(() -> {
+            latch.countDown();
+            dataStoreCategory.start(
+                    latch::countDown,
+                    (error) -> {
+                        throw new RuntimeException(error);
+                    }
+            );
+        }, (error) -> {
+            throw new RuntimeException(error);
+        });
+        latch.await(10, TimeUnit.SECONDS);
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -183,11 +183,14 @@ public final class Orchestrator {
         }
         LOG.info("Orchestrator lock acquired.");
         return Completable.fromAction(action)
-            .doFinally(() -> {
-                startStopSemaphore.release();
-                LOG.info("Orchestrator lock released.");
-            }
-        );
+            .andThen(
+                Completable.fromAction(
+                    () -> {
+                        startStopSemaphore.release();
+                        LOG.info("Orchestrator lock released.");
+                    }
+                )
+            );
     }
 
     private void unknownState(State state) throws DataStoreException {


### PR DESCRIPTION

- [x ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

Fix lock contention issue when running DataStore.start() from the callback of DataStore.stop(), as suggested in the Amplify documentation here: DataStore.start() from the callback of DataStore.stop()

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [x] Added Integration Tests
- [x] Ran existing unit tests
- [ x] Manual testing

*Documentation update required?*
- [ x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
