### PR TITLE
feat(notification) Large images are displayed when expanding notifications

### DIFF
--- a/aws-push-notifications-pinpoint-common/src/main/java/com/amplifyframework/pushnotifications/pinpoint/PushNotificationsUtils.kt
+++ b/aws-push-notifications-pinpoint-common/src/main/java/com/amplifyframework/pushnotifications/pinpoint/PushNotificationsUtils.kt
@@ -134,6 +134,11 @@ class PushNotificationsUtils(
                 setContentIntent(pendingIntent)
                 setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 setLargeIcon(largeImageIcon)
+                setStyle(
+                    NotificationCompat.BigPictureStyle()
+                        .bigPicture(largeImageIcon)
+                        .bigLargeIcon(null)
+                )
                 setAutoCancel(true)
             }
 


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
None

*Description of changes:*
When displaying a notification with an image through Amplify, there is an issue where the attached image does not enlarge even when in the expanded state. To resolve this, I made changes to the settings based on the official Android documentation. Currently, even when the notification is in the expanded state, the appearance does not change, which I believe is different from the expected behavior by the user.

reference link:
https://developer.android.com/develop/ui/views/notifications/expanded#kotlin

*How did you test these changes?*
We have not confirmed whether it is accurately reflected in the UI. We executed Lint and cAT to confirm, and Lint was executed without any issues, but cAT originally failed. 

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

reference link:
https://docs.amplify.aws/android/build-a-backend/push-notifications/set-up-push-notifications/

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
