### PR TITLE
chore: pin github actions by commit hash

### DIFF
--- a/.github/workflows/closed_issue_message.yml
+++ b/.github/workflows/closed_issue_message.yml
@@ -8,7 +8,7 @@ jobs:
     auto_comment:
         runs-on: ubuntu-latest
         steps:
-        - uses: aws-actions/closed-issue-message@v1
+        - uses: aws-actions/closed-issue-message@36b7048ea77bb834d16e7a7c5b5471ac767a4ca1 # v1
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/codecov_code_coverage.yml
+++ b/.github/workflows/codecov_code_coverage.yml
@@ -24,10 +24,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       # Execute unit tests
       - name: Setup Java
-        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2  # v3
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3
         with:
           java-version: '11'
           distribution: 'corretto'

--- a/.github/workflows/codecov_code_coverage.yml
+++ b/.github/workflows/codecov_code_coverage.yml
@@ -24,10 +24,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
       # Execute unit tests
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2  # v3
         with:
           java-version: '11'
           distribution: 'corretto'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
       with:
         java-version: 11
     - name: Grant execute permission for gradlew

--- a/.github/workflows/maven_release_publisher.yml
+++ b/.github/workflows/maven_release_publisher.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@aa26d1f8263bab82a43a78fc0492f30464b7e20f # v1
         with:
           role-to-assume: ${{ secrets.AMPLIFY_ANDROID_RELEASE_PUBLISHER_ROLE }}
           aws-region: us-east-1
       - name: Start Integration Test
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@d5a04846cedab61a0b7c897af0548af0d8fb14fb # v1
         with:
           project-name: AmplifyAndroid-IntegrationTest
           env-vars-for-codebuild: |
@@ -26,11 +26,11 @@ jobs:
           ORG_GRADLE_PROJECT_useAwsSdkReleaseBuild: true
           NUMBER_OF_DEVICES_TO_TEST: 3
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@aa26d1f8263bab82a43a78fc0492f30464b7e20f # v1
         with:
           role-to-assume: ${{ secrets.AMPLIFY_ANDROID_RELEASE_PUBLISHER_ROLE }}
           aws-region: us-east-1
       - name: Start Maven Release Build
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@d5a04846cedab61a0b7c897af0548af0d8fb14fb # v1
         with:
           project-name: AmplifyAndroid-ReleasePublisher

--- a/.github/workflows/maven_release_publisher.yml
+++ b/.github/workflows/maven_release_publisher.yml
@@ -16,7 +16,7 @@ jobs:
           role-to-assume: ${{ secrets.AMPLIFY_ANDROID_RELEASE_PUBLISHER_ROLE }}
           aws-region: us-east-1
       - name: Start Integration Test
-        uses: aws-actions/aws-codebuild-run-build@d5a04846cedab61a0b7c897af0548af0d8fb14fb # v1
+        uses: aws-actions/aws-codebuild-run-build@f202c327329cbbebd13f986f74af162a8539b5fd # v1
         with:
           project-name: AmplifyAndroid-IntegrationTest
           env-vars-for-codebuild: |
@@ -31,6 +31,6 @@ jobs:
           role-to-assume: ${{ secrets.AMPLIFY_ANDROID_RELEASE_PUBLISHER_ROLE }}
           aws-region: us-east-1
       - name: Start Maven Release Build
-        uses: aws-actions/aws-codebuild-run-build@d5a04846cedab61a0b7c897af0548af0d8fb14fb # v1
+        uses: aws-actions/aws-codebuild-run-build@f202c327329cbbebd13f986f74af162a8539b5fd # v1
         with:
           project-name: AmplifyAndroid-ReleasePublisher

--- a/.github/workflows/maven_release_publisher.yml
+++ b/.github/workflows/maven_release_publisher.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@aa26d1f8263bab82a43a78fc0492f30464b7e20f # v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           role-to-assume: ${{ secrets.AMPLIFY_ANDROID_RELEASE_PUBLISHER_ROLE }}
           aws-region: us-east-1
@@ -26,7 +26,7 @@ jobs:
           ORG_GRADLE_PROJECT_useAwsSdkReleaseBuild: true
           NUMBER_OF_DEVICES_TO_TEST: 3
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@aa26d1f8263bab82a43a78fc0492f30464b7e20f # v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           role-to-assume: ${{ secrets.AMPLIFY_ANDROID_RELEASE_PUBLISHER_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -19,7 +19,7 @@ jobs:
         sudo add-apt-repository -y ppa:git-core/ppa
         sudo apt-get update
         sudo apt-get install git -y
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         ref: ${{ env.BASE_BRANCH }}
         fetch-depth: 0

--- a/.github/workflows/release_pr_approval_count.yml
+++ b/.github/workflows/release_pr_approval_count.yml
@@ -14,7 +14,7 @@ jobs:
             &&  startsWith(github.event.pull_request.title, 'release:')
         }}
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
         id: get_approval_count
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4
+    - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da  #v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         operations-per-run: 200

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da  #v4
+    - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         operations-per-run: 200


### PR DESCRIPTION
- [X] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes: Pin github actions by commit-hash instead of tags

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [X] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
