### PR TITLE
chore: Ignore AWSDataStorePluginTest

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/AWSDataStorePluginTest.java
@@ -52,6 +52,7 @@ import com.amplifyframework.testutils.sync.SynchronousDataStore;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
@@ -84,6 +85,7 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("SameParameterValue")
 @RunWith(RobolectricTestRunner.class)
+@Ignore("Test class is unstable on CI - to be enabled after investigation")
 public final class AWSDataStorePluginTest {
     private static final Logger LOG = Amplify.Logging.forNamespace("amplify:datastore:test");
     private static final long TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:* Ignore the AWSDataStorePluginTest class due to tests inconsistently failing on CI. This test class has also been disabled in Amplify Android v2 (more info [here](https://github.com/aws-amplify/amplify-android/pull/2262#issuecomment-1409148931)).

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
