### PR TITLE
fix(notifications): create notification channel when plugin is configured

### DIFF
--- a/aws-push-notifications-pinpoint-utils/src/main/java/com/amplifyframework/pushnotifications/pinpoint/utils/PushNotificationsUtils.kt
+++ b/aws-push-notifications-pinpoint-utils/src/main/java/com/amplifyframework/pushnotifications/pinpoint/utils/PushNotificationsUtils.kt
@@ -39,12 +39,16 @@ import kotlinx.coroutines.withContext
 
 class PushNotificationsUtils(
     private val context: Context,
-    private var channelId: String = PushNotificationsConstants.DEFAULT_NOTIFICATION_CHANNEL_ID
+    private val channelId: String = PushNotificationsConstants.DEFAULT_NOTIFICATION_CHANNEL_ID
 ) {
+    init {
+        retrieveNotificationChannel()
+    }
+
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
     private fun isNotificationChannelSupported() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
 
-    private fun retrieveNotificationChannel(channelId: String): NotificationChannel? {
+    private fun retrieveNotificationChannel(): NotificationChannel? {
         var channel: NotificationChannel? = null
         val notificationManager = ContextCompat.getSystemService(context, NotificationManager::class.java)
         if (isNotificationChannelSupported()) {
@@ -116,7 +120,7 @@ class PushNotificationsUtils(
                 notificationIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
-            val notificationChannel = retrieveNotificationChannel(channelId)
+            val notificationChannel = retrieveNotificationChannel()
             val builder = if (isNotificationChannelSupported() && notificationChannel != null) {
                 NotificationCompat.Builder(context, notificationChannel.id)
             } else {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- create default notification channel when plugin is configured to prompt permissions dialog

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
