### PR TITLE
fix(datastore): Ignore ApiAuthExceptions when subscribing or syncing models

### DIFF
--- a/aws-api/build.gradle.kts
+++ b/aws-api/build.gradle.kts
@@ -39,6 +39,8 @@ dependencies {
     testImplementation(libs.test.jsonassert)
     testImplementation(libs.test.junit)
     testImplementation(libs.test.mockito.core)
+    testImplementation(libs.test.mockk)
+    testImplementation(libs.test.kotest.assertions)
     testImplementation(libs.test.mockwebserver)
     testImplementation(libs.rxjava)
     testImplementation(libs.test.robolectric)

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -610,7 +610,7 @@ public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
         if (AuthModeStrategyType.MULTIAUTH.equals(authModeStrategyType)) {
             // If it gets here, we know that the request is an AppSyncGraphQLRequest because
             // getAuthModeStrategyType checks for that, so we can safely cast the graphQLRequest.
-            return MutiAuthSubscriptionOperation.<R>builder()
+            return MultiAuthSubscriptionOperation.<R>builder()
                                                 .subscriptionEndpoint(clientDetails.getSubscriptionEndpoint())
                                                 .graphQlRequest((AppSyncGraphQLRequest<R>) graphQLRequest)
                                                 .responseFactory(gqlResponseFactory)

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperation.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.api.aws;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiException.ApiAuthException;
@@ -48,7 +49,6 @@ final class MultiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
     private final Action onSubscriptionComplete;
     private final AtomicBoolean canceled;
     private final AuthRuleRequestDecorator requestDecorator;
-
     private AuthorizationTypeIterator authTypes;
     private String subscriptionId;
     private Future<?> subscriptionFuture;
@@ -178,6 +178,21 @@ final class MultiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
     private void emitErrorAndCancelSubscription(ApiException apiException) {
         cancel();
         onSubscriptionError.accept(apiException);
+    }
+
+    @VisibleForTesting
+    boolean isCanceled() {
+        return canceled.get();
+    }
+
+    @VisibleForTesting
+    void setCanceled(boolean canceled) {
+        this.canceled.set(canceled);
+    }
+
+    @VisibleForTesting
+    Future<?> getSubscriptionFuture() {
+        return subscriptionFuture;
     }
 
     static final class Builder<T> {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperation.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-final class MutiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
+final class MultiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
     private static final Logger LOG = Amplify.Logging.logger(CategoryType.API, "amplify:aws-api");
 
     private final SubscriptionEndpoint subscriptionEndpoint;
@@ -53,7 +53,7 @@ final class MutiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
     private String subscriptionId;
     private Future<?> subscriptionFuture;
 
-    private MutiAuthSubscriptionOperation(Builder<T> builder) {
+    private MultiAuthSubscriptionOperation(Builder<T> builder) {
         super(builder.graphQlRequest, builder.responseFactory);
         this.subscriptionEndpoint = builder.subscriptionEndpoint;
         this.onSubscriptionStart = builder.onSubscriptionStart;
@@ -114,7 +114,7 @@ final class MutiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
                 request,
                 authorizationType,
                 subscriptionId -> {
-                    MutiAuthSubscriptionOperation.this.subscriptionId = subscriptionId;
+                    MultiAuthSubscriptionOperation.this.subscriptionId = subscriptionId;
                     onSubscriptionStart.accept(subscriptionId);
                 },
                 response -> {
@@ -245,8 +245,8 @@ final class MutiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
         }
 
         @NonNull
-        public MutiAuthSubscriptionOperation<T> build() {
-            return new MutiAuthSubscriptionOperation<>(this);
+        public MultiAuthSubscriptionOperation<T> build() {
+            return new MultiAuthSubscriptionOperation<>(this);
         }
     }
 }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/MutiAuthSubscriptionOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/MutiAuthSubscriptionOperation.java
@@ -120,7 +120,7 @@ final class MutiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
                 },
                 response -> {
                     if (response.hasErrors() && hasAuthRelatedErrors(response) && authTypes.hasNext()) {
-                        // If there are auth-related errors, dispatch an ApiAuthException
+                        // If there are auth-related errors queue up a retry with the next authType
                         executorService.submit(this::dispatchRequest);
                     } else {
                         // Otherwise, we just want to dispatch it as a next item and
@@ -139,8 +139,10 @@ final class MutiAuthSubscriptionOperation<T> extends GraphQLOperation<T> {
                 onSubscriptionComplete
             );
         } else {
-            emitErrorAndCancelSubscription(new ApiException("Unable to establish subscription connection.",
-                                                        AmplifyException.TODO_RECOVERY_SUGGESTION));
+            emitErrorAndCancelSubscription(new ApiAuthException(
+                "Unable to establish subscription connection with any of the compatible auth types.",
+                "Check your application logs for detail."
+            ));
         }
 
     }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/MutiAuthSubscriptionOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/MutiAuthSubscriptionOperation.java
@@ -17,7 +17,6 @@ package com.amplifyframework.api.aws;
 
 import androidx.annotation.NonNull;
 
-import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiException.ApiAuthException;
 import com.amplifyframework.api.aws.auth.AuthRuleRequestDecorator;

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperationTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperationTest.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws
+
+import com.amplifyframework.api.ApiException
+import com.amplifyframework.api.ApiException.ApiAuthException
+import com.amplifyframework.api.aws.auth.AuthRuleRequestDecorator
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.api.graphql.GraphQLResponse
+import com.amplifyframework.core.Action
+import com.amplifyframework.core.Consumer
+import com.amplifyframework.core.model.AuthStrategy
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelOperation
+import com.amplifyframework.core.model.ModelSchema
+import com.amplifyframework.core.model.annotations.AuthRule
+import com.amplifyframework.core.model.annotations.ModelConfig
+import com.amplifyframework.util.MockExecutorService
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.ExecutorService
+import org.junit.Test
+
+/**
+ * Unit tests for the [MultiAuthSubscriptionOperation] class.
+ */
+class MultiAuthSubscriptionOperationTest {
+
+    private val executor = MockExecutorService()
+    private val endpoint = MockSubscriptionEndpoint()
+    private val decorator: AuthRuleRequestDecorator = mockk(relaxed = true)
+
+    private val onStart: (String) -> Unit = mockk(relaxed = true)
+    private val onNext: (GraphQLResponse<String>) -> Unit = mockk(relaxed = true)
+    private val onError: (ApiException) -> Unit = mockk(relaxed = true)
+    private val onComplete: () -> Unit = mockk(relaxed = true)
+
+//region start tests
+
+    @Test
+    fun `start emits exception if already cancelled`() {
+        val operation = createOperation()
+        operation.isCanceled = true
+        operation.start()
+        verify {
+            onError(any())
+        }
+    }
+
+//endregion
+//region cancellation tests
+
+    @Test
+    fun `cancel cancels the subscription future`() {
+        executor.autoRunTasks = false
+        val operation = createOperation()
+        operation.start()
+        operation.cancel()
+        operation.subscriptionFuture.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `cancel does nothing if not started`() {
+        executor.autoRunTasks = false
+        val operation = createOperation()
+        operation.cancel()
+        executor.queue.shouldBeEmpty()
+    }
+
+    @Test
+    fun `cancel releases subscription`() {
+        val operation = createOperation()
+        operation.start()
+        endpoint.invokeOnStart()
+        operation.cancel()
+        endpoint.verifyReleased()
+    }
+
+//endregion
+//region error tests
+
+    @Test
+    fun `operation is cancelled if authtypes are exhausted`() {
+        val operation = createOperation()
+        operation.start()
+        endpoint.invokeOnStart()
+        endpoint.invokeOnError(ApiAuthException("", "")) // error on first auth type
+        endpoint.invokeOnStart()
+        endpoint.invokeOnError(ApiAuthException("", "")) // error on second auth type
+        endpoint.verifyReleased()
+    }
+
+    @Test
+    fun `operation emits ApiAuthException if authtypes are exhausted`() {
+        val operation = createOperation()
+        operation.start()
+        endpoint.invokeOnError(ApiAuthException("", "")) // error on first auth type
+        endpoint.invokeOnError(ApiAuthException("", "")) // error on second auth type
+        verify {
+            onError(any<ApiAuthException>())
+        }
+    }
+
+    @Test
+    fun `next authtype is tried if requestDecorator throws ApiAuthException`() {
+        every { decorator.decorate(any<GraphQLRequest<*>>(), any()) } throws ApiAuthException("", "")
+        val operation = createOperation()
+        operation.start()
+        executor.numTasksQueued shouldBe 2 // One for each auth type
+        endpoint.verifyNumSubscriptionRequests(1) // Only one should send a subscription request
+    }
+
+    @Test
+    fun `next authtype is tried if response contains auth errors`() {
+        val response = mockAuthErrorResponse()
+        val operation = createOperation()
+        operation.start()
+        endpoint.invokeOnResponse(response)
+        executor.numTasksQueued shouldBe 2 // One for each auth type
+        endpoint.verifyNumSubscriptionRequests(2)
+    }
+
+    @Test
+    fun `error is emitted if requestDecorator throws ApiException`() {
+        val exception = ApiException("", "")
+        every { decorator.decorate(any<GraphQLRequest<*>>(), any()) } throws exception
+        val operation = createOperation()
+        operation.start()
+        verify {
+            onError(exception)
+        }
+    }
+
+//endregion
+//region Success tests
+
+    @Test
+    fun `onStart is called`() {
+        val operation = createOperation()
+        operation.start()
+        endpoint.invokeOnStart()
+        verify {
+            onStart(endpoint.subscriptionId)
+        }
+    }
+
+    @Test
+    fun `onNext is called`() {
+        val response = mockk<GraphQLResponse<String>>() {
+            every { hasErrors() } returns false
+        }
+        val operation = createOperation()
+        operation.start()
+        endpoint.invokeOnResponse(response)
+        verify {
+            onNext(response)
+        }
+    }
+
+    @Test
+    fun `onComplete is called`() {
+        val operation = createOperation()
+        operation.start()
+        endpoint.invokeOnComplete()
+        verify {
+            onComplete()
+        }
+    }
+
+//endregion
+
+    private fun createOperation(
+        subscriptionEndpoint: SubscriptionEndpoint = endpoint.endpoint,
+        onSubscriptionStart: (String) -> Unit = onStart,
+        onNextItem: (GraphQLResponse<String>) -> Unit = onNext,
+        onSubscriptionError: (ApiException) -> Unit = onError,
+        onSubscriptionComplete: () -> Unit = onComplete,
+        executorService: ExecutorService = executor,
+        requestDecorator: AuthRuleRequestDecorator = decorator,
+        graphQlRequest: AppSyncGraphQLRequest<String> = mockk {
+            every { modelSchema } returns ModelSchema.fromModelClass(ModelWithTwoAuthModes::class.java)
+            every { authRuleOperation } returns ModelOperation.READ
+            every { content } returns ""
+        }
+    ): MultiAuthSubscriptionOperation<String> {
+        val operation = MultiAuthSubscriptionOperation.builder<String>()
+            .subscriptionEndpoint(subscriptionEndpoint)
+            .onSubscriptionStart(onSubscriptionStart)
+            .onNextItem(onNextItem)
+            .onSubscriptionError(onSubscriptionError)
+            .onSubscriptionComplete(onSubscriptionComplete)
+            .executorService(executorService)
+            .requestDecorator(requestDecorator)
+            .graphQlRequest(graphQlRequest)
+            .build()
+        return operation
+    }
+
+    private fun mockAuthErrorResponse() = mockk<GraphQLResponse<String>> {
+        every { hasErrors() } returns true
+        every { errors } returns listOf(
+            mockk { every { extensions } returns mapOf("errorType" to "Unauthorized") }
+        )
+    }
+
+    private class MockSubscriptionEndpoint {
+        val endpoint = mockk<SubscriptionEndpoint>() {
+            every { releaseSubscription(any()) } just Runs
+        }
+        val subscriptionId = "subId"
+
+        var onStart: Consumer<String>? = null
+        var onResponse: Consumer<GraphQLResponse<String>>? = null
+        var onError: Consumer<ApiException>? = null
+        var onComplete: Action? = null
+
+        init {
+            every { endpoint.requestSubscription<String>(any(), any(), any(), any(), any(), any()) } answers {
+                onStart = arg(2)
+                onResponse = arg(3)
+                onError = arg(4)
+                onComplete = arg(5)
+            }
+        }
+
+        fun invokeOnStart() = onStart?.accept(subscriptionId)
+        fun invokeOnResponse(response: GraphQLResponse<String>) = onResponse?.accept(response)
+        fun invokeOnError(error: ApiException) = onError?.accept(error)
+        fun invokeOnComplete() = onComplete?.call()
+
+        fun verifyReleased() = verify {
+            endpoint.releaseSubscription(subscriptionId)
+        }
+
+        fun verifyNumSubscriptionRequests(expected: Int) = verify(exactly = expected) {
+            endpoint.requestSubscription<String>(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @ModelConfig(
+        authRules = [
+            AuthRule(
+                allow = AuthStrategy.OWNER,
+                operations = [ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ]
+            ), AuthRule(
+                allow = AuthStrategy.PUBLIC,
+                operations = [ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ]
+            )
+        ]
+    )
+    private class ModelWithTwoAuthModes : Model
+}

--- a/aws-api/src/test/java/com/amplifyframework/util/MockExecutorService.kt
+++ b/aws-api/src/test/java/com/amplifyframework/util/MockExecutorService.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.util
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+
+/**
+ * An implementation of [ExecutorService] that can run tasks synchronously either automatically or on demand
+ */
+class MockExecutorService(var autoRunTasks: Boolean = true) : ExecutorService {
+    val queue = mutableListOf<Runnable>()
+    var numTasksQueued = 0
+
+    override fun execute(command: Runnable) { submit(command) }
+
+    override fun <T : Any> submit(task: Callable<T>): Future<T> {
+        val future = CompletableFuture<T>()
+        queueTask {
+            future.complete(task.call())
+        }
+        return future
+    }
+
+    override fun <T : Any> submit(task: Runnable, result: T): Future<T> {
+        val future = CompletableFuture<T>()
+        queueTask {
+            task.run()
+            future.complete(result)
+        }
+        return future
+    }
+    override fun submit(task: Runnable): Future<*> {
+        val future = CompletableFuture<Unit>()
+        queueTask {
+            task.run()
+            future.complete(Unit)
+        }
+        return future
+    }
+
+    // Remaining API is not implemented
+    override fun shutdown() {}
+    override fun shutdownNow(): List<Runnable> = queue
+    override fun isShutdown() = false
+    override fun isTerminated() = false
+    override fun awaitTermination(timeout: Long, unit: TimeUnit) = false
+    override fun <T : Any> invokeAll(tasks: MutableCollection<out Callable<T>>) = emptyList<Future<T>>()
+    override fun <T : Any> invokeAll(
+        tasks: MutableCollection<out Callable<T>>,
+        timeout: Long,
+        unit: TimeUnit
+    ) = emptyList<Future<T>>()
+    override fun <T : Any> invokeAny(tasks: MutableCollection<out Callable<T>>): T? = null
+    override fun <T : Any> invokeAny(
+        tasks: MutableCollection<out Callable<T>>,
+        timeout: Long,
+        unit: TimeUnit?
+    ): T? = null
+
+    fun runNext() {
+        val task = queue.removeFirstOrNull()
+        task?.run()
+    }
+
+    private fun queueTask(runnable: Runnable) {
+        numTasksQueued++
+        if (autoRunTasks) {
+            runnable.run()
+        } else {
+            queue.add(runnable)
+        }
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -198,8 +198,7 @@ final class SubscriptionProcessor {
                 emitter::onNext,
                 dataStoreException -> {
                     if (ErrorInspector.contains(dataStoreException, ApiException.ApiAuthException.class) ||
-                            isExceptionType(dataStoreException, AppSyncErrorType.UNAUTHORIZED))
-                    {
+                            isExceptionType(dataStoreException, AppSyncErrorType.UNAUTHORIZED)) {
                         // Ignore Unauthorized errors, so that DataStore can still be used even if the user is only
                         // authorized to read a subset of the models.
                         latch.countDown();

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.Action;
@@ -40,6 +41,7 @@ import com.amplifyframework.datastore.appsync.AppSync;
 import com.amplifyframework.datastore.appsync.AppSyncExtensions;
 import com.amplifyframework.datastore.appsync.AppSyncExtensions.AppSyncErrorType;
 import com.amplifyframework.datastore.appsync.ModelWithMetadata;
+import com.amplifyframework.datastore.utils.ErrorInspector;
 import com.amplifyframework.hub.HubChannel;
 import com.amplifyframework.hub.HubEvent;
 import com.amplifyframework.logging.Logger;
@@ -195,7 +197,9 @@ final class SubscriptionProcessor {
                 },
                 emitter::onNext,
                 dataStoreException -> {
-                    if (isExceptionType(dataStoreException, AppSyncErrorType.UNAUTHORIZED)) {
+                    if (ErrorInspector.contains(dataStoreException, ApiException.ApiAuthException.class) ||
+                            isExceptionType(dataStoreException, AppSyncErrorType.UNAUTHORIZED))
+                    {
                         // Ignore Unauthorized errors, so that DataStore can still be used even if the user is only
                         // authorized to read a subset of the models.
                         latch.countDown();

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessorTest.java
@@ -17,6 +17,7 @@ package com.amplifyframework.datastore.syncengine;
 
 import android.util.Pair;
 
+import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.SubscriptionType;
 import com.amplifyframework.core.Action;
@@ -60,6 +61,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests the {@link SubscriptionProcessor}.
@@ -73,11 +76,13 @@ public final class SubscriptionProcessorTest {
     private Merger merger;
     private SubscriptionProcessor subscriptionProcessor;
     private SchemaRegistry schemaRegistry;
+    private Consumer<Throwable> onFailure;
 
     /**
      * Sets up an {@link SubscriptionProcessor} and associated test dependencies.
      * @throws DataStoreException on error building the {@link DataStoreConfiguration}
      */
+    @SuppressWarnings("unchecked")
     @Before
     public void setup() throws DataStoreException {
         ModelProvider modelProvider = AmplifyModelProvider.getInstance();
@@ -86,6 +91,7 @@ public final class SubscriptionProcessorTest {
         this.modelSchemas = sortedModels(modelProvider);
         this.appSync = mock(AppSync.class);
         this.merger = mock(Merger.class);
+        this.onFailure = (Consumer<Throwable>) mock(Consumer.class);
         DataStoreConfiguration dataStoreConfiguration = DataStoreConfiguration.builder()
                 .syncExpression(BlogOwner.class, () -> BlogOwner.NAME.beginsWith("John"))
                 .build();
@@ -97,7 +103,7 @@ public final class SubscriptionProcessorTest {
                 .schemaRegistry(schemaRegistry)
                 .merger(merger)
                 .queryPredicateProvider(queryPredicateProvider)
-                .onFailure(throwable -> { })
+                .onFailure(onFailure)
                 .build();
     }
 
@@ -112,6 +118,7 @@ public final class SubscriptionProcessorTest {
     /**
      * When {@link SubscriptionProcessor#startSubscriptions()} is invoked,
      * the {@link AppSync} client receives subscription requests.
+     * @throws DataStoreException If test is broken
      */
     @Test
     public void appSyncInvokedWhenSubscriptionsStarted() throws DataStoreException {
@@ -139,7 +146,6 @@ public final class SubscriptionProcessorTest {
 
         // Act: start some subscriptions.
         subscriptionProcessor.startSubscriptions();
-
 
         // Make sure that all of the subscriptions have been
         Observable.fromIterable(seen.entrySet())
@@ -173,13 +179,46 @@ public final class SubscriptionProcessorTest {
     }
 
     /**
+     * Verifies that an exception caused by an ApiAuthException will NOT call onFailure. This is because models may
+     * fail to subscribe due to authorization failure, but we want to continue to subscribe the other models.
+     * @throws DataStoreException On failure to arrange mocking
+     */
+    @Test
+    public void apiAuthExceptionIsIgnored() throws DataStoreException {
+        Answer<Cancelable> answer = invocation -> {
+            final int modelSchemaIndex = 0;
+            final int startConsumerIndex = 1;
+            final int errorConsumerIndex = 3;
+            ModelSchema modelSchema = invocation.getArgument(modelSchemaIndex);
+            Consumer<String> onStart = invocation.getArgument(startConsumerIndex);
+            Consumer<DataStoreException> onError = invocation.getArgument(errorConsumerIndex);
+            onStart.accept(RandomString.string());
+            if (modelSchema.equals(modelSchemas.get(1))) {
+                onError.accept(
+                    new DataStoreException(
+                        "Failure for model",
+                        new ApiException.ApiAuthException("Simulated auth failure", "This is intentional"),
+                        "This is intentional"
+                    )
+                );
+            }
+            return new NoOpCancelable();
+        };
+        arrangeSubscriptions(appSync, answer, modelSchemas, SubscriptionType.values());
+
+        subscriptionProcessor.startSubscriptions();
+
+        verify(onFailure, never()).accept(any());
+    }
+
+    /**
      * Return whether a response with a BlogOwner with the given name gets merged with the merger.
      * @param name name of the BlogOwner returned in the subscription
      * @return whether the data was merged
      * @throws DataStoreException On failure to arrange mocking
      * @throws InterruptedException On failure to await latch
      */
-    private boolean isDataMergedWhenBufferDrainedForBlogOwnerNamed(String name) 
+    private boolean isDataMergedWhenBufferDrainedForBlogOwnerNamed(String name)
             throws DataStoreException, InterruptedException {
         // By default, start the subscriptions up.
         arrangeStartedSubscriptions(appSync, modelSchemas, SubscriptionType.values());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ gson = "2.8.9"
 json = "20210307"
 jsonassert = "1.5.0"
 junit = "4.13.2"
+kotest = "5.6.2"
 kotlin = "1.7.10"
 kotlin-serialization = "1.3.3"
 maplibre = "9.6.0"
@@ -106,6 +107,7 @@ test-aws-sdk-core = { module = "com.amazonaws:aws-android-sdk-core", version.ref
 test-json = { module = "org.json:json", version.ref = "json" }
 test-jsonassert = { module = "org.skyscreamer:jsonassert", version.ref="jsonassert" }
 test-junit = { module = "junit:junit", version.ref = "junit" }
+test-kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref="coroutines" }
 test-kotlin-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref="kotlin" }
 test-kotlin-kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref="kotlin" }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* 
#2399

*Description of changes:*
- Api category emits an `ApiAuthException` from `MultiAuthSubscriptionOperation` if authTypes are exhausted when trying to establish a subscription (this is already how the multi-auth sync worked, and appeared to be the intended implementation based on existing code comments).
- Datastore ignores `ApiAuthException` encountered when starting the `SubscriptionProcessor` and the `SyncProcessor`. This effectively skips those models and allows syncing/subscribing to continue for other models.

*How did you test these changes?*
- Used schema from issue and verified that DataStore starts normally after fix.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
