### PR TITLE
chore: ignore canary tests resending confirmation code and remove duplicate delete …

### DIFF
--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTest.kt
@@ -138,6 +138,7 @@ class AuthCanaryTest {
     }
 
     @Test
+    @Ignore("Sending sign up confirmation code is disabled in the user pool.")
     fun resendSignUpCode() {
         signUpUser(tempUsername, tempPassword)
         val latch = CountDownLatch(1)
@@ -345,6 +346,7 @@ class AuthCanaryTest {
     }
 
     @Test
+    @Ignore("Test fails when run too frequently due to resend confirmation code limit exceeded.")
     fun resendUserAttributeConfirmationCode() {
         signInUser(username, password)
         val latch = CountDownLatch(1)
@@ -427,7 +429,10 @@ class AuthCanaryTest {
         signInUser(tempUsername, tempPassword)
         val latch = CountDownLatch(1)
         Amplify.Auth.deleteUser(
-            { latch.countDown() },
+            {
+                signedUpNewUser = false
+                latch.countDown()
+            },
             { fail("Delete user failed: $it") }
         )
         assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))


### PR DESCRIPTION
…user call

- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:* In the deleteUser test, avoid trying to delete the user a second time if the user has already been deleted. Also, ignore tests that resend a confirmation code due to limit exceeded or verification being disabled.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
