### PR TITLE
fix(auth): Populate name in AuthDevice

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -1358,12 +1358,14 @@ internal class RealAWSCognitoAuthPlugin(
                             accessToken = tokens.value?.accessToken
                         }
                     )
-                val _devices = response?.devices
-                val authdeviceList = mutableListOf<AuthDevice>()
-                _devices?.forEach {
-                    authdeviceList.add(AuthDevice.fromId(it.deviceKey ?: ""))
-                }
-                onSuccess.accept(authdeviceList)
+
+                val devices = response?.devices?.map { device ->
+                    val id = device.deviceKey ?: ""
+                    val name = device.deviceAttributes?.find { it.name == "device_name" }?.value
+                    AuthDevice.fromId(id, name)
+                } ?: emptyList()
+
+                onSuccess.accept(devices)
             } catch (e: Exception) {
                 onError.accept(CognitoAuthExceptionConverter.lookup(e, "Fetch devices failed."))
             }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
#2701 

*Description of changes:*
- `name` property is now set in `AuthDevice` when calling `fetchDevices`.

This change is based on #2690, please merge that first.

*How did you test these changes?*
- Ensured device name was set in AuthDevice

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
