### PR TITLE
chore: use correct bundler to restore GH action functionality

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd scripts
-        gem install bundler
+        gem install bundler -v '~>1'
         bundle install --full-index
     - name: Configure git options
       run: |


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

[GH prepare next release action is failing
](https://github.com/aws-amplify/amplify-android/actions/runs/7297791357/job/19887618638#step:5:14) -- fix is to specific bundler version (or use higher ruby version)

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
