### PR TITLE
datastore(fix): Fixes previous PR which was inadvertently creating multiple websockets.

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -141,17 +141,17 @@ final class SubscriptionEndpoint {
             pendingSubscriptionIds.add(subscriptionId);
             socketListener = webSocketListener;
             socket = webSocket;
-        }
 
-        // Every request waits here for the connection to be ready.
-        Connection connection = socketListener.waitForConnectionReady();
-        if (connection.hasFailure()) {
-            // If the latch didn't count all the way down
-            if (pendingSubscriptionIds.remove(subscriptionId)) {
-                // The subscription was pending, so we need to emit an error.
-                onSubscriptionError.accept(
-                    new ApiException(connection.getFailureReason(), AmplifyException.TODO_RECOVERY_SUGGESTION));
-                return;
+            // Every request waits here for the connection to be ready.
+            Connection connection = socketListener.waitForConnectionReady();
+            if (connection.hasFailure()) {
+                // If the latch didn't count all the way down
+                if (pendingSubscriptionIds.remove(subscriptionId)) {
+                    // The subscription was pending, so we need to emit an error.
+                    onSubscriptionError.accept(
+                        new ApiException(connection.getFailureReason(), AmplifyException.TODO_RECOVERY_SUGGESTION));
+                    return;
+                }
             }
         }
 
@@ -257,7 +257,7 @@ final class SubscriptionEndpoint {
         dispatcher.dispatchNextMessage(data);
     }
 
-    synchronized void releaseSubscription(String subscriptionId) throws ApiException {
+    void releaseSubscription(String subscriptionId) throws ApiException {
         // First thing we should do is remove it from the pending subscription collection so
         // the other methods can't grab a hold of the subscription.
         final Subscription<?> subscription = subscriptions.get(subscriptionId);


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

Continuation of https://github.com/aws-amplify/amplify-android/pull/2718

The previous PR was inadvertently creating multiple websockets. This is because the websocket lock had a check 
`if (webSocketListener == null || webSocketListener.isDisconnectedState())` which would create a new ws. Because we were rapidly sending, every subscription request was in a disconnected state. 

This PR waits for the ws connection to open, before it adds the subscriptions

Additionally, I also discovered that disconnecting the websocket takes too long due to the same issue we observed in https://github.com/aws-amplify/amplify-android/pull/2718 with the creation of the subscriptions.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
