### PR TITLE
fix(auth): Use java.time.Instant for AWSTemporaryCredentials expiration

### DIFF
--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/AWSCredentialsFactoryTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/AWSCredentialsFactoryTest.kt
@@ -15,11 +15,14 @@
 
 package com.amplifyframework.auth
 
+import aws.smithy.kotlin.runtime.time.toJvmInstant
 import com.amplifyframework.auth.AWSCredentials.Factory.createAWSCredentials
+import org.junit.Test
+import java.time.Instant
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertIsNot
 import kotlin.test.assertTrue
-import org.junit.Test
 
 class AWSCredentialsFactoryTest {
 
@@ -45,8 +48,11 @@ class AWSCredentialsFactoryTest {
 
     @Test
     fun `factory creates AWSTemporaryCredentials object when both session or expiry is not null`() {
-        val credentials = createAWSCredentials("accessKey", "secret", "ST", 12L)
+        val expectedExpirationInSeconds = Instant.now().epochSecond
+        val credentials = createAWSCredentials("accessKey", "secret", "ST", expectedExpirationInSeconds)
 
         assertIs<AWSTemporaryCredentials>(credentials)
+        assertEquals(expectedExpirationInSeconds, credentials.expiration.toJvmInstant().epochSecond)
+        assertEquals(expectedExpirationInSeconds, credentials.expiresAt.epochSecond)
     }
 }

--- a/aws-core/src/main/java/com/amplifyframework/auth/AWSCredentials.kt
+++ b/aws-core/src/main/java/com/amplifyframework/auth/AWSCredentials.kt
@@ -17,6 +17,7 @@ package com.amplifyframework.auth
 
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.toJvmInstant
 
 /**
  * Provides access to the AWS credentials used for accessing AWS services: AWS
@@ -81,13 +82,29 @@ class AWSTemporaryCredentials(
      */
     val sessionToken: String,
 
+    @Deprecated(
+        "Use expiresAt instead, which is based off java.time.Instant",
+        ReplaceWith("expiresAt", "java.time.Instant")
+    )
+    val expiration: Instant
+) : AWSCredentials(accessKeyId, secretAccessKey) {
+
     /**
      * The expiration.
      */
-    val expiration: Instant
-) : AWSCredentials(accessKeyId, secretAccessKey)
+    val expiresAt: java.time.Instant
+
+    init {
+
+        // Assigning and suppressing expiration usage here instead of inline assignment, as the suppress annotation was
+        // showing in code highlighting.
+        @Suppress("DEPRECATION")
+        expiresAt = expiration.toJvmInstant()
+    }
+}
 
 internal fun AWSCredentials.toSdkCredentials(): Credentials {
+    @Suppress("DEPRECATION")
     return Credentials(
         accessKeyId = this.accessKeyId,
         secretAccessKey = this.secretAccessKey,


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
