### PR TITLE
chore: Remove the release-kotlin_v block from prepare release script

### DIFF
--- a/scripts/fastlane/Fastfile
+++ b/scripts/fastlane/Fastfile
@@ -23,16 +23,8 @@ platform :android do |options|
           doc_files_to_update: ["#{project_root}/README.md", "#{project_root}/rxbindings/README.md"],
           release_title: 'Amplify Android',
           changelog_path: "#{project_root}/CHANGELOG.md",
-        },
-        {
-          release_tag_prefix: 'release-kotlin_v',
-          gradle_properties_path: "#{project_root}/core-kotlin/gradle.properties",
-          doc_files_to_update: [],
-          release_title: 'Amplify Android Kotlin Facade',
-          changelog_path: "#{project_root}/core-kotlin/CHANGELOG.md",
         }
       ]
     }
   end
 end
-


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Removed this block from the fastfile as the kotlin-core library is now versioned together with the rest of Amplify

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
