### PR TITLE
fix(datastore): Fix DataStore peek exception

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -116,11 +116,11 @@ final class MutationProcessor {
     private Completable drainMutationOutbox() {
         PendingMutation<? extends Model> next;
         do {
-            next = mutationOutbox.peek();
-            if (next == null) {
-                return Completable.complete();
-            }
             try {
+                next = mutationOutbox.peek();
+                if (next == null) {
+                    return Completable.complete();
+                }
                 processOutboxItem(next)
                     .blockingAwait();
             } catch (RuntimeException error) {


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
peek() also uses a blockingAwait which can cause an exception if in progress when DataStore is cleared.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
