### PR TITLE
fix(datastore): Remove unnecessary synchronized causing subscription slowness

### DIFF
--- a/aws-api/src/androidTest/java/com/amplifyframework/api/aws/SubscriptionEndpointTest.java
+++ b/aws-api/src/androidTest/java/com/amplifyframework/api/aws/SubscriptionEndpointTest.java
@@ -52,6 +52,7 @@ public final class SubscriptionEndpointTest {
     private SubscriptionEndpoint subscriptionEndpoint;
     private String eventId;
     private Set<String> subscriptionIdsForRelease;
+    private ApiConfiguration apiConfiguration;
 
     /**
      * Create an {@link SubscriptionEndpoint}.
@@ -68,7 +69,7 @@ public final class SubscriptionEndpointTest {
             .getJSONObject("plugins")
             .getJSONObject("awsAPIPlugin");
         AWSApiPluginConfiguration pluginConfiguration = AWSApiPluginConfigurationReader.readFrom(configJson);
-        ApiConfiguration apiConfiguration = pluginConfiguration.getApi(endpointConfigKey);
+        apiConfiguration = pluginConfiguration.getApi(endpointConfigKey);
         assertNotNull(apiConfiguration);
 
         final GraphQLResponse.Factory responseFactory = new GsonGraphQLResponseFactory();
@@ -184,6 +185,7 @@ public final class SubscriptionEndpointTest {
             executor.execute(() ->
                 subscriptionEndpoint.requestSubscription(
                     request,
+                    apiConfiguration.getAuthorizationType(),
                     onResult,
                     item -> {
                         final String message;

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -117,7 +117,7 @@ final class SubscriptionEndpoint {
                             onSubscriptionComplete);
     }
 
-    synchronized <T> void requestSubscription(
+    <T> void requestSubscription(
             @NonNull GraphQLRequest<T> request,
             @NonNull AuthorizationType authType,
             @NonNull Consumer<String> onSubscriptionStarted,
@@ -180,6 +180,8 @@ final class SubscriptionEndpoint {
                 .toString();
 
             socket.send(jsonMessage);
+            LOG.info("Send to ws: " + jsonMessage);
+
         } catch (JSONException | ApiException exception) {
             // If the subscriptionId was still pending, then we can call the onSubscriptionError
             if (pendingSubscriptionIds.remove(subscriptionId)) {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -166,7 +166,6 @@ final class SubscriptionEndpoint {
                 .toString();
 
             socket.send(jsonMessage);
-
         } catch (JSONException | ApiException exception) {
             // If the subscriptionId was still pending, then we can call the onSubscriptionError
             if (pendingSubscriptionIds.remove(subscriptionId)) {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -103,20 +103,6 @@ final class SubscriptionEndpoint {
         this.okHttpClient = okHttpClientBuilder.build();
     }
 
-    synchronized <T> void requestSubscription(
-        @NonNull GraphQLRequest<T> request,
-        @NonNull Consumer<String> onSubscriptionStarted,
-        @NonNull Consumer<GraphQLResponse<T>> onNextItem,
-        @NonNull Consumer<ApiException> onSubscriptionError,
-        @NonNull Action onSubscriptionComplete) {
-        requestSubscription(request,
-                            apiConfiguration.getAuthorizationType(),
-                            onSubscriptionStarted,
-                            onNextItem,
-                            onSubscriptionError,
-                            onSubscriptionComplete);
-    }
-
     <T> void requestSubscription(
             @NonNull GraphQLRequest<T> request,
             @NonNull AuthorizationType authType,

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -166,7 +166,6 @@ final class SubscriptionEndpoint {
                 .toString();
 
             socket.send(jsonMessage);
-            LOG.info("Send to ws: " + jsonMessage);
 
         } catch (JSONException | ApiException exception) {
             // If the subscriptionId was still pending, then we can call the onSubscriptionError

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SubscriptionProcessor.java
@@ -150,8 +150,9 @@ final class SubscriptionProcessor {
             LOG.debug("Waiting for subscriptions to start.");
             subscriptionsStarted = latch.abortableAwait(adjustedTimeoutSeconds, TimeUnit.SECONDS);
         } catch (InterruptedException exception) {
-            LOG.warn("Subscription operations were interrupted during setup.");
-            return;
+            String errorMessage = "Subscription operations were interrupted during setup.";
+            LOG.warn(errorMessage);
+            throw new DataStoreException(errorMessage, "Retry");
         }
 
         if (subscriptionsStarted) {


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

When DataStore is started, Create, Update, Delete subscriptions are made for each model. If I have 10 models, this results in 30 subscriptions established. Subscriptions are established over a single websocket connection by sending a websocket event per subscription. We wait until all subscriptions have been established (ws response message for each subscription) before we proceed with syncing/merging items.

An errant `synchronized` is causing subscription events to being be processed 1 at a time, and not in parallel.

If I have 10 models (30 subscriptions) and each ws event takes the server 200ms to acknowledge, establishing subscriptions would take the current build ~ 6 seconds. Allowing ws events in parallel will complete this effort in ~ 200ms.

Buggy State: 
Send Model1 Create -> Model1 Create Response -> Send Model1 Delete -> Model1 Delete Response -> Send Model1 Update -> Model1 Update Response -> Send Model2 Create -> Model2 Create Response -> ...

Fixed State: 
Send Model1 Create, Send Model1 Delete, Send Model1 Update, Send Model2 Create .... -> Wait for all acks

* The method is synchronized (problem): [https://github.com/aws-amplify/amplify-android/blob/2145c0ac26ab9b406c36b299b3ab96[…]ain/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java](https://github.com/aws-amplify/amplify-android/blob/2145c0ac26ab9b406c36b299b3ab96c116ec2b60/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java#L120)
* Inside the method, there is another synchronized lock (necessary) to only create 1 WS: [https://github.com/aws-amplify/amplify-android/blob/2145c0ac26ab9b406c36b299b3ab96[…]ain/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java](https://github.com/aws-amplify/amplify-android/blob/2145c0ac26ab9b406c36b299b3ab96c116ec2b60/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java#L137)
* Here is where we await inside the synchronized method for a single ws event response, causing the non-blocking ws.send methods to only send 1 event at a time: [https://github.com/aws-amplify/amplify-android/blob/2145c0ac26ab9b406c36b299b3ab96[…]ain/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java](https://github.com/aws-amplify/amplify-android/blob/2145c0ac26ab9b406c36b299b3ab96c116ec2b60/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java#L206)

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
