### PR TITLE
fix(datastore): Fix test failure introduced with slower test runs from SQLite

### DIFF
--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -492,7 +492,8 @@ public final class SyncProcessorTest {
         );
 
         actualSyncTimeRecords.blockingForEach(record ->
-            assertTrue(RecentTimeWindow.contains(record.getLastSyncTime()))
+            assertTrue("Time window of " + (Time.now() - record.getLastSyncTime()) +
+                    " exceeded maximum", RecentTimeWindow.contains(record.getLastSyncTime()))
         );
 
         // Cleanup!
@@ -956,7 +957,7 @@ public final class SyncProcessorTest {
     }
 
     static final class RecentTimeWindow {
-        private static final long ACCEPTABLE_DRIFT_MS = TimeUnit.SECONDS.toMillis(1);
+        private static final long ACCEPTABLE_DRIFT_MS = TimeUnit.SECONDS.toMillis(2);
 
         private RecentTimeWindow() {}
 


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
I believe the change from InMemoryRepository to SQLite repository in Robolectric slowed our tests down a bit here where sync time record window needs bumped. I also improved logging to ensure that if this fails again, we can see if it was a reasonable amount of time, or proof of incorrect sync.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
