### PR TITLE
fix(auth): Fix for adding missing parameter for resolving device SRP

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
@@ -21,6 +21,7 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.RespondToAuthChalle
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
+import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.cognito.helpers.SRPHelper
 import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
 import com.amplifyframework.auth.exceptions.ServiceException
@@ -40,6 +41,7 @@ internal object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
     private const val KEY_SALT = "SALT"
     private const val KEY_SECRET_BLOCK = "SECRET_BLOCK"
     private const val KEY_SRP_A = "SRP_A"
+    private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_SRP_B = "SRP_B"
     private const val KEY_USERNAME = "USERNAME"
     private const val KEY_DEVICE_KEY = "DEVICE_KEY"
@@ -56,16 +58,25 @@ internal object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
 
                 srpHelper = SRPHelper(deviceMetadata?.deviceSecret ?: "")
 
+                val challengeResponse = mutableMapOf(
+                    KEY_USERNAME to username,
+                    KEY_DEVICE_KEY to (deviceMetadata?.deviceKey ?: ""),
+                    KEY_SRP_A to srpHelper.getPublicA()
+                )
+
+                val secretHash = AuthHelper.getSecretHash(
+                    username,
+                    configuration.userPool?.appClient,
+                    configuration.userPool?.appClientSecret
+                )
+                secretHash?.let { challengeResponse[KEY_SECRET_HASH] = it }
+
                 cognitoAuthService.cognitoIdentityProviderClient?.let { client ->
                     val respondToAuthChallenge = client.respondToAuthChallenge(
                         RespondToAuthChallengeRequest.invoke {
                             challengeName = ChallengeNameType.DeviceSrpAuth
                             clientId = configuration.userPool?.appClient
-                            challengeResponses = mapOf(
-                                KEY_USERNAME to username,
-                                KEY_DEVICE_KEY to (deviceMetadata?.deviceKey ?: ""),
-                                KEY_SRP_A to srpHelper.getPublicA()
-                            )
+                            challengeResponses = challengeResponse
                             clientMetadata = event.metadata
                             pinpointEndpointId?.let { analyticsMetadata { analyticsEndpointId = it } }
                             encodedContextData?.let { userContextData { encodedData = it } }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* 2504

*Description of changes:* Currently the respondToAuth api for device SRP does not include the secret hash param and this PR adds that.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
