### PR TITLE
fix(datastore): Load pending mutations one at a time from outbox (v1)

### DIFF
--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/BasicCloudSyncInstrumentationTest.java
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/BasicCloudSyncInstrumentationTest.java
@@ -231,16 +231,17 @@ public final class BasicCloudSyncInstrumentationTest {
                 .build();
         String modelName = BlogOwner.class.getSimpleName();
 
-        // Expect two mutations to be published to AppSync.
+        // Expect one mutation to be published to AppSync. The create and update mutations
+        // are merged into one create mutation.
         HubAccumulator richardAccumulator =
-            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, richard.getId()), 2)
+            HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, richard.getId()), 1)
                 .start();
 
         // Create an item, then update it and save it again.
         dataStore.save(richard);
         dataStore.save(updatedRichard);
 
-        // Verify that 2 mutations were published.
+        // Verify that 1 mutation was published.
         richardAccumulator.await(60, TimeUnit.SECONDS);
 
         // Verify that the updatedRichard is saved in the DataStore.
@@ -268,16 +269,17 @@ public final class BasicCloudSyncInstrumentationTest {
                 .build();
         String modelName = BlogOwner.class.getSimpleName();
 
-        // Expect two mutations to be published to AppSync.
+        // Expect one mutation to be published to AppSync. The create and update mutations
+        // are merged into one create mutation.
         HubAccumulator accumulator =
-                HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, owner.getId()), 2)
+                HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, owner.getId()), 1)
                         .start();
 
         // Create an item, then update it with different field and save it again.
         dataStore.save(owner);
         dataStore.save(updatedOwner);
 
-        // Verify that 2 mutations were published.
+        // Verify that 1 mutation was published.
         accumulator.await(60, TimeUnit.SECONDS);
 
         // Verify that the updatedOwner is saved in the DataStore.
@@ -308,9 +310,10 @@ public final class BasicCloudSyncInstrumentationTest {
                 .build();
         String modelName = BlogOwner.class.getSimpleName();
 
-        // Expect two mutations to be published to AppSync.
+        // Expect one mutation of anotherOwner to be published to AppSync. The create and update
+        // mutations are merged into one create mutation.
         HubAccumulator accumulator =
-                HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, anotherOwner.getId()), 2)
+                HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, anotherOwner.getId()), 1)
                         .start();
 
         // Create an item, then update it with different field and save it again.
@@ -318,7 +321,7 @@ public final class BasicCloudSyncInstrumentationTest {
         dataStore.save(anotherOwner);
         dataStore.save(updatedOwner);
 
-        // Verify that 2 mutations were published.
+        // Verify that 1 mutation was published.
         accumulator.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Verify that the updatedOwner is saved in the DataStore.
@@ -341,15 +344,9 @@ public final class BasicCloudSyncInstrumentationTest {
         BlogOwner owner = BlogOwner.builder()
                 .name("Jean")
                 .build();
-        String modelName = BlogOwner.class.getSimpleName();
         
-        HubAccumulator accumulator =
-                HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, owner.getId()), 2)
-                        .start();
         dataStore.save(owner);
         dataStore.delete(owner);
-        
-        accumulator.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         
         // Verify that the owner is deleted from the local data store.
         assertThrows(NoSuchElementException.class, () -> dataStore.get(BlogOwner.class, owner.getId()));
@@ -466,7 +463,7 @@ public final class BasicCloudSyncInstrumentationTest {
         String modelName = BlogOwner.class.getSimpleName();
         
         HubAccumulator accumulator =
-                HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, owner.getId()), 2)
+                HubAccumulator.create(HubChannel.DATASTORE, publicationOf(modelName, owner.getId()), 1)
                         .start();
         // Create new and then immediately update
         dataStore.save(owner);

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationQueue.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationQueue.java
@@ -27,8 +27,11 @@ import java.util.Map;
  * The {@link MutationQueue} is a LinkedHashMap like container , the goal of using this container is to
  * achieve O(1) time complexity for both getting a {@link PendingMutation} and update an existing mutation with
  * valid id.
- * MutationQueue is implementing the Queue interface and provide most of the queue operations,
+ * MutationQueue is implementing the Queue interface and provide most of the queue operations.
+ * 
+ * @deprecated This class was released with public visibility but is not intended to be consumed.
  */
+@Deprecated
 public final class MutationQueue {
 
     private final Map<TimeBasedUuid, Node> mutationMap = new HashMap<>();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationQueue.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationQueue.java
@@ -30,6 +30,7 @@ import java.util.Map;
  * MutationQueue is implementing the Queue interface and provide most of the queue operations.
  * 
  * @deprecated This class was released with public visibility but is not intended to be consumed.
+ *             It will be removed in future versions of Amplify.
  */
 @Deprecated
 public final class MutationQueue {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/PendingMutation.java
@@ -24,6 +24,7 @@ import com.amplifyframework.core.model.ModelSchema;
 import com.amplifyframework.core.model.annotations.Index;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.DataStoreException;
@@ -277,6 +278,9 @@ public final class PendingMutation<T extends Model> implements Comparable<Pendin
     @ModelConfig(pluralName = "PersistentRecords", type = Model.Type.SYSTEM)
     @Index(fields = "containedModelClassName", name = "containedModelClassNameBasedIndex")
     public static final class PersistentRecord implements Model, Comparable<PersistentRecord> {
+        static final QueryField ID = QueryField.field("PersistentRecord", "id");
+        static final QueryField CONTAINED_MODEL_ID = QueryField.field("PersistentRecord", "containedModelId");
+
         @ModelField(targetType = "ID", isRequired = true)
         private final String id;
 

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationQueueTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/MutationQueueTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests the {@link MutationQueue}.
  */
+@SuppressWarnings("deprecation")
 @RunWith(RobolectricTestRunner.class)
 public final class MutationQueueTest {
     private ModelSchema schema;

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/PersistentMutationOutboxTest.java
@@ -55,14 +55,13 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests the {@link MutationOutbox}.
  */
-@SuppressWarnings("ResultOfMethodCallIgnored") // blockingAwait(...) calls
 @RunWith(RobolectricTestRunner.class)
 public final class PersistentMutationOutboxTest {
+
     private static final long TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);
 
     private ModelSchema schema;
     private PersistentMutationOutbox mutationOutbox;
-    private MutationQueue mutationQueue;
     private PendingMutation.Converter converter;
     private SynchronousStorageAdapter storage;
 
@@ -75,16 +74,16 @@ public final class PersistentMutationOutboxTest {
         schema = ModelSchema.fromModelClass(BlogOwner.class);
         InMemoryStorageAdapter inMemoryStorageAdapter = InMemoryStorageAdapter.create();
         storage = SynchronousStorageAdapter.delegatingTo(inMemoryStorageAdapter);
-        mutationQueue = new MutationQueue();
-        mutationOutbox = new PersistentMutationOutbox(inMemoryStorageAdapter, mutationQueue);
+        mutationOutbox = new PersistentMutationOutbox(inMemoryStorageAdapter);
         converter = new GsonPendingMutationConverter();
     }
 
     /**
      * Enqueueing a mutation should publish current outbox status.
+     * @throws InterruptedException If interrupted while awaiting terminal result in test observer
      */
     @Test
-    public void outboxStatusIsPublishedToHubOnEnqueue() {
+    public void outboxStatusIsPublishedToHubOnEnqueue() throws InterruptedException {
         BlogOwner raphael = BlogOwner.builder()
                 .name("Raphael Kim")
                 .build();
@@ -98,7 +97,10 @@ public final class PersistentMutationOutboxTest {
 
         // Enqueue an save for a Raphael BlogOwner object,
         // and make sure that outbox status is published to hub.
-        mutationOutbox.enqueue(createRaphael).test();
+        TestObserver<Void> saveObserver = mutationOutbox.enqueue(createRaphael).test();
+        saveObserver.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        saveObserver.assertNoErrors().assertComplete();
+        saveObserver.dispose();
         statusAccumulator.await();
     }
 
@@ -223,7 +225,8 @@ public final class PersistentMutationOutboxTest {
             .build();
         PendingMutation<BlogOwner> deleteBillGates = PendingMutation.deletion(bill, schema);
         storage.save(converter.toRecord(deleteBillGates));
-        mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         TestObserver<Void> testObserver = mutationOutbox.remove(deleteBillGates.getMutationId()).test();
 
@@ -263,7 +266,8 @@ public final class PersistentMutationOutboxTest {
             .build();
         PendingMutation<BlogOwner> updateCandidateBernie = PendingMutation.update(candidateBernie, schema);
         storage.save(converter.toRecord(updateCandidateBernie));
-        mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Remove first item.
         TestObserver<Void> firstRemoval = mutationOutbox.remove(createSenatorBernie.getMutationId()).test();
@@ -311,8 +315,9 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> pendingMutation = PendingMutation.instance(
             mutationId, joe, schema, PendingMutation.Type.CREATE, QueryPredicates.all()
         );
-        mutationOutbox.enqueue(pendingMutation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(pendingMutation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
+        assertTrue(completed);
         assertTrue(mutationOutbox.hasPendingMutation(modelId));
         assertFalse(mutationOutbox.hasPendingMutation(mutationId.toString()));
     }
@@ -339,10 +344,9 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> unrelatedMutation = PendingMutation.instance(
             mutationId, joe, schema, PendingMutation.Type.CREATE, QueryPredicates.all()
         );
-        storage.save(converter.toRecord(unrelatedMutation));
 
         assertFalse(mutationOutbox.hasPendingMutation(joeId));
-        assertFalse(mutationOutbox.hasPendingMutation(mutationId.toString()));
+        assertFalse(mutationOutbox.hasPendingMutation(unrelatedMutation.getMutationId().toString()));
     }
 
     /**
@@ -362,7 +366,8 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> existingCreation =
             PendingMutation.creation(modelInExistingMutation, schema);
         String existingCreationId = existingCreation.getMutationId().toString();
-        mutationOutbox.enqueue(existingCreation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(existingCreation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Act: try to create the blog owner again -- but there's already a pending creation
         BlogOwner modelInIncomingMutation = modelInExistingMutation.copyOfBuilder()
@@ -406,7 +411,8 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> existingUpdate =
             PendingMutation.update(modelInExistingMutation, schema);
         String exitingUpdateId = existingUpdate.getMutationId().toString();
-        mutationOutbox.enqueue(existingUpdate).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(existingUpdate).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Act: try to CREATE tony again -- but isn't he already created, if there's an update?
         BlogOwner modelInIncomingMutation = modelInExistingMutation.copyOfBuilder()
@@ -451,7 +457,8 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> existingDeletion =
             PendingMutation.deletion(modelInExistingMutation, schema);
         String existingDeletionId = existingDeletion.getMutationId().toString();
-        mutationOutbox.enqueue(existingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(existingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Act: try to create tony, but wait -- if we're already deleting him...
         BlogOwner modelInIncomingMutation = modelInExistingMutation.copyOfBuilder()
@@ -495,7 +502,8 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> existingDeletion =
             PendingMutation.deletion(modelInExistingMutation, schema);
         String existingDeletionId = existingDeletion.getMutationId().toString();
-        mutationOutbox.enqueue(existingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(existingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Act: try to update tony, but wait ... aren't we deleting tony?
         BlogOwner modelInIncomingMutation = modelInExistingMutation.copyOfBuilder()
@@ -539,7 +547,8 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> existingUpdate =
             PendingMutation.update(modelInExistingMutation, schema);
         String existingUpdateId = existingUpdate.getMutationId().toString();
-        mutationOutbox.enqueue(existingUpdate).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(existingUpdate).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Act: try to enqueue a new update mutation when there already is one
         BlogOwner modelInIncomingMutation = modelInExistingMutation.copyOfBuilder()
@@ -577,8 +586,9 @@ public final class PersistentMutationOutboxTest {
             next
         );
         // Remove the first one from the queue
-        mutationOutbox.remove(existingUpdate.getMutationId())
+        boolean removeCompleted = mutationOutbox.remove(existingUpdate.getMutationId())
             .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(removeCompleted);
 
         // Get the next one
         next = mutationOutbox.peek();
@@ -791,7 +801,8 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> existingCreation =
             PendingMutation.creation(modelInExistingMutation, schema);
         String existingCreationId = existingCreation.getMutationId().toString();
-        mutationOutbox.enqueue(existingCreation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(existingCreation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Act: try to enqueue an update even whilst the creation is pending
         BlogOwner modelInIncomingMutation = modelInExistingMutation.copyOfBuilder()
@@ -849,11 +860,15 @@ public final class PersistentMutationOutboxTest {
             .build();
         PendingMutation<BlogOwner> existingCreation = PendingMutation.creation(joe, schema);
         String existingCreationId = existingCreation.getMutationId().toString();
-        mutationOutbox.enqueue(existingCreation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(existingCreation)
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         PendingMutation<BlogOwner> incomingDeletion = PendingMutation.deletion(joe, schema);
         String incomingDeletionId = incomingDeletion.getMutationId().toString();
-        mutationOutbox.enqueue(incomingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean otherEnqueueCompleted = mutationOutbox.enqueue(incomingDeletion)
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(otherEnqueueCompleted);
 
         assertTrue(storage.query(PersistentRecord.class,
                 Where.identifier(PersistentRecord.class, existingCreationId)).isEmpty());
@@ -878,11 +893,14 @@ public final class PersistentMutationOutboxTest {
             .build();
         PendingMutation<BlogOwner> exitingUpdate = PendingMutation.update(joe, schema);
         String existingUpdateId = exitingUpdate.getMutationId().toString();
-        mutationOutbox.enqueue(exitingUpdate).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(exitingUpdate).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         PendingMutation<BlogOwner> incomingDeletion = PendingMutation.deletion(joe, schema);
         String incomingDeletionId = incomingDeletion.getMutationId().toString();
-        mutationOutbox.enqueue(incomingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean otherEnqueueCompleted = mutationOutbox.enqueue(incomingDeletion)
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(otherEnqueueCompleted);
 
         // The original mutation ID is preserved.
         List<PendingMutation.PersistentRecord> existingMutationRecords =
@@ -931,8 +949,11 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> incomingDeletion = PendingMutation.deletion(sammy, schema);
         assertNotEquals(exitingDeletion.getMutationId(), incomingDeletion.getMutationId());
 
-        mutationOutbox.enqueue(exitingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        mutationOutbox.enqueue(incomingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(exitingDeletion).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
+        boolean otherEnqueueCompleted = mutationOutbox.enqueue(incomingDeletion)
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(otherEnqueueCompleted);
 
         // Existing record is still there
         List<PersistentRecord> existingMutationRecords =
@@ -964,14 +985,16 @@ public final class PersistentMutationOutboxTest {
             .name("Tony Jon Swanssssssssson yee-haw!")
             .build();
         PendingMutation<BlogOwner> originalCreation = PendingMutation.creation(tonyWrongName, schema);
-        mutationOutbox.enqueue(originalCreation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(originalCreation).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Update tony - we spelled his name wrong originally
         BlogOwner tonySpelledRight = tonyWrongName.copyOfBuilder()
             .name("Tony Jon (\"TJ\") Swanson")
             .build();
-        mutationOutbox.enqueue(PendingMutation.update(tonySpelledRight, schema))
-            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean otherEnqueueCompleted = mutationOutbox.enqueue(PendingMutation.update(tonySpelledRight, schema))
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(otherEnqueueCompleted);
 
         // Assert: an event for the original creation, then another for the update
         eventsObserver.awaitCount(2)
@@ -990,10 +1013,11 @@ public final class PersistentMutationOutboxTest {
         TestObserver<OutboxEvent> eventsObserver = mutationOutbox.events().test();
 
         // Enqueue one
-        mutationOutbox.enqueue(PendingMutation.deletion(BlogOwner.builder()
-            .name("Tony Swanson")
-            .build(), schema
+        boolean completed = mutationOutbox.enqueue(PendingMutation.deletion(BlogOwner.builder()
+                .name("Tony Swanson")
+                .build(), schema
         )).blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Assert: we got an event!
         eventsObserver.awaitCount(1)
@@ -1004,7 +1028,7 @@ public final class PersistentMutationOutboxTest {
 
     /**
      * If the queue contains multiple items, then
-     * {@link MutationQueue#nextMutationForModelId(String)}
+     * {@link MutationOutbox#getMutationForModelId(String)}
      * returns the first one.
      * @throws DataStoreException On failure to arrange content into storage
      */
@@ -1022,11 +1046,12 @@ public final class PersistentMutationOutboxTest {
         PendingMutation<BlogOwner> secondMutation = PendingMutation.update(updatedJoe, schema);
         storage.save(updatedJoe, converter.toRecord(secondMutation));
 
-        mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.load().blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
+        assertTrue(completed);
         assertEquals(
             firstMutation,
-            mutationQueue.nextMutationForModelId(originalJoe.getId())
+            mutationOutbox.getMutationForModelId(originalJoe.getId())
         );
     }
 
@@ -1042,27 +1067,31 @@ public final class PersistentMutationOutboxTest {
             .name("Joe")
             .build();
         PendingMutation<BlogOwner> creation = PendingMutation.creation(joe, schema);
-        mutationOutbox.enqueue(creation)
+        boolean completed = mutationOutbox.enqueue(creation)
             // Act: mark it as in-flight, after enqueue.
             .andThen(mutationOutbox.markInFlight(creation.getMutationId()))
             .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         // Now, look at what happens when we enqueue a new mutation.
         PendingMutation<BlogOwner> deletion = PendingMutation.deletion(joe, schema);
-        mutationOutbox.enqueue(deletion)
-            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean otherEnqueueCompleted = mutationOutbox.enqueue(deletion)
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(otherEnqueueCompleted);
 
         PendingMutation<? extends Model> next = mutationOutbox.peek();
         assertNotNull(next);
         assertEquals(creation, next);
-        mutationOutbox.remove(next.getMutationId())
-            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean removeCompleted = mutationOutbox.remove(next.getMutationId())
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(removeCompleted);
 
         next = mutationOutbox.peek();
         assertNotNull(next);
         assertEquals(deletion, next);
-        mutationOutbox.remove(next.getMutationId())
-            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean otherRemoveCompleted = mutationOutbox.remove(next.getMutationId())
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(otherRemoveCompleted);
 
         assertNull(mutationOutbox.peek());
     }
@@ -1078,10 +1107,12 @@ public final class PersistentMutationOutboxTest {
             .name("Tabitha Stevens of Beaver Falls, Idaho")
             .build();
         PendingMutation<BlogOwner> creation = PendingMutation.creation(tabby, schema);
-        mutationOutbox.enqueue(creation)
+        boolean enqueueCompleted = mutationOutbox.enqueue(creation)
             .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        mutationOutbox.remove(creation.getMutationId())
+        assertTrue(enqueueCompleted);
+        boolean removeCompleted = mutationOutbox.remove(creation.getMutationId())
             .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(removeCompleted);
 
         // Now, if we try to make that mutation as in-flight, its an error, since its already processed.
         TestObserver<Void> observer = mutationOutbox.markInFlight(creation.getMutationId()).test();
@@ -1130,8 +1161,9 @@ public final class PersistentMutationOutboxTest {
             .name("Tabitha Stevens of Beaver Falls, Idaho")
             .build();
         PendingMutation<BlogOwner> creation = PendingMutation.creation(tabby, schema);
-        mutationOutbox.enqueue(creation)
-            .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        boolean completed = mutationOutbox.enqueue(creation)
+                .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
 
         TestObserver<Void> observer = mutationOutbox.remove(creation.getMutationId())
             .andThen(mutationOutbox.remove(creation.getMutationId()))
@@ -1160,8 +1192,9 @@ public final class PersistentMutationOutboxTest {
                 .name("Tabitha Stevens of Beaver Falls, Idaho")
                 .build();
         PendingMutation<BlogOwner> creation = PendingMutation.creation(tabby, schema);
-        mutationOutbox.enqueue(creation)
+        boolean completed = mutationOutbox.enqueue(creation)
                 .blockingAwait(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(completed);
         TestObserver<Void> observer = mutationOutbox.remove(creation.getMutationId())
                 .andThen(mutationOutbox.markInFlight(creation.getMutationId())).test();
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #1869

*Description of changes:* Modifies the PersistentMutationOutbox to load pending mutations one at a time, rather than storing all pending mutations in a queue, to reduce memory usage.

*How did you test these changes?*
Ran existing tests and tested in a sample app.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
