### PR TITLE
fix(api): Handle delete request with no body

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
@@ -125,10 +125,14 @@ public final class RestRequestFactory {
                 );
                 break;
             case DELETE:
-                populateBody(
-                        requestBuilder,
-                        requestData, (builder, data) -> builder.delete(RequestBody.create(data))
-                );
+                if (requestData != null) {
+                    populateBody(
+                            requestBuilder,
+                            requestData, (builder, data) -> builder.delete(RequestBody.create(data))
+                    );
+                } else {
+                    requestBuilder.delete();
+                }
                 break;
             default:
                 break;

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestRequestFactoryTest.java
@@ -190,6 +190,7 @@ public final class RestRequestFactoryTest {
                 null,
                 HttpMethod.DELETE);
         assertNotNull("Request should not be null", request);
+        assertEquals(HttpMethod.DELETE.name(), request.method());
     }
 
     /**
@@ -207,6 +208,7 @@ public final class RestRequestFactoryTest {
                 null,
                 HttpMethod.DELETE);
         assertNotNull("Request should not be null", request);
+        assertEquals(HttpMethod.DELETE.name(), request.method());
     }
 
     /**


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #1932

*Description of changes:* When a delete request was executed with no body, Amplify defaulted to executing a get request instead. This PR adds a check for no body when creating the delete request so that a delete request is still created whether there is a body or not.

*How did you test these changes?*
Updated existing unit tests and tested in a sample app.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
