### PR TITLE
fix(api): Allow null associations on non-required fields.

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -381,8 +381,10 @@ public final class AppSyncGraphQLRequestFactory {
             if (association == null) {
                 result.put(fieldName, fieldValue);
             } else if (association.isOwner()) {
-                Model target = (Model) Objects.requireNonNull(fieldValue);
-                result.put(association.getTargetName(), target.getPrimaryKeyString());
+                if (fieldValue != null) {
+                    Model target = (Model) fieldValue;
+                    result.put(association.getTargetName(), target.getPrimaryKeyString());
+                }
             }
             // Ignore if field is associated, but is not a "belongsTo" relationship
         }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.java
@@ -56,24 +56,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 /**
- * Converts provided model or class type into a request container
- * with automatically generated GraphQL documents that follow
- * AppSync specifications.
+ * Converts provided model or class type into a request container with automatically generated GraphQL documents that
+ * follow AppSync specifications.
  */
 public final class AppSyncGraphQLRequestFactory {
     private static final int DEFAULT_QUERY_LIMIT = 1000;
 
     // This class should not be instantiated
-    private AppSyncGraphQLRequestFactory() {}
+    private AppSyncGraphQLRequestFactory() {
+    }
 
     /**
-     * Creates a {@link GraphQLRequest} that represents a query that expects a single value as a result.
-     * The request will be created with the correct document based on the model schema and
-     * variables based on given {@code objectId}.
-     *
+     * Creates a {@link GraphQLRequest} that represents a query that expects a single value as a result. The request
+     * will be created with the correct document based on the model schema and variables based on given
+     * {@code objectId}.
      * @param modelClass the model class.
      * @param objectId the model identifier.
      * @param <R> the response type.
@@ -82,30 +80,29 @@ public final class AppSyncGraphQLRequestFactory {
      * @throws IllegalStateException when the model schema does not contain the expected information.
      */
     public static <R, T extends Model> GraphQLRequest<R> buildQuery(
-            Class<T> modelClass,
-            String objectId
+        Class<T> modelClass,
+        String objectId
     ) {
         try {
             return AppSyncGraphQLRequest.builder()
-                    .modelClass(modelClass)
-                    .operation(QueryType.GET)
-                    .requestOptions(new ApiGraphQLRequestOptions())
-                    .responseType(modelClass)
-                    .variable("id", "ID!", objectId)
-                    .build();
+                       .modelClass(modelClass)
+                       .operation(QueryType.GET)
+                       .requestOptions(new ApiGraphQLRequestOptions())
+                       .responseType(modelClass)
+                       .variable("id", "ID!", objectId)
+                       .build();
         } catch (AmplifyException exception) {
             throw new IllegalStateException(
-                    "Could not generate a schema for the specified class",
-                    exception
+                "Could not generate a schema for the specified class",
+                exception
             );
         }
     }
 
     /**
-     * Creates a {@link GraphQLRequest} that represents a query that expects multiple values as a result.
-     * The request will be created with the correct document based on the model schema and variables
-     * for filtering based on the given predicate.
-     *
+     * Creates a {@link GraphQLRequest} that represents a query that expects multiple values as a result. The request
+     * will be created with the correct document based on the model schema and variables for filtering based on the
+     * given predicate.
      * @param modelClass the model class.
      * @param predicate the model predicate.
      * @param <R> the response type.
@@ -114,20 +111,19 @@ public final class AppSyncGraphQLRequestFactory {
      * @throws IllegalStateException when the model schema does not contain the expected information.
      */
     public static <R, T extends Model> GraphQLRequest<R> buildQuery(
-            Class<T> modelClass,
-            QueryPredicate predicate
+        Class<T> modelClass,
+        QueryPredicate predicate
     ) {
         Type dataType = TypeMaker.getParameterizedType(PaginatedResult.class, modelClass);
         return buildQuery(modelClass, predicate, DEFAULT_QUERY_LIMIT, dataType);
     }
 
     /**
-     * Creates a {@link GraphQLRequest} that represents a query that expects multiple values as a result
-     * within a certain range (i.e. paginated).
-     *
-     * The request will be created with the correct document based on the model schema and variables
-     * for filtering based on the given predicate and pagination.
-     *
+     * Creates a {@link GraphQLRequest} that represents a query that expects multiple values as a result within a
+     * certain range (i.e. paginated).
+     * <p>
+     * The request will be created with the correct document based on the model schema and variables for filtering based
+     * on the given predicate and pagination.
      * @param modelClass the model class.
      * @param predicate the predicate for filtering.
      * @param limit the page size/limit.
@@ -136,27 +132,27 @@ public final class AppSyncGraphQLRequestFactory {
      * @return a valid {@link GraphQLRequest} instance.
      */
     public static <R, T extends Model> GraphQLRequest<R> buildPaginatedResultQuery(
-            Class<T> modelClass,
-            QueryPredicate predicate,
-            int limit
+        Class<T> modelClass,
+        QueryPredicate predicate,
+        int limit
     ) {
         Type responseType = TypeMaker.getParameterizedType(PaginatedResult.class, modelClass);
         return buildQuery(modelClass, predicate, limit, responseType);
     }
 
     static <R, T extends Model> GraphQLRequest<R> buildQuery(
-            Class<T> modelClass,
-            QueryPredicate predicate,
-            int limit,
-            Type responseType
+        Class<T> modelClass,
+        QueryPredicate predicate,
+        int limit,
+        Type responseType
     ) {
         try {
             String modelName = ModelSchema.fromModelClass(modelClass).getName();
             AppSyncGraphQLRequest.Builder builder = AppSyncGraphQLRequest.builder()
-                    .modelClass(modelClass)
-                    .operation(QueryType.LIST)
-                    .requestOptions(new ApiGraphQLRequestOptions())
-                    .responseType(responseType);
+                                                        .modelClass(modelClass)
+                                                        .operation(QueryType.LIST)
+                                                        .requestOptions(new ApiGraphQLRequestOptions())
+                                                        .responseType(responseType);
 
             if (!QueryPredicates.all().equals(predicate)) {
                 String filterType = "Model" + Casing.capitalizeFirst(modelName) + "FilterInput";
@@ -167,15 +163,14 @@ public final class AppSyncGraphQLRequestFactory {
             return builder.build();
         } catch (AmplifyException exception) {
             throw new IllegalStateException(
-                    "Could not generate a schema for the specified class",
-                    exception
+                "Could not generate a schema for the specified class",
+                exception
             );
         }
     }
 
     /**
      * Creates a {@link GraphQLRequest} that represents a mutation of a given type.
-     *
      * @param model the model instance.
      * @param predicate the model predicate.
      * @param type the mutation type.
@@ -185,9 +180,9 @@ public final class AppSyncGraphQLRequestFactory {
      * @throws IllegalStateException when the model schema does not contain the expected information.
      */
     public static <R, T extends Model> GraphQLRequest<R> buildMutation(
-            T model,
-            QueryPredicate predicate,
-            MutationType type
+        T model,
+        QueryPredicate predicate,
+        MutationType type
     ) {
         try {
             Class<? extends Model> modelClass = model.getClass();
@@ -195,13 +190,13 @@ public final class AppSyncGraphQLRequestFactory {
             String graphQlTypeName = schema.getName();
 
             AppSyncGraphQLRequest.Builder builder = AppSyncGraphQLRequest.builder()
-                    .operation(type)
-                    .modelClass(modelClass)
-                    .requestOptions(new ApiGraphQLRequestOptions())
-                    .responseType(modelClass);
+                                                        .operation(type)
+                                                        .modelClass(modelClass)
+                                                        .requestOptions(new ApiGraphQLRequestOptions())
+                                                        .responseType(modelClass);
 
             String inputType =
-                    Casing.capitalize(type.toString()) +
+                Casing.capitalize(type.toString()) +
                     Casing.capitalizeFirst(graphQlTypeName) +
                     "Input!"; // CreateTodoInput
 
@@ -213,7 +208,7 @@ public final class AppSyncGraphQLRequestFactory {
 
             if (!QueryPredicates.all().equals(predicate)) {
                 String conditionType =
-                        "Model" +
+                    "Model" +
                         Casing.capitalizeFirst(graphQlTypeName) +
                         "ConditionInput";
                 builder.variable("condition", conditionType, parsePredicate(predicate));
@@ -222,15 +217,14 @@ public final class AppSyncGraphQLRequestFactory {
             return builder.build();
         } catch (AmplifyException exception) {
             throw new IllegalStateException(
-                    "Could not generate a schema for the specified class",
-                    exception
+                "Could not generate a schema for the specified class",
+                exception
             );
         }
     }
 
     /**
      * Creates a {@link GraphQLRequest} that represents a subscription of a given type.
-     *
      * @param modelClass the model type.
      * @param subscriptionType the subscription type.
      * @param <R> the response type.
@@ -239,20 +233,20 @@ public final class AppSyncGraphQLRequestFactory {
      * @throws IllegalStateException when the model schema does not contain the expected information.
      */
     public static <R, T extends Model> GraphQLRequest<R> buildSubscription(
-            Class<T> modelClass,
-            SubscriptionType subscriptionType
+        Class<T> modelClass,
+        SubscriptionType subscriptionType
     ) {
         try {
             return AppSyncGraphQLRequest.builder()
-                    .modelClass(modelClass)
-                    .operation(subscriptionType)
-                    .requestOptions(new ApiGraphQLRequestOptions())
-                    .responseType(modelClass)
-                    .build();
+                       .modelClass(modelClass)
+                       .operation(subscriptionType)
+                       .requestOptions(new ApiGraphQLRequestOptions())
+                       .responseType(modelClass)
+                       .build();
         } catch (AmplifyException exception) {
             throw new IllegalStateException(
-                    "Failed to build GraphQLRequest",
-                    exception
+                "Failed to build GraphQLRequest",
+                exception
             );
         }
     }
@@ -262,8 +256,8 @@ public final class AppSyncGraphQLRequestFactory {
             QueryPredicateOperation<?> qpo = (QueryPredicateOperation<?>) queryPredicate;
             QueryOperator<?> op = qpo.operator();
             return Collections.singletonMap(
-                    qpo.field(),
-                    Collections.singletonMap(appSyncOpType(op.type()), appSyncOpValue(op))
+                qpo.field(),
+                Collections.singletonMap(appSyncOpType(op.type()), appSyncOpValue(op))
             );
         } else if (queryPredicate instanceof QueryPredicateGroup) {
             QueryPredicateGroup qpg = (QueryPredicateGroup) queryPredicate;
@@ -316,7 +310,7 @@ public final class AppSyncGraphQLRequestFactory {
             default:
                 throw new IllegalStateException(
                     "Tried to parse an unsupported QueryOperator type. Check if a new QueryOperator.Type enum " +
-                    "has been created which is not supported in the AppSyncGraphQLRequestFactory."
+                        "has been created which is not supported in the AppSyncGraphQLRequestFactory."
                 );
         }
     }
@@ -347,13 +341,13 @@ public final class AppSyncGraphQLRequestFactory {
             default:
                 throw new IllegalStateException(
                     "Tried to parse an unsupported QueryOperator type. Check if a new QueryOperator.Type enum " +
-                    "has been created which is not implemented yet."
+                        "has been created which is not implemented yet."
                 );
         }
     }
 
     private static Map<String, Object> getDeleteMutationInputMap(
-            @NonNull ModelSchema schema, @NonNull Model instance) throws AmplifyException {
+        @NonNull ModelSchema schema, @NonNull Model instance) throws AmplifyException {
         final Map<String, Object> input = new HashMap<>();
         for (String fieldName : schema.getPrimaryIndexFields()) {
             input.put(fieldName, extractFieldValue(fieldName, instance, schema));
@@ -362,7 +356,7 @@ public final class AppSyncGraphQLRequestFactory {
     }
 
     private static Map<String, Object> getMapOfFieldNameAndValues(
-            @NonNull ModelSchema schema, @NonNull Model instance) throws AmplifyException {
+        @NonNull ModelSchema schema, @NonNull Model instance) throws AmplifyException {
         if (!instance.getClass().getSimpleName().equals(schema.getName())) {
             throw new AmplifyException(
                 "The object provided is not an instance of " + schema.getName() + ".",
@@ -407,16 +401,16 @@ public final class AppSyncGraphQLRequestFactory {
     }
 
     private static Object extractFieldValue(String fieldName, Model instance, ModelSchema schema)
-            throws AmplifyException {
+        throws AmplifyException {
         try {
             Field privateField = instance.getClass().getDeclaredField(fieldName);
             privateField.setAccessible(true);
             return privateField.get(instance);
         } catch (Exception exception) {
             throw new AmplifyException(
-                    "An invalid field was provided. " + fieldName + " is not present in " + schema.getName(),
-                    exception,
-                    "Check if this model schema is a correct representation of the fields in the provided Object");
+                "An invalid field was provided. " + fieldName + " is not present in " + schema.getName(),
+                exception,
+                "Check if this model schema is a correct representation of the fields in the provided Object");
         }
     }
 }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryTest.java
@@ -108,13 +108,13 @@ public final class AppSyncGraphQLRequestFactoryTest {
         // Arrange a person to delete, using UUID from test resource file
         final String expectedId = "dfcdac69-0662-41df-a67b-48c62a023f97";
         final Person tony = Person.builder()
-            .firstName("Tony")
-            .lastName("Swanson")
-            .age(19)
-            .dob(new Temporal.Date("2000-01-15"))
-            .id(expectedId)
-            .relationship(MaritalStatus.single)
-            .build();
+                                .firstName("Tony")
+                                .lastName("Swanson")
+                                .age(19)
+                                .dob(new Temporal.Date("2000-01-15"))
+                                .id(expectedId)
+                                .relationship(MaritalStatus.single)
+                                .build();
 
         // Act: build a mutation
         GraphQLRequest<Person> requestToDeleteTony = AppSyncGraphQLRequestFactory.buildMutation(
@@ -138,11 +138,11 @@ public final class AppSyncGraphQLRequestFactoryTest {
     @Test
     public void validateDeleteWithCustomPrimaryKey() throws AmplifyException, JSONException {
         final Item item = Item.builder()
-                .orderId("123a7asa")
-                .status(Status.IN_TRANSIT)
-                .createdAt(new Temporal.DateTime("2021-04-20T15:20:32.651Z"))
-                .name("Gummy Bears")
-                .build();
+                              .orderId("123a7asa")
+                              .status(Status.IN_TRANSIT)
+                              .createdAt(new Temporal.DateTime("2021-04-20T15:20:32.651Z"))
+                              .name("Gummy Bears")
+                              .build();
         JSONAssert.assertEquals(
             Resources.readAsString("delete-item.txt"),
             AppSyncGraphQLRequestFactory.buildMutation(item, QueryPredicates.all(), MutationType.DELETE).getContent(),
@@ -159,30 +159,29 @@ public final class AppSyncGraphQLRequestFactoryTest {
         // Arrange a person to delete, using UUID from test resource file
         final String expectedId = "dfcdac69-0662-41df-a67b-48c62a023f97";
         final Person tony = Person.builder()
-                .firstName("Tony")
-                .lastName("Swanson")
-                .age(19)
-                .dob(new Temporal.Date("2000-01-15"))
-                .id(expectedId)
-                .relationship(MaritalStatus.single)
-                .build();
+                                .firstName("Tony")
+                                .lastName("Swanson")
+                                .age(19)
+                                .dob(new Temporal.Date("2000-01-15"))
+                                .id(expectedId)
+                                .relationship(MaritalStatus.single)
+                                .build();
 
         // Act: build a mutation
         GraphQLRequest<Person> requestToDeleteTony = AppSyncGraphQLRequestFactory.buildMutation(
-                tony, Person.ID.beginsWith("e6"), MutationType.UPDATE
+            tony, Person.ID.beginsWith("e6"), MutationType.UPDATE
         );
 
         // Assert: expected is actual
         JSONAssert.assertEquals(
-                Resources.readAsString("update-person-with-predicate.txt"),
-                requestToDeleteTony.getContent(),
-                true
+            Resources.readAsString("update-person-with-predicate.txt"),
+            requestToDeleteTony.getContent(),
+            true
         );
     }
 
     /**
-     * Validates construction of a subscription request using a class and an
-     * {@link SubscriptionType}.
+     * Validates construction of a subscription request using a class and an {@link SubscriptionType}.
      * @throws JSONException from JSONAssert.assertEquals
      */
     @Test
@@ -206,21 +205,21 @@ public final class AppSyncGraphQLRequestFactoryTest {
     public void validateDateSerializer() throws JSONException {
         // Create expectation
         final Meeting meeting1 = Meeting.builder()
-                .name("meeting1")
-                .id("45a5f600-8aa8-41ac-a529-aed75036f5be")
-                .date(new Temporal.Date("2001-02-03"))
-                .dateTime(new Temporal.DateTime("2001-02-03T01:30:15Z"))
-                .time(new Temporal.Time("01:22:33"))
-                .timestamp(new Temporal.Timestamp(1234567890000L, TimeUnit.MILLISECONDS))
-                .build();
+                                     .name("meeting1")
+                                     .id("45a5f600-8aa8-41ac-a529-aed75036f5be")
+                                     .date(new Temporal.Date("2001-02-03"))
+                                     .dateTime(new Temporal.DateTime("2001-02-03T01:30:15Z"))
+                                     .time(new Temporal.Time("01:22:33"))
+                                     .timestamp(new Temporal.Timestamp(1234567890000L, TimeUnit.MILLISECONDS))
+                                     .build();
 
         // Act: build a mutation to create a Meeting
         GraphQLRequest<Meeting> requestToCreateMeeting1 =
-                AppSyncGraphQLRequestFactory.buildMutation(meeting1, QueryPredicates.all(), MutationType.CREATE);
+            AppSyncGraphQLRequestFactory.buildMutation(meeting1, QueryPredicates.all(), MutationType.CREATE);
 
         // Assert: expected is actual
         JSONAssert.assertEquals(Resources.readAsString("create-meeting1.txt"),
-                requestToCreateMeeting1.getContent(), true);
+            requestToCreateMeeting1.getContent(), true);
     }
 
     /**
@@ -236,10 +235,11 @@ public final class AppSyncGraphQLRequestFactoryTest {
         // Act
         Todo todo = new Todo("111", "Mop the floor", null);
         @SuppressWarnings("unchecked")
-        Map<String, Object> actual = (Map<String, Object>)
-            AppSyncGraphQLRequestFactory.buildMutation(todo, QueryPredicates.all(), MutationType.CREATE)
-                .getVariables()
-                .get("input");
+        Map<String, Object> actual = (Map<String, Object>) AppSyncGraphQLRequestFactory.buildMutation(
+            todo,
+            QueryPredicates.all(),
+            MutationType.CREATE
+        ).getVariables().get("input");
 
         // Assert
         assertEquals(expected, actual);
@@ -259,10 +259,10 @@ public final class AppSyncGraphQLRequestFactoryTest {
         // Act
         Todo todo = new Todo("111", "Mop the floor", "johndoe");
         @SuppressWarnings("unchecked")
-        Map<String, Object> actual = (Map<String, Object>)
-            AppSyncGraphQLRequestFactory.buildMutation(todo, QueryPredicates.all(), MutationType.CREATE)
-                .getVariables()
-                .get("input");
+        Map<String, Object> actual = (Map<String, Object>) AppSyncGraphQLRequestFactory.buildMutation(
+            todo,
+            QueryPredicates.all(),
+            MutationType.CREATE).getVariables().get("input");
 
         // Assert
         assertEquals(expected, actual);
@@ -282,15 +282,17 @@ public final class AppSyncGraphQLRequestFactoryTest {
         // Create a Note that doesn't have a value for the optional measurement relation.
         Note note = new Note("abc", "text", null);
         @SuppressWarnings("unchecked")
-        Map<String, Object> actual = (Map<String, Object>) AppSyncGraphQLRequestFactory.buildMutation(note, QueryPredicates.all(), MutationType.CREATE)
-                                                               .getVariables()
-                                                               .get("input");
+        Map<String, Object> actual = (Map<String, Object>) AppSyncGraphQLRequestFactory.buildMutation(
+            note,
+            QueryPredicates.all(),
+            MutationType.CREATE
+        ).getVariables().get("input");
 
         // Assert
         assertEquals(expected, actual);
     }
 
-    @ModelConfig(authRules = { @AuthRule(allow = AuthStrategy.OWNER) })
+    @ModelConfig(authRules = {@AuthRule(allow = AuthStrategy.OWNER)})
     static final class Todo implements Model {
         @com.amplifyframework.core.model.annotations.ModelField(targetType = "ID", isRequired = true)
         private final String id;
@@ -301,7 +303,8 @@ public final class AppSyncGraphQLRequestFactoryTest {
         @com.amplifyframework.core.model.annotations.ModelField
         private final String owner;
 
-        @SuppressWarnings("ParameterName") // checkstyle wants variable names to be >2 chars, but id is only 2.
+        @SuppressWarnings("ParameterName")
+            // checkstyle wants variable names to be >2 chars, but id is only 2.
         Todo(String id, String description, String owner) {
             this.id = id;
             this.description = description;
@@ -314,7 +317,7 @@ public final class AppSyncGraphQLRequestFactoryTest {
     }
 
     @ModelConfig(authRules = {@AuthRule(allow = AuthStrategy.OWNER)})
-    @Index(name = "byMeasurement", fields = {"measurement_id"})
+    @Index(name = "byMeasurement", fields = "measurement_id")
     static final class Note implements Model {
         @ModelField(targetType = "ID", isRequired = true)
         private final String id;
@@ -322,13 +325,13 @@ public final class AppSyncGraphQLRequestFactoryTest {
         private final String text;
 
         @ModelField(targetType = "Measurement")
-        @BelongsTo(targetName = "measurement_id", targetNames = {"measurement_id"}, type = Measurement.class)
-        private final Measurement Measurement;
+        @BelongsTo(targetName = "measurement_id", targetNames = "measurement_id", type = Measurement.class)
+        private final Measurement measurement;
 
-        private Note(String id, String text, Measurement Measurement) {
-            this.id = id;
+        private Note(String idString, String text, Measurement measurement) {
+            this.id = idString;
             this.text = text;
-            this.Measurement = Measurement;
+            this.measurement = measurement;
         }
 
         public String getId() {
@@ -348,8 +351,8 @@ public final class AppSyncGraphQLRequestFactoryTest {
         @HasMany(associatedWith = "Measurement", type = Note.class)
         private final List<Note> notes = null;
 
-        Measurement(String id, Integer value) {
-            this.id = id;
+        Measurement(String idString, Integer value) {
+            this.id = idString;
             this.value = value;
         }
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* 
#2431

*Description of changes:*
Don't throw an exception if an association field is null when creating a mutation.

This is because it is valid for the field to be null if it's not required. Codegen does not mark such fields as required in the generated models. If it _is_ required then attempting to submit the mutation with a null value will result in an error response.

*How did you test these changes?*
Checked that the schema provided in the original issue could now create a Note class without a customer association.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
