### PR TITLE
chore(liveness): add close codes to websocket apis

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -254,7 +254,7 @@ internal class LivenessWebSocket(
         val deviceManufacturer = Build.MANUFACTURER.replace(" ", "_")
         val deviceName = Build.MODEL.replace(" ", "_")
         var userAgent = "${UserAgent.string()} os/Android/${Build.VERSION.SDK_INT} md/device/$deviceName " +
-            "md/device-manufacturer/$deviceManufacturer api/rekognitionstreaming/$amplifyVersion"
+                "md/device-manufacturer/$deviceManufacturer api/rekognitionstreaming/$amplifyVersion"
 
         if (!livenessVersion.isNullOrBlank()) {
             userAgent += " api/liveness/$livenessVersion"
@@ -481,9 +481,9 @@ internal class LivenessWebSocket(
         }
     }
 
-    fun destroy() {
-        // Close gracefully
-        webSocket?.close(NORMAL_SOCKET_CLOSURE_STATUS_CODE, null)
+    fun destroy(reasonCode: Int = NORMAL_SOCKET_CLOSURE_STATUS_CODE) {
+        // Close with provided reason code
+        webSocket?.close(reasonCode, null)
     }
 
     fun adjustedDate(date: Long = Date().time): Long {
@@ -493,7 +493,7 @@ internal class LivenessWebSocket(
     private fun isTimeDiffSafe(diffInMillis: Long) = kotlin.math.abs(diffInMillis) < FOUR_MINUTES
 
     companion object {
-        private const val NORMAL_SOCKET_CLOSURE_STATUS_CODE = 1000
+        internal const val NORMAL_SOCKET_CLOSURE_STATUS_CODE = 1000
         private const val FOUR_MINUTES = 1000 * 60 * 4
         @VisibleForTesting val datePattern = "EEE, d MMM yyyy HH:mm:ss z"
         private val LOG = Amplify.Logging.logger(CategoryType.PREDICTIONS, "amplify:aws-predictions")

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -493,7 +493,7 @@ internal class LivenessWebSocket(
     private fun isTimeDiffSafe(diffInMillis: Long) = kotlin.math.abs(diffInMillis) < FOUR_MINUTES
 
     companion object {
-        internal const val NORMAL_SOCKET_CLOSURE_STATUS_CODE = 1000
+        private const val NORMAL_SOCKET_CLOSURE_STATUS_CODE = 1000
         private const val FOUR_MINUTES = 1000 * 60 * 4
         @VisibleForTesting val datePattern = "EEE, d MMM yyyy HH:mm:ss z"
         private val LOG = Amplify.Logging.logger(CategoryType.PREDICTIONS, "amplify:aws-predictions")

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -254,7 +254,7 @@ internal class LivenessWebSocket(
         val deviceManufacturer = Build.MANUFACTURER.replace(" ", "_")
         val deviceName = Build.MODEL.replace(" ", "_")
         var userAgent = "${UserAgent.string()} os/Android/${Build.VERSION.SDK_INT} md/device/$deviceName " +
-                "md/device-manufacturer/$deviceManufacturer api/rekognitionstreaming/$amplifyVersion"
+            "md/device-manufacturer/$deviceManufacturer api/rekognitionstreaming/$amplifyVersion"
 
         if (!livenessVersion.isNullOrBlank()) {
             userAgent += " api/liveness/$livenessVersion"

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
@@ -179,8 +179,8 @@ internal class RunFaceLivenessSession(
         }
     }
 
-    private fun stopLivenessSession() {
+    private fun stopLivenessSession(reasonCode: Int = LivenessWebSocket.NORMAL_SOCKET_CLOSURE_STATUS_CODE) {
         livenessWebSocket.clientStoppedSession = true
-        livenessWebSocket.destroy()
+        livenessWebSocket.destroy(reasonCode)
     }
 }

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
@@ -181,6 +181,6 @@ internal class RunFaceLivenessSession(
 
     private fun stopLivenessSession(reasonCode: Int?) {
         livenessWebSocket.clientStoppedSession = true
-        livenessWebSocket.destroy(reasonCode ?: LivenessWebSocket.NORMAL_SOCKET_CLOSURE_STATUS_CODE)
+        reasonCode?.let { livenessWebSocket.destroy(it) } ?: livenessWebSocket.destroy()
     }
 }

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
@@ -179,8 +179,8 @@ internal class RunFaceLivenessSession(
         }
     }
 
-    private fun stopLivenessSession(reasonCode: Int = LivenessWebSocket.NORMAL_SOCKET_CLOSURE_STATUS_CODE) {
+    private fun stopLivenessSession(reasonCode: Int?) {
         livenessWebSocket.clientStoppedSession = true
-        livenessWebSocket.destroy(reasonCode)
+        livenessWebSocket.destroy(reasonCode ?: LivenessWebSocket.NORMAL_SOCKET_CLOSURE_STATUS_CODE)
     }
 }

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
@@ -16,14 +16,13 @@
 package com.amplifyframework.predictions.models
 
 import com.amplifyframework.annotations.InternalAmplifyApi
-import com.amplifyframework.core.Action
 
 @InternalAmplifyApi
 class FaceLivenessSession(
     val challenges: List<FaceLivenessSessionChallenge>,
     private val onVideoEvent: (VideoEvent) -> Unit,
     private val onChallengeResponseEvent: (ChallengeResponseEvent) -> Unit,
-    private val stopLivenessSession: Action
+    private val stopLivenessSession: (Int) -> Unit
 ) {
 
     fun sendVideoEvent(videoEvent: VideoEvent) {
@@ -34,7 +33,7 @@ class FaceLivenessSession(
         onChallengeResponseEvent(challengeResponseEvent)
     }
 
-    fun stopSession() {
-        stopLivenessSession.call()
+    fun stopSession(reasonCode: Int) {
+        stopLivenessSession(reasonCode)
     }
 }

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
@@ -33,6 +33,7 @@ class FaceLivenessSession(
         onChallengeResponseEvent(challengeResponseEvent)
     }
 
+    @JvmOverloads
     fun stopSession(reasonCode: Int? = null) {
         stopLivenessSession(reasonCode)
     }

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
@@ -33,7 +33,7 @@ class FaceLivenessSession(
         onChallengeResponseEvent(challengeResponseEvent)
     }
 
-    fun stopSession(reasonCode: Int?) {
+    fun stopSession(reasonCode: Int? = null) {
         stopLivenessSession(reasonCode)
     }
 }

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
@@ -22,7 +22,7 @@ class FaceLivenessSession(
     val challenges: List<FaceLivenessSessionChallenge>,
     private val onVideoEvent: (VideoEvent) -> Unit,
     private val onChallengeResponseEvent: (ChallengeResponseEvent) -> Unit,
-    private val stopLivenessSession: (Int) -> Unit
+    private val stopLivenessSession: (Int?) -> Unit
 ) {
 
     fun sendVideoEvent(videoEvent: VideoEvent) {
@@ -33,7 +33,7 @@ class FaceLivenessSession(
         onChallengeResponseEvent(challengeResponseEvent)
     }
 
-    fun stopSession(reasonCode: Int) {
+    fun stopSession(reasonCode: Int?) {
         stopLivenessSession(reasonCode)
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
Liveness can pass error code to websocket on close.  [UI PR](https://github.com/aws-amplify/amplify-ui-android/pull/106).

*How did you test these changes?*
Local testing with breakpoint in `destroy()` to make sure close code is being sent; sending session ids to liveness team.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
