### PR TITLE
Revert "feat(aws-datastore): Make the Sync Engine pausable/resumable on connectivity changes (#2306)"

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -41,7 +41,6 @@ import com.amplifyframework.core.model.query.Where;
 import com.amplifyframework.core.model.query.predicate.QueryPredicate;
 import com.amplifyframework.core.model.query.predicate.QueryPredicates;
 import com.amplifyframework.datastore.appsync.AppSyncClient;
-import com.amplifyframework.datastore.events.NetworkStatusEvent;
 import com.amplifyframework.datastore.model.ModelProviderLocator;
 import com.amplifyframework.datastore.storage.ItemChangeMapper;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
@@ -50,7 +49,6 @@ import com.amplifyframework.datastore.storage.sqlite.SQLiteStorageAdapter;
 import com.amplifyframework.datastore.syncengine.Orchestrator;
 import com.amplifyframework.datastore.syncengine.ReachabilityMonitor;
 import com.amplifyframework.hub.HubChannel;
-import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.logging.Logger;
 
 import org.json.JSONObject;
@@ -114,8 +112,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             AppSyncClient.via(api),
             () -> pluginConfiguration,
             () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API,
-            reachabilityMonitor,
-            isSyncRetryEnabled
+                isSyncRetryEnabled
         );
 
     }
@@ -149,7 +146,6 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             AppSyncClient.via(api, this.authModeStrategy),
             () -> pluginConfiguration,
             () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API,
-            reachabilityMonitor,
             isSyncRetryEnabled
         );
     }
@@ -268,18 +264,31 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         );
 
         reachabilityMonitor.configure(context);
-
-        waitForInitialization().subscribe(this::observeNetworkStatus);
+        observeNetworkStatus();
     }
 
-    private void publishNetworkStatusEvent(boolean active) {
-        Amplify.Hub.publish(HubChannel.DATASTORE,
-                HubEvent.create(DataStoreChannelEventName.NETWORK_STATUS, new NetworkStatusEvent(active)));
-    }
-
+    /**
+     * Start the datastore when the network is available, and stop the datastore when it is not
+     * available.
+     */
     private void observeNetworkStatus() {
         reachabilityMonitor.getObservable()
-                .subscribe(this::publishNetworkStatusEvent);
+            .doOnNext(networkIsAvailable -> {
+                if (networkIsAvailable) {
+                    LOG.info("Network available, start datastore");
+                    start(
+                        (Action) () -> { },
+                        ((e) -> LOG.error("Error starting datastore plugin after network event: " + e))
+                    );
+                } else {
+                    LOG.info("Network lost, stop datastore");
+                    stop(
+                        (Action) () -> { },
+                        ((e) -> LOG.error("Error stopping datastore plugin after network event: " + e))
+                    );
+                }
+            })
+            .subscribe();
     }
 
     @WorkerThread

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/Orchestrator.java
@@ -28,6 +28,7 @@ import com.amplifyframework.datastore.DataStoreChannelEventName;
 import com.amplifyframework.datastore.DataStoreConfigurationProvider;
 import com.amplifyframework.datastore.DataStoreException;
 import com.amplifyframework.datastore.appsync.AppSync;
+import com.amplifyframework.datastore.events.NetworkStatusEvent;
 import com.amplifyframework.datastore.storage.LocalStorageAdapter;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
@@ -42,7 +43,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
-import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.Action;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
@@ -63,8 +63,6 @@ public final class Orchestrator {
     private final MutationOutbox mutationOutbox;
     private final CompositeDisposable disposables;
     private final Semaphore startStopSemaphore;
-    private final ReachabilityMonitor reachabilityMonitor;
-    private Disposable monitorNetworkChangesDisposable;
 
     /**
      * Constructs a new Orchestrator.
@@ -82,7 +80,6 @@ public final class Orchestrator {
      *        The reference to the variable returned by the provider only get set after the plugin's
      *        {@link AWSDataStorePlugin#configure(JSONObject, Context)} is invoked by Amplify.
      * @param targetState The desired state of operation - online, or offline
-     * @param reachabilityMonitor The reachability monitor to use.
      * @param isSyncRetryEnabled enable or disable the SyncProcessor retry
      */
     public Orchestrator(
@@ -92,7 +89,6 @@ public final class Orchestrator {
             @NonNull final AppSync appSync,
             @NonNull final DataStoreConfigurationProvider dataStoreConfigurationProvider,
             @NonNull final Supplier<State> targetState,
-            @NonNull final ReachabilityMonitor reachabilityMonitor,
             final boolean isSyncRetryEnabled) {
         Objects.requireNonNull(schemaRegistry);
         Objects.requireNonNull(modelProvider);
@@ -136,7 +132,6 @@ public final class Orchestrator {
         this.storageObserver = new StorageObserver(localStorageAdapter, mutationOutbox);
         this.currentState = new AtomicReference<>(State.STOPPED);
         this.targetState = targetState;
-        this.reachabilityMonitor = reachabilityMonitor;
         this.disposables = new CompositeDisposable();
 
         this.startStopSemaphore = new Semaphore(1);
@@ -152,19 +147,10 @@ public final class Orchestrator {
         return performSynchronized(() -> {
             switch (targetState.get()) {
                 case LOCAL_ONLY:
-                    if (monitorNetworkChangesDisposable != null) {
-                        monitorNetworkChangesDisposable.dispose();
-                        monitorNetworkChangesDisposable = null;
-                    }
                     transitionToLocalOnly();
                     break;
                 case SYNC_VIA_API:
-                    boolean isOnline = reachabilityMonitor.getObservable().blockingFirst();
-                    if (isOnline) {
-                        transitionToApiSync();
-                    } else {
-                        transitionToLocalOnly();
-                    }
+                    transitionToApiSync();
                     break;
                 case STOPPED:
                 default:
@@ -301,7 +287,6 @@ public final class Orchestrator {
      * Start syncing models to and from a remote API.
      */
     private void startApiSync() {
-        monitorNetworkChanges();
         LOG.info("Setting currentState to SYNC_VIA_API");
         currentState.set(State.SYNC_VIA_API);
         disposables.add(
@@ -325,6 +310,7 @@ public final class Orchestrator {
                     }
                     return;
                 }
+                publishNetworkStatusEvent(true);
 
                 long startTime = System.currentTimeMillis();
                 LOG.debug("About to hydrate...");
@@ -363,6 +349,11 @@ public final class Orchestrator {
         );
     }
 
+    private void publishNetworkStatusEvent(boolean active) {
+        Amplify.Hub.publish(HubChannel.DATASTORE,
+                HubEvent.create(DataStoreChannelEventName.NETWORK_STATUS, new NetworkStatusEvent(active)));
+    }
+
     private void publishReadyEvent() {
         Amplify.Hub.publish(HubChannel.DATASTORE, HubEvent.create(DataStoreChannelEventName.READY));
     }
@@ -373,33 +364,16 @@ public final class Orchestrator {
             return;
         }
         LOG.warn("API sync failed - transitioning to LOCAL_ONLY.", exception);
+        publishNetworkStatusEvent(false);
         Completable.fromAction(this::transitionToLocalOnly)
             .doOnError(error -> LOG.warn("Transition to LOCAL_ONLY failed.", error))
             .subscribe();
-    }
-
-    private void monitorNetworkChanges() {
-        if (monitorNetworkChangesDisposable != null) {
-            monitorNetworkChangesDisposable.dispose();
-        }
-
-        monitorNetworkChangesDisposable = reachabilityMonitor.getObservable()
-            .skip(1) // We skip the current online state, we only care about transitions
-            .filter(ignore -> !State.STOPPED.equals(currentState.get()))
-            .subscribe(isOnline -> {
-                if (isOnline) {
-                    startApiSync();
-                } else {
-                    stopApiSync();
-                }
-            });
     }
 
     /**
      * Stop all model synchronization with the remote API.
      */
     private void stopApiSync() {
-        monitorNetworkChanges();
         LOG.info("Setting currentState to LOCAL_ONLY");
         currentState.set(State.LOCAL_ONLY);
         disposables.clear();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/StorageObserver.java
@@ -66,10 +66,6 @@ final class StorageObserver {
             .doOnSubscribe(disposable ->
                 LOG.info("Now observing local storage. Local changes will be enqueued to mutation outbox.")
             )
-            .filter(possiblySystemChange -> {
-                // Only enqueue mutations for USER models
-                return Model.Type.USER.equals(possiblySystemChange.modelSchema().getModelType());
-            })
             .filter(possiblyCyclicChange -> {
                 // Don't continue if the storage change was caused by the sync engine itself
                 return !StorageItemChange.Initiator.SYNC_ENGINE.equals(possiblyCyclicChange.initiator());

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/OrchestratorTest.java
@@ -103,18 +103,15 @@ public final class OrchestratorTest {
         schemaRegistry.clear();
         schemaRegistry.register(modelProvider.models());
 
-        when(reachabilityMonitor.getObservable()).thenReturn(Observable.just(true));
-
-        orchestrator = new Orchestrator(
-            modelProvider,
-            schemaRegistry,
-            localStorageAdapter,
-            appSync,
-            DataStoreConfiguration::defaults,
-            () -> Orchestrator.State.SYNC_VIA_API,
-            reachabilityMonitor,
-            true
-        );
+        orchestrator =
+            new Orchestrator(modelProvider,
+                schemaRegistry,
+                localStorageAdapter,
+                appSync,
+                DataStoreConfiguration::defaults,
+                () -> Orchestrator.State.SYNC_VIA_API,
+                    true
+            );
     }
 
     /**


### PR DESCRIPTION
This reverts commit fc94e4c4f3e9ba4ba9faedfd62a018d04be8363e.

- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
