### PR TITLE
fix(auth): Fix for when alias is used to sign in and deviceKey is stored with the entered username instead of retrieved username

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/MigrateAuthCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/MigrateAuthCognitoActions.kt
@@ -31,6 +31,7 @@ internal object MigrateAuthCognitoActions : MigrateAuthActions {
     private const val KEY_USERNAME = "USERNAME"
     private const val KEY_PASSWORD = "PASSWORD"
     private const val KEY_SECRET_HASH = "SECRET_HASH"
+    private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
 
     override fun initiateMigrateAuthAction(event: SignInEvent.EventType.InitiateMigrateAuth) =
         Action<AuthEnvironment>("InitMigrateAuth") { id, dispatcher ->
@@ -58,8 +59,15 @@ internal object MigrateAuthCognitoActions : MigrateAuthActions {
                 }
 
                 if (response != null) {
+                    val username = AuthHelper.getActiveUsername(
+                        username = event.username,
+                        alternateUsername = response.challengeParameters?.get(KEY_USERNAME),
+                        userIDForSRP = response.challengeParameters?.get(
+                            KEY_USERID_FOR_SRP
+                        )
+                    )
                     SignInChallengeHelper.evaluateNextStep(
-                        event.username,
+                        username,
                         response.challengeName,
                         response.session,
                         response.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActions.kt
@@ -65,7 +65,7 @@ internal object SRPCognitoActions : SRPActions {
                 secretHash?.let { authParams[KEY_SECRET_HASH] = it }
 
                 val encodedContextData = getUserContextData(event.username)
-                var deviceMetadata = getDeviceMetadata(event.username)
+                val deviceMetadata = getDeviceMetadata(event.username)
                 deviceMetadata?.let { authParams[KEY_DEVICE_KEY] = it.deviceKey }
                 val pinpointEndpointId = getPinpointEndpointId()
 
@@ -80,7 +80,7 @@ internal object SRPCognitoActions : SRPActions {
 
                 when (initiateAuthResponse?.challengeName) {
                     ChallengeNameType.PasswordVerifier -> {
-                        deviceMetadata = getDeviceMetadata(
+                        val updatedDeviceMetadata = getDeviceMetadata(
                             AuthHelper.getActiveUsername(
                                 username = event.username,
                                 alternateUsername = initiateAuthResponse.challengeParameters?.get(KEY_USERNAME),
@@ -91,7 +91,7 @@ internal object SRPCognitoActions : SRPActions {
                         )
 
                         initiateAuthResponse.challengeParameters?.let { params ->
-                            val challengeParams = deviceMetadata?.deviceKey?.let {
+                            val challengeParams = updatedDeviceMetadata?.deviceKey?.let {
                                 params.plus(KEY_DEVICE_KEY to it)
                             } ?: params
 
@@ -99,7 +99,7 @@ internal object SRPCognitoActions : SRPActions {
                                 SRPEvent.EventType.RespondPasswordVerifier(
                                     challengeParams,
                                     event.metadata,
-                                    initiateAuthResponse?.session
+                                    initiateAuthResponse.session
                                 )
                             )
                         } ?: throw Exception("Auth challenge parameters are empty.")

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActions.kt
@@ -45,6 +45,7 @@ internal object SRPCognitoActions : SRPActions {
     private const val KEY_USER_ID_FOR_SRP = "USER_ID_FOR_SRP"
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_USERNAME = "USERNAME"
+    private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
     private const val KEY_DEVICE_KEY = "DEVICE_KEY"
     private const val KEY_CHALLENGE_NAME = "CHALLENGE_NAME"
 
@@ -64,7 +65,7 @@ internal object SRPCognitoActions : SRPActions {
                 secretHash?.let { authParams[KEY_SECRET_HASH] = it }
 
                 val encodedContextData = getUserContextData(event.username)
-                val deviceMetadata = getDeviceMetadata(event.username)
+                var deviceMetadata = getDeviceMetadata(event.username)
                 deviceMetadata?.let { authParams[KEY_DEVICE_KEY] = it.deviceKey }
                 val pinpointEndpointId = getPinpointEndpointId()
 
@@ -78,19 +79,31 @@ internal object SRPCognitoActions : SRPActions {
                 }
 
                 when (initiateAuthResponse?.challengeName) {
-                    ChallengeNameType.PasswordVerifier -> initiateAuthResponse.challengeParameters?.let { params ->
-                        val challengeParams = deviceMetadata?.deviceKey?.let {
-                            params.plus(KEY_DEVICE_KEY to it)
-                        } ?: params
-
-                        SRPEvent(
-                            SRPEvent.EventType.RespondPasswordVerifier(
-                                challengeParams,
-                                event.metadata,
-                                initiateAuthResponse.session
+                    ChallengeNameType.PasswordVerifier -> {
+                        deviceMetadata = getDeviceMetadata(
+                            AuthHelper.getActiveUsername(
+                                username = event.username,
+                                alternateUsername = initiateAuthResponse.challengeParameters?.get(KEY_USERNAME),
+                                userIDForSRP = initiateAuthResponse.challengeParameters?.get(
+                                    KEY_USERID_FOR_SRP
+                                )
                             )
                         )
-                    } ?: throw Exception("Auth challenge parameters are empty.")
+
+                        initiateAuthResponse.challengeParameters?.let { params ->
+                            val challengeParams = deviceMetadata?.deviceKey?.let {
+                                params.plus(KEY_DEVICE_KEY to it)
+                            } ?: params
+
+                            SRPEvent(
+                                SRPEvent.EventType.RespondPasswordVerifier(
+                                    challengeParams,
+                                    event.metadata,
+                                    initiateAuthResponse?.session
+                                )
+                            )
+                        } ?: throw Exception("Auth challenge parameters are empty.")
+                    }
                     else -> throw Exception("Not yet implemented.")
                 }
             } catch (e: Exception) {
@@ -143,7 +156,6 @@ internal object SRPCognitoActions : SRPActions {
                             val challengeParams = deviceMetadata?.deviceKey?.let {
                                 params.plus(KEY_DEVICE_KEY to it)
                             } ?: params
-
                             SRPEvent(
                                 SRPEvent.EventType.RespondPasswordVerifier(
                                     challengeParams,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomCognitoActions.kt
@@ -33,6 +33,7 @@ internal object SignInCustomCognitoActions : CustomSignInActions {
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_USERNAME = "USERNAME"
     private const val KEY_DEVICE_KEY = "DEVICE_KEY"
+    private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
     override fun initiateCustomSignInAuthAction(event: CustomSignInEvent.EventType.InitiateCustomSignIn): Action =
         Action<AuthEnvironment>("InitCustomAuth") { id, dispatcher ->
             logger.verbose("$id Starting execution")
@@ -63,8 +64,15 @@ internal object SignInCustomCognitoActions : CustomSignInActions {
                 if (initiateAuthResponse?.challengeName == ChallengeNameType.CustomChallenge &&
                     initiateAuthResponse.challengeParameters != null
                 ) {
-                    SignInChallengeHelper.evaluateNextStep(
+                    val activeUserName = AuthHelper.getActiveUsername(
                         username = event.username,
+                        alternateUsername = initiateAuthResponse.challengeParameters?.get(KEY_USERNAME),
+                        userIDForSRP = initiateAuthResponse.challengeParameters?.get(
+                            KEY_USERID_FOR_SRP
+                        )
+                    )
+                    SignInChallengeHelper.evaluateNextStep(
+                        username = activeUserName,
                         challengeNameType = initiateAuthResponse.challengeName,
                         session = initiateAuthResponse.session,
                         challengeParameters = initiateAuthResponse.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthHelper.kt
@@ -56,6 +56,13 @@ internal open class AuthHelper {
             }
         }
 
+        /**
+         * This method is used to capture the activeUsername we should be using to store and retreive device Metadata.
+         * This becomes more important when an alias is used to signin instead of a username where cognito then
+         * generates the username on the customers behalf and returns it. We need to then use that username to store
+         * and retrieve device information as the username that the customer entered will no longer be available when
+         * respondToAuthChallenge/confirmSignIn calls are made.
+         * */
         fun getActiveUsername(username: String, alternateUsername: String?, userIDForSRP: String?): String {
             return alternateUsername ?: (userIDForSRP ?: username)
         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthHelper.kt
@@ -55,5 +55,9 @@ internal open class AuthHelper {
                     }
             }
         }
+
+        fun getActiveUsername(username: String, alternateUsername: String?, userIDForSRP: String?): String {
+            return alternateUsername ?: (userIDForSRP ?: username)
+        }
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
@@ -543,4 +543,32 @@ class AuthValidationTest {
             every { newDeviceMetadata } returns null
         }
     }
+
+    @Test
+    fun `test getActiveUsername returns correct username when active and userIDforSRP is null`() {
+        val username = AuthHelper.getActiveUsername("username", null, null)
+        assertEquals(username, "username")
+    }
+
+    @Test
+    fun `getActiveUsername returns correct username when userIDforSRP is null & alternate is same as username`() {
+        val username = AuthHelper.getActiveUsername("username", "username", null)
+        assertEquals(username, "username")
+    }
+
+    @Test
+    fun `getActiveUsername returns correct username when userIDforSRP is null & alternate is different as username`() {
+        val username = AuthHelper.getActiveUsername(
+            "username", "userID12322", null
+        )
+        assertEquals(username, "userID12322")
+    }
+
+    @Test
+    fun `test getActiveUsername returns correct username when userIDforSRP is not null null and alternate is null`() {
+        val username = AuthHelper.getActiveUsername(
+            "username", null, "userID12322"
+        )
+        assertEquals(username, "userID12322")
+    }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignInTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignInTestCaseGenerator.kt
@@ -137,6 +137,22 @@ object SignInTestCaseGenerator : SerializableProvider {
         ).toJsonElement()
     )
 
+    private val mockedRespondToAuthCustomChallengeResponseWithAlias = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "respondToAuthChallenge",
+        ResponseType.Success,
+        mapOf(
+            "session" to "someSession",
+            "challengeName" to "CUSTOM_CHALLENGE",
+            "challengeParameters" to mapOf(
+                "SALT" to "abc",
+                "SECRET_BLOCK" to "secretBlock",
+                "SRP_B" to "def",
+                "USERNAME" to "alternateUsername"
+            )
+        ).toJsonElement()
+    )
+
     private val mockedIdentityIdResponse = MockResponse(
         CognitoType.CognitoIdentity,
         "getId",
@@ -198,6 +214,23 @@ object SignInTestCaseGenerator : SerializableProvider {
                     "SECRET_BLOCK" to "secretBlock",
                     "SRP_B" to "def",
                     "USERNAME" to username
+                )
+            )
+        ).toJsonElement()
+    )
+
+    private val mockedSignInCustomAuthChallengeExpectationWithAlias = ExpectationShapes.Amplify(
+        apiName = AuthAPI.signIn,
+        responseType = ResponseType.Success,
+        response = mapOf(
+            "isSignedIn" to false,
+            "nextStep" to mapOf(
+                "signInStep" to "CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE",
+                "additionalInfo" to mapOf(
+                    "SALT" to "abc",
+                    "SECRET_BLOCK" to "secretBlock",
+                    "SRP_B" to "def",
+                    "USERNAME" to "alternateUsername"
                 )
             )
         ).toJsonElement()
@@ -413,6 +446,32 @@ object SignInTestCaseGenerator : SerializableProvider {
         )
     )
 
+    private val customAuthWithSRPCaseWhenAliasIsUsedToSignIn = FeatureTestCase(
+        description = "Test that Custom Auth signIn invokes proper cognito request and returns password challenge when alias is used",
+        preConditions = PreConditions(
+            "authconfiguration.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitiateAuthResponse,
+                mockedRespondToAuthCustomChallengeResponseWithAlias
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to "",
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to mapOf("authFlow" to AuthFlowType.CUSTOM_AUTH_WITH_SRP.toString())
+            ).toJsonElement()
+        ),
+        validations = listOf(
+            mockedSignInCustomAuthChallengeExpectationWithAlias,
+            ExpectationShapes.State("CustomSignIn_SigningIn.json")
+        )
+    )
+
     private val customAuthWithSRPWhenResourceNotFoundExceptionCase = FeatureTestCase(
         description = "Test that Custom Auth signIn invokes ResourceNotFoundException" +
             " and then received proper cognito request and returns password challenge",
@@ -450,6 +509,7 @@ object SignInTestCaseGenerator : SerializableProvider {
         signInWhenAlreadySigningInAuthCase,
         customAuthWithSRPWhenResourceNotFoundExceptionCase,
         customAuthCaseWhenResourceNotFoundExceptionCase,
-        signInWhenResourceNotFoundExceptionCase
+        signInWhenResourceNotFoundExceptionCase,
+        customAuthWithSRPCaseWhenAliasIsUsedToSignIn
     )
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignInTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignInTestCaseGenerator.kt
@@ -447,7 +447,8 @@ object SignInTestCaseGenerator : SerializableProvider {
     )
 
     private val customAuthWithSRPCaseWhenAliasIsUsedToSignIn = FeatureTestCase(
-        description = "Test that Custom Auth signIn invokes proper cognito request and returns password challenge when alias is used",
+        description = "Test that Custom Auth signIn invokes proper cognito request " +
+            "and returns password challenge when alias is used",
         preConditions = PreConditions(
             "authconfiguration.json",
             "SignedOut_Configured.json",

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_Custom_Auth_signIn_invokes_proper_cognito_request_and_returns_password_challenge_when_alias_is_used.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_Custom_Auth_signIn_invokes_proper_cognito_request_and_returns_password_challenge_when_alias_is_used.json
@@ -1,0 +1,74 @@
+{
+    "description": "Test that Custom Auth signIn invokes proper cognito request and returns password challenge when alias is used",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "PASSWORD_VERIFIER",
+                    "challengeParameters": {
+                        "SALT": "abc",
+                        "SECRET_BLOCK": "secretBlock",
+                        "SRP_B": "def",
+                        "USERNAME": "username",
+                        "USER_ID_FOR_SRP": "userId"
+                    }
+                }
+            },
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "session": "someSession",
+                    "challengeName": "CUSTOM_CHALLENGE",
+                    "challengeParameters": {
+                        "SALT": "abc",
+                        "SECRET_BLOCK": "secretBlock",
+                        "SRP_B": "def",
+                        "USERNAME": "alternateUsername"
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": ""
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "CUSTOM_AUTH_WITH_SRP"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": false,
+                "nextStep": {
+                    "signInStep": "CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE",
+                    "additionalInfo": {
+                        "SALT": "abc",
+                        "SECRET_BLOCK": "secretBlock",
+                        "SRP_B": "def",
+                        "USERNAME": "alternateUsername"
+                    }
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "CustomSignIn_SigningIn.json"
+        }
+    ]
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2609

*Description of changes:*

When a user signs in with their alias instead of a username and the userpool is not configured to sign in with username, cognito assigns a username to that user (generally a generated UUID). However this breaks the current flow in a way that device ID gets generated each time as there is no stored device information for the new generated username for when we have to do respondToAuthChallenge we use the username returned from the service and not the username that was entered by the user. 
This PR will fix that flow for Custom Auth (with/without SRP and SRP).

Important to note: 

This fix does not fix device tracking for when AuthFlow is `USER_PASSWORD_AUTH ` as InitiateAuth in user_password_auth does not have access to deviceTracking. 

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [x] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
