### PR TITLE
fix: revert JSON format changes, notify_comments needs to be in this form

### DIFF
--- a/.github/workflows/notify_comments.yml
+++ b/.github/workflows/notify_comments.yml
@@ -26,4 +26,4 @@ jobs:
           BODY: ${{ toJson(github.event.comment.body) }}
           COMMENT_URL: ${{github.event.comment.html_url}}
         shell: bash
-        run: echo $COMMENT | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"body":"{}", "issue":"'$COMMENT_URL'"}'
+        run: echo $BODY | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"body":"{}", "issue":"'$COMMENT_URL'"}'

--- a/.github/workflows/notify_comments.yml
+++ b/.github/workflows/notify_comments.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run webhook curl command
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_COMMENT_WEBHOOK_URL }}
-          COMMENT: ${{ toJson(github.event.comment.body) }}
+          BODY: ${{ toJson(github.event.comment.body) }}
           COMMENT_URL: ${{github.event.comment.html_url}}
         shell: bash
-        run: echo $COMMENT | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"comment":"{}", "commentUrl":"'$COMMENT_URL'"}'
+        run: echo $COMMENT | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"body":"{}", "issue":"'$COMMENT_URL'"}'


### PR DESCRIPTION
correct form:
```json
{
  "body": "Example text",
  "issue": "Example text"
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
