### PR TITLE
fix(flutter/datastore): Nullable custom type arrays

### DIFF
--- a/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModelAdapter.java
+++ b/aws-api-appsync/src/main/java/com/amplifyframework/datastore/appsync/SerializedModelAdapter.java
@@ -116,8 +116,13 @@ public final class SerializedModelAdapter
                 continue;
             }
 
-            JsonElement fieldValue = item.getValue();
             String fieldName = field.getName();
+            JsonElement fieldValue = item.getValue();
+            if (fieldValue.isJsonNull()) {
+                LOGGER.verbose(String.format("Field %s is null", fieldName));
+                serializedData.put(fieldName, null);
+                continue;
+            }
 
             boolean isModel = field.isModel();
             boolean isCustomType = field.isCustomType();

--- a/aws-api-appsync/src/test/java/com/amplifyframework/datastore/appsync/SerializedModelAdapterTest.java
+++ b/aws-api-appsync/src/test/java/com/amplifyframework/datastore/appsync/SerializedModelAdapterTest.java
@@ -64,7 +64,7 @@ public final class SerializedModelAdapterTest {
         GsonTemporalAdapters.register(builder);
         SerializedModelAdapter.register(builder);
         SerializedCustomTypeAdapter.register(builder);
-        gson = builder.create();
+        gson = builder.serializeNulls().create();
     }
 
     /**
@@ -162,6 +162,7 @@ public final class SerializedModelAdapterTest {
         contactSerializedData.put("email", "test@test.com");
         contactSerializedData.put("phone", phone);
         contactSerializedData.put("additionalPhoneNumbers", additionalPhoneNumbers);
+        contactSerializedData.put("aliases", null);
         SerializedCustomType contact = SerializedCustomType.builder()
                 .serializedData(contactSerializedData)
                 .customTypeSchema(contactSchema)
@@ -170,6 +171,7 @@ public final class SerializedModelAdapterTest {
         Map<String, Object> personSerializedData = new HashMap<>();
         personSerializedData.put("fullName", "Tester Test");
         personSerializedData.put("contact", contact);
+        personSerializedData.put("additionalContacts", null);
         personSerializedData.put("id", "some-unique-id");
         SerializedModel person = SerializedModel.builder()
                 .modelSchema(personSchema)
@@ -327,6 +329,14 @@ public final class SerializedModelAdapterTest {
                 .isArray(true)
                 .isRequired(true)
                 .build());
+        contactFields.put("aliases", CustomTypeField.builder()
+                .name("aliases")
+                .targetType("Contact")
+                .javaClassForValue(Map.class)
+                .isCustomType(true)
+                .isArray(true)
+                .isRequired(false)
+                .build());
         return CustomTypeSchema.builder()
                 .name("Contact")
                 .pluralName("Contacts")
@@ -354,6 +364,14 @@ public final class SerializedModelAdapterTest {
                 .javaClassForValue(Map.class)
                 .isRequired(true)
                 .isCustomType(true)
+                .build());
+        personFields.put("additionalContacts", ModelField.builder()
+                .name("additionalContacts")
+                .targetType("Contact")
+                .javaClassForValue(Map.class)
+                .isRequired(false)
+                .isCustomType(true)
+                .isArray(true)
                 .build());
         return ModelSchema.builder()
                 .name("Person")

--- a/aws-api-appsync/src/test/resources/serde-for-blog-in-serialized-model.json
+++ b/aws-api-appsync/src/test/resources/serde-for-blog-in-serialized-model.json
@@ -59,17 +59,23 @@
       "owner": {
         "name": "BelongsTo",
         "targetName": "blogOwnerId",
+        "targetNames": null,
+        "associatedName": null,
         "associatedType": "BlogOwner"
       },
       "posts": {
         "name": "HasMany",
         "associatedName": "blog",
-        "associatedType": "Post"
+        "associatedType": "Post",
+        "targetNames": null,
+        "targetName": null
       }
     },
     "indexes": {},
     "modelClass": "com.amplifyframework.core.model.SerializedModel",
-    "modelSchemaVersion": 0
+    "listPluralName": null,
+    "modelType": null,
+    "syncPluralName": null
   },
   "serializedData": {
     "owner": {

--- a/aws-api-appsync/src/test/resources/serde-for-meeting-in-serialized-model.json
+++ b/aws-api-appsync/src/test/resources/serde-for-meeting-in-serialized-model.json
@@ -2,9 +2,10 @@
   "id": "970f1b78-8786-4762-a43a-17c70f966684",
   "modelSchema": {
     "name": "Meeting",
-    "modelSchemaVersion": 0,
     "pluralName": "Meetings",
     "authRules": [],
+    "listPluralName": null,
+    "modelType": null,
     "fields": {
       "date": {
         "name": "date",
@@ -79,6 +80,7 @@
         "authRules": []
       }
     },
+    "syncPluralName": null,
     "associations": {},
     "indexes": {},
     "modelClass": "com.amplifyframework.core.model.SerializedModel",

--- a/aws-api-appsync/src/test/resources/serialized-model-with-nested-custom-type-se-deserialization.json
+++ b/aws-api-appsync/src/test/resources/serialized-model-with-nested-custom-type-se-deserialization.json
@@ -64,6 +64,7 @@
             }
           }
         ],
+        "aliases": null,
         "phone": {
           "serializedData": {
             "number": "41555555555",
@@ -109,6 +110,15 @@
             "targetType": "Phone",
             "isArray": true
           },
+          "aliases": {
+            "javaClassForValue": "java.util.Map",
+            "isRequired": false,
+            "isCustomType": true,
+            "name": "aliases",
+            "isEnum": false,
+            "targetType": "Contact",
+            "isArray": true
+          },
           "phone": {
             "javaClassForValue": "java.util.Map",
             "isRequired": true,
@@ -130,18 +140,34 @@
         }
       }
     },
+    "additionalContacts": null,
     "fullName": "Tester Test",
     "id": "some-unique-id"
   },
   "id": "some-unique-id",
   "modelSchema": {
     "associations": {},
+    "listPluralName": null,
     "pluralName": "People",
     "authRules": [],
     "indexes": {},
+    "modelClass": null,
     "name": "Person",
     "modelSchemaVersion": 0,
+    "modelType": null,
     "fields": {
+      "additionalContacts": {
+        "javaClassForValue": "java.util.Map",
+        "isRequired": false,
+        "isCustomType": true,
+        "isReadOnly": false,
+        "isModel": false,
+        "authRules": [],
+        "name": "additionalContacts",
+        "isEnum": false,
+        "targetType": "Contact",
+        "isArray": true
+      },
       "contact": {
         "javaClassForValue": "java.util.Map",
         "isRequired": true,
@@ -178,6 +204,7 @@
         "targetType": "ID",
         "isArray": false
       }
-    }
+    },
+    "syncPluralName": null
   }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

https://github.com/aws-amplify/amplify-flutter/issues/3575

*Description of changes:*

When a custom type array is not required and `null` is returned from AppSync, deserialization will fail since `getAsJsonArray` will throw for `null` values.

This resolves the issue by checking if a field is `null` before attempting deserialization.

*How did you test these changes?*

Added test case for `null` custom type array.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
