### PR TITLE
fix(Predictions): Fix Liveness InvalidSignatureException

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -443,8 +443,9 @@ internal class LivenessWebSocket(
                         it.secretAccessKey,
                         Pair(":date", eventDate)
                     )
-                    val signedPayloadBytes = signedPayload.chunked(2).map { hexChar -> hexChar.toInt(16).toByte() }
-                        .toByteArray()
+                    val signedPayloadBytes = signedPayload.chunked(2).map {
+                        hexChar -> hexChar.toInt(16).toByte()
+                    }.toByteArray()
                     val encodedRequest = LivenessEventStream.encode(
                         encodedPayload.array(),
                         mapOf(

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -443,8 +443,8 @@ internal class LivenessWebSocket(
                         it.secretAccessKey,
                         Pair(":date", eventDate)
                     )
-                    val signedPayloadBytes = signedPayload.chunked(2).map {
-                        hexChar -> hexChar.toInt(16).toByte()
+                    val signedPayloadBytes = signedPayload.chunked(2).map { hexChar ->
+                        hexChar.toInt(16).toByte()
                     }.toByteArray()
                     val encodedRequest = LivenessEventStream.encode(
                         encodedPayload.array(),

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -52,7 +52,11 @@ import java.util.Date
 import java.util.Locale
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -97,6 +101,15 @@ internal class LivenessWebSocket(
     @VisibleForTesting internal var webSocketError: PredictionsException? = null
     internal var clientStoppedSession = false
     val json = Json { ignoreUnknownKeys = true }
+
+    // Sending events to the websocket requires processing synchronously because we rely on proper ordered
+    // prior signatures. When sending events, we send each of these events to an async queue to process 1 at a time.
+    private val sendEventScope = CoroutineScope(Job() + Dispatchers.IO)
+    private val sendEventQueueChannel = Channel<Job>(capacity = Channel.UNLIMITED).apply {
+        sendEventScope.launch {
+            consumeEach { it.join() }
+        }
+    }
 
     @VisibleForTesting
     internal var webSocketListener = object : WebSocketListener() {
@@ -409,76 +422,86 @@ internal class LivenessWebSocket(
     }
 
     private fun sendClientInfoEvent(clientInfoEvent: ClientSessionInformationEvent) {
-        credentials?.let {
-            val jsonString = Json.encodeToString(clientInfoEvent)
-            val jsonPayload = jsonString.encodeUtf8().toByteArray()
-            val encodedPayload = LivenessEventStream.encode(
-                jsonPayload,
-                mapOf(
-                    ":event-type" to "ClientSessionInformationEvent",
-                    ":message-type" to "event",
-                    ":content-type" to "application/json"
-                )
-            )
-            val eventDate = Date(adjustedDate())
-            val signedPayload = signer.getSignedFrame(
-                region,
-                encodedPayload.array(),
-                it.secretAccessKey,
-                Pair(":date", eventDate)
-            )
-            val signedPayloadBytes = signedPayload.chunked(2).map { hexChar -> hexChar.toInt(16).toByte() }
-                .toByteArray()
-            val encodedRequest = LivenessEventStream.encode(
-                encodedPayload.array(),
-                mapOf(
-                    ":date" to eventDate,
-                    ":chunk-signature" to signedPayloadBytes
-                )
-            )
+        // Add event to send queue to ensure proper ordering of signatures
+        sendEventQueueChannel.trySend(
+            sendEventScope.launch(start = CoroutineStart.LAZY) {
+                credentials?.let {
+                    val jsonString = Json.encodeToString(clientInfoEvent)
+                    val jsonPayload = jsonString.encodeUtf8().toByteArray()
+                    val encodedPayload = LivenessEventStream.encode(
+                        jsonPayload,
+                        mapOf(
+                            ":event-type" to "ClientSessionInformationEvent",
+                            ":message-type" to "event",
+                            ":content-type" to "application/json"
+                        )
+                    )
+                    val eventDate = Date(adjustedDate())
+                    val signedPayload = signer.getSignedFrame(
+                        region,
+                        encodedPayload.array(),
+                        it.secretAccessKey,
+                        Pair(":date", eventDate)
+                    )
+                    val signedPayloadBytes = signedPayload.chunked(2).map { hexChar -> hexChar.toInt(16).toByte() }
+                        .toByteArray()
+                    val encodedRequest = LivenessEventStream.encode(
+                        encodedPayload.array(),
+                        mapOf(
+                            ":date" to eventDate,
+                            ":chunk-signature" to signedPayloadBytes
+                        )
+                    )
 
-            webSocket?.send(ByteString.of(*encodedRequest.array()))
-        }
+                    webSocket?.send(ByteString.of(*encodedRequest.array()))
+                }
+            }
+        )
     }
 
     fun sendVideoEvent(videoBytes: ByteArray, videoEventTime: Long) {
-        if (videoBytes.isNotEmpty()) {
-            videoEndTimestamp = adjustedDate(videoEventTime)
-        }
-        credentials?.let {
-            val videoBuffer = ByteBuffer.wrap(videoBytes)
-            val videoEvent = VideoEvent(
-                timestampMillis = adjustedDate(videoEventTime),
-                videoChunk = videoBuffer
-            )
-            val videoJsonString = Json.encodeToString(videoEvent)
-            val videoJsonPayload = videoJsonString.encodeUtf8().toByteArray()
-            val encodedVideoPayload = LivenessEventStream.encode(
-                videoJsonPayload,
-                mapOf(
-                    ":event-type" to "VideoEvent",
-                    ":message-type" to "event",
-                    ":content-type" to "application/json"
-                )
-            )
-            val videoEventDate = Date(adjustedDate())
-            val signedVideoPayload = signer.getSignedFrame(
-                region,
-                encodedVideoPayload.array(),
-                it.secretAccessKey,
-                Pair(":date", videoEventDate)
-            )
-            val signedVideoPayloadBytes = signedVideoPayload.chunked(2)
-                .map { hexChar -> hexChar.toInt(16).toByte() }.toByteArray()
-            val encodedVideoRequest = LivenessEventStream.encode(
-                encodedVideoPayload.array(),
-                mapOf(
-                    ":date" to videoEventDate,
-                    ":chunk-signature" to signedVideoPayloadBytes
-                )
-            )
-            webSocket?.send(ByteString.of(*encodedVideoRequest.array()))
-        }
+        // Add event to send queue to ensure proper ordering of signatures
+        sendEventQueueChannel.trySend(
+            sendEventScope.launch(start = CoroutineStart.LAZY) {
+                if (videoBytes.isNotEmpty()) {
+                    videoEndTimestamp = adjustedDate(videoEventTime)
+                }
+                credentials?.let {
+                    val videoBuffer = ByteBuffer.wrap(videoBytes)
+                    val videoEvent = VideoEvent(
+                        timestampMillis = adjustedDate(videoEventTime),
+                        videoChunk = videoBuffer
+                    )
+                    val videoJsonString = Json.encodeToString(videoEvent)
+                    val videoJsonPayload = videoJsonString.encodeUtf8().toByteArray()
+                    val encodedVideoPayload = LivenessEventStream.encode(
+                        videoJsonPayload,
+                        mapOf(
+                            ":event-type" to "VideoEvent",
+                            ":message-type" to "event",
+                            ":content-type" to "application/json"
+                        )
+                    )
+                    val videoEventDate = Date(adjustedDate())
+                    val signedVideoPayload = signer.getSignedFrame(
+                        region,
+                        encodedVideoPayload.array(),
+                        it.secretAccessKey,
+                        Pair(":date", videoEventDate)
+                    )
+                    val signedVideoPayloadBytes = signedVideoPayload.chunked(2)
+                        .map { hexChar -> hexChar.toInt(16).toByte() }.toByteArray()
+                    val encodedVideoRequest = LivenessEventStream.encode(
+                        encodedVideoPayload.array(),
+                        mapOf(
+                            ":date" to videoEventDate,
+                            ":chunk-signature" to signedVideoPayloadBytes
+                        )
+                    )
+                    webSocket?.send(ByteString.of(*encodedVideoRequest.array()))
+                }
+            }
+        )
     }
 
     fun destroy(reasonCode: Int = NORMAL_SOCKET_CLOSURE_STATUS_CODE) {


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

We send video and client events over the liveness websocket. Video events and client events are sent from different threads. If a video and client event are sent at identical time, prior signatures may get mixed up, causing an invalid signature event. This approach uses a coroutine channel queue to ensure outbound websocket events are processed 1 at a time.

*How did you test these changes?*

Manual testing

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
