### PR TITLE
chore: Add group and version back to all subprojects

### DIFF
--- a/aws-analytics-pinpoint/build.gradle
+++ b/aws-analytics-pinpoint/build.gradle
@@ -22,6 +22,8 @@ apply from: rootProject.file("configuration/publishing.gradle")
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
+group = POM_GROUP
+
 dependencies {
     implementation project(path: ':core')
     implementation project(path: ':aws-auth-cognito')
@@ -46,4 +48,3 @@ dependencies {
     implementation dependency.androidx.test.junit
     androidTestImplementation project(path: ':aws-analytics-pinpoint')
 }
-

--- a/aws-api-appsync/build.gradle
+++ b/aws-api-appsync/build.gradle
@@ -17,6 +17,8 @@ apply plugin: 'com.android.library'
 apply from: rootProject.file('configuration/checkstyle.gradle')
 apply from: rootProject.file('configuration/publishing.gradle')
 
+group = POM_GROUP
+
 dependencies {
     implementation project(':core')
 

--- a/aws-api/build.gradle
+++ b/aws-api/build.gradle
@@ -18,6 +18,8 @@ apply plugin: 'kotlin-android'
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 
+group = POM_GROUP
+
 dependencies {
     api project(':core')
     implementation project(':aws-api-appsync')
@@ -45,4 +47,3 @@ dependencies {
     androidTestImplementation dependency.androidx.test.junit
     androidTestImplementation dependency.rxjava
 }
-

--- a/aws-auth-cognito/build.gradle
+++ b/aws-auth-cognito/build.gradle
@@ -22,6 +22,8 @@ apply plugin: 'kotlin-android'
 apply from: rootProject.file("configuration/publishing.gradle")
 apply from: rootProject.file("configuration/checkstyle.gradle")
 
+group = POM_GROUP
+
 dependencies {
     implementation project(path: ':core')
     implementation dependency.kotlin.coroutines

--- a/aws-geo-location/build.gradle
+++ b/aws-geo-location/build.gradle
@@ -18,6 +18,8 @@ apply plugin: 'kotlin-android'
 apply from: rootProject.file('configuration/checkstyle.gradle')
 apply from: rootProject.file('configuration/publishing.gradle')
 
+group = POM_GROUP
+
 dependencies {
     implementation project(':core')
     // ToDo: Remove fixed dependency to cognito and abstract it to core
@@ -39,4 +41,3 @@ dependencies {
 afterEvaluate {
     it.android.kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
 }
-

--- a/aws-predictions-tensorflow/build.gradle
+++ b/aws-predictions-tensorflow/build.gradle
@@ -17,6 +17,8 @@ apply plugin: 'com.android.library'
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 
+group = POM_GROUP
+
 dependencies {
     implementation project(':core')
     implementation dependency.androidx.appcompat
@@ -26,4 +28,3 @@ dependencies {
     testImplementation dependency.junit
     testImplementation dependency.mockito
 }
-

--- a/aws-predictions/build.gradle
+++ b/aws-predictions/build.gradle
@@ -18,6 +18,8 @@ apply plugin: 'kotlin-android'
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 
+group = POM_GROUP
+
 dependencies {
     implementation project(path: ':core')
     implementation project(path: ':aws-auth-cognito')
@@ -39,4 +41,3 @@ dependencies {
     androidTestImplementation dependency.mockkandroid
     androidTestImplementation dependency.rxjava
 }
-

--- a/aws-storage-s3/build.gradle
+++ b/aws-storage-s3/build.gradle
@@ -18,6 +18,8 @@ apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 apply plugin: 'kotlin-android'
 
+group = POM_GROUP
+
 dependencies {
     implementation project(path: ':core')
     implementation project(path: ':aws-auth-cognito')
@@ -46,4 +48,3 @@ dependencies {
     androidTestImplementation dependency.androidx.test.workmanager
     androidTestImplementation project(path: ':aws-storage-s3')
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,8 @@ ext {
 }
 
 subprojects { project ->
+    project.group = POM_GROUP
+
     apply plugin: 'org.jlleitschuh.gradle.ktlint'
     ktlint {
         android.set(true)

--- a/configuration/publishing.gradle
+++ b/configuration/publishing.gradle
@@ -17,6 +17,8 @@
 apply plugin: 'signing'
 apply plugin: 'maven-publish'
 
+version = project.ext.VERSION_NAME
+
 def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
 }
@@ -131,4 +133,3 @@ afterEvaluate { project ->
         }
     }
 }
-

--- a/core-kotlin/build.gradle
+++ b/core-kotlin/build.gradle
@@ -17,6 +17,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply from: rootProject.file("configuration/publishing.gradle")
 
+group = POM_GROUP
+
 dependencies {
     implementation dependency.kotlin.stdlib
     implementation dependency.kotlin.coroutines

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,6 +18,8 @@ apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 apply plugin: 'kotlin-android'
 
+group = POM_GROUP
+
 android {
     kotlinOptions{
         moduleName = "com.amplifyframework.core"

--- a/maplibre-adapter/build.gradle
+++ b/maplibre-adapter/build.gradle
@@ -21,6 +21,8 @@ plugins {
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 
+group = POM_GROUP
+
 ext {
     minSdkVersion = 24
 }

--- a/rxbindings/build.gradle
+++ b/rxbindings/build.gradle
@@ -21,6 +21,8 @@ plugins {
 apply from: rootProject.file("configuration/checkstyle.gradle")
 apply from: rootProject.file("configuration/publishing.gradle")
 
+group = POM_GROUP
+
 dependencies {
     implementation project(path: ':core')
     implementation dependency.androidx.annotation


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Version and group are specified for each subproject. These are required for building the dependencies section of the pom file. Adding the group in each build.gradle avoids errors when using the framework as an included build.

*How did you test these changes?*
- Published artifacts to maven local and ensured the dependencies sections were correct
- Pulled framework into test app as an included build and ensured app built correctly

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
