### PR TITLE
fix(auth): fix for when reset password next sign in step is not triggered

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
@@ -17,6 +17,7 @@ package com.amplifyframework.auth.cognito.actions
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.PasswordResetRequiredException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.RespondToAuthChallengeRequest
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.AuthEnvironment
@@ -155,6 +156,15 @@ internal object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
                     )
                 } ?: throw InvalidUserPoolConfigurationException()
             } catch (exception: Exception) {
+                if (exception is PasswordResetRequiredException) {
+                    SignInChallengeHelper.evaluateNextStep(
+                        username = username,
+                        challengeNameType = ChallengeNameType.fromValue("RESET_PASSWORD"),
+                        session = null,
+                        challengeParameters = null,
+                        authenticationResult = null
+                    )
+                }
                 if (exception is NotAuthorizedException) {
                     credentialStoreClient.clearCredentials(CredentialType.Device(username))
                 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActions.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.auth.cognito.actions
 import aws.sdk.kotlin.services.cognitoidentityprovider.initiateAuth
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.PasswordResetRequiredException
 import aws.sdk.kotlin.services.cognitoidentityprovider.respondToAuthChallenge
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.AuthEnvironment
@@ -220,6 +221,15 @@ internal object SRPCognitoActions : SRPActions {
                     )
                 }
             } catch (e: Exception) {
+                if (e is PasswordResetRequiredException) {
+                    SignInChallengeHelper.evaluateNextStep(
+                        username = event.challengeParameters.getValue(KEY_USERNAME),
+                        challengeNameType = ChallengeNameType.fromValue("RESET_PASSWORD"),
+                        session = null,
+                        challengeParameters = null,
+                        authenticationResult = null
+                    )
+                }
                 val errorEvent = SRPEvent(SRPEvent.EventType.ThrowPasswordVerifierError(e))
                 logger.verbose("$id Sending event ${errorEvent.type}")
                 dispatcher.send(errorEvent)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInChallengeCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInChallengeCognitoActions.kt
@@ -16,6 +16,7 @@
 package com.amplifyframework.auth.cognito.actions
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.PasswordResetRequiredException
 import aws.sdk.kotlin.services.cognitoidentityprovider.respondToAuthChallenge
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.helpers.AuthHelper
@@ -80,6 +81,15 @@ internal object SignInChallengeCognitoActions : SignInChallengeActions {
                 )
             )
         } catch (e: Exception) {
+            if (e is PasswordResetRequiredException) {
+                SignInChallengeHelper.evaluateNextStep(
+                    username = challenge.username ?: "",
+                    challengeNameType = ChallengeNameType.fromValue("RESET_PASSWORD"),
+                    session = null,
+                    challengeParameters = null,
+                    authenticationResult = null
+                )
+            }
             SignInChallengeEvent(SignInChallengeEvent.EventType.ThrowError(e, challenge))
         }
         logger.verbose("$id Sending event ${evt.type}")

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomCognitoActions.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.auth.cognito.actions
 import aws.sdk.kotlin.services.cognitoidentityprovider.initiateAuth
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.PasswordResetRequiredException
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
@@ -78,6 +79,15 @@ internal object SignInCustomCognitoActions : CustomSignInActions {
                     )
                 }
             } catch (e: Exception) {
+                if (e is PasswordResetRequiredException) {
+                    SignInChallengeHelper.evaluateNextStep(
+                        username = event.username,
+                        challengeNameType = ChallengeNameType.fromValue("RESET_PASSWORD"),
+                        session = null,
+                        challengeParameters = null,
+                        authenticationResult = null
+                    )
+                }
                 val errorEvent = SignInEvent(SignInEvent.EventType.ThrowError(e))
                 logger.verbose("$id Sending event ${errorEvent.type}")
                 dispatcher.send(errorEvent)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
