### PR TITLE
fix(storage): upload/download fewer files in storage stress test to avoid S3 throttling exception

### DIFF
--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/StorageStressTest.kt
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/StorageStressTest.kt
@@ -53,6 +53,7 @@ class StorageStressTest {
         private val downloadOptions = StorageDownloadFileOptions.builder().accessLevel(TESTING_ACCESS_LEVEL).build()
         private const val TRANSFER_TIMEOUT = 10 * 60_000L // 10 minutes
         private const val STRESS_TEST_TIMEOUT = 10 * 60_000L
+        private const val FILE_COUNT = 10
 
         /**
          * Initialize mobile client and configure the storage.
@@ -75,7 +76,7 @@ class StorageStressTest {
     }
 
     /**
-     * Calls Storage.downloadFile with random temporary files of size 1MB 50 times
+     * Calls Storage.downloadFile with random temporary files of size 1MB 10 times
      */
     @Test
     fun testDownloadManyFiles() {
@@ -87,8 +88,8 @@ class StorageStressTest {
         // Upload 25 small test files
         var key: String
         smallFiles = mutableListOf()
-        val uploadLatch = CountDownLatch(50)
-        repeat(50) {
+        val uploadLatch = CountDownLatch(FILE_COUNT)
+        repeat(FILE_COUNT) {
             key = "${SMALL_FILE_NAME}${UUID.randomUUID()}"
             val smallFile = RandomTempFile(key, SMALL_FILE_SIZE)
             synchronousStorage.uploadFile(key, smallFile, uploadOptions, TRANSFER_TIMEOUT)
@@ -101,7 +102,7 @@ class StorageStressTest {
         Sleep.milliseconds(1000)
         // Upload 1 large test file
         Log.i("STORAGE_STRESS_TEST", "@BeforeClass Large Upload Started")
-        val downloadLatch = CountDownLatch(50)
+        val downloadLatch = CountDownLatch(FILE_COUNT)
         smallFiles.forEach {
             Thread {
                 val downloadFile = RandomTempFile()
@@ -116,12 +117,12 @@ class StorageStressTest {
     }
 
     /**
-     * Calls Storage.uploadFile with random temporary files of size 1MB 50 times
+     * Calls Storage.uploadFile with random temporary files of size 1MB 10 times
      */
     @Test
     fun testUploadManyFiles() {
-        val uploadLatch = CountDownLatch(50)
-        repeat(50) {
+        val uploadLatch = CountDownLatch(FILE_COUNT)
+        repeat(FILE_COUNT) {
             val key = "${SMALL_FILE_NAME}${UUID.randomUUID()}"
             val smallFile = RandomTempFile(key, SMALL_FILE_SIZE)
             synchronousStorage.uploadFile(key, smallFile, uploadOptions, TRANSFER_TIMEOUT)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Use parameter for 10 uploads/downloads instead of 50

*How did you test these changes?*
ran stress test with correct amplifyconfiguration.json

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
