### PR TITLE
fix(datastore): Release semaphore if an error occurs while starting or stopping the Orchestrator

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,33 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="ENABLE_SECOND_REFORMAT" value="true" />
     <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="true" />
+        </value>
+      </option>
+      <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+      <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+      <option name="JD_ADD_BLANK_AFTER_DESCRIPTION" value="false" />
       <option name="JD_INDENT_ON_CONTINUATION" value="true" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
@@ -16,6 +43,17 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="120" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+      <option name="WRAP_COMMENTS" value="true" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="USE_RELATIVE_INDENTS" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="XML">
       <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
@@ -131,12 +169,12 @@
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
-      <indentOptions>
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      </indentOptions>
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="0" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -194,15 +194,13 @@ public final class Orchestrator {
                     "Retry your request."));
         }
         LOG.info("Orchestrator lock acquired.");
-        return Completable.fromAction(action)
-            .andThen(
-                Completable.fromAction(
-                    () -> {
-                        startStopSemaphore.release();
-                        LOG.info("Orchestrator lock released.");
-                    }
-                )
-            );
+        return Completable.fromAction(action).doOnError((e) -> {
+            startStopSemaphore.release();
+            LOG.info("Orchestrator lock released.");
+        }).andThen(Completable.fromAction(() -> {
+            startStopSemaphore.release();
+            LOG.info("Orchestrator lock released.");
+        }));
     }
 
     private void unknownState(State state) throws DataStoreException {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -15,13 +15,9 @@
 
 package com.amplifyframework.datastore.syncengine;
 
-import android.content.Context;
-import androidx.annotation.NonNull;
-
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.GraphQLBehavior;
 import com.amplifyframework.api.graphql.MutationType;
-import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.SchemaRegistry;
 import com.amplifyframework.core.model.temporal.Temporal;
@@ -35,7 +31,6 @@ import com.amplifyframework.datastore.storage.InMemoryStorageAdapter;
 import com.amplifyframework.datastore.storage.SynchronousStorageAdapter;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
-import com.amplifyframework.logging.Logger;
 import com.amplifyframework.testmodels.commentsblog.BlogOwner;
 import com.amplifyframework.testutils.HubAccumulator;
 import com.amplifyframework.testutils.mocks.ApiMocking;
@@ -57,21 +52,24 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests the {@link Orchestrator}.
  */
 @RunWith(RobolectricTestRunner.class)
 public final class OrchestratorTest {
-    private static final Logger LOG = Amplify.Logging.forNamespace("amplify:aws-datastore:test");
 
     private Orchestrator orchestrator;
     private HubAccumulator orchestratorInitObserver;
-    private GraphQLBehavior mockApi;
-    private InMemoryStorageAdapter localStorageAdapter;
-    private BlogOwner susan;
+    private final GraphQLBehavior mockApi = mock(GraphQLBehavior.class);
+    private final InMemoryStorageAdapter localStorageAdapter = InMemoryStorageAdapter.create();
+    private final BlogOwner susan = BlogOwner.builder().name("Susan Quimby").build();
+
+    private final ReachabilityMonitor reachabilityMonitor = mock(ReachabilityMonitor.class);
 
     /**
      * Setup mocks and other common elements.
@@ -81,75 +79,59 @@ public final class OrchestratorTest {
     @Before
     public void setup() throws AmplifyException {
         ShadowLog.stream = System.out;
-        // Arrange: create a BlogOwner
-        susan = BlogOwner.builder().name("Susan Quimby").build();
 
         // SYNC_QUERIES_READY indicates that the sync queries have completed.
         orchestratorInitObserver =
             HubAccumulator.create(HubChannel.DATASTORE, DataStoreChannelEventName.SYNC_QUERIES_READY, 1)
-                          .start();
+                .start();
 
-        ModelMetadata metadata = new ModelMetadata(susan.getId(),
-                                                   false,
-                                                   1,
-                                                   Temporal.Timestamp.now());
+        ModelMetadata metadata = new ModelMetadata(
+            susan.getId(),
+            false,
+            1,
+            Temporal.Timestamp.now()
+        );
         ModelWithMetadata<BlogOwner> modelWithMetadata = new ModelWithMetadata<>(susan, metadata);
         // Mock behaviors from for the API category
-        mockApi = mock(GraphQLBehavior.class);
         ApiMocking.mockSubscriptionStart(mockApi);
         ApiMocking.mockSuccessfulMutation(mockApi, susan.getId(), modelWithMetadata);
         ApiMocking.mockSuccessfulQuery(mockApi, modelWithMetadata);
         AppSyncClient appSync = AppSyncClient.via(mockApi);
 
-        localStorageAdapter = InMemoryStorageAdapter.create();
         ModelProvider modelProvider = SimpleModelProvider.withRandomVersion(BlogOwner.class);
         SchemaRegistry schemaRegistry = SchemaRegistry.instance();
         schemaRegistry.clear();
         schemaRegistry.register(modelProvider.models());
 
-        ReachabilityMonitor reachabilityMonitor = new ReachabilityMonitor() {
-            @Override
-            public void configure(@NonNull Context context) { }
+        when(reachabilityMonitor.getObservable()).thenReturn(Observable.just(true));
 
-            @Override
-            public void configure(@NonNull Context context, @NonNull ConnectivityProvider connectivityProvider) {}
-
-            @NonNull
-            @Override
-            public Observable<Boolean> getObservable() {
-                return Observable.just(true);
-            }
-        };
-
-        orchestrator =
-            new Orchestrator(modelProvider,
-                schemaRegistry,
-                localStorageAdapter,
-                appSync,
-                DataStoreConfiguration::defaults,
-                () -> Orchestrator.State.SYNC_VIA_API,
-                reachabilityMonitor,
-                true
-            );
+        orchestrator = new Orchestrator(
+            modelProvider,
+            schemaRegistry,
+            localStorageAdapter,
+            appSync,
+            DataStoreConfiguration::defaults,
+            () -> Orchestrator.State.SYNC_VIA_API,
+            reachabilityMonitor,
+            true
+        );
     }
 
     /**
-     * When an item is placed into storage, a cascade of
-     * things happen which should ultimately result in a mutation call
-     * to the API category, with an {@link MutationType} corresponding to the type of
-     * modification that was made to the storage.
+     * When an item is placed into storage, a cascade of things happen which should ultimately result in a mutation call
+     * to the API category, with an {@link MutationType} corresponding to the type of modification that was made to the
+     * storage.
      * @throws AmplifyException On failure to load model schema into registry
      */
     @SuppressWarnings("unchecked") // Casting ? in HubEvent<?> to PendingMutation<? extends Model>
     @Test
     public void itemsPlacedInStorageArePublishedToNetwork() throws AmplifyException {
         // Arrange: orchestrator is running
-        orchestrator.start().test();
+        orchestrator.start().test().assertComplete();
 
         orchestratorInitObserver.await(10, TimeUnit.SECONDS);
-        HubAccumulator accumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, isProcessed(susan), 1)
-                  .start();
+        HubAccumulator accumulator = HubAccumulator.create(HubChannel.DATASTORE, isProcessed(susan), 1).start();
+
         // Act: Put BlogOwner into storage, and wait for it to complete.
         SynchronousStorageAdapter.delegatingTo(localStorageAdapter).save(susan);
 
@@ -174,16 +156,16 @@ public final class OrchestratorTest {
     @Test
     public void preventConcurrentStateTransitions() {
         // Arrange: orchestrator is running
-        orchestrator.start().test();
+        orchestrator.start().test().assertComplete();
 
         // Try to start it in a new thread.
         boolean success = Completable.create(emitter -> {
             new Thread(() -> orchestrator.start()
-                .subscribe(emitter::onComplete, emitter::onError)
+                                 .subscribe(emitter::onComplete, emitter::onError)
             ).start();
 
             // Try to start it again on the current thread.
-            orchestrator.start().test();
+            orchestrator.start().test().assertComplete();
         }).blockingAwait(5, TimeUnit.SECONDS);
         assertTrue("Failed to start orchestrator on a background thread", success);
 
@@ -191,5 +173,26 @@ public final class OrchestratorTest {
         verify(mockApi, times(1)).query(any(), any(), any());
 
         assertTrue(orchestrator.stop().blockingAwait(5, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Verify that an error that occurs during a start/stop still releases the semaphore and allows retrying.
+     */
+    @Test
+    public void preventLockupOnStartStopError() {
+        IllegalStateException exception = new IllegalStateException("Simulated failure");
+
+        // Not a particularly realistic failure, but the exact cause isn't important.
+        when(reachabilityMonitor.getObservable()).thenThrow(exception);
+
+        // This will fail, but it should not leave the orchestrator in a bad state.
+        orchestrator.start().test().assertError(exception);
+
+        // Reset the mock so that it won't throw an error on second attempt
+        reset(reachabilityMonitor);
+        when(reachabilityMonitor.getObservable()).thenReturn(Observable.just(true));
+
+        // Now we should be able to start successfully
+        orchestrator.start().test().assertComplete();
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2263

*Description of changes:* Add a `doOnError` operator to release the semaphore if Orchestrator encounters an error during start or stop. This restores the prior behaviour of `doFinally` that was removed here: https://github.com/aws-amplify/amplify-android/pull/2209/files#diff-eaf24d0ba1fee6a80c5684eccb0f02cdeea76297bf4b41047b2ea9728deb8127L186

*How did you test these changes?* Unit test

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
