### PR TITLE
chore: Use the short branch name when creating the release branch

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -9,7 +9,7 @@ on:
 env:
   GIT_USER_NAME: amplify-android-dev+ghops
   GIT_USER_EMAIL: amplify-android-dev+ghops@amazon.com
-  BASE_BRANCH: ${{ github.event.ref }}
+  BASE_BRANCH: ${{ github.ref_name }}
 jobs:
   create_pr_for_next_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- The `ref_name` from the [GitHub Context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) has the short name of the branch the workflow is being run from (e.g. `main`). The ref from the event was the fully formed ref (e.g. `refs/heads/main`) which is not what we want. 

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
