### PR TITLE
fix(liveness): Read facematch timeout from server event JSON

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/FaceTargetMatchingParameters.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/FaceTargetMatchingParameters.kt
@@ -22,5 +22,6 @@ data class FaceTargetMatchingParameters internal constructor(
     val targetIouWidthThreshold: Float,
     val targetIouHeightThreshold: Float,
     val faceIouWidthThreshold: Float,
-    val faceIouHeightThreshold: Float
+    val faceIouHeightThreshold: Float,
+    val ovalFitTimeout: Int
 )

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/ChallengeConfig.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/ChallengeConfig.kt
@@ -28,5 +28,6 @@ internal data class ChallengeConfig(
     @SerialName("OvalIouWidthThreshold") val ovalIouWidthThreshold: Float,
     @SerialName("OvalIouHeightThreshold") val ovalIouHeightThreshold: Float,
     @SerialName("FaceIouWidthThreshold") val faceIouWidthThreshold: Float,
-    @SerialName("FaceIouHeightThreshold") val faceIouHeightThreshold: Float
+    @SerialName("FaceIouHeightThreshold") val faceIouHeightThreshold: Float,
+    @SerialName("OvalFitTimeout") val ovalFitTimeout: Int
 )

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
@@ -87,7 +87,8 @@ internal class RunFaceLivenessSession(
             challengeConfig.ovalIouWidthThreshold,
             challengeConfig.ovalIouHeightThreshold,
             challengeConfig.faceIouWidthThreshold,
-            challengeConfig.faceIouHeightThreshold
+            challengeConfig.faceIouHeightThreshold,
+            challengeConfig.ovalFitTimeout
         )
         val faceTargetChallenge = FaceTargetChallenge(
             ovalParameters.width,

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessEventStreamTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessEventStreamTest.kt
@@ -100,14 +100,21 @@ internal class LivenessEventStreamTest {
         val event = ServerSessionInformationEvent(
             sessionInformation = SessionInformation(
                 challenge = ServerChallenge(
-                    faceMovementAndLightChallenge = FaceMovementAndLightServerChallenge(
-                        ovalParameters = OvalParameters(1.0f, 2.0f, .5f, .7f),
-                        lightChallengeType = LightChallengeType.SEQUENTIAL,
-                        challengeConfig = ChallengeConfig(1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 10),
-                        colorSequences = listOf(
+                    faceMovementAndLightChallenge = FaceMovementAndLightServerChallenge(ovalParameters = OvalParameters(1.0f, 2.0f, .5f, .7f), lightChallengeType = LightChallengeType.SEQUENTIAL, challengeConfig = ChallengeConfig(
+                            1.0f,
+                            1.1f,
+                            1.2f,
+                            1.3f,
+                            1.4f,
+                            1.5f,
+                            1.6f,
+                            1.7f,
+                            1.8f,
+                            1.9f,
+                            10
+                        ), colorSequences = listOf(
                             ColorSequence(FreshnessColor(listOf(0, 1, 2)), 4.0f, 5.0f)
-                        )
-                    )
+                        ))
                 )
             )
         )

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessEventStreamTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessEventStreamTest.kt
@@ -103,7 +103,7 @@ internal class LivenessEventStreamTest {
                     faceMovementAndLightChallenge = FaceMovementAndLightServerChallenge(
                         ovalParameters = OvalParameters(1.0f, 2.0f, .5f, .7f),
                         lightChallengeType = LightChallengeType.SEQUENTIAL,
-                        challengeConfig = ChallengeConfig(1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f),
+                        challengeConfig = ChallengeConfig(1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 10),
                         colorSequences = listOf(
                             ColorSequence(FreshnessColor(listOf(0, 1, 2)), 4.0f, 5.0f)
                         )

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessEventStreamTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessEventStreamTest.kt
@@ -100,7 +100,10 @@ internal class LivenessEventStreamTest {
         val event = ServerSessionInformationEvent(
             sessionInformation = SessionInformation(
                 challenge = ServerChallenge(
-                    faceMovementAndLightChallenge = FaceMovementAndLightServerChallenge(ovalParameters = OvalParameters(1.0f, 2.0f, .5f, .7f), lightChallengeType = LightChallengeType.SEQUENTIAL, challengeConfig = ChallengeConfig(
+                    faceMovementAndLightChallenge = FaceMovementAndLightServerChallenge(
+                        ovalParameters = OvalParameters(1.0f, 2.0f, .5f, .7f),
+                        lightChallengeType = LightChallengeType.SEQUENTIAL,
+                        challengeConfig = ChallengeConfig(
                             1.0f,
                             1.1f,
                             1.2f,
@@ -112,9 +115,11 @@ internal class LivenessEventStreamTest {
                             1.8f,
                             1.9f,
                             10
-                        ), colorSequences = listOf(
+                        ),
+                        colorSequences = listOf(
                             ColorSequence(FreshnessColor(listOf(0, 1, 2)), 4.0f, 5.0f)
-                        ))
+                        )
+                    )
                 )
             )
         )

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
@@ -216,7 +216,8 @@ internal class LivenessWebSocketTest {
                             1.6f,
                             1.7f,
                             1.8f,
-                            1.9f
+                            1.9f,
+                            10
                         ),
                         colorSequences = listOf(
                             ColorSequence(FreshnessColor(listOf(0, 1, 2)), 4.0f, 5.0f)


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Read facematch timeout from server -- add it to the JSON structure that we're deserializing from.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
