### PR TITLE
feat(geo): Submit multiple batches of locations in one WorkManager run

### DIFF
--- a/aws-geo-location/build.gradle
+++ b/aws-geo-location/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation dependency.androidx.sqlite
 
     testImplementation project(':testutils')
+    testImplementation dependency.androidx.test.core
+    testImplementation dependency.androidx.test.workmanager
     testImplementation dependency.junit
     testImplementation dependency.robolectric
     testImplementation dependency.mockk

--- a/aws-geo-location/src/test/java/com/amplifyframework/geo/location/tracking/BatchLocationUpdateTest.kt
+++ b/aws-geo-location/src/test/java/com/amplifyframework/geo/location/tracking/BatchLocationUpdateTest.kt
@@ -1,0 +1,135 @@
+/*
+ *
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ *
+ */
+
+package com.amplifyframework.geo.location.tracking
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.TestListenableWorkerBuilder
+import aws.sdk.kotlin.services.location.LocationClient
+import aws.sdk.kotlin.services.location.model.BatchUpdateDevicePositionResponse
+import aws.sdk.kotlin.services.location.model.DevicePositionUpdate
+import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
+import com.amplifyframework.geo.location.database.LocationDao
+import com.amplifyframework.geo.location.database.worker.UploadWorker
+import com.amplifyframework.geo.location.service.AmazonLocationService
+import com.amplifyframework.geo.models.GeoLocation
+import com.amplifyframework.geo.models.GeoPosition
+import com.amplifyframework.geo.options.GeoTrackingSessionOptions
+import com.amplifyframework.geo.options.GeoUpdateLocationOptions
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Instant.now
+import java.util.Date
+
+@RunWith(RobolectricTestRunner::class)
+class BatchLocationUpdateTest {
+    private lateinit var uploadWorker: UploadWorker
+    private lateinit var context: Context
+    private lateinit var geoService: AmazonLocationService
+    private lateinit var mockLocationDao: LocationDao
+    private val id = "ID"
+    private val tracker = "TRACKER"
+    private val mockAlsClient = mockk<LocationClient>(relaxed = true)
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        val mockCredentialsProvider: CredentialsProvider = mockk()
+
+        mockkObject(LocationClient.Companion)
+        every {LocationClient.invoke(any<LocationClient.Config>())}.returns(mockAlsClient)
+        every {LocationClient.invoke(any<LocationClient.Config.Builder.() -> Unit>())}.returns(mockAlsClient)
+        coEvery {mockAlsClient.batchUpdateDevicePosition(any())}.returns(
+            BatchUpdateDevicePositionResponse.invoke {  })
+
+        geoService = AmazonLocationService(mockCredentialsProvider, "placeholder region")
+        UploadWorker.geoService = geoService
+        UploadWorker.deviceId = id
+        mockLocationDao = mockk()
+        coEvery {mockLocationDao.removeAll(any())}.returns(0)
+        UploadWorker.locationDao = mockLocationDao
+        UploadWorker.options = GeoTrackingSessionOptions.defaults()
+        uploadWorker = TestListenableWorkerBuilder<UploadWorker>(context)
+            .build()
+    }
+
+    @Test
+    fun `writes batch of locations to database`() {
+        runBlocking {
+            val positionList = mutableListOf(
+                position(65.0, 75.0),
+                position(66.0, 75.0),
+            )
+
+            geoService.updateLocations(id, positionList, GeoUpdateLocationOptions.defaults())
+
+            positionList.clear()
+            positionList.add(position(67.0, 75.0))
+            positionList.add(position(68.0, 75.0))
+            positionList.add(position(69.0, 75.0))
+
+            geoService.updateLocations(id, positionList, GeoUpdateLocationOptions.defaults())
+        }
+
+
+        coVerify {mockAlsClient.batchUpdateDevicePosition(withArg { request ->
+            when (request.updates!!.size) {
+                2 -> {
+                    // batch 1
+                    assertEq(request.updates!![0], position(65.0, 75.0))
+                    assertEq(request.updates!![1], position(66.0, 75.0))
+                }
+                3 -> {
+                    // batch 2
+                    assertEq(request.updates!![0], position(67.0, 75.0))
+                    assertEq(request.updates!![1], position(68.0, 75.0))
+                    assertEq(request.updates!![2], position(69.0, 75.0))
+                }
+                else -> assert(false)
+            }
+        })}
+
+        confirmVerified(mockAlsClient)
+    }
+
+    private fun position(lat: Double = 45.0, long: Double = 45.0): GeoPosition {
+        val pos = GeoPosition()
+        pos.location = GeoLocation(lat, long)
+        pos.deviceID = id
+        pos.timeStamp = Date.from(now())
+        pos.tracker = tracker
+        return pos
+    }
+
+    private fun assertEq(p1: DevicePositionUpdate, p2: GeoPosition) {
+        assertEquals(p1.position!![1], p2.location.latitude, .001)
+        assertEquals(p1.position!![0], p2.location.longitude, .001)
+        assert(p1.deviceId == p2.deviceID)
+    }
+}

--- a/aws-geo-location/src/test/java/com/amplifyframework/geo/location/tracking/LocationTrackingServiceTest.kt
+++ b/aws-geo-location/src/test/java/com/amplifyframework/geo/location/tracking/LocationTrackingServiceTest.kt
@@ -20,7 +20,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**

--- a/aws-geo-location/src/test/java/com/amplifyframework/geo/location/tracking/UploadWorkerTest.kt
+++ b/aws-geo-location/src/test/java/com/amplifyframework/geo/location/tracking/UploadWorkerTest.kt
@@ -1,0 +1,257 @@
+/*
+ *
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ *
+ */
+
+package com.amplifyframework.geo.location.tracking
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.amplifyframework.geo.location.database.LocationDao
+import com.amplifyframework.geo.location.database.LocationEntity
+import com.amplifyframework.geo.location.database.worker.UploadWorker
+import com.amplifyframework.geo.location.service.AmazonLocationService
+import com.amplifyframework.geo.models.GeoLocation
+import com.amplifyframework.geo.models.GeoPosition
+import com.amplifyframework.geo.options.BatchingOptions
+import com.amplifyframework.geo.options.GeoTrackingSessionOptions
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.Runs
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Instant
+import java.util.Date
+
+/**
+ * Unit tests for the [UploadWorker] class.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class UploadWorkerTest {
+    private lateinit var uploadWorker: UploadWorker
+    private lateinit var context: Context
+    private lateinit var mockGeoService: AmazonLocationService
+    private lateinit var mockLocationDao: LocationDao
+    private val id = "ID"
+    private val tracker = "TRACKER"
+    private val lat = 47.6154086
+    private val long = -122.3349685
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        mockGeoService = mockk()
+        coEvery {mockGeoService.updateLocations(any(), any(), any())}.returns(Unit)
+        UploadWorker.geoService = mockGeoService
+        UploadWorker.deviceId = id
+        mockLocationDao = mockk()
+        coEvery {mockLocationDao.removeAll(any())}.returns(0)
+        UploadWorker.locationDao = mockLocationDao
+        UploadWorker.options = GeoTrackingSessionOptions.defaults()
+        uploadWorker = TestListenableWorkerBuilder<UploadWorker>(context)
+            .build()
+    }
+
+    @Test
+    fun `uploads locations`() {
+        val now = Instant.now()
+        coEvery {mockLocationDao.getAll()}.returns(
+            listOf(LocationEntity(1, id, tracker, now, lat, long))
+        )
+
+        runBlocking {
+            val result = uploadWorker.doWork()
+            assertTrue(result.outputData.size() == 0) // success!
+            coVerify { mockLocationDao.getAll() }
+            coVerify { mockGeoService.updateLocations(id, withArg {
+                assertTrue(it.size == 1)
+                val position = it[0]
+                assertTrue(position.deviceID == id)
+                assertTrue(position.tracker == tracker)
+                assertTrue(position.location.latitude == lat)
+                assertTrue(position.location.longitude == long)
+            }, any()) }
+            coVerify { mockLocationDao.removeAll(withArg {
+                assertTrue(it.size == 1)
+                val position = (it as List<LocationEntity>)[0]
+                assertTrue(position.deviceId == id)
+                assertTrue(position.tracker == tracker)
+                assertTrue(position.latitude == lat)
+                assertTrue(position.longitude == long)
+            }) }
+        }
+        confirmVerified(mockGeoService, mockLocationDao)
+    }
+
+    @Test
+    fun `batches locations by distance`() {
+        // setup: 5 locations, with distance-based batching.  the third location barely does not exceed the distance,
+        // so we start a new batch after processing location 3.  locations 4 and 5 are submitted in their own batch.
+        val now = Instant.now()
+        val options = GeoTrackingSessionOptions.builder()
+            .withBatchingOptions(BatchingOptions.metersTravelled(11133))
+            .build()
+        UploadWorker.options = options
+        val locations = (0 until 5).map {
+            LocationEntity(it.toLong(), id, tracker, now, lat + it * .05, long)
+        }
+        coEvery {mockLocationDao.getAll()}.returns(locations)
+
+        runBlocking {
+            val result = uploadWorker.doWork()
+            assertTrue(result.outputData.size() == 0) // success!
+            coVerify { mockLocationDao.getAll() }
+            coVerify { mockGeoService.updateLocations(id, withArg {
+                when(it.size) {
+                    3 -> {
+                        // batch 1
+                        assertEq(it[0], position(lat + 0 * .05, long))
+                        assertEq(it[1], position(lat + 1 * .05, long))
+                        assertEq(it[2], position(lat + 2 * .05, long))
+                    }
+                    2 -> {
+                        // batch 2
+                        assertEq(it[0], position(lat + 3 * .05, long))
+                        assertEq(it[1], position(lat + 4 * .05, long))
+                    }
+                    else -> assert(false)
+                }
+            }, any()) }
+            coVerify { mockLocationDao.removeAll(withArg {
+                assertTrue(it.size == 5)
+                for (i in 0 until 5) {
+                    val position = (it as List<LocationEntity>)[i]
+                    assertTrue(position.deviceId == id)
+                    assertTrue(position.tracker == tracker)
+                    assertEquals(position.latitude, lat + i * .05, 0.001)
+                    assertTrue(position.longitude == long)
+                }
+            }) }
+        }
+        confirmVerified(mockGeoService, mockLocationDao)
+    }
+
+    @Test
+    fun `batches locations by time`() {
+        // setup: 5 locations, with time-based batching.  the third location barely does not exceed the time threshold,
+        // so we start a new batch after processing location 3.  locations 4 and 5 are submitted in their own batch.
+        val now = Instant.now()
+        val options = GeoTrackingSessionOptions.builder()
+            .withBatchingOptions(BatchingOptions.secondsElapsed(7))
+            .build()
+        UploadWorker.options = options
+        val locations = (0 until 5).map {
+            LocationEntity(it.toLong(), id, tracker, now.plusMillis(it * 3000L), lat + it * .05, long)
+        }
+        coEvery {mockLocationDao.getAll()}.returns(locations)
+
+        runBlocking {
+            val result = uploadWorker.doWork()
+            assertTrue(result.outputData.size() == 0) // success!
+            coVerify { mockLocationDao.getAll() }
+            coVerify { mockGeoService.updateLocations(id, withArg {
+                when(it.size) {
+                    3 -> {
+                        // batch 1
+                        assertEq(it[0], position(lat + 0 * .05, long))
+                        assertEq(it[1], position(lat + 1 * .05, long))
+                        assertEq(it[2], position(lat + 2 * .05, long))
+                    }
+                    2 -> {
+                        // batch 2
+                        assertEq(it[0], position(lat + 3 * .05, long))
+                        assertEq(it[1], position(lat + 4 * .05, long))
+                    }
+                    else -> assert(false)
+                }
+            }, any()) }
+            coVerify { mockLocationDao.removeAll(withArg {
+                assertTrue(it.size == 5)
+                for (i in 0 until 5) {
+                    val position = (it as List<LocationEntity>)[i]
+                    assertTrue(position.deviceId == id)
+                    assertTrue(position.tracker == tracker)
+                    assertEquals(position.latitude, lat + i * .05, 0.001)
+                    assertTrue(position.longitude == long)
+                }
+            }) }
+        }
+        confirmVerified(mockGeoService, mockLocationDao)
+    }
+
+    @Test
+    fun `supports proxy delegate`() {
+        val mockProxyDelegate: GeoTrackingSessionOptions.LocationProxyDelegate = mockk()
+        coEvery {mockProxyDelegate.updatePositions(any())}.just(Runs)
+        UploadWorker.options = GeoTrackingSessionOptions.builder().withProxyDelegate(
+            mockProxyDelegate
+        ).build()
+        val now = Instant.now()
+        val locations = (0 until 5).map {
+            LocationEntity(it.toLong(), id, tracker, now.plusMillis(it * 3000L), lat + it * .05, long)
+        }
+        coEvery {mockLocationDao.getAll()}.returns(locations)
+
+        runBlocking {
+            val result = uploadWorker.doWork()
+            assertTrue(result.outputData.size() == 0) // success!
+            coVerify { mockLocationDao.getAll() }
+
+            coVerify { mockProxyDelegate.updatePositions(withArg {
+                assertTrue(it.size == 5)
+                for (i in 0 until 5) {
+                    val position = it[i]
+                    assertEq(position, position(lat + i * .05, long))
+                }
+            }) }
+
+            coVerify { mockLocationDao.removeAll(withArg {
+                assertTrue(it.size == 5)
+                for (i in 0 until 5) {
+                    val position = (it as List<LocationEntity>)[i]
+                    assertTrue(position.deviceId == id)
+                    assertTrue(position.tracker == tracker)
+                    assertEquals(position.latitude, lat + i * .05, 0.001)
+                    assertTrue(position.longitude == long)
+                }
+            }) }
+        }
+    }
+
+    private fun position(lat: Double = 45.0, long: Double = 45.0): GeoPosition {
+        val pos = GeoPosition()
+        pos.location = GeoLocation(lat, long)
+        pos.deviceID = id
+        pos.timeStamp = Date.from(Instant.now())
+        pos.tracker = tracker
+        return pos
+    }
+
+    private fun assertEq(p1: GeoPosition, p2: GeoPosition) {
+        assertEquals(p1.location.latitude, p2.location.latitude, .001)
+        assertEquals(p1.location.longitude, p2.location.longitude, .001)
+        assert(p1.deviceID == p2.deviceID)
+        assert(p1.tracker == p2.tracker)
+    }
+}

--- a/core/src/main/java/com/amplifyframework/geo/options/BatchingOptions.java
+++ b/core/src/main/java/com/amplifyframework/geo/options/BatchingOptions.java
@@ -42,10 +42,10 @@ public class BatchingOptions {
      * the batch; or 2) cumulative distance between each location in the batch.
      * Which option to choose is up for discussion.
      */
-    private OptionalInt distanceTravelled = OptionalInt.empty();
+    private OptionalInt metersTravelled = OptionalInt.empty();
 
-    public OptionalInt getDistanceTravelled() {
-        return distanceTravelled;
+    public OptionalInt getMetersTravelled() {
+        return metersTravelled;
     }
 
     private double distance(GeoPosition a, GeoPosition b) {
@@ -55,13 +55,13 @@ public class BatchingOptions {
     }
 
     // would this position exceed the batch?
-    public boolean thresholdReached(GeoPosition first, GeoPosition last) {
-        if (secondsElapsed.isPresent() &&
-                secondsElapsed.getAsInt() < last.timeStamp.getTime() - first.timeStamp.getTime()) {
+    public boolean thresholdReached(GeoPosition curr, GeoPosition first) {
+        long timeDiff = (curr.timeStamp.getTime() - first.timeStamp.getTime()) / 1000;
+        if (secondsElapsed.isPresent() && secondsElapsed.getAsInt() < timeDiff) {
             return true;
         }
-        return distanceTravelled.isPresent() &&
-                distanceTravelled.getAsInt() < distance(first, last);
+        return metersTravelled.isPresent() &&
+                metersTravelled.getAsInt() < distance(curr, first);
     }
 
     private BatchingOptions() {}
@@ -70,8 +70,8 @@ public class BatchingOptions {
         this.secondsElapsed = OptionalInt.of(secondsElapsed);
     }
 
-    private void setDistanceTravelled(int distanceTravelled) {
-        this.distanceTravelled = OptionalInt.of(distanceTravelled);
+    private void setMetersTravelled(int metersTravelled) {
+        this.metersTravelled = OptionalInt.of(metersTravelled);
     }
 
     public static BatchingOptions none() {
@@ -84,9 +84,9 @@ public class BatchingOptions {
         return options;
     }
 
-    public static BatchingOptions distanceTravelled(int distanceTravelled) {
+    public static BatchingOptions metersTravelled(int metersTravelled) {
         BatchingOptions options = new BatchingOptions();
-        options.setDistanceTravelled(distanceTravelled);
+        options.setMetersTravelled(metersTravelled);
         return options;
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

When WorkManager does work, process all events currently in the DB and put them into batches, instead of the current implementation where we stop after the first batch, which can cause the DB size to grow arbitrarily over time.

- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
