### PR TITLE
chore(geo): Device tracking -- use encrypted shared prefs for device ID

### DIFF
--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
@@ -388,7 +388,6 @@ class AWSLocationGeoPlugin(
                 locationTracker.database.sharedPreferences.getId()
         GeoDeviceType.DEVICE -> locationTracker.database.sharedPreferences.getId()
         else -> // GeoDeviceType.USER
-            (credentialsProvider as CognitoCredentialsProvider).getIdentityId() + " - " +
-                locationTracker.database.sharedPreferences.getId()
+            (credentialsProvider as CognitoCredentialsProvider).getIdentityId()
     }
 }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
@@ -73,7 +73,6 @@ class AWSLocationGeoPlugin(
 
     private lateinit var configuration: GeoConfiguration
     private lateinit var geoService: GeoService<LocationClient>
-    private lateinit var sharedPreferences: SharedPreferences
     private lateinit var locationTracker: LocationTracker
 
     private val executor = Executors.newCachedThreadPool()
@@ -102,7 +101,6 @@ class AWSLocationGeoPlugin(
             this.configuration =
                 userConfiguration ?: GeoConfiguration.fromJson(pluginConfiguration).build()
             this.geoService = AmazonLocationService(credentialsProvider, configuration.region)
-            this.sharedPreferences = context.getSharedPreferences(GEO_PLUGIN_KEY, MODE_PRIVATE)
             val uploadWorkRequest: PeriodicWorkRequest = PeriodicWorkRequestBuilder<UploadWorker>(
                 15,
                 TimeUnit.MINUTES
@@ -387,10 +385,10 @@ class AWSLocationGeoPlugin(
         GeoDeviceType.UNCHECKED -> id
         GeoDeviceType.USER_AND_DEVICE ->
             (credentialsProvider as CognitoCredentialsProvider).getIdentityId() + " - " +
-                sharedPreferences.getId()
-        GeoDeviceType.DEVICE -> sharedPreferences.getId()
+                locationTracker.database.sharedPreferences.getId()
+        GeoDeviceType.DEVICE -> locationTracker.database.sharedPreferences.getId()
         else -> // GeoDeviceType.USER
             (credentialsProvider as CognitoCredentialsProvider).getIdentityId() + " - " +
-                sharedPreferences.getId()
+                locationTracker.database.sharedPreferences.getId()
     }
 }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/AWSLocationGeoPlugin.kt
@@ -16,8 +16,6 @@
 package com.amplifyframework.geo.location
 
 import android.content.Context
-import android.content.Context.MODE_PRIVATE
-import android.content.SharedPreferences
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
@@ -33,6 +31,7 @@ import com.amplifyframework.geo.GeoCategoryPlugin
 import com.amplifyframework.geo.GeoException
 import com.amplifyframework.geo.location.auth.CognitoCredentialsProvider
 import com.amplifyframework.geo.location.configuration.GeoConfiguration
+import com.amplifyframework.geo.location.database.GeoDatabase
 import com.amplifyframework.geo.location.database.worker.UploadWorker
 import com.amplifyframework.geo.location.options.AmazonLocationSearchByCoordinatesOptions
 import com.amplifyframework.geo.location.options.AmazonLocationSearchByTextOptions
@@ -90,6 +89,8 @@ class AWSLocationGeoPlugin(
         CognitoCredentialsProvider(authCategory)
     }
 
+    private lateinit var database: GeoDatabase
+
     override fun getPluginKey(): String {
         return GEO_PLUGIN_KEY
     }
@@ -113,6 +114,7 @@ class AWSLocationGeoPlugin(
             )
             UploadWorker.geoService = geoService as AmazonLocationService
             locationTracker = LocationTracker(context)
+            database = GeoDatabase(context)
         } catch (error: Exception) {
             throw GeoException(
                 "Failed to configure AWSLocationGeoPlugin.",
@@ -297,7 +299,7 @@ class AWSLocationGeoPlugin(
             {
                 val id = device.resolvedId()
                 // Remove any updates that have been saved to the local database
-                locationTracker.clearSavedLocations(id, tracker)
+                database.locationDao.removeAll(id, tracker)
                 // Remove any updates that have already been sent to the back end
                 geoService.deleteLocationHistory(id, tracker)
             },
@@ -385,8 +387,8 @@ class AWSLocationGeoPlugin(
         GeoDeviceType.UNCHECKED -> id
         GeoDeviceType.USER_AND_DEVICE ->
             (credentialsProvider as CognitoCredentialsProvider).getIdentityId() + " - " +
-                locationTracker.database.sharedPreferences.getId()
-        GeoDeviceType.DEVICE -> locationTracker.database.sharedPreferences.getId()
+                database.sharedPreferences.getId()
+        GeoDeviceType.DEVICE -> database.sharedPreferences.getId()
         else -> // GeoDeviceType.USER
             (credentialsProvider as CognitoCredentialsProvider).getIdentityId()
     }

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/service/AmazonLocationService.kt
@@ -127,7 +127,9 @@ internal class AmazonLocationService(
                 this.deviceId = deviceId
                 // Amazon Location Service uses [longitude, latitude]
                 this.position = listOf(position.location.longitude, position.location.latitude)
-                this.sampleTime = Instant.fromEpochSeconds(position.timeStamp.time)
+                this.sampleTime = position.timeStamp?.let {
+                    Instant.fromEpochSeconds(it.time)
+                } ?: Instant.now()
                 this.positionProperties = options.positionProperties.properties
             }
             updateList.add(devicePositionUpdate)

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/tracking/LocationTracker.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/tracking/LocationTracker.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  */
 internal class LocationTracker(private val context: Context) {
     private var serviceConnection: LocationServiceConnection? = null
-    private val database by lazy { GeoDatabase(context) }
+    internal val database by lazy { GeoDatabase(context) }
 
     /**
      * Start a new tracking session

--- a/aws-geo-location/src/main/java/com/amplifyframework/geo/location/tracking/LocationTracker.kt
+++ b/aws-geo-location/src/main/java/com/amplifyframework/geo/location/tracking/LocationTracker.kt
@@ -22,7 +22,6 @@ import android.content.ServiceConnection
 import android.os.IBinder
 import androidx.annotation.VisibleForTesting
 import com.amplifyframework.geo.GeoException
-import com.amplifyframework.geo.location.database.GeoDatabase
 import com.amplifyframework.geo.location.tracking.LocationTrackingService.LocationServiceBinder
 import com.amplifyframework.geo.options.GeoTrackingSessionOptions
 import kotlin.coroutines.resume
@@ -34,7 +33,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  */
 internal class LocationTracker(private val context: Context) {
     private var serviceConnection: LocationServiceConnection? = null
-    internal val database by lazy { GeoDatabase(context) }
 
     /**
      * Start a new tracking session
@@ -74,10 +72,6 @@ internal class LocationTracker(private val context: Context) {
         serviceConnection?.binder?.service?.stopTracking()
         serviceConnection?.let { context.unbindService(it) }
         serviceConnection = null
-    }
-
-    suspend fun clearSavedLocations(deviceId: String, tracker: String) {
-        database.locationDao.removeAll(deviceId, tracker)
     }
 
     @VisibleForTesting

--- a/aws-geo-location/src/test/java/com/amplifyframework/geo/location/tracking/LocationTrackingServiceTest.kt
+++ b/aws-geo-location/src/test/java/com/amplifyframework/geo/location/tracking/LocationTrackingServiceTest.kt
@@ -119,8 +119,8 @@ internal class LocationTrackingServiceTest {
         coVerify(exactly = 2) {
             dao.insert(
                 withArg { entity ->
-                    assertEquals(65.0, entity.latitude)
-                    assertEquals(75.0, entity.longitude)
+                    assertEquals(65.0, entity.latitude, 0.01)
+                    assertEquals(75.0, entity.longitude, 0.01)
                     assertEquals(data.deviceId, entity.deviceId)
                     assertEquals(data.tracker, entity.tracker)
                 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

Use the `EncryptedSharedPreferences` used for DB encryption passphrase in order to also store device ID

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
