### PR TITLE
fix(auth): Fix for sending session expired when an invalid grant exception is received

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
@@ -103,12 +103,13 @@ internal class AuthEnvironment internal constructor(
     }
 
     suspend fun getDeviceMetadata(username: String): DeviceMetadata.Metadata? {
-        val deviceCredentials =
+        var deviceCredentials =
             credentialStoreClient.loadCredentials(CredentialType.Device(username)) as? AmplifyCredential.DeviceData
         if (deviceCredentials == null) {
             logger.warn("loadCredentials returned unexpected AmplifyCredential Type.")
+            deviceCredentials = AmplifyCredential.DeviceData(DeviceMetadata.Empty)
         }
-        return (deviceCredentials as AmplifyCredential.DeviceData).deviceMetadata as? DeviceMetadata.Metadata
+        return deviceCredentials.deviceMetadata as? DeviceMetadata.Metadata
     }
 }
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -81,6 +81,7 @@ import com.amplifyframework.auth.cognito.result.RevokeTokenError
 import com.amplifyframework.auth.cognito.usecases.ResetPasswordUseCase
 import com.amplifyframework.auth.exceptions.ConfigurationException
 import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.ServiceException
 import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.auth.exceptions.UnknownException
@@ -1053,9 +1054,12 @@ internal class RealAWSCognitoAuthPlugin(
                                         onSuccess.accept(AmplifyCredential.Empty.getCognitoSession(error.exception))
                                         sendHubEvent(AuthChannelEventName.SESSION_EXPIRED.toString())
                                     }
+                                    is ServiceException -> {
+                                        onSuccess.accept(AmplifyCredential.Empty.getCognitoSession(error.exception))
+                                    }
                                     else -> {
                                         val errorResult = UnknownException("Fetch auth session failed.", error)
-                                        onSuccess.accept(error.amplifyCredential.getCognitoSession(errorResult))
+                                        onError.accept(errorResult)
                                     }
                                 }
                             }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -142,16 +142,16 @@ import com.amplifyframework.statemachine.codegen.states.SRPSignInState
 import com.amplifyframework.statemachine.codegen.states.SignInChallengeState
 import com.amplifyframework.statemachine.codegen.states.SignInState
 import com.amplifyframework.statemachine.codegen.states.SignOutState
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 
 internal class RealAWSCognitoAuthPlugin(
     private val configuration: AuthConfiguration,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
@@ -33,6 +33,7 @@ import com.amplifyframework.statemachine.codegen.actions.FetchAuthSessionActions
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
+import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.LoginsMapProvider
 import com.amplifyframework.statemachine.codegen.data.SignedInData
 import com.amplifyframework.statemachine.codegen.events.AuthorizationEvent
@@ -62,7 +63,7 @@ internal object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                 secretHash?.let { authParameters[KEY_SECRET_HASH] = it }
 
                 val encodedContextData = getUserContextData(username)
-                val deviceMetadata = getDeviceMetadata(username)
+                val deviceMetadata: DeviceMetadata.Metadata? = getDeviceMetadata(username)
                 deviceMetadata?.let { authParameters[KEY_DEVICE_KEY] = it.deviceKey }
                 val pinpointEndpointId = getPinpointEndpointId()
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/InvalidGrantException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/InvalidGrantException.kt
@@ -14,11 +14,11 @@
  */
 package com.amplifyframework.auth.cognito.exceptions.service
 
-import com.amplifyframework.auth.exceptions.ServiceException
+import com.amplifyframework.auth.AuthException
 
 /**
  * Could not perform the action because the token was unable to be parsed
  * @param message Explains the reason for the exception
  */
 open class InvalidGrantException(message: String, description: String?) :
-    ServiceException(message, description ?: TODO_RECOVERY_SUGGESTION)
+    AuthException(message, description ?: TODO_RECOVERY_SUGGESTION)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/InvalidGrantException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/InvalidGrantException.kt
@@ -20,5 +20,5 @@ import com.amplifyframework.auth.exceptions.ServiceException
  * Could not perform the action because the token was unable to be parsed
  * @param message Explains the reason for the exception
  */
-open class InvalidGrantException(message: String) :
-    ServiceException(message, TODO_RECOVERY_SUGGESTION)
+open class InvalidGrantException(message: String, description: String?) :
+    ServiceException(message, description ?: TODO_RECOVERY_SUGGESTION)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/HostedUIHttpHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/HostedUIHttpHelper.kt
@@ -67,6 +67,7 @@ internal object HostedUIHttpHelper {
                 connection.errorStream
             }
             val responseString = responseStream.bufferedReader().use(BufferedReader::readText)
+
             return parseTokenResponse(responseString)
         } else {
             throw ServiceException(
@@ -87,7 +88,7 @@ internal object HostedUIHttpHelper {
 
             response.error?.let {
                 if (it == "invalid_grant") {
-                    throw SessionExpiredException(cause = InvalidGrantException(it, response.errorDescription))
+                    throw SessionExpiredException(it, cause = InvalidGrantException(it, response.errorDescription))
                 } else {
                     throw ServiceException(it, AmplifyException.TODO_RECOVERY_SUGGESTION)
                 }
@@ -100,11 +101,13 @@ internal object HostedUIHttpHelper {
                 expiration = response.expiration
             )
         } catch (e: Exception) {
-            throw ServiceException(
-                message = e.message ?: "An unknown service error has occurred",
-                recoverySuggestion = AmplifyException.TODO_RECOVERY_SUGGESTION,
-                cause = e
-            )
+            if (e !is SessionExpiredException && e !is ServiceException) {
+                throw ServiceException(
+                    message = e.message ?: "An unknown service error has occurred",
+                    recoverySuggestion = AmplifyException.TODO_RECOVERY_SUGGESTION,
+                    cause = e
+                )
+            } else throw e
         }
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/HostedUIHttpHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/HostedUIHttpHelper.kt
@@ -20,6 +20,7 @@ import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.exceptions.service.InvalidGrantException
 import com.amplifyframework.auth.cognito.exceptions.service.ParseTokenException
 import com.amplifyframework.auth.exceptions.ServiceException
+import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import java.io.BufferedReader
 import java.io.DataOutputStream
@@ -86,7 +87,7 @@ internal object HostedUIHttpHelper {
 
             response.error?.let {
                 if (it == "invalid_grant") {
-                    throw InvalidGrantException(it)
+                    throw SessionExpiredException(cause = InvalidGrantException(it, response.errorDescription))
                 } else {
                     throw ServiceException(it, AmplifyException.TODO_RECOVERY_SUGGESTION)
                 }
@@ -114,7 +115,8 @@ internal class FetchTokenResponse(
     @SerialName("id_token") val idToken: String? = null,
     @SerialName("refresh_token") val refreshToken: String? = null,
     @SerialName("expires_in") private val expiresIn: Int? = null,
-    @SerialName("error") val error: String? = null
+    @SerialName("error") val error: String? = null,
+    @SerialName("error_description") val errorDescription: String? = null
 ) {
     val expiration = expiresIn?.let { Instant.now().plus(it.seconds).epochSeconds }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/FetchAuthSessionTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/FetchAuthSessionTestCaseGenerator.kt
@@ -94,7 +94,9 @@ object FetchAuthSessionTestCaseGenerator : SerializableProvider {
 
     private val refreshSuccessCase: FeatureTestCase = baseCase.copy(
         description = "AuthSession object is successfully returned after refresh",
-        preConditions = baseCase.preConditions.copy(
+        preConditions = PreConditions(
+            "authconfiguration.json",
+            "SignedIn_SessionEstablished.json",
             mockedResponses = listOf(mockedInitiateAuthResponse)
         ),
         api = API(

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/FetchAuthSessionTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/FetchAuthSessionTestCaseGenerator.kt
@@ -50,6 +50,27 @@ object FetchAuthSessionTestCaseGenerator : SerializableProvider {
         ).toJsonElement()
     )
 
+    private val mockedIdentityIdResponse = MockResponse(
+        CognitoType.CognitoIdentity,
+        "getId",
+        ResponseType.Success,
+        mapOf("identityId" to "someIdentityId").toJsonElement()
+    )
+
+    private val mockedAWSCredentialsResponse = MockResponse(
+        CognitoType.CognitoIdentity,
+        "getCredentialsForIdentity",
+        ResponseType.Success,
+        mapOf(
+            "credentials" to mapOf(
+                "accessKeyId" to "someAccessKey",
+                "secretKey" to "someSecretKey",
+                "sessionToken" to AuthStateJsonGenerator.dummyToken,
+                "expiration" to 2342134
+            )
+        ).toJsonElement()
+    )
+
     private val expectedSuccess = AWSCognitoAuthSession(
         isSignedIn = true,
         identityIdResult = AuthSessionResult.success("someIdentityId"),
@@ -102,9 +123,9 @@ object FetchAuthSessionTestCaseGenerator : SerializableProvider {
         api = API(
             name = AuthAPI.fetchAuthSession,
             params = JsonObject(emptyMap()),
-            options = mapOf("forceRefresh" to true).toJsonElement(),
+            JsonObject(emptyMap())
         ),
-        validations = baseCase.validations
+        validations = listOf(apiReturnValidation)
     )
 
     private val identityPoolCase: FeatureTestCase = baseCase.copy(

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_after_refresh.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/fetchAuthSession/AuthSession_object_is_successfully_returned_after_refresh.json
@@ -24,7 +24,6 @@
         "params": {
         },
         "options": {
-            "forceRefresh": true
         }
     },
     "validations": [


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2481

*Description of changes:* When we get an invalid_grant exception back from cognito we do not send the session expired hub event but we should as that means your session is no longer valid. This PR fixes that. Cognito also sends the error_description which was not captured

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
