### PR TITLE
fix(analytics): Remove test dependencies from implementation configuration

### DIFF
--- a/aws-analytics-pinpoint/build.gradle
+++ b/aws-analytics-pinpoint/build.gradle
@@ -37,7 +37,8 @@ dependencies {
     testImplementation dependency.mockito
     testImplementation dependency.mockitoinline
     testImplementation dependency.robolectric
-    implementation dependency.androidx.test.core
+    testImplementation dependency.androidx.test.junit
+    testImplementation dependency.androidx.test.core
     testImplementation dependency.kotlin.test.coroutines
     testImplementation project(path: ':aws-analytics-pinpoint')
 
@@ -45,6 +46,6 @@ dependencies {
     androidTestImplementation dependency.androidx.test.core
     androidTestImplementation dependency.androidx.test.runner
     androidTestImplementation dependency.kotlin.test.coroutines
-    implementation dependency.androidx.test.junit
+    androidTestImplementation dependency.androidx.test.junit
     androidTestImplementation project(path: ':aws-analytics-pinpoint')
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
#2249 

*Description of changes:*
Removes test dependencies from the `implementation` configuration, adding them to the proper `testImplementation` or `androidTestImplementation` configurations instead.

*How did you test these changes?*
Verified that module still built and unit and integration tests still passed.

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
