### PR TITLE
chore: Match Java version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ guide](https://docs.amplify.aws/lib/project-setup/prereq/q/platform/android).
 
 ### Specifying Gradle Dependencies
 
-To begin, include Amplify from your `app` module's `build.gradle`
-dependencies section:
+To begin, include Amplify from your `app` module's `build.gradle` (Groovy DSL) dependencies section:
+For kotlin DSL, checkout [the migration guide](https://developer.android.com/build/migrate-to-kotlin-dsl).
 
 ```groovy
 dependencies {
@@ -82,9 +82,9 @@ dependencies {
 }
 ```
 
-### Java 8 Requirement
+### Java 11 Requirement
 
-Amplify Android _requires_ Java 8 features. Please add a `compileOptions`
+Amplify Android _requires_ Java 11 features. Please add a `compileOptions`
 block inside your app's `build.gradle`, as below:
 
 ```gradle

--- a/README.md
+++ b/README.md
@@ -82,17 +82,17 @@ dependencies {
 }
 ```
 
-### Java 11 Requirement
+### Java 8 Requirement
 
-Amplify Android _requires_ Java 11 features. Please add a `compileOptions`
+Amplify Android _requires_ Java 8 features. Please add a `compileOptions`
 block inside your app's `build.gradle`, as below:
 
 ```gradle
 android {
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_8
+        targetCompatibility JavaVersion.VERSION_8
     }
 }
 ```

--- a/amplify-tools/publishing.gradle
+++ b/amplify-tools/publishing.gradle
@@ -212,7 +212,7 @@ afterEvaluate { project ->
         }
     }
 
-    if (JavaVersion.current().isJava11Compatible()) {
+    if (JavaVersion.current().isJava8Compatible()) {
         allprojects {
             tasks.withType(Javadoc) {
                 options.addStringOption('Xdoclint:none', '-quiet')

--- a/amplify-tools/publishing.gradle
+++ b/amplify-tools/publishing.gradle
@@ -212,7 +212,7 @@ afterEvaluate { project ->
         }
     }
 
-    if (JavaVersion.current().isJava8Compatible()) {
+    if (JavaVersion.current().isJava11Compatible()) {
         allprojects {
             tasks.withType(Javadoc) {
                 options.addStringOption('Xdoclint:none', '-quiet')


### PR DESCRIPTION
- [✅] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

Amplify Android now requires Java 11 LTS features, this PR aims to resolve few remaining issues.
Also added migration guide in the readme file to provide support for Gradle Kotlin DSL users

*How did you test these changes?*
Tested on local machine

*Documentation update required?*
- [✅] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
