### PR TITLE
fix(predictions): Fix processing for table title blocks

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformers.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/adapter/TextractResultTransformers.java
@@ -151,9 +151,11 @@ public final class TextractResultTransformers {
 
         // Each TABLE block contains CELL blocks
         doForEachRelatedBlock(block, blockMap, cellBlock -> {
-            rows.add(cellBlock.getRowIndex() - 1);
-            cols.add(cellBlock.getColumnIndex() - 1);
-            cells.add(fetchTableCell(cellBlock, blockMap));
+            if (cellBlock.getRowIndex() != null && cellBlock.getColumnIndex() != null) {
+                rows.add(cellBlock.getRowIndex() - 1);
+                cols.add(cellBlock.getColumnIndex() - 1);
+                cells.add(fetchTableCell(cellBlock, blockMap));
+            }
         });
 
         return Table.builder()

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ ext {
     compileSdkVersion = 30
     minSdkVersion = 16
     targetSdkVersion = 30
-    awsSDKReleaseVersion = '2.65.0'
+    awsSDKReleaseVersion = '2.66.0'
     awsSdkVersion = useAwsSdkReleaseBuild() ? awsSDKReleaseVersion : "latest.integration"
     fragmentVersion = '1.3.1'
     navigationVersion = '2.3.4'


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:* TABLE_TITLE was added as a new block type that can be returned by Amazon Textract when identifying a table in an image. This block type may not have a row or column index so this PR adds a null check for these values when transforming the blocks to an Amplify type.

*How did you test these changes?*
Tested in a sample app.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
