### PR TITLE
release: Amplify Android 2.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Release 2.14.8](https://github.com/aws-amplify/amplify-android/releases/tag/release_v2.14.8)
+
+### Miscellaneous
+- **liveness:** add close codes to websocket apis ([#2638](https://github.com/aws-amplify/amplify-android/issues/2638))
+
+[See all changes between 2.14.7 and 2.14.8](https://github.com/aws-amplify/amplify-android/compare/release_v2.14.7...release_v2.14.8)
+
+
 ## [Release 2.14.7](https://github.com/aws-amplify/amplify-android/releases/tag/release_v2.14.7)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ dependencies section:
 ```groovy
 dependencies {
     // Only specify modules that provide functionality your app will use
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:2.14.7'
-    implementation 'com.amplifyframework:aws-api:2.14.7'
-    implementation 'com.amplifyframework:aws-auth-cognito:2.14.7'
-    implementation 'com.amplifyframework:aws-datastore:2.14.7'
-    implementation 'com.amplifyframework:aws-predictions:2.14.7'
-    implementation 'com.amplifyframework:aws-storage-s3:2.14.7'
-    implementation 'com.amplifyframework:aws-geo-location:2.14.7'
-    implementation 'com.amplifyframework:aws-push-notifications-pinpoint:2.14.7'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:2.14.8'
+    implementation 'com.amplifyframework:aws-api:2.14.8'
+    implementation 'com.amplifyframework:aws-auth-cognito:2.14.8'
+    implementation 'com.amplifyframework:aws-datastore:2.14.8'
+    implementation 'com.amplifyframework:aws-predictions:2.14.8'
+    implementation 'com.amplifyframework:aws-storage-s3:2.14.8'
+    implementation 'com.amplifyframework:aws-geo-location:2.14.8'
+    implementation 'com.amplifyframework:aws-push-notifications-pinpoint:2.14.8'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx4g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-VERSION_NAME=2.14.7
+VERSION_NAME=2.14.8
 
 POM_GROUP=com.amplifyframework
 POM_URL=https://github.com/aws-amplify/amplify-android

--- a/rxbindings/README.md
+++ b/rxbindings/README.md
@@ -24,7 +24,7 @@ library. In your module's `build.gradle`:
 ```gradle
 dependencies {
     // Add this line.
-    implementation 'com.amplifyframework:rxbindings:2.14.7'
+    implementation 'com.amplifyframework:rxbindings:2.14.8'
 }
 ```
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

manually-created release PR because Ruby GH action isn't working (see #2659)