### PR TITLE
chore: Force maplibre to use at least Amplify gson version

### DIFF
--- a/maplibre-adapter/build.gradle.kts
+++ b/maplibre-adapter/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(project(":core"))
     implementation(dependency.aws.signing)
     implementation(dependency.maplibre.sdk)
+    implementation(dependency.gson) // forces maplibre to pull at least the same gson version as other amplify libs
     implementation(dependency.maplibre.annotations)
     implementation(dependency.okhttp)
     implementation(dependency.kotlin.coroutines)


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
