### PR TITLE
Auto-detect multi-auth based on model config

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -146,7 +146,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             modelProvider,
             schemaRegistry,
             sqliteStorageAdapter,
-            AppSyncClient.via(api, this.authModeStrategy),
+            AppSyncClient.via(api),
             () -> pluginConfiguration,
             () -> api.getPlugins().isEmpty() ? Orchestrator.State.LOCAL_ONLY : Orchestrator.State.SYNC_VIA_API,
             reachabilityMonitor,
@@ -754,9 +754,11 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
         /**
          * Sets the authorization mode strategy which will be used by DataStore sync engine
          * when interacting with the API plugin.
+         * @deprecated Auth mode strategy is automatically detected based on the auth rules of the type.
          * @param authModeStrategy One of the options from the {@link AuthModeStrategyType} enum.
          * @return An implementation of the {@link ModelProvider} interface.
          */
+        @Deprecated
         public Builder authModeStrategy(AuthModeStrategyType authModeStrategy) {
             this.authModeStrategy = authModeStrategy;
             return this;

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.Action;
@@ -197,6 +198,9 @@ final class SubscriptionProcessor {
                     if (isExceptionType(dataStoreException, AppSyncErrorType.UNAUTHORIZED)) {
                         // Ignore Unauthorized errors, so that DataStore can still be used even if the user is only
                         // authorized to read a subset of the models.
+                        latch.countDown();
+                    } else if (dataStoreException.getCause() instanceof ApiException.ApiAuthException) {
+                        // This can also be an unauthorized exception, ignore for the same reason as above
                         latch.countDown();
                         LOG.warn("Unauthorized failure:" + subscriptionType.name() + " " + modelSchema.getName());
                     } else if (isExceptionType(dataStoreException, AppSyncErrorType.OPERATION_DISABLED)) {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

Remaining issues:
1. The model doesn’t actually have the global auth rule for API key public access attached, so it doesn't detect multi-auth (or even if it did, it wouldn't try to use the API key).  Also fun fact, I found out that the global auth rule doesn’t apply on types with more specific auth types by digging into the VTL.
2. The orchestrator immediately enters local sync mode once any type sync fails, even if the other types would’ve succeeded in their syncs.
3. Not sure if we can just deprecate a plugin config like this 😰

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
