### PR TITLE
fix(datastore): Fix aliasing of column names

### DIFF
--- a/aws-datastore/src/androidTest/assets/schemas/phonecall/phone.json
+++ b/aws-datastore/src/androidTest/assets/schemas/phonecall/phone.json
@@ -5,10 +5,10 @@
             "associatedType": "Call",
             "name": "HasMany"
         },
-        "ownedBy": {
+        "ownerOfPhone": {
             "associatedType": "Person",
             "name": "BelongsTo",
-            "targetName": "ownedById"
+            "targetName": "ownerOfPhoneId"
         }
     },
     "authRules": [],
@@ -33,24 +33,24 @@
             "name": "number",
             "targetType": "String"
         },
-        "ownedById": {
+        "ownerOfPhoneId": {
             "authRules": [],
             "isArray": false,
             "isEnum": false,
             "isModel": false,
             "isRequired": true,
             "javaClassForValue": "java.lang.String",
-            "name": "ownedById",
+            "name": "ownerOfPhoneId",
             "targetType": "ID"
         },
-        "ownedBy": {
+        "ownerOfPhone": {
             "authRules": [],
             "isArray": false,
             "isEnum": false,
             "isModel": true,
             "isRequired": true,
             "javaClassForValue": "com.amplifyframework.core.model.SerializedModel",
-            "name": "ownedBy",
+            "name": "ownerOfPhone",
             "targetType": "Person"
         },
         "calls": {

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapterQueryTest.java
@@ -202,11 +202,11 @@ public final class SQLiteStorageAdapterQueryTest {
         
         final Phone phoneCalling = Phone.builder()
                 .number("123-456-7890")
-                .ownedBy(personCalling)
+                .ownerOfPhone(personCalling)
                 .build();
         final Phone phoneCalled = Phone.builder()
                 .number("567-890-1234")
-                .ownedBy(personCalled)
+                .ownerOfPhone(personCalled)
                 .build();
         
         final Call phoneCall = Call.builder()
@@ -424,11 +424,11 @@ public final class SQLiteStorageAdapterQueryTest {
 
         final Phone phoneCalling = Phone.builder()
                 .number("123-456-7890")
-                .ownedBy(personCalling)
+                .ownerOfPhone(personCalling)
                 .build();
         final Phone phoneCalled = Phone.builder()
                 .number("567-890-1234")
-                .ownedBy(personCalled)
+                .ownerOfPhone(personCalled)
                 .build();
 
         adapter.save(personCalling);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteCommandFactory.java
@@ -191,7 +191,7 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
             Iterator<SQLiteColumn> columnsIterator = Objects.requireNonNull(columns.get(tableAlias)).iterator();
             while (columnsIterator.hasNext()) {
                 final SQLiteColumn column = columnsIterator.next();
-                String columnName = column.getQuotedColumnName().replace(column.getTableName(), tableAlias);
+                String columnName = column.getQuotedColumnName().replaceFirst(column.getTableName(), tableAlias);
                 selectColumns.append(columnName);
                 // Alias columns with a unique alias to avoid duplicate column names or alias names
                 String columnAlias = column.getAliasedName()
@@ -542,8 +542,8 @@ final class SQLiteCommandFactory implements SQLCommandFactory {
             }
 
             // Reference the foreign key and primary key using the corresponding table's alias.
-            String foreignKeyName = foreignKey.getQuotedColumnName().replace(table.getName(), tableAlias);
-            String ownedTablePrimaryKeyName = ownedTable.getPrimaryKeyColumnName().replace(ownedTableName,
+            String foreignKeyName = foreignKey.getQuotedColumnName().replaceFirst(table.getName(), tableAlias);
+            String ownedTablePrimaryKeyName = ownedTable.getPrimaryKeyColumnName().replaceFirst(ownedTableName,
                     ownedTableAlias);
             joinStatement.append(SqlKeyword.ON)
                 .append(SqlKeyword.DELIMITER)

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/phonecall/Phone.java
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/phonecall/Phone.java
@@ -23,10 +23,10 @@ import java.util.UUID;
 public final class Phone implements Model {
   public static final QueryField ID = field("Phone", "id");
   public static final QueryField NUMBER = field("Phone", "number");
-  public static final QueryField OWNED_BY = field("Phone", "ownedById");
+  public static final QueryField OWNER_OF_PHONE = field("Phone", "ownerOfPhoneId");
   private final @ModelField(targetType="ID", isRequired = true) String id;
   private final @ModelField(targetType="String", isRequired = true) String number;
-  private final @ModelField(targetType="Person", isRequired = true) @BelongsTo(targetName = "ownedById", type = Person.class) Person ownedBy;
+  private final @ModelField(targetType="Person", isRequired = true) @BelongsTo(targetName = "ownerOfPhoneId", type = Person.class) Person ownerOfPhone;
   private final @ModelField(targetType="Call") @HasMany(associatedWith = "id", type = Call.class) List<Call> calls = null;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
@@ -43,8 +43,8 @@ public final class Phone implements Model {
       return number;
   }
   
-  public Person getOwnedBy() {
-      return ownedBy;
+  public Person getOwnerOfPhone() {
+      return ownerOfPhone;
   }
   
   public List<Call> getCalls() {
@@ -59,10 +59,10 @@ public final class Phone implements Model {
       return updatedAt;
   }
   
-  private Phone(String id, String number, Person ownedBy) {
+  private Phone(String id, String number, Person ownerOfPhone) {
     this.id = id;
     this.number = number;
-    this.ownedBy = ownedBy;
+    this.ownerOfPhone = ownerOfPhone;
   }
   
   @Override
@@ -75,7 +75,7 @@ public final class Phone implements Model {
       Phone phone = (Phone) obj;
       return ObjectsCompat.equals(getId(), phone.getId()) &&
               ObjectsCompat.equals(getNumber(), phone.getNumber()) &&
-              ObjectsCompat.equals(getOwnedBy(), phone.getOwnedBy()) &&
+              ObjectsCompat.equals(getOwnerOfPhone(), phone.getOwnerOfPhone()) &&
               ObjectsCompat.equals(getCreatedAt(), phone.getCreatedAt()) &&
               ObjectsCompat.equals(getUpdatedAt(), phone.getUpdatedAt());
       }
@@ -86,7 +86,7 @@ public final class Phone implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getNumber())
-      .append(getOwnedBy())
+      .append(getOwnerOfPhone())
       .append(getCreatedAt())
       .append(getUpdatedAt())
       .toString()
@@ -99,7 +99,7 @@ public final class Phone implements Model {
       .append("Phone {")
       .append("id=" + String.valueOf(getId()) + ", ")
       .append("number=" + String.valueOf(getNumber()) + ", ")
-      .append("ownedBy=" + String.valueOf(getOwnedBy()) + ", ")
+      .append("ownerOfPhone=" + String.valueOf(getOwnerOfPhone()) + ", ")
       .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
       .append("updatedAt=" + String.valueOf(getUpdatedAt()))
       .append("}")
@@ -139,14 +139,14 @@ public final class Phone implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       number,
-      ownedBy);
+      ownerOfPhone);
   }
   public interface NumberStep {
-    OwnedByStep number(String number);
+    OwnerOfPhoneStep number(String number);
   }
 
-  public interface OwnedByStep {
-    BuildStep ownedBy(Person ownedBy);
+  public interface OwnerOfPhoneStep {
+    BuildStep ownerOfPhone(Person ownerOfPhone);
   }
   
 
@@ -156,10 +156,10 @@ public final class Phone implements Model {
   }
   
 
-  public static class Builder implements NumberStep, OwnedByStep, BuildStep {
+  public static class Builder implements NumberStep, OwnerOfPhoneStep, BuildStep {
     private String id;
     private String number;
-    private Person ownedBy;
+    private Person ownerOfPhone;
     @Override
      public Phone build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -167,19 +167,19 @@ public final class Phone implements Model {
         return new Phone(
           id,
           number,
-          ownedBy);
+          ownerOfPhone);
     }
     
     @Override
-     public OwnedByStep number(String number) {
+     public OwnerOfPhoneStep number(String number) {
         Objects.requireNonNull(number);
         this.number = number;
         return this;
     }
     
     @Override
-     public BuildStep ownedBy(Person ownedBy) {
-        this.ownedBy = ownedBy;
+     public BuildStep ownerOfPhone(Person ownerOfPhone) {
+        this.ownerOfPhone = ownerOfPhone;
         return this;
     }
     
@@ -206,10 +206,10 @@ public final class Phone implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String number, Person ownedBy) {
+    private CopyOfBuilder(String id, String number, Person ownerOfPhone) {
       super.id(id);
       super.number(number)
-        .ownedBy(ownedBy);
+        .ownerOfPhone(ownerOfPhone);
     }
     
     @Override
@@ -218,8 +218,8 @@ public final class Phone implements Model {
     }
     
     @Override
-     public CopyOfBuilder ownedBy(Person ownedBy) {
-      return (CopyOfBuilder) super.ownedBy(ownedBy);
+     public CopyOfBuilder ownerOfPhone(Person ownerOfPhone) {
+      return (CopyOfBuilder) super.ownerOfPhone(ownerOfPhone);
     }
   }
   

--- a/testmodels/src/main/java/com/amplifyframework/testmodels/phonecall/schema.graphql
+++ b/testmodels/src/main/java/com/amplifyframework/testmodels/phonecall/schema.graphql
@@ -6,8 +6,8 @@ type Person @model {
 type Phone @model {
     id: ID!
     number: String!
-    ownedById: ID!
-    ownedBy: Person! @connection(fields: ["ownedById"])
+    ownerOfPhoneId: ID!
+    ownerOfPhone: Person! @connection(fields: ["ownerOfPhoneId"])
     calls: [Call] @connection(fields: ["id"])
 }
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2035

*Description of changes:* When there are multiple tables of the same type in a query, the columns are given an alias to make them unique. In the case of a column like `Phone.ownerOfPhone`, only replace the first occurrence of the table name `Phone` with the aliased table name to avoid an unknown column name error.

*How did you test these changes?*
Updated an existing integration test to also test for the specific case described in the issue.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [x] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
