### PR TITLE
chore(all): Do not exclude all meta-inf

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,7 +164,7 @@ fun Project.configureAndroid() {
         // dependencies (Apache's httpcore and httpclient), both of which include
         // META-INF/DEPENDENCIES. Tried a couple other options to no avail.
         packagingOptions {
-            resources.excludes.add("META-INF/*")
+            resources.excludes.add("META-INF/DEPENDENCIES")
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,7 +164,12 @@ fun Project.configureAndroid() {
         // dependencies (Apache's httpcore and httpclient), both of which include
         // META-INF/DEPENDENCIES. Tried a couple other options to no avail.
         packagingOptions {
-            resources.excludes.add("META-INF/DEPENDENCIES")
+            resources.excludes.addAll(
+                listOf(
+                    "META-INF/DEPENDENCIES",
+                    "META-INF/LICENSE.md"
+                )
+            )
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -167,7 +167,8 @@ fun Project.configureAndroid() {
             resources.excludes.addAll(
                 listOf(
                     "META-INF/DEPENDENCIES",
-                    "META-INF/LICENSE.md"
+                    "META-INF/LICENSE.md",
+                    "META-INF/LICENSE-notice.md"
                 )
             )
         }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Recent PR changed the exclude rule to exclude all META-INF files, this is incorrect.

*How did you test these changes?*
- Ensured `kotlin_module` was included in build artifacts

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
