### PR TITLE
fix(push): Prevent Unintended OptOuts

### DIFF
--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/PinpointManager.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/PinpointManager.kt
@@ -17,6 +17,7 @@ package com.amplifyframework.analytics.pinpoint
 import android.content.Context
 import aws.sdk.kotlin.services.pinpoint.PinpointClient
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
+import com.amplifyframework.core.store.EncryptedKeyValueRepository
 import com.amplifyframework.pinpoint.core.AnalyticsClient
 import com.amplifyframework.pinpoint.core.TargetingClient
 import com.amplifyframework.pinpoint.core.data.AndroidAppDetails
@@ -61,12 +62,18 @@ internal class PinpointManager constructor(
             Context.MODE_PRIVATE
         )
 
+        val encryptedStore = EncryptedKeyValueRepository(
+            context,
+            "${awsPinpointConfiguration.appId}$PINPOINT_SHARED_PREFS_SUFFIX"
+        )
+
         val androidAppDetails = AndroidAppDetails(context, awsPinpointConfiguration.appId)
         val androidDeviceDetails = AndroidDeviceDetails(context)
         targetingClient = TargetingClient(
             context,
             pinpointClient,
-            sharedPrefs,
+            encryptedStore,
+            sharedPrefs.getUniqueId(),
             androidAppDetails,
             androidDeviceDetails,
         )

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/PinpointManager.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/PinpointManager.kt
@@ -73,7 +73,7 @@ internal class PinpointManager constructor(
             context,
             pinpointClient,
             encryptedStore,
-            sharedPrefs.getUniqueId(),
+            sharedPrefs,
             androidAppDetails,
             androidDeviceDetails,
         )

--- a/aws-analytics-pinpoint/src/test/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPluginBehaviorTest.kt
+++ b/aws-analytics-pinpoint/src/test/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPluginBehaviorTest.kt
@@ -150,7 +150,8 @@ class AWSPinpointAnalyticsPluginBehaviorTest {
                 sharedPrefs.getUniqueId(),
                 androidAppDetails,
                 androidDeviceDetails,
-                ApplicationProvider.getApplicationContext()
+                ApplicationProvider.getApplicationContext(),
+                mockk()
             )
         }
         val actualEndpoint = slot<EndpointProfile>()

--- a/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/EventRecorder.kt
+++ b/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/EventRecorder.kt
@@ -18,6 +18,7 @@ import android.content.Context
 import android.database.Cursor
 import android.net.Uri
 import aws.sdk.kotlin.services.pinpoint.PinpointClient
+import aws.sdk.kotlin.services.pinpoint.model.ChannelType
 import aws.sdk.kotlin.services.pinpoint.model.EndpointDemographic
 import aws.sdk.kotlin.services.pinpoint.model.EndpointItemResponse
 import aws.sdk.kotlin.services.pinpoint.model.EndpointLocation
@@ -286,12 +287,10 @@ class EventRecorder(
             demographic = endpointDemographic
             effectiveDate = endpointProfile.effectiveDate.millisToIsoDate()
 
-            if (endpointProfile.address != "" && endpointProfile.channelType != null) {
+            if (endpointProfile.address != "" && endpointProfile.channelType == ChannelType.Gcm) {
                 optOut = "NONE" // no opt out, send notifications
                 address = endpointProfile.address
                 channelType = endpointProfile.channelType
-            } else {
-                optOut = "ALL" // opt out from all notifications
             }
 
             attributes = endpointProfile.allAttributes

--- a/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/TargetingClient.kt
+++ b/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/TargetingClient.kt
@@ -42,13 +42,13 @@ import com.amplifyframework.pinpoint.core.models.AWSPinpointUserProfileBehavior
 import com.amplifyframework.pinpoint.core.util.getUniqueId
 import com.amplifyframework.pinpoint.core.util.millisToIsoDate
 import com.amplifyframework.pinpoint.core.util.putString
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
-import java.util.concurrent.ConcurrentHashMap
 
 @InternalAmplifyApi
 class TargetingClient(
@@ -157,13 +157,6 @@ class TargetingClient(
      * TargetingClient attributes and Metrics are added to the endpoint profile.
      */
     fun updateEndpointProfile() {
-        // Add global attributes.
-        for ((key, value) in globalAttributes) {
-            endpointProfile.addAttribute(key, value)
-        }
-        for ((key, value) in globalMetrics) {
-            endpointProfile.addMetric(key, value)
-        }
         executeUpdate(currentEndpoint())
     }
 
@@ -174,6 +167,13 @@ class TargetingClient(
      * @param endpointProfile An instance of an EndpointProfile to be updated
      */
     fun updateEndpointProfile(endpointProfile: EndpointProfile) {
+        // Add global attributes.
+        for ((key, value) in globalAttributes) {
+            endpointProfile.addAttribute(key, value)
+        }
+        for ((key, value) in globalMetrics) {
+            endpointProfile.addMetric(key, value)
+        }
         executeUpdate(endpointProfile)
     }
 

--- a/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/TargetingClient.kt
+++ b/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/TargetingClient.kt
@@ -15,6 +15,7 @@
 package com.amplifyframework.pinpoint.core
 
 import android.content.Context
+import android.content.SharedPreferences
 import aws.sdk.kotlin.services.pinpoint.PinpointClient
 import aws.sdk.kotlin.services.pinpoint.model.ChannelType
 import aws.sdk.kotlin.services.pinpoint.model.EndpointDemographic
@@ -38,25 +39,36 @@ import com.amplifyframework.pinpoint.core.endpointProfile.EndpointProfile
 import com.amplifyframework.pinpoint.core.endpointProfile.EndpointProfileLocation
 import com.amplifyframework.pinpoint.core.endpointProfile.EndpointProfileUser
 import com.amplifyframework.pinpoint.core.models.AWSPinpointUserProfileBehavior
+import com.amplifyframework.pinpoint.core.util.getUniqueId
 import com.amplifyframework.pinpoint.core.util.millisToIsoDate
+import com.amplifyframework.pinpoint.core.util.putString
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.json.JSONException
+import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
 
 @InternalAmplifyApi
 class TargetingClient(
     context: Context,
     private val pinpointClient: PinpointClient,
     store: KeyValueRepository,
-    uniqueId: String,
+    private val prefs: SharedPreferences,
     appDetails: AndroidAppDetails,
     deviceDetails: AndroidDeviceDetails,
     coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
-    private val endpointProfile = EndpointProfile(uniqueId, appDetails, deviceDetails, context, store)
+    private val endpointProfile = EndpointProfile(prefs.getUniqueId(), appDetails, deviceDetails, context, store)
+    private val globalAttributes: MutableMap<String, List<String>>
+    private val globalMetrics: MutableMap<String, Double>
     private val coroutineScope = CoroutineScope(coroutineDispatcher)
 
+    init {
+        globalAttributes = loadAttributes()
+        globalMetrics = loadMetrics()
+    }
 
     /**
      * Allows you to tie a user to their actions and record traits about them. It includes
@@ -126,6 +138,17 @@ class TargetingClient(
      * @return The current device endpoint profile
      */
     fun currentEndpoint(): EndpointProfile {
+        // Add global attributes.
+        if (globalAttributes.isNotEmpty()) {
+            for ((key, value) in globalAttributes) {
+                endpointProfile.addAttribute(key, value)
+            }
+        }
+        if (globalMetrics.isNotEmpty()) {
+            for ((key, value) in globalMetrics) {
+                endpointProfile.addMetric(key, value)
+            }
+        }
         return endpointProfile
     }
 
@@ -134,6 +157,13 @@ class TargetingClient(
      * TargetingClient attributes and Metrics are added to the endpoint profile.
      */
     fun updateEndpointProfile() {
+        // Add global attributes.
+        for ((key, value) in globalAttributes) {
+            endpointProfile.addAttribute(key, value)
+        }
+        for ((key, value) in globalMetrics) {
+            endpointProfile.addMetric(key, value)
+        }
         executeUpdate(currentEndpoint())
     }
 
@@ -184,9 +214,7 @@ class TargetingClient(
             this.location = location
             this.demographic = demographic
             effectiveDate = endpointProfile.effectiveDate.millisToIsoDate()
-            if (endpointProfile.address == "" && endpointProfile.channelType == ChannelType.Gcm) {
-                optOut = "ALL" // opt out from all notifications if we have a push channel type but no token
-            } else if (endpointProfile.address != "" && endpointProfile.channelType != null) {
+            if (endpointProfile.address != "" && endpointProfile.channelType == ChannelType.Gcm) {
                 optOut = "NONE" // no opt out, send notifications
                 address = endpointProfile.address
                 channelType = endpointProfile.channelType
@@ -215,11 +243,141 @@ class TargetingClient(
         }
     }
 
+    private fun saveAttributes() {
+        val jsonObject = JSONObject(globalAttributes as MutableMap<*, *>)
+        val jsonString = jsonObject.toString()
+        prefs.putString(CUSTOM_ATTRIBUTES_KEY, jsonString)
+    }
+
+    private fun loadAttributes(): MutableMap<String, List<String>> {
+        val outputMap: MutableMap<String, List<String>> = ConcurrentHashMap()
+        val jsonString: String? = prefs.getString(CUSTOM_ATTRIBUTES_KEY, null)
+        if (jsonString.isNullOrBlank()) {
+            return outputMap
+        }
+        try {
+            val jsonObject = JSONObject(jsonString)
+            val keysItr = jsonObject.keys()
+            while (keysItr.hasNext()) {
+                val key = keysItr.next()
+                val jsonArray = jsonObject.getJSONArray(key)
+                val listValues: MutableList<String> = ArrayList()
+                for (i in 0 until jsonArray.length()) {
+                    listValues.add(jsonArray.getString(i))
+                }
+                outputMap[key] = listValues
+            }
+        } catch (e: JSONException) {
+            e.printStackTrace()
+        }
+        return outputMap
+    }
+
+    private fun saveMetrics() {
+        val jsonObject = JSONObject(globalMetrics as MutableMap<*, *>)
+        val jsonString = jsonObject.toString()
+        prefs.putString(CUSTOM_METRICS_KEY, jsonString)
+    }
+
+    private fun loadMetrics(): MutableMap<String, Double> {
+        val outputMap: MutableMap<String, Double> = ConcurrentHashMap()
+        val jsonString: String? = prefs.getString(CUSTOM_METRICS_KEY, null)
+        if (jsonString.isNullOrBlank()) {
+            return outputMap
+        }
+        try {
+            val jsonObject = JSONObject(jsonString)
+            val keysItr = jsonObject.keys()
+            while (keysItr.hasNext()) {
+                val key = keysItr.next()
+                val value = jsonObject.getDouble(key)
+                outputMap[key] = value
+            }
+        } catch (e: JSONException) {
+            e.printStackTrace()
+        }
+        return outputMap
+    }
+
+    /**
+     * Adds the specified attribute to the current endpoint profile generated by this client.
+     * Note: The maximum allowed attributes/metrics is 250. Attempts to add more may be ignored
+     *
+     * @param attributeName   the name of the  attribute to add
+     * @param attributeValues the value of the  attribute
+     */
+    fun addAttribute(attributeName: String?, attributeValues: List<String>?) {
+        if (attributeName == null) {
+            LOG.debug("Null attribute name provided to addGlobalAttribute.")
+            return
+        }
+        if (attributeValues == null) {
+            LOG.debug("Null attribute values provided to addGlobalAttribute.")
+            return
+        }
+        globalAttributes[attributeName] = attributeValues
+        saveAttributes()
+    }
+
+    /**
+     * Removes the specified attribute. All subsequently created events will no
+     * longer have this global attribute. from the current endpoint profile generated by this client.
+     *
+     * @param attributeName the name of the attribute to remove
+     */
+    fun removeAttribute(attributeName: String?) {
+        if (attributeName == null) {
+            LOG.warn("Null attribute name provided to removeGlobalAttribute.")
+            return
+        }
+        endpointProfile.addAttribute(attributeName, null)
+        globalAttributes.remove(attributeName)
+        saveAttributes()
+    }
+
+    /**
+     * Adds the specified metric to the current endpoint profile generated by this client. Note: The
+     * maximum allowed attributes and metrics on an endpoint update is 250. Attempts
+     * to add more may be ignored
+     *
+     * @param metricName  the name of the metric to add
+     * @param metricValue the value of the metric
+     */
+    fun addMetric(metricName: String?, metricValue: Double?) {
+        if (metricName == null) {
+            LOG.warn("Null metric name provided to addGlobalMetric.")
+            return
+        }
+        if (metricValue == null) {
+            LOG.warn("Null metric value provided to addGlobalMetric.")
+            return
+        }
+        globalMetrics[metricName] = metricValue
+        saveMetrics()
+    }
+
+    /**
+     * Removes the specified metric from the current endpoint profile generated by this client.
+     *
+     * @param metricName the name of the metric to remove
+     */
+    fun removeMetric(metricName: String?) {
+        if (metricName == null) {
+            LOG.warn("Null metric name provided to removeGlobalMetric.")
+            return
+        }
+        endpointProfile.addMetric(metricName, null)
+        globalMetrics.remove(metricName)
+        saveMetrics()
+    }
+
     companion object {
         @InternalAmplifyApi
         const val AWS_PINPOINT_PUSHNOTIFICATIONS_DEVICE_TOKEN_KEY = "FCMDeviceToken"
 
         private val LOG = Amplify.Logging.logger(CategoryType.ANALYTICS, "amplify:aws-analytics-pinpoint")
+        private const val CUSTOM_ATTRIBUTES_KEY = "ENDPOINT_PROFILE_CUSTOM_ATTRIBUTES"
+        private const val CUSTOM_METRICS_KEY = "ENDPOINT_PROFILE_CUSTOM_METRICS"
 
         private const val USER_NAME_KEY = "name"
         private const val USER_PLAN_KEY = "plan"

--- a/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/endpointProfile/EndpointProfile.kt
+++ b/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/endpointProfile/EndpointProfile.kt
@@ -20,6 +20,8 @@ import aws.sdk.kotlin.services.pinpoint.model.ChannelType
 import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.category.CategoryType
+import com.amplifyframework.core.store.KeyValueRepository
+import com.amplifyframework.pinpoint.core.TargetingClient
 import com.amplifyframework.pinpoint.core.data.AndroidAppDetails
 import com.amplifyframework.pinpoint.core.data.AndroidDeviceDetails
 import com.amplifyframework.pinpoint.core.util.millisToIsoDate
@@ -39,14 +41,17 @@ class EndpointProfile(
     uniqueId: String,
     appDetails: AndroidAppDetails,
     deviceDetails: AndroidDeviceDetails,
-    applicationContext: Context
+    applicationContext: Context,
+    private val store: KeyValueRepository
 ) {
     private val attributes: MutableMap<String, List<String>> = ConcurrentHashMap()
     private val metrics: MutableMap<String, Double> = ConcurrentHashMap()
     private val currentNumOfAttributesAndMetrics = AtomicInteger(0)
 
     var channelType: ChannelType? = null
-    var address: String = ""
+    val address: String get() {
+        return store.get(TargetingClient.AWS_PINPOINT_PUSHNOTIFICATIONS_DEVICE_TOKEN_KEY) ?: ""
+    }
 
     private val country: String = try {
         applicationContext.resources.configuration.locales[0].isO3Country

--- a/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/ConstructTargetingClasses.kt
+++ b/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/ConstructTargetingClasses.kt
@@ -88,7 +88,7 @@ internal fun constructTargetingClient(): TargetingClient {
         applicationContext,
         pinpointClient,
         store,
-        prefs.getUniqueId(),
+        prefs,
         appDetails,
         deviceDetails,
     )

--- a/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/ConstructTargetingClasses.kt
+++ b/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/ConstructTargetingClasses.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
 import aws.sdk.kotlin.services.pinpoint.PinpointClient
+import com.amplifyframework.core.store.KeyValueRepository
 import com.amplifyframework.pinpoint.core.data.AndroidAppDetails
 import com.amplifyframework.pinpoint.core.data.AndroidDeviceDetails
 import com.amplifyframework.pinpoint.core.endpointProfile.EndpointProfile
@@ -48,6 +49,7 @@ internal val country = "en_US"
 internal val effectiveDate = 0L
 
 internal val preferences = mockk<SharedPreferences>()
+internal val store = mockk<KeyValueRepository>()
 internal val appDetails = AndroidAppDetails(appID, appTitle, packageName, versionCode, versionName)
 internal val deviceDetails = AndroidDeviceDetails(carrier = carrier, locale = locale)
 internal val applicationContext = mockk<Context>()
@@ -55,6 +57,7 @@ internal val applicationContext = mockk<Context>()
 internal fun setup() {
     mockkStatic("com.amplifyframework.pinpoint.core.util.SharedPreferencesUtilKt")
     every { preferences.getUniqueId() }.returns(uniqueID)
+    every { store.get(TargetingClient.AWS_PINPOINT_PUSHNOTIFICATIONS_DEVICE_TOKEN_KEY) } returns ""
     every { applicationContext.resources.configuration.locales[0].isO3Country }
         .returns(country)
 }
@@ -65,7 +68,8 @@ internal fun constructEndpointProfile(): EndpointProfile {
         preferences.getUniqueId(),
         appDetails,
         deviceDetails,
-        applicationContext
+        applicationContext,
+        store
     )
     endpointProfile.effectiveDate = effectiveDate
     return endpointProfile
@@ -83,8 +87,9 @@ internal fun constructTargetingClient(): TargetingClient {
     return TargetingClient(
         applicationContext,
         pinpointClient,
-        prefs,
+        store,
+        prefs.getUniqueId(),
         appDetails,
-        deviceDetails
+        deviceDetails,
     )
 }

--- a/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/TargetingClientTest.kt
+++ b/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/TargetingClientTest.kt
@@ -81,7 +81,6 @@ class TargetingClientTest {
         val expectedToken = "token123"
         every { store.get(TargetingClient.AWS_PINPOINT_PUSHNOTIFICATIONS_DEVICE_TOKEN_KEY) } returns expectedToken
 
-
         val updateEndpointResponse = UpdateEndpointResponse.invoke {}
         coEvery { pinpointClient.updateEndpoint(ofType(UpdateEndpointRequest::class)) }.returns(updateEndpointResponse)
         targetingClient.updateEndpointProfile()
@@ -107,7 +106,6 @@ class TargetingClientTest {
 
         val expectedToken = ""
         every { store.get(TargetingClient.AWS_PINPOINT_PUSHNOTIFICATIONS_DEVICE_TOKEN_KEY) } returns expectedToken
-
 
         val updateEndpointResponse = UpdateEndpointResponse.invoke {}
         coEvery { pinpointClient.updateEndpoint(ofType(UpdateEndpointRequest::class)) }.returns(updateEndpointResponse)

--- a/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/TargetingClientTest.kt
+++ b/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/TargetingClientTest.kt
@@ -100,33 +100,6 @@ class TargetingClientTest {
     }
 
     @Test
-    fun testUpdateEndpointProfileOptsOut() = runTest {
-        setup()
-        targetingClient = constructTargetingClient()
-        targetingClient.currentEndpoint().channelType = ChannelType.Gcm
-
-        val expectedToken = ""
-        every { store.get(TargetingClient.AWS_PINPOINT_PUSHNOTIFICATIONS_DEVICE_TOKEN_KEY) } returns expectedToken
-
-
-        val updateEndpointResponse = UpdateEndpointResponse.invoke {}
-        coEvery { pinpointClient.updateEndpoint(ofType(UpdateEndpointRequest::class)) }.returns(updateEndpointResponse)
-        targetingClient.updateEndpointProfile()
-
-        coVerify {
-            pinpointClient.updateEndpoint(
-                coWithArg {
-                    assertNotNull(it.endpointRequest)
-                    val request: EndpointRequest = it.endpointRequest!!
-                    assertEquals("app id", it.applicationId)
-                    assertEquals(expectedToken, request.address)
-                    assertEquals("ALL", request.optOut)
-                }
-            )
-        }
-    }
-
-    @Test
     fun testUpdateEndpointProfileOptOutNotTouched() = runTest {
         setup()
         targetingClient = constructTargetingClient()

--- a/aws-push-notifications-pinpoint/src/main/java/com/amplifyframework/pushnotifications/pinpoint/AWSPinpointPushNotificationsPlugin.kt
+++ b/aws-push-notifications-pinpoint/src/main/java/com/amplifyframework/pushnotifications/pinpoint/AWSPinpointPushNotificationsPlugin.kt
@@ -139,7 +139,7 @@ class AWSPinpointPushNotificationsPlugin : PushNotificationsPlugin<PinpointClien
             context,
             pinpointClient,
             store,
-            preferences.getUniqueId(),
+            preferences,
             androidAppDetails,
             androidDeviceDetails
         )


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

Issue #1
During Amplify's configuration, a call is made to the FirebaseMessaging sdk to grab the token. However, this call is asynchronous (FirebaseMessaging.getInstance().token.addOnCompleteListener) and if a Amplify.Notifications.Push.identifyUser() call is made before the token is returned, it will not locate the token and send OptOut = NONE.

Issue #2
Amplify Push Notifications and Amplify Analytics are appearing to conflict with one another. Each library updates the same endpoint/profile. Each time an analytics endpoint is sent (or even configured), it will send an endpoint update without the token and push channel type. This results in OptOut = All getting set. I was able to observe this by creating a sample app with 2 buttons. The first button called Amplify.Notifications.Push.identifyUser(). The second button called Amplify.Analytics.identifyUser(). When the push button was clicked, the profile was updated with OptOut = NONE. When the analytics button was clicked, OptOut = ALL becomes set.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
