### PR TITLE
chore: Modify the bump_version branch name to be specific to the base branch

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -38,7 +38,7 @@ jobs:
         bundle exec fastlane android configure_git_options git_user_email:$GIT_USER_EMAIL git_user_name:$GIT_USER_NAME
     - name: Create/checkout a branch for the release
       run: |
-        branch_name=bump_version
+        branch_name=bump_version_${{ env.BASE_BRANCH }}
         git fetch --all
         (git branch -D $branch_name &>/dev/null) && (echo 'Existing $branch_name branch deleted') || (echo 'No existing $branch_name branch to delete.')
         git checkout -b $branch_name


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- When creating a release PR the branch name will now be e.g. `bump_version_v1` or `bump_version_main.` This allows us to have v1 and v2 release PRs in progress concurrently.

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
