### PR TITLE
fix(auth): Fix for confirm sign in state machine callback

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -659,6 +659,22 @@ internal class RealAWSCognitoAuthPlugin(
                         )
                     }
                     signInState is SignInState.ResolvingChallenge &&
+                        signInState.challengeState is SignInChallengeState.WaitingForAnswer -> {
+                        authStateMachine.cancel(token)
+                        val authSignInResult = AuthSignInResult(
+                            false,
+                            AuthNextSignInStep(
+                                AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE,
+                                (
+                                    signInState.challengeState as
+                                        SignInChallengeState.WaitingForAnswer
+                                    ).challenge.parameters ?: mapOf(),
+                                null
+                            )
+                        )
+                        onSuccess.accept(authSignInResult)
+                    }
+                    signInState is SignInState.ResolvingChallenge &&
                         signInState.challengeState is SignInChallengeState.Error -> {
                         authStateMachine.cancel(token)
                         onError.accept(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignInChallengeState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignInChallengeState.kt
@@ -63,6 +63,9 @@ internal sealed class SignInChallengeState : State {
                         val action = challengeActions.resetToWaitingForAnswer(challengeEvent, challengeEvent.challenge)
                         StateResolution(Error(challengeEvent.exception, challengeEvent.challenge), listOf(action))
                     }
+                    is SignInChallengeEvent.EventType.WaitForAnswer -> {
+                        StateResolution(WaitingForAnswer(challengeEvent.challenge), listOf())
+                    }
 
                     else -> defaultResolution
                 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:* When confirmsignin state goes to waiting for answer the callbacks to confirmsignin state machine onsuccess are never received. This PR fixes this.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
