### PR TITLE
chore: Add annotation to restrict API usage

### DIFF
--- a/annotations/src/main/java/com/amplifyframework/annotations/InternalAmplifyApi.kt
+++ b/annotations/src/main/java/com/amplifyframework/annotations/InternalAmplifyApi.kt
@@ -34,4 +34,4 @@ package com.amplifyframework.annotations
     AnnotationTarget.FIELD,
     AnnotationTarget.CONSTRUCTOR,
 )
-public annotation class RestrictToAmplify
+public annotation class InternalAmplifyApi

--- a/annotations/src/main/java/com/amplifyframework/annotations/RestrictToAmplify.kt
+++ b/annotations/src/main/java/com/amplifyframework/annotations/RestrictToAmplify.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.annotations
+
+/**
+ * API marked with this annotation is internal to Amplify, and it is not intended to be used outside.
+ * It could be modified or removed without any notice.
+ *
+ * We strongly recommend to not use such API.
+ */
+@Suppress("DEPRECATION")
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is internal to Amplify and should not be used. It could be removed or changed without notice.",
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.CONSTRUCTOR,
+)
+public annotation class RestrictToAmplify

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -18,9 +18,9 @@ package com.amplifyframework.auth.cognito
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.amplifyframework.AmplifyException
+import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthDevice
 import com.amplifyframework.auth.AuthException
@@ -94,7 +94,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
 
     private lateinit var pluginConfigurationJSON: JSONObject
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @InternalAmplifyApi
     fun getPluginConfiguration(): JSONObject {
         return pluginConfigurationJSON
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,8 @@ tasks.register<Delete>("clean").configure {
 }
 
 val optInAnnotations = listOf(
-    "com.amplifyframework.annotations.InternalApiWarning"
+    "com.amplifyframework.annotations.InternalApiWarning",
+    "com.amplifyframework.annotations.RestrictToAmplify"
 )
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ tasks.register<Delete>("clean").configure {
 
 val optInAnnotations = listOf(
     "com.amplifyframework.annotations.InternalApiWarning",
-    "com.amplifyframework.annotations.RestrictToAmplify"
+    "com.amplifyframework.annotations.InternalAmplifyApi"
 )
 
 subprojects {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:* Add an annotation similar to Android's RestrictTo since RestrictTo does not work for Kotlin classes and APIs.

*How did you test these changes?*
Tested the annotation in a sample app.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
