### PR TITLE
fix(geo): Bump MapLibre SDK to 9.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ ext {
         okhttp: 'com.squareup.okhttp3:okhttp:5.0.0-alpha.9',
         gson: 'com.google.code.gson:gson:2.8.9',
         maplibre: [
-            sdk: 'org.maplibre.gl:android-sdk:9.5.2',
+            sdk: 'org.maplibre.gl:android-sdk:9.6.0',
             annotations: 'org.maplibre.gl:android-plugin-annotation-v9:1.0.0'
         ],
         rxandroid: 'io.reactivex.rxjava3:rxandroid:3.0.0',


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
#2250

*Description of changes:*
- Bumped MapLibre SDK from 9.5.2 to 9.6.0. This resolves duplicate class errors for apps using `androidx.core:core-ktx:1.7.0` and above.

*How did you test these changes?*
- Ensured maps work as expected after dependency update
- Ensured app with `androidx.core:core-ktx:1.7.0` and `mapslibre-adapter` dependency built and ran with no duplicate class errors.

- [ ] Added Unit Tests
- [ ] Added Integration Tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
