### PR TITLE
fix(predictions): null check values returned from service

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSTranslateService.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/AWSTranslateService.kt
@@ -15,7 +15,6 @@
 package com.amplifyframework.predictions.aws.service
 
 import aws.sdk.kotlin.services.translate.TranslateClient
-import aws.sdk.kotlin.services.translate.TranslateClient.Companion.invoke
 import aws.sdk.kotlin.services.translate.translateText
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 import com.amplifyframework.core.Consumer


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:* Some values returned from various services used in predictions can be null. Add null checks for these values to prevent errors when transforming them to Amplify types.

*How did you test these changes?*
Existing unit and integration tests passed (integration test previously failed).

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
