### PR TITLE
fix(auth): Add required hash param to cognito api calls

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -1145,7 +1145,10 @@ internal class RealAWSCognitoAuthPlugin(
                 val encodedData = authEnvironment.getUserContextData(username)
                 val pinpointEndpointId = authEnvironment.getPinpointEndpointId()
 
-                ResetPasswordUseCase(cognitoIdentityProviderClient, appClient).execute(
+                ResetPasswordUseCase(
+                    cognitoIdentityProviderClient, appClient,
+                    configuration.userPool?.appClientSecret
+                ).execute(
                     username,
                     options,
                     encodedData,
@@ -1195,6 +1198,11 @@ internal class RealAWSCognitoAuthPlugin(
                         this.username = username
                         this.confirmationCode = confirmationCode
                         password = newPassword
+                        secretHash = AuthHelper.getSecretHash(
+                            username,
+                            configuration.userPool?.appClient,
+                            configuration.userPool?.appClientSecret
+                        )
                         clientMetadata =
                             (options as? AWSCognitoAuthConfirmResetPasswordOptions)?.metadata ?: mapOf()
                         clientId = configuration.userPool?.appClient

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ResetPasswordUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ResetPasswordUseCase.kt
@@ -23,6 +23,7 @@ import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.cognito.CognitoAuthExceptionConverter
+import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthResetPasswordOptions
 import com.amplifyframework.auth.options.AuthResetPasswordOptions
 import com.amplifyframework.auth.result.AuthResetPasswordResult
@@ -37,7 +38,8 @@ import kotlinx.coroutines.withContext
  */
 internal class ResetPasswordUseCase(
     private val cognitoIdentityProviderClient: CognitoIdentityProviderClient,
-    private val appClientId: String
+    private val appClientId: String,
+    private val appClientSecret: String?
 ) {
     suspend fun execute(
         username: String,
@@ -53,6 +55,11 @@ internal class ResetPasswordUseCase(
                     this.username = username
                     this.clientMetadata = (options as? AWSCognitoAuthResetPasswordOptions)?.metadata ?: mapOf()
                     this.clientId = appClientId
+                    this.secretHash = AuthHelper.getSecretHash(
+                        username,
+                        appClientId,
+                        appClientSecret
+                    )
                     encodedContextData?.let { this.userContextData { encodedData = it } }
                     pinpointEndpointId?.let {
                         this.analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = it }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
@@ -109,9 +109,11 @@ class RealAWSCognitoAuthPluginTest {
 
     private var logger = mockk<Logger>(relaxed = true)
     private val appClientId = "app Client Id"
+    private val appClientSecret = "app Client Secret"
     private var authConfiguration = mockk<AuthConfiguration> {
         every { userPool } returns UserPoolConfiguration.invoke {
             this.appClientId = this@RealAWSCognitoAuthPluginTest.appClientId
+            this.appClientSecret = this@RealAWSCognitoAuthPluginTest.appClientSecret
             this.pinpointAppId = null
         }
     }
@@ -532,6 +534,11 @@ class RealAWSCognitoAuthPluginTest {
             confirmationCode = code
             clientMetadata = mapOf()
             clientId = appClientId
+            secretHash = AuthHelper.getSecretHash(
+                username,
+                appClientId,
+                appClientSecret
+            )
             userContextData = null
             analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = expectedEndpointId }
         }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ResetPasswordUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ResetPasswordUseCaseTest.kt
@@ -23,6 +23,7 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeliveryMediumType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ForgotPasswordRequest
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ForgotPasswordResponse
 import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.options.AuthResetPasswordOptions
 import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.step.AuthNextResetPasswordStep
@@ -51,6 +52,7 @@ class ResetPasswordUseCaseTest {
 
     private val dummyClientId = "app client id"
     private val dummyUserName = "username"
+    private val dummyAppClientSecret = "app client secret"
     private val expectedPinpointEndpointId = "abc123"
 
     private val mockCognitoIPClient: CognitoIdentityProviderClient = mockk()
@@ -64,7 +66,7 @@ class ResetPasswordUseCaseTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(mainThreadSurrogate)
-        resetPasswordUseCase = ResetPasswordUseCase(mockCognitoIPClient, dummyClientId)
+        resetPasswordUseCase = ResetPasswordUseCase(mockCognitoIPClient, dummyClientId, dummyAppClientSecret)
     }
 
     @After
@@ -82,6 +84,11 @@ class ResetPasswordUseCaseTest {
             username = dummyUserName
             clientMetadata = mapOf()
             clientId = dummyClientId
+            secretHash = AuthHelper.getSecretHash(
+                username,
+                dummyClientId,
+                dummyAppClientSecret
+            )
             analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = expectedPinpointEndpointId }
         }
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
#2179

*Description of changes:*
Added missing hash parameter to cognito api that requires it

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
