### PR TITLE
fix(auth): Fix for when authstate goes to an invalid state on confirmSignIn when it should accept the error state as is

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -681,7 +681,8 @@ internal class RealAWSCognitoAuthPlugin(
                     }
 
                     signInState is SignInState.ResolvingChallenge &&
-                        signInState.challengeState is SignInChallengeState.Error -> {
+                        signInState.challengeState is SignInChallengeState.Error &&
+                        (signInState.challengeState as SignInChallengeState.Error).hasNewResponse -> {
                         authStateMachine.cancel(token)
                         onError.accept(
                             CognitoAuthExceptionConverter.lookup(
@@ -691,6 +692,7 @@ internal class RealAWSCognitoAuthPlugin(
                                 "Confirm Sign in failed."
                             )
                         )
+                        (signInState.challengeState as SignInChallengeState.Error).hasNewResponse = false
                     }
                 }
             }, {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -615,7 +615,7 @@ internal class RealAWSCognitoAuthPlugin(
             val signInState = (authNState as? AuthenticationState.SigningIn)?.signInState
             if (signInState is SignInState.ResolvingChallenge) {
                 when (signInState.challengeState) {
-                    is SignInChallengeState.WaitingForAnswer -> {
+                    is SignInChallengeState.WaitingForAnswer, is SignInChallengeState.Error -> {
                         _confirmSignIn(challengeResponse, options, onSuccess, onError)
                     }
                     else -> {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInChallengeCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInChallengeCognitoActions.kt
@@ -80,7 +80,7 @@ internal object SignInChallengeCognitoActions : SignInChallengeActions {
                 )
             )
         } catch (e: Exception) {
-            SignInChallengeEvent(SignInChallengeEvent.EventType.ThrowError(e, challenge))
+            SignInChallengeEvent(SignInChallengeEvent.EventType.ThrowError(e, challenge, true))
         }
         logger.verbose("$id Sending event ${evt.type}")
         dispatcher.send(evt)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignInChallengeEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignInChallengeEvent.kt
@@ -25,7 +25,11 @@ internal class SignInChallengeEvent(val eventType: EventType, override val time:
         data class VerifyChallengeAnswer(val answer: String, val metadata: Map<String, String>) : EventType()
         data class FinalizeSignIn(val accessToken: String) : EventType()
         data class Verified(val id: String = "") : EventType()
-        data class ThrowError(val exception: Exception, val challenge: AuthChallenge) : EventType()
+        data class ThrowError(
+            val exception: Exception,
+            val challenge: AuthChallenge,
+            val hasNewResponse: Boolean = false
+        ) : EventType()
     }
 
     override val type: String = eventType.javaClass.simpleName

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignInChallengeState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignInChallengeState.kt
@@ -31,7 +31,11 @@ internal sealed class SignInChallengeState : State {
     ) : SignInChallengeState()
     data class Verifying(val id: String = "") : SignInChallengeState()
     data class Verified(val id: String = "") : SignInChallengeState()
-    data class Error(val exception: Exception, val challenge: AuthChallenge) : SignInChallengeState()
+    data class Error(
+        val exception: Exception,
+        val challenge: AuthChallenge,
+        var hasNewResponse: Boolean = false
+    ) : SignInChallengeState()
 
     class Resolver(private val challengeActions: SignInChallengeActions) : StateMachineResolver<SignInChallengeState> {
         override val defaultState: SignInChallengeState = NotStarted()
@@ -63,7 +67,7 @@ internal sealed class SignInChallengeState : State {
                 is Verifying -> when (challengeEvent) {
                     is SignInChallengeEvent.EventType.Verified -> StateResolution(Verified())
                     is SignInChallengeEvent.EventType.ThrowError -> {
-                        StateResolution(Error(challengeEvent.exception, challengeEvent.challenge), listOf())
+                        StateResolution(Error(challengeEvent.exception, challengeEvent.challenge, true), listOf())
                     }
                     is SignInChallengeEvent.EventType.WaitForAnswer -> {
                         StateResolution(WaitingForAnswer(challengeEvent.challenge, true), listOf())


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
