### PR TITLE
fix(datastore): Load pending mutations one at a time from outbox

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationQueue.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationQueue.java
@@ -27,8 +27,11 @@ import java.util.Map;
  * The {@link MutationQueue} is a LinkedHashMap like container , the goal of using this container is to
  * achieve O(1) time complexity for both getting a {@link PendingMutation} and update an existing mutation with
  * valid id.
- * MutationQueue is implementing the Queue interface and provide most of the queue operations,
+ * MutationQueue is implementing the Queue interface and provide most of the queue operations.
+ * 
+ * @deprecated This class was released with public visibility but is not intended to be consumed.
  */
+@Deprecated
 public final class MutationQueue {
 
     private final Map<TimeBasedUuid, Node> mutationMap = new HashMap<>();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationQueue.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationQueue.java
@@ -30,6 +30,7 @@ import java.util.Map;
  * MutationQueue is implementing the Queue interface and provide most of the queue operations.
  * 
  * @deprecated This class was released with public visibility but is not intended to be consumed.
+ *             It will be removed in future versions of Amplify.
  */
 @Deprecated
 public final class MutationQueue {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.annotations.Index;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
@@ -277,6 +278,9 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     @ModelConfig(pluralName = "PersistentRecords", type = Model.Type.SYSTEM)
     @Index(fields = "containedModelClassName", name = "containedModelClassNameBasedIndex")
     public static final class PersistentRecord implements Model, Comparable<PersistentRecord> {
+        static final QueryField ID = QueryField.field("PersistentRecord", "id");
+        static final QueryField CONTAINED_MODEL_ID = QueryField.field("PersistentRecord", "containedModelId");
+        
         @ModelField(targetType = "ID", isRequired = true)
         private final String id;
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutbox.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.SerializedModel;
+import com.amplifyframework.core.model.query.Page;
 import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
@@ -34,12 +35,11 @@ import com.amplifyframework.datastore.storage.StorageItemChange;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.logging.Logger;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -65,7 +65,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
     private final Subject<OutboxEvent> events;
     private final Semaphore semaphore;
     private PendingMutation<? extends Model> loadedMutation;
-    private int numMutationsInStorage;
+    private int numMutationsInOutbox;
 
     PersistentMutationOutbox(@NonNull final LocalStorageAdapter localStorageAdapter) {
         this.storage = Objects.requireNonNull(localStorageAdapter);
@@ -74,7 +74,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
         this.events = PublishSubject.<OutboxEvent>create().toSerialized();
         this.semaphore = new Semaphore(1);
         this.loadedMutation = null;
-        this.numMutationsInStorage = 0;
+        this.numMutationsInOutbox = 0;
     }
 
     @Override
@@ -86,7 +86,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
     @VisibleForTesting
     PendingMutation<? extends Model> getMutationForModelId(@NonNull String modelId) {
         Objects.requireNonNull(modelId);
-        final List<PendingMutation<? extends Model>> mutationResult = new ArrayList<>();
+        AtomicReference<PendingMutation<? extends Model>> mutationResult = new AtomicReference<>();
         Completable.create(emitter -> {
             storage.query(PendingMutation.PersistentRecord.class,
                     Where.matches(PendingMutation.PersistentRecord.CONTAINED_MODEL_ID.eq(modelId)),
@@ -94,7 +94,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
                     if (results.hasNext()) {
                         try {
                             PendingMutation.PersistentRecord persistentRecord = results.next();
-                            mutationResult.add(converter.fromRecord(persistentRecord));
+                            mutationResult.set(converter.fromRecord(persistentRecord));
                         } catch (Throwable throwable) {
                             emitter.onError(throwable);
                         }
@@ -108,15 +108,12 @@ final class PersistentMutationOutbox implements MutationOutbox {
         .doOnTerminate(semaphore::release)
             .blockingAwait();
 
-        if (mutationResult.isEmpty()) {
-            return null;
-        }
-        return mutationResult.get(0);
+        return mutationResult.get();
     }
 
     private PendingMutation<? extends Model> getMutationById(@NonNull String mutationId) {
         Objects.requireNonNull(mutationId);
-        final List<PendingMutation<? extends Model>> mutationResult = new ArrayList<>();
+        AtomicReference<PendingMutation<? extends Model>> mutationResult = new AtomicReference<>();
         Completable.create(emitter -> {
             storage.query(PendingMutation.PersistentRecord.class,
                     Where.matches(PendingMutation.PersistentRecord.ID.eq(mutationId)),
@@ -124,7 +121,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
                     if (results.hasNext()) {
                         try {
                             PendingMutation.PersistentRecord persistentRecord = results.next();
-                            mutationResult.add(converter.fromRecord(persistentRecord));
+                            mutationResult.set(converter.fromRecord(persistentRecord));
                         } catch (Throwable throwable) {
                             emitter.onError(throwable);
                         }
@@ -138,10 +135,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
         .doOnTerminate(semaphore::release)
             .blockingAwait();
 
-        if (mutationResult.isEmpty()) {
-            return null;
-        }
-        return mutationResult.get(0);
+        return mutationResult.get();
     }
 
     @NonNull
@@ -155,7 +149,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
             @SuppressWarnings("unchecked")
             PendingMutation<T> existingMutation = (PendingMutation<T>) getMutationForModelId(modelId);
             if (existingMutation == null || inFlightMutations.contains(existingMutation.getMutationId())) {
-                return save(incomingMutation)
+                return save(incomingMutation, true)
                     .andThen(notifyContentAvailable());
             } else {
                 return resolveConflict(existingMutation, incomingMutation);
@@ -172,7 +166,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
         return mutationConflictHandler.resolve();
     }
 
-    private <T extends Model> Completable save(PendingMutation<T> pendingMutation) {
+    private <T extends Model> Completable save(PendingMutation<T> pendingMutation, boolean addingNewMutation) {
         PendingMutation.PersistentRecord item = converter.toRecord(pendingMutation);
         return Completable.create(emitter -> storage.save(
                 item,
@@ -185,7 +179,9 @@ final class PersistentMutationOutbox implements MutationOutbox {
                 // So, let's skip the unwrapping, and use the thing that was enqueued,
                 // the pendingMutation, directly.
                 LOG.info("Successfully enqueued " + pendingMutation);
-                numMutationsInStorage += 1;
+                if (addingNewMutation) {
+                    numMutationsInOutbox += 1;
+                }
                 announceEventEnqueued(pendingMutation);
                 publishCurrentOutboxStatus();
                 emitter.onComplete();
@@ -222,8 +218,8 @@ final class PersistentMutationOutbox implements MutationOutbox {
                     ignored -> {
                         inFlightMutations.remove(pendingMutationId);
                         LOG.info("Successfully removed from mutations outbox" + pendingMutation);
-                        numMutationsInStorage -= 1;
-                        final boolean contentAvailable = numMutationsInStorage > 0;
+                        numMutationsInOutbox -= 1;
+                        final boolean contentAvailable = numMutationsInOutbox > 0;
                         if (contentAvailable) {
                             subscriber.onSuccess(OutboxEvent.CONTENT_AVAILABLE);
                         } else {
@@ -242,25 +238,18 @@ final class PersistentMutationOutbox implements MutationOutbox {
     public Completable load() {
         return Completable.create(emitter -> {
             inFlightMutations.clear();
-            storage.query(PendingMutation.PersistentRecord.class, Where.matchesAll(),
+            storage.query(PendingMutation.PersistentRecord.class, Where.matchesAll().paginated(Page.firstResult()),
                 results -> {
-                    if (!results.hasNext()) {
-                        loadedMutation = null;
-                    }
-                    boolean firstResult = true;
-                    numMutationsInStorage = 0;
-                    while (results.hasNext()) {
-                        numMutationsInStorage += 1;
-                        PendingMutation.PersistentRecord persistentRecord = results.next();
-                        if (firstResult) {
-                            firstResult = false;
-                            try {
-                                loadedMutation = converter.fromRecord(persistentRecord);
-                            } catch (Throwable throwable) {
-                                emitter.onError(throwable);
-                                return;
-                            }
+                    if (results.hasNext()) {
+                        try {
+                            PendingMutation.PersistentRecord persistentRecord = results.next();
+                            loadedMutation = converter.fromRecord(persistentRecord);
+                        } catch (Throwable throwable) {
+                            emitter.onError(throwable);
+                            return;
                         }
+                    } else {
+                        loadedMutation = null;
                     }
                     // Publish outbox status upon loading
                     publishCurrentOutboxStatus();
@@ -324,7 +313,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
     private void publishCurrentOutboxStatus() {
         Amplify.Hub.publish(
             HubChannel.DATASTORE,
-            new OutboxStatusEvent(numMutationsInStorage == 0).toHubEvent()
+            new OutboxStatusEvent(numMutationsInOutbox == 0).toHubEvent()
         );
     }
 
@@ -408,7 +397,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
                                 incoming.getModelSchema(),
                                 PendingMutation.Type.CREATE);
                         return removeNotLocking(existing.getMutationId())
-                                .andThen(saveAndNotify(mergedPendingMutation));
+                                .andThen(saveAndNotify(mergedPendingMutation, true));
                     } else {
                         return overwriteExistingAndNotify(PendingMutation.Type.CREATE, QueryPredicates.all());
                     }
@@ -426,13 +415,13 @@ final class PersistentMutationOutbox implements MutationOutbox {
                                     incoming.getModelSchema(),
                                     PendingMutation.Type.UPDATE);
                             return removeNotLocking(existing.getMutationId())
-                                    .andThen(saveAndNotify(mergedPendingMutation));
+                                    .andThen(saveAndNotify(mergedPendingMutation, true));
                         } else {
-                            return removeNotLocking(existing.getMutationId()).andThen(saveAndNotify(incoming));
+                            return removeNotLocking(existing.getMutationId()).andThen(saveAndNotify(incoming, true));
                         }
                     } else {
                         // If it has a condition, we want to just add it to the queue
-                        return saveAndNotify(incoming);
+                        return saveAndNotify(incoming, true);
                     }
                 case DELETE:
                     // Incoming update after a delete -> throw exception
@@ -452,7 +441,7 @@ final class PersistentMutationOutbox implements MutationOutbox {
                     //
                     if (inFlightMutations.contains(existing.getMutationId())) {
                         // Existing create is already in flight, then save the delete
-                        return save(incoming);
+                        return save(incoming, true);
                     } else {
                         // The existing create mutation hasn't made it to the remote store, so we
                         // ignore the incoming and remove the existing create mutation from outbox.
@@ -474,12 +463,12 @@ final class PersistentMutationOutbox implements MutationOutbox {
             TimeBasedUuid id = existing.getMutationId();
             T item = incoming.getMutatedItem();
             ModelSchema schema = incoming.getModelSchema();
-            return save(PendingMutation.instance(id, item, schema, type, predicate))
+            return save(PendingMutation.instance(id, item, schema, type, predicate), false)
                 .andThen(notifyContentAvailable());
         }
 
-        private Completable saveAndNotify(PendingMutation<T> incoming) {
-            return save(incoming)
+        private Completable saveAndNotify(PendingMutation<T> incoming, boolean addedNewMutation) {
+            return save(incoming, addedNewMutation)
                 .andThen(notifyContentAvailable());
         }
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationQueueTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationQueueTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests the {@link MutationQueue}.
  */
+@SuppressWarnings("deprecation")
 @RunWith(RobolectricTestRunner.class)
 public final class MutationQueueTest {
     private ModelSchema schema;

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -246,28 +246,37 @@ public final class PersistentMutationOutboxTest {
      * notifies the system that there is more work to be done, even though we've successfully
      * processed an event. The system will continue processing items from the outbox until
      * all have been processed.
-     * @throws DataStoreException On failure to arrange data into storage
      * @throws InterruptedException If thread interrupted while waiting for events
      */
     @Test
-    public void notifiesWhenContentAvailableAfterDelete() throws DataStoreException, InterruptedException {
-        // Start watching the events stream. We'll expect a notification here once,
-        // after the first deletion.
-        TestObserver<OutboxEvent> firstEventObserver = mutationOutbox.events().test();
+    public void notifiesWhenContentAvailableAfterDelete() throws InterruptedException {
+        // Start watching the events stream. We'll expect a notification here 3 times:
+        // after the first enqueue, after the second enqueue, after the first deletion.
+        TestObserver<OutboxEvent> enqueueEventObserver = mutationOutbox.events().test();
 
         // Arrange a few mutations into the queue.
         BlogOwner senatorBernie = BlogOwner.builder()
             .name("Senator Bernard Sanders")
             .build();
         PendingMutation<BlogOwner> createSenatorBernie = PendingMutation.creation(senatorBernie, schema);
-        storage.save(converter.toRecord(createSenatorBernie));
-        BlogOwner candidateBernie = senatorBernie.copyOfBuilder()
-            .name("Democratic Presidential Candidate, Bernard Sanders")
-            .build();
-        PendingMutation<BlogOwner> updateCandidateBernie = PendingMutation.update(candidateBernie, schema);
-        storage.save(converter.toRecord(updateCandidateBernie));
-        boolean completed = mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        assertTrue(completed);
+        boolean createCompleted = mutationOutbox.enqueue(createSenatorBernie)
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(createCompleted);
+
+        BlogOwner sam = BlogOwner.builder()
+                .name("Sam Watson")
+                .build();
+        PendingMutation<BlogOwner> insertSam = PendingMutation.creation(sam, schema);
+        boolean updateCompleted = mutationOutbox.enqueue(insertSam)
+            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(updateCompleted);
+
+        enqueueEventObserver
+                .awaitCount(2)
+                .assertValues(OutboxEvent.CONTENT_AVAILABLE, OutboxEvent.CONTENT_AVAILABLE)
+                .assertNoErrors();
+
+        TestObserver<OutboxEvent> firstRemoveEventObserver = mutationOutbox.events().test();
 
         // Remove first item.
         TestObserver<Void> firstRemoval = mutationOutbox.remove(createSenatorBernie.getMutationId()).test();
@@ -279,16 +288,16 @@ public final class PersistentMutationOutboxTest {
 
         // One event is observed on events(), since there are still some pending mutations
         // that need to be processed.
-        firstEventObserver
+        firstRemoveEventObserver
             .awaitCount(1)
             .assertValues(OutboxEvent.CONTENT_AVAILABLE)
             .assertNoErrors();
 
         // Get ready to watch the events() again.
-        TestObserver<OutboxEvent> secondEventObserver = mutationOutbox.events().test();
+        TestObserver<OutboxEvent> secondRemoveEventObserver = mutationOutbox.events().test();
 
         // Remove the next item.
-        TestObserver<Void> secondRemoval = mutationOutbox.remove(updateCandidateBernie.getMutationId()).test();
+        TestObserver<Void> secondRemoval = mutationOutbox.remove(insertSam.getMutationId()).test();
         secondRemoval.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         secondRemoval
             .assertNoErrors()
@@ -296,8 +305,8 @@ public final class PersistentMutationOutboxTest {
             .dispose();
 
         // This time, we don't see any event on events(), since the outbox has become empty.
-        secondEventObserver.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        secondEventObserver.assertNoValues().assertNoErrors();
+        secondRemoveEventObserver.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        secondRemoveEventObserver.assertNoValues().assertNoErrors();
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -1028,7 +1028,7 @@ public final class PersistentMutationOutboxTest {
 
     /**
      * If the queue contains multiple items, then
-     * {@link MutationQueue#nextMutationForModelId(String)}
+     * {@link MutationOutbox#getMutationForModelId(String)}
      * returns the first one.
      * @throws DataStoreException On failure to arrange content into storage
      */


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #1869

*Description of changes:* Modifies the PersistentMutationOutbox to load pending mutations one at a time, rather than storing all pending mutations in a queue, to reduce memory usage.

*How did you test these changes?*
Ran existing tests and tested in a sample app.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
