### PR TITLE
chore: Prevent Instrumentation Test device conflicts

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLLazySubscribeInstrumentationTest.kt
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/GraphQLLazySubscribeInstrumentationTest.kt
@@ -46,12 +46,13 @@ class GraphQLLazySubscribeInstrumentationTest {
 
     companion object {
 
-        lateinit var instrumentationRunId: String
+        val instrumentationRunId by lazy {
+            UUID.randomUUID().toString()
+        }
 
         @JvmStatic
         @BeforeClass
         fun setUp() {
-            instrumentationRunId = UUID.randomUUID().toString()
             val context = ApplicationProvider.getApplicationContext<Context>()
             val config = AmplifyConfiguration.fromConfigFile(context, R.raw.amplifyconfigurationlazy)
             Amplify.addPlugin(AWSApiPlugin())

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/StorageCanaryTest.kt
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/StorageCanaryTest.kt
@@ -75,7 +75,7 @@ class StorageCanaryTest {
     fun uploadFile() {
         val latch = CountDownLatch(1)
         val file = createFile(1)
-        val fileKey = "ExampleKey"
+        val fileKey = UUID.randomUUID().toString()
         Amplify.Storage.uploadFile(
             fileKey,
             file,


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Prevents API Subscribe instrumentation tests from conflicting with each other when running at the same time.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
