### PR TITLE
fix(auth): Fix for missing exception type for sign in

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CognitoAuthExceptionConverter.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CognitoAuthExceptionConverter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.ResourceNotFoundExc
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.SoftwareTokenMfaNotFoundException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.TooManyFailedAttemptsException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.TooManyRequestsException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserLambdaValidationException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserNotConfirmedException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserNotFoundException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UsernameExistsException
@@ -88,6 +89,11 @@ internal class CognitoAuthExceptionConverter {
                     com.amplifyframework.auth.cognito.exceptions.service.TooManyRequestsException(error)
                 is PasswordResetRequiredException ->
                     com.amplifyframework.auth.cognito.exceptions.service.PasswordResetRequiredException(error)
+                is UserLambdaValidationException ->
+                    com.amplifyframework.auth.cognito.exceptions.service.UserLambdaValidationException(
+                        error.message,
+                        error
+                    )
                 else -> UnknownException(fallbackMessage, error)
             }
         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/UserLambdaValidationException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/UserLambdaValidationException.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.auth.cognito.exceptions.service
+
+import com.amplifyframework.auth.exceptions.ServiceException
+
+/**
+ * Could not perform the action because the password given is invalid.
+ * @param cause The underlying cause of this exception
+ */
+open class UserLambdaValidationException(message: String?, cause: Throwable?) :
+    ServiceException("User validation exception with the Lambda service.", message ?: "", cause)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2523

*Description of changes:* UserLambda exception was not present in the converter and instead we were sending an unknown exception back to the customer. This fixes that.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
