### PR TITLE
fix(datastore): Prevent stop from interrupting subsequent start call

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -295,10 +295,11 @@ final class SubscriptionEndpoint {
         subscriptions.remove(subscriptionId);
 
         // If we have zero subscriptions, close the WebSocket
-        if (subscriptions.size() == 0) {
+        if (subscriptions.isEmpty() && pendingSubscriptionIds.isEmpty()) {
             LOG.info("No more active subscriptions. Closing web socket.");
             timeoutWatchdog.stop();
             webSocket.close(NORMAL_CLOSURE_STATUS, "No active subscriptions");
+            webSocketListener = null;
         }
     }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -73,6 +73,7 @@ final class SubscriptionEndpoint {
     private final TimeoutWatchdog timeoutWatchdog;
     private final Set<String> pendingSubscriptionIds;
     private final OkHttpClient okHttpClient;
+    private final Object webSocketLock = new Object();
     private WebSocket webSocket;
     private AmplifyWebSocketListener webSocketListener;
 
@@ -126,26 +127,35 @@ final class SubscriptionEndpoint {
         Objects.requireNonNull(onSubscriptionError);
         Objects.requireNonNull(onSubscriptionComplete);
 
-        // The first call to subscribe OR a disconnected websocket listener will
-        // force a new connection to be created.
-        if (webSocketListener == null || webSocketListener.isDisconnectedState()) {
-            webSocketListener = new AmplifyWebSocketListener();
-            try {
-                webSocket = okHttpClient.newWebSocket(new Request.Builder()
-                    .url(buildConnectionRequestUrl(authType))
-                    .addHeader("Sec-WebSocket-Protocol", "graphql-ws")
-                    .header("User-Agent", UserAgent.string())
-                    .build(), webSocketListener);
-            } catch (ApiException apiException) {
-                onSubscriptionError.accept(apiException);
-                return;
+        final String subscriptionId = UUID.randomUUID().toString();
+        final AmplifyWebSocketListener socketListener;
+        final WebSocket socket;
+
+        synchronized (webSocketLock) {
+            // The first call to subscribe OR a disconnected websocket listener will
+            // force a new connection to be created.
+            if (webSocketListener == null || webSocketListener.isDisconnectedState()) {
+                webSocketListener = new AmplifyWebSocketListener();
+                try {
+                    webSocket = okHttpClient.newWebSocket(new Request.Builder()
+                                                              .url(buildConnectionRequestUrl(authType))
+                                                              .addHeader("Sec-WebSocket-Protocol", "graphql-ws")
+                                                              .header("User-Agent", UserAgent.string())
+                                                              .build(), webSocketListener);
+                } catch (ApiException apiException) {
+                    onSubscriptionError.accept(apiException);
+                    return;
+                }
+
             }
 
+            pendingSubscriptionIds.add(subscriptionId);
+            socketListener = webSocketListener;
+            socket = webSocket;
         }
-        final String subscriptionId = UUID.randomUUID().toString();
-        pendingSubscriptionIds.add(subscriptionId);
+
         // Every request waits here for the connection to be ready.
-        Connection connection = webSocketListener.waitForConnectionReady();
+        Connection connection = socketListener.waitForConnectionReady();
         if (connection.hasFailure()) {
             // If the latch didn't count all the way down
             if (pendingSubscriptionIds.remove(subscriptionId)) {
@@ -166,7 +176,7 @@ final class SubscriptionEndpoint {
                 .put("authorization", authorizer.createHeadersForSubscription(request, authType))))
                 .toString();
 
-            webSocket.send(jsonMessage);
+            socket.send(jsonMessage);
         } catch (JSONException | ApiException exception) {
             // If the subscriptionId was still pending, then we can call the onSubscriptionError
             if (pendingSubscriptionIds.remove(subscriptionId)) {
@@ -273,8 +283,8 @@ final class SubscriptionEndpoint {
 
         // Only do this if the subscription was NOT pending.
         // Otherwise it would probably fail since it was never established in the first place.
-
-        if (!wasSubscriptionPending && !webSocketListener.isDisconnectedState()) {
+        final AmplifyWebSocketListener socketListener = webSocketListener;
+        if (!wasSubscriptionPending && socketListener != null && !socketListener.isDisconnectedState()) {
             try {
                 String jsonMessage = new JSONObject()
                     .put("type", "stop")
@@ -292,14 +302,15 @@ final class SubscriptionEndpoint {
             subscription.awaitSubscriptionCompleted();
         }
 
-        subscriptions.remove(subscriptionId);
-
         // If we have zero subscriptions, close the WebSocket
-        if (subscriptions.isEmpty() && pendingSubscriptionIds.isEmpty()) {
-            LOG.info("No more active subscriptions. Closing web socket.");
-            timeoutWatchdog.stop();
-            webSocket.close(NORMAL_CLOSURE_STATUS, "No active subscriptions");
-            webSocketListener = null;
+        synchronized (webSocketLock) {
+            subscriptions.remove(subscriptionId);
+            if (subscriptions.isEmpty() && pendingSubscriptionIds.isEmpty()) {
+                LOG.info("No more active subscriptions. Closing web socket.");
+                timeoutWatchdog.stop();
+                webSocket.close(NORMAL_CLOSURE_STATUS, "No active subscriptions");
+                webSocketListener = null;
+            }
         }
     }
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
#1690 

*Description of changes:*
- Ensure that a websocket that is in the process of being closed is not re-used to start new subscriptions. This fixes the following code sample from [our docs](https://docs.amplify.aws/lib/datastore/sync/q/platform/android/#reevaluate-expressions-at-runtime):

```kotlin
Amplify.DataStore.stop(
        {
            Amplify.DataStore.start(
                { Log.i("MyAmplifyApp", "DataStore started") },
                { Log.e("MyAmplifyApp", "Error starting DataStore", it) }
            )
        },
        { Log.e("MyAmplifyApp", "Error clearing DataStore", it) }
    )
```

**NB**: There is a caveat that this fix works as expected for the above code snippet, but it does **not** necessarily work if there are _multiple_ levels of `stop`/`start` calls nested within each other.

*How did you test these changes?*
- Verified that calling `start` from the `stop` callback now starts all subscriptions as normal.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
