### PR TITLE
fix(datastore): Fix retry local after a deletion

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/ConflictResolver.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/ConflictResolver.java
@@ -99,7 +99,12 @@ final class ConflictResolver {
                 LOG.debug(String.format("Conflict handler decision: %s", decision));
                 @SuppressWarnings("unchecked")
                 ConflictResolutionDecision<T> typedDecision = (ConflictResolutionDecision<T>) decision;
-                return resolveModelAndMetadata(conflictData, metadata, typedDecision);
+                return resolveModelAndMetadata(
+                    conflictData,
+                    metadata,
+                    typedDecision,
+                    pendingMutation.getMutationType()
+                );
             });
     }
 
@@ -156,30 +161,42 @@ final class ConflictResolver {
     private <T extends Model> Single<ModelWithMetadata<T>> resolveModelAndMetadata(
             @NonNull ConflictData<T> conflictData,
             @NonNull ModelMetadata metadata,
-            @NonNull ConflictResolutionDecision<T> decision) {
+            @NonNull ConflictResolutionDecision<T> decision,
+            @NonNull PendingMutation.Type mutationType) {
 
         switch (decision.getResolutionStrategy()) {
             case RETRY_LOCAL:
-                return publish(conflictData.getLocal(), metadata.getVersion());
+                // When retrying the local mutation we pass the mutation type so that we can correctly retry a deletion
+                // instead of an update
+                return publish(conflictData.getLocal(), metadata.getVersion(), mutationType);
             case APPLY_REMOTE:
                 // No network operations to do. The resolution is just to return
                 // the resolved data, so it can be applied locally.
                 return Single.just(new ModelWithMetadata<>(conflictData.getRemote(), metadata));
             case RETRY:
-                return publish(decision.getCustomModel(), metadata.getVersion());
+                // When retrying with a custom model the mutation is always an update
+                return publish(decision.getCustomModel(), metadata.getVersion(), PendingMutation.Type.UPDATE);
             default:
                 throw new IllegalStateException("Unknown resolution strategy = " + decision.getResolutionStrategy());
         }
     }
 
     @NonNull
-    private <T extends Model> Single<ModelWithMetadata<T>> publish(@NonNull T model, int version) {
+    private <T extends Model> Single<ModelWithMetadata<T>> publish(
+        @NonNull T model,
+        int version,
+        @NonNull PendingMutation.Type mutationType
+    ) {
         return Single
             .<GraphQLResponse<ModelWithMetadata<T>>>create(emitter -> {
                 //SchemaRegistry.instance().getModelSchemaForModelClass method supports schema generation for flutter
                 //models.
                 final ModelSchema schema = SchemaRegistry.instance().getModelSchemaForModelClass(model.getModelName());
-                appSync.update(model, schema, version, emitter::onSuccess, emitter::onError);
+                if (mutationType == PendingMutation.Type.DELETE) {
+                    appSync.delete(model, schema, version, emitter::onSuccess, emitter::onError);
+                } else {
+                    appSync.update(model, schema, version, emitter::onSuccess, emitter::onError);
+                }
             })
             .flatMap(response -> {
                 if (response.hasErrors() || !response.hasData()) {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

#2261 

*Description of changes:*

If a conflict occurs during a deletion and a retry local strategy is used in the conflict handler then we want to invoke a delete operation. This was previously always doing an update operation, which would result in the deletion being lost.

*How did you test these changes?*
- Followed these reproduction steps:
  - Configure DataStore with a `conflictHandler` that always returns a `retryLocal()` decision.
  - Sync a model to the device
  - Put the device into airplane mode
  - Delete the model on the device
  - In DynamoDB, increase the version number of that model
  - Turn off airplane mode on the device
 
When the device tries to publish the pending mutation it will result in a conflict because the version numbers do not match. The conflict handler will initiate a retry of the local deletion. The expected behaviour is that this retry will delete the record.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
