### PR TITLE
chore: Supply base_branch when calling `create_next_release_pr` lane

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -48,7 +48,7 @@ jobs:
         RELEASE_TAG: ${{ github.event.inputs.release_tag }}
       run: |
         cd scripts
-        bundle exec fastlane android create_next_release_pr release_tag:"$RELEASE_TAG"
+        bundle exec fastlane android create_next_release_pr release_tag:"$RELEASE_TAG" base_branch:"$BASE_BRANCH"
     - name: Check modified file content
       run: |
         cat gradle.properties


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- When calling the `create_next_release_pr` we specify the base branch selected when running the github action. This will be used in the lane to set the base branch when opening the PR. See https://github.com/aws-amplify/amplify-ci-support/pull/131

*How did you test these changes?*
(Please add a line here how the changes were tested)

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
