### PR TITLE
Revert "fix(datastore): register network callback only once in reachability monitor"

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/ReachabilityMonitor.kt
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/ReachabilityMonitor.kt
@@ -22,7 +22,8 @@ import android.net.Network
 import androidx.annotation.VisibleForTesting
 import com.amplifyframework.datastore.DataStoreException
 import io.reactivex.rxjava3.core.Observable
-import io.reactivex.rxjava3.subjects.BehaviorSubject
+import io.reactivex.rxjava3.core.ObservableEmitter
+import io.reactivex.rxjava3.core.ObservableOnSubscribe
 import java.util.concurrent.TimeUnit
 
 /**
@@ -53,39 +54,42 @@ public interface ReachabilityMonitor {
 }
 
 private class ReachabilityMonitorImpl constructor(val schedulerProvider: SchedulerProvider) : ReachabilityMonitor {
-    private val subject = BehaviorSubject.create<Boolean>()
-    private var connectivityProvider: ConnectivityProvider? = null
+    private var emitter: ObservableOnSubscribe<Boolean>? = null
 
     override fun configure(context: Context) {
         return configure(context, DefaultConnectivityProvider())
     }
 
     override fun configure(context: Context, connectivityProvider: ConnectivityProvider) {
-        this.connectivityProvider = connectivityProvider
-        connectivityProvider.registerDefaultNetworkCallback(
-            context,
-            object : NetworkCallback() {
-                override fun onAvailable(network: Network) {
-                    subject.onNext(true)
-                }
-
-                override fun onLost(network: Network) {
-                    subject.onNext(false)
-                }
-            }
-        )
+        emitter = ObservableOnSubscribe { emitter ->
+            val callback = getCallback(emitter)
+            connectivityProvider.registerDefaultNetworkCallback(context, callback)
+            // Provide the current network status upon subscription.
+            emitter.onNext(connectivityProvider.hasActiveNetwork)
+        }
     }
 
     override fun getObservable(): Observable<Boolean> {
-        connectivityProvider?.let { connectivityProvider ->
-            return subject.subscribeOn(schedulerProvider.io())
-                .doOnSubscribe { subject.onNext(connectivityProvider.hasActiveNetwork) }
+        emitter?.let { emitter ->
+            return Observable.create(emitter)
+                .subscribeOn(schedulerProvider.io())
                 .debounce(250, TimeUnit.MILLISECONDS, schedulerProvider.computation())
         } ?: run {
             throw DataStoreException(
                 "ReachabilityMonitor has not been configured.",
                 "Call ReachabilityMonitor.configure() before calling ReachabilityMonitor.getObservable()"
             )
+        }
+    }
+
+    private fun getCallback(emitter: ObservableEmitter<Boolean>): NetworkCallback {
+        return object : NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                emitter.onNext(true)
+            }
+            override fun onLost(network: Network) {
+                emitter.onNext(false)
+            }
         }
     }
 }


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2449

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
