### PR TITLE
feat(auth): Expose AuthConfiguration directly

### DIFF
--- a/aws-auth-cognito/build.gradle.kts
+++ b/aws-auth-cognito/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     testImplementation(libs.test.robolectric)
     testImplementation(libs.test.androidx.core)
     testImplementation(libs.test.kotlin.reflection)
+    testImplementation(libs.test.kotest.assertions)
 
     androidTestImplementation(libs.gson)
     //noinspection GradleDependency

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoLegacyCredentialStoreInstrumentationTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoLegacyCredentialStoreInstrumentationTest.kt
@@ -20,7 +20,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.amplifyframework.auth.cognito.data.AWSCognitoLegacyCredentialStore
 import com.amplifyframework.auth.cognito.testutils.AuthConfigurationProvider
 import com.amplifyframework.auth.cognito.testutils.CredentialStoreUtil
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/CredentialStoreStateMachineInstrumentationTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/CredentialStoreStateMachineInstrumentationTest.kt
@@ -20,7 +20,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.amplifyframework.auth.cognito.data.AWSCognitoAuthCredentialStore
 import com.amplifyframework.auth.cognito.testutils.AuthConfigurationProvider
 import com.amplifyframework.auth.cognito.testutils.CredentialStoreUtil
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.google.gson.Gson
 import org.json.JSONObject
 import org.junit.Before

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/testutils/AuthConfigurationProvider.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/testutils/AuthConfigurationProvider.kt
@@ -15,7 +15,7 @@
 
 package com.amplifyframework.auth.cognito.testutils
 
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import kotlinx.serialization.Serializable

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -61,7 +61,6 @@ import com.amplifyframework.core.Action
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.core.category.CategoryType
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -100,9 +100,13 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     private lateinit var pluginConfigurationJSON: JSONObject
 
     @InternalAmplifyApi
+    @Deprecated("Use getAuthConfiguration instead", replaceWith = ReplaceWith("getAuthConfiguration()"))
     fun getPluginConfiguration(): JSONObject {
         return pluginConfigurationJSON
     }
+
+    @InternalAmplifyApi
+    fun getAuthConfiguration() = realPlugin.configuration
 
     @InternalAmplifyApi
     fun addToUserAgent(type: AWSCognitoAuthMetadataType, value: String) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthService.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthService.kt
@@ -22,7 +22,6 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.endpoints.CognitoIdentity
 import aws.smithy.kotlin.runtime.client.RequestInterceptorContext
 import aws.smithy.kotlin.runtime.client.endpoints.Endpoint
 import aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 
 interface AWSCognitoAuthService {
     val cognitoIdentityProviderClient: CognitoIdentityProviderClient?

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -13,12 +13,15 @@
  * permissions and limitations under the License.
  */
 
-package com.amplifyframework.statemachine.codegen.data
+package com.amplifyframework.auth.cognito
 
 import androidx.annotation.IntRange
 import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.cognito.options.AuthFlowType
+import com.amplifyframework.statemachine.codegen.data.IdentityPoolConfiguration
+import com.amplifyframework.statemachine.codegen.data.OauthConfiguration
+import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
 import org.json.JSONArray
 import org.json.JSONObject
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
@@ -23,7 +23,6 @@ import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.Environment
 import com.amplifyframework.statemachine.StateMachineEvent
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CredentialType
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.events.AuthEvent

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CredentialStoreClient.kt
@@ -21,7 +21,6 @@ import com.amplifyframework.auth.cognito.data.AWSCognitoLegacyCredentialStore
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.StateChangeListenerToken
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CredentialType
 import com.amplifyframework.statemachine.codegen.events.CredentialStoreEvent
 import com.amplifyframework.statemachine.codegen.states.CredentialStoreState

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -136,7 +136,6 @@ import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.StateChangeListenerToken
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.FederatedToken
 import com.amplifyframework.statemachine.codegen.data.HostedUIErrorData
 import com.amplifyframework.statemachine.codegen.data.SignInData

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -173,7 +173,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 
 internal class RealAWSCognitoAuthPlugin(
-    private val configuration: AuthConfiguration,
+    val configuration: AuthConfiguration,
     private val authEnvironment: AuthEnvironment,
     private val authStateMachine: AuthStateMachine,
     private val logger: Logger

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStore.kt
@@ -16,12 +16,11 @@
 package com.amplifyframework.auth.cognito.data
 
 import android.content.Context
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.core.store.KeyValueRepository
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.AuthCredentialStore
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -29,7 +28,7 @@ internal class AWSCognitoAuthCredentialStore(
     val context: Context,
     private val authConfiguration: AuthConfiguration,
     isPersistenceEnabled: Boolean = true,
-    keyValueRepoFactory: KeyValueRepositoryFactory = KeyValueRepositoryFactory(),
+    keyValueRepoFactory: KeyValueRepositoryFactory = KeyValueRepositoryFactory()
 ) : AuthCredentialStore {
 
     companion object {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
@@ -17,12 +17,12 @@ package com.amplifyframework.auth.cognito.data
 
 import android.content.Context
 import com.amplifyframework.auth.AuthProvider
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.auth.cognito.helpers.SessionHelper
 import com.amplifyframework.auth.cognito.helpers.identityProviderName
 import com.amplifyframework.core.store.KeyValueRepository
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.AuthCredentialStore
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
@@ -184,7 +184,9 @@ internal class AWSCognitoLegacyCredentialStore(
 
         return if (accessKey == null && secretKey == null && sessionToken == null) {
             null
-        } else AWSCredentials(accessKey, secretKey, sessionToken, expiration)
+        } else {
+            AWSCredentials(accessKey, secretKey, sessionToken, expiration)
+        }
     }
 
     private fun retrieveIdentityId() = idAndCredentialsKeyValue.get(namespace(ID_KEY))
@@ -224,8 +226,11 @@ internal class AWSCognitoLegacyCredentialStore(
         val deviceGroupKey = deviceKeyValue.get(DEVICE_GROUP_KEY)
         val deviceSecretKey = deviceKeyValue.get(DEVICE_SECRET_KEY)
 
-        return if (deviceKey.isNullOrEmpty() && deviceGroupKey.isNullOrEmpty()) DeviceMetadata.Empty
-        else DeviceMetadata.Metadata(deviceKey ?: "", deviceGroupKey ?: "", deviceSecretKey)
+        return if (deviceKey.isNullOrEmpty() && deviceGroupKey.isNullOrEmpty()) {
+            DeviceMetadata.Empty
+        } else {
+            DeviceMetadata.Metadata(deviceKey ?: "", deviceGroupKey ?: "", deviceSecretKey)
+        }
     }
 
     private fun retrieveCognitoUserPoolTokens(keys: Map<String, String>): CognitoUserPoolTokens? {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AuthConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AuthConfiguration.kt
@@ -25,11 +25,6 @@ import org.json.JSONObject
 private const val configName = "Default"
 
 @InternalAmplifyApi
-enum class VerificationMechanism {
-    PhoneNumber, Email
-}
-
-@InternalAmplifyApi
 data class PasswordProtectionSettings(
     @IntRange(from = 6, to = 99) val length: Int,
     val requiresNumber: Boolean,
@@ -49,7 +44,7 @@ data class AuthConfiguration internal constructor(
     val authFlowType: AuthFlowType,
     val signUpAttributes: List<AuthUserAttributeKey>,
     val usernameAttributes: List<AuthUserAttributeKey>,
-    val verificationMechanisms: List<VerificationMechanism>,
+    val verificationMechanisms: List<AuthUserAttributeKey>,
     val passwordProtectionSettings: PasswordProtectionSettings?
 ) {
 
@@ -73,10 +68,7 @@ data class AuthConfiguration internal constructor(
             } ?: emptyList()
 
             val verificationMechanisms = authConfig?.optJSONArray("verificationMechanisms")?.map {
-                when (getString(it)) {
-                    "EMAIL" -> VerificationMechanism.Email
-                    else -> VerificationMechanism.PhoneNumber
-                }
+                AuthUserAttributeKey.custom(getString(it).lowercase())
             } ?: emptyList()
 
             return AuthConfiguration(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/IdentityPoolConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/IdentityPoolConfiguration.kt
@@ -15,16 +15,18 @@
 
 package com.amplifyframework.statemachine.codegen.data
 
+import com.amplifyframework.annotations.InternalAmplifyApi
 import org.json.JSONObject
 
 /**
  * Configuration options for specifying cognito identity pool.
  */
-internal data class IdentityPoolConfiguration internal constructor(val builder: Builder) {
-    val region: String? = builder.region
-    val poolId: String? = builder.poolId
-
-    companion object {
+@InternalAmplifyApi
+data class IdentityPoolConfiguration internal constructor(
+    val region: String?,
+    val poolId: String?
+) {
+    internal companion object {
         private const val DEFAULT_REGION = "us-east-1"
 
         /**
@@ -40,7 +42,7 @@ internal data class IdentityPoolConfiguration internal constructor(val builder: 
          * Returns a builder object populated from JSON.
          * @return populated builder instance.
          */
-        internal fun fromJson(configJson: JSONObject): Builder {
+        fun fromJson(configJson: JSONObject): Builder {
             return Builder(configJson)
         }
 
@@ -50,7 +52,7 @@ internal data class IdentityPoolConfiguration internal constructor(val builder: 
     /**
      * Builder class for constructing [IdentityPoolConfiguration].
      */
-    class Builder constructor(
+    internal class Builder(
         configJson: JSONObject? = null
     ) {
         var region: String? = DEFAULT_REGION
@@ -65,7 +67,10 @@ internal data class IdentityPoolConfiguration internal constructor(val builder: 
 
         fun region(region: String) = apply { this.region = region }
         fun poolId(poolId: String) = apply { this.poolId = poolId }
-        fun build() = IdentityPoolConfiguration(this)
+        fun build() = IdentityPoolConfiguration(
+            region = region,
+            poolId = poolId
+        )
     }
 
     private enum class Config(val key: String) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/OauthConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/OauthConfiguration.kt
@@ -15,9 +15,11 @@
 
 package com.amplifyframework.statemachine.codegen.data
 
+import com.amplifyframework.annotations.InternalAmplifyApi
 import org.json.JSONObject
 
-internal data class OauthConfiguration internal constructor(
+@InternalAmplifyApi
+data class OauthConfiguration internal constructor(
     val appClient: String,
     val appSecret: String?,
     val domain: String,
@@ -25,7 +27,7 @@ internal data class OauthConfiguration internal constructor(
     val signInRedirectURI: String,
     val signOutRedirectURI: String
 ) {
-    companion object {
+    internal companion object {
 
         fun fromJson(jsonObject: JSONObject?): OauthConfiguration? {
             return jsonObject?.run {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/UserPoolConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/UserPoolConfiguration.kt
@@ -15,21 +15,24 @@
 
 package com.amplifyframework.statemachine.codegen.data
 
+import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.auth.AuthException
 import org.json.JSONObject
 
 /**
  * Configuration options for specifying cognito user pool.
  */
-internal data class UserPoolConfiguration internal constructor(val builder: Builder) {
-    val region: String? = builder.region
-    val endpoint: String? = builder.endpoint
-    val poolId: String? = builder.poolId
-    val appClient: String? = builder.appClientId
-    val appClientSecret: String? = builder.appClientSecret
-    val pinpointAppId: String? = builder.pinpointAppId
+@InternalAmplifyApi
+data class UserPoolConfiguration internal constructor(
+    val region: String?,
+    val endpoint: String?,
+    val poolId: String?,
+    val appClient: String?,
+    val appClientSecret: String?,
+    val pinpointAppId: String?
+) {
 
-    companion object {
+    internal companion object {
         private const val DEFAULT_REGION = "us-east-1"
 
         /**
@@ -45,7 +48,7 @@ internal data class UserPoolConfiguration internal constructor(val builder: Buil
          * Returns a builder object populated from JSON.
          * @return populated builder instance.
          */
-        internal fun fromJson(configJson: JSONObject): Builder {
+        fun fromJson(configJson: JSONObject): Builder {
             return Builder(configJson)
         }
 
@@ -55,7 +58,7 @@ internal data class UserPoolConfiguration internal constructor(val builder: Buil
     /**
      * Builder class for constructing [UserPoolConfiguration].
      */
-    class Builder constructor(
+    internal class Builder constructor(
         configJson: JSONObject? = null
     ) {
         var region: String? = DEFAULT_REGION
@@ -82,7 +85,14 @@ internal data class UserPoolConfiguration internal constructor(val builder: Buil
         fun appClientId(appClientId: String) = apply { this.appClientId = appClientId }
         fun appClientSecret(appClientSecret: String) = apply { this.appClientSecret = appClientSecret }
         fun pinpointAppId(pinpointAppId: String) = apply { this.pinpointAppId = pinpointAppId }
-        fun build() = UserPoolConfiguration(this)
+        fun build() = UserPoolConfiguration(
+            region = region,
+            endpoint = endpoint,
+            poolId = poolId,
+            appClient = appClientId,
+            appClientSecret = appClientSecret,
+            pinpointAppId = pinpointAppId
+        )
 
         @Throws(AuthException::class)
         private fun validateEndpoint(endpoint: String?): String? {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthEvent.kt
@@ -15,9 +15,9 @@
 
 package com.amplifyframework.statemachine.codegen.events
 
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.statemachine.StateMachineEvent
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import java.util.Date
 
 internal class AuthEvent(val eventType: EventType, override val time: Date? = null) :

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthenticationEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthenticationEvent.kt
@@ -15,9 +15,9 @@
 
 package com.amplifyframework.statemachine.codegen.events
 
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.statemachine.StateMachineEvent
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.SignInData
 import com.amplifyframework.statemachine.codegen.data.SignOutData

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginFeatureTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginFeatureTest.kt
@@ -28,7 +28,6 @@ import com.amplifyframework.auth.cognito.featuretest.serializers.deserializeToAu
 import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CredentialType
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.states.AuthState
@@ -53,7 +52,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.json.JSONObject
 import org.junit.After

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthServiceTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthServiceTest.kt
@@ -42,7 +42,11 @@ class AWSCognitoAuthServiceTest {
                 .region(expectedUserPoolRegion)
                 .build(),
             oauth = null,
-            authFlowType = AuthFlowType.USER_SRP_AUTH
+            authFlowType = AuthFlowType.USER_SRP_AUTH,
+            signUpAttributes = emptyList(),
+            usernameAttributes = emptyList(),
+            verificationMechanisms = emptyList(),
+            passwordProtectionSettings = null
         )
 
         val testObject = AWSCognitoAuthService.fromConfiguration(config)

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthServiceTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthServiceTest.kt
@@ -16,7 +16,6 @@
 package com.amplifyframework.auth.cognito
 
 import com.amplifyframework.auth.cognito.options.AuthFlowType
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.IdentityPoolConfiguration
 import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
 import kotlin.test.assertEquals

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
@@ -30,7 +30,6 @@ import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.SignedOutData

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
@@ -86,7 +86,6 @@ import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.SignInMethod

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTestBase.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTestBase.kt
@@ -34,7 +34,6 @@ import com.amplifyframework.statemachine.codegen.actions.SignOutActions
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.LoginsMapProvider

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/SetupTOTPCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/SetupTOTPCognitoActionsTest.kt
@@ -24,12 +24,12 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifySoftwareToken
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifySoftwareTokenResponseType
 import aws.sdk.kotlin.services.cognitoidentityprovider.verifySoftwareToken
 import com.amplifyframework.auth.cognito.AWSCognitoAuthService
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.StoreClientBehavior
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.EventDispatcher
 import com.amplifyframework.statemachine.StateMachineEvent
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.SignInTOTPSetupData
 import com.amplifyframework.statemachine.codegen.events.SetupTOTPEvent
 import io.mockk.coEvery

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/SignInChallengeCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/SignInChallengeCognitoActionsTest.kt
@@ -20,6 +20,7 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.RespondToAuthChalle
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.cognito.AWSCognitoAuthService
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.StoreClientBehavior
 import com.amplifyframework.logging.Logger
@@ -27,7 +28,6 @@ import com.amplifyframework.statemachine.EventDispatcher
 import com.amplifyframework.statemachine.StateMachineEvent
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CredentialType
 import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
 import io.mockk.coEvery

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStoreTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStoreTest.kt
@@ -16,10 +16,10 @@
 package com.amplifyframework.auth.cognito.data
 
 import android.content.Context
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.core.store.KeyValueRepository
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.IdentityPoolConfiguration
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
@@ -73,7 +73,7 @@ class AWSCognitoAuthCredentialStoreTest {
             mockFactory.create(
                 mockContext,
                 keyValueRepoID,
-                true,
+                true
             )
         ).thenReturn(mockKeyValue)
 
@@ -203,7 +203,7 @@ class AWSCognitoAuthCredentialStoreTest {
                 "username",
                 Date(0),
                 SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_SRP_AUTH),
-                CognitoUserPoolTokens("idToken", "accessToken", "refreshToken", expiration),
+                CognitoUserPoolTokens("idToken", "accessToken", "refreshToken", expiration)
             ),
             "identityPool",
             AWSCredentials(

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStoreTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStoreTest.kt
@@ -16,10 +16,10 @@
 package com.amplifyframework.auth.cognito.data
 
 import android.content.Context
+import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.core.store.KeyValueRepository
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
-import com.amplifyframework.statemachine.codegen.data.AuthConfiguration
 import com.amplifyframework.statemachine.codegen.data.AuthCredentialStore
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
@@ -115,7 +115,7 @@ class AWSCognitoLegacyCredentialStoreTest {
             mockFactory.create(
                 mockContext,
                 AWSCognitoLegacyCredentialStore.AWS_KEY_VALUE_STORE_NAMESPACE_IDENTIFIER,
-                true,
+                true
             )
         ).thenReturn(mockKeyValue)
 
@@ -123,7 +123,7 @@ class AWSCognitoLegacyCredentialStoreTest {
             mockFactory.create(
                 mockContext,
                 AWSCognitoLegacyCredentialStore.APP_TOKENS_INFO_CACHE,
-                true,
+                true
             )
         ).thenReturn(mockKeyValue)
 
@@ -131,7 +131,7 @@ class AWSCognitoLegacyCredentialStoreTest {
             mockFactory.create(
                 mockContext,
                 AWSCognitoLegacyCredentialStore.AWS_MOBILE_CLIENT_PROVIDER,
-                true,
+                true
             )
         ).thenReturn(mockKeyValue)
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/codegen/data/AuthConfigurationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/codegen/data/AuthConfigurationTest.kt
@@ -1,0 +1,148 @@
+package com.amplifyframework.statemachine.codegen.data
+
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.options.AuthFlowType
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.json.JSONObject
+import org.junit.Test
+
+class AuthConfigurationTest {
+    val jsonObject = JSONObject(
+        """
+            {
+                "UserAgent": "aws-amplify-cli/0.1.0",
+                "Version": "0.1.0",
+                "IdentityManager": {
+                    "Default": {}
+                },
+                "CredentialsProvider": {
+                    "CognitoIdentity": {
+                        "Default": {
+                            "PoolId": "identity-pool-id",
+                            "Region": "us-east-1"
+                        }
+                    }
+                },
+                "CognitoUserPool": {
+                    "Default": {
+                        "PoolId": "user-pool-id",
+                        "AppClientId": "user-app-id",
+                        "Region": "us-east-1"
+                    }
+                },
+                "Auth": {
+                    "Default": {
+                        "authenticationFlowType": "USER_SRP_AUTH",
+                        "OAuth": {
+                          "AppClientId": "testAppClientId",
+                          "AppClientSecret": "testAppClientSecret",
+                          "WebDomain": "webDomain",
+                          "Scopes": ["oauth"],
+                          "SignInRedirectURI": "http://example.com/signin",
+                          "SignOutRedirectURI": "http://example.com/signout"
+                        },
+                        "socialProviders": [],
+                        "usernameAttributes": ["USERNAME", "PHONE_NUMBER"],
+                        "signupAttributes": [
+                            "EMAIL", "NAME", "BIRTHDATE"
+                        ],
+                        "passwordProtectionSettings": {
+                            "passwordPolicyMinLength": 10,
+                            "passwordPolicyCharacters": ["REQUIRES_NUMBERS", "REQUIRES_LOWER"]
+                        },
+                        "mfaConfiguration": "OFF",
+                        "mfaTypes": [
+                            "SMS"
+                        ],
+                        "verificationMechanisms": [
+                            "PHONE_NUMBER", "EMAIL"
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+    )
+
+    @Test
+    fun `parses auth configuration`() {
+        val configuration = AuthConfiguration.fromJson(jsonObject)
+
+        configuration.authFlowType shouldBe AuthFlowType.USER_SRP_AUTH
+        configuration.usernameAttributes shouldContainExactly listOf(
+            UsernameAttribute.Username,
+            UsernameAttribute.PhoneNumber
+        )
+        configuration.signUpAttributes shouldContainExactly listOf(
+            AuthUserAttributeKey.email(),
+            AuthUserAttributeKey.name(),
+            AuthUserAttributeKey.birthdate()
+        )
+        configuration.passwordProtectionSettings?.shouldNotBeNull()
+        configuration.passwordProtectionSettings?.run {
+            length shouldBe 10
+            requiresUpper.shouldBeFalse()
+            requiresLower.shouldBeTrue()
+            requiresSpecial.shouldBeFalse()
+            requiresNumber.shouldBeTrue()
+        }
+        configuration.verificationMechanisms shouldContainExactly listOf(
+            VerificationMechanism.PhoneNumber,
+            VerificationMechanism.Email
+        )
+    }
+
+    @Test
+    fun `signupAttributes is empty if json field is missing`() {
+        getAuthConfig().remove("signupAttributes")
+        val configuration = AuthConfiguration.fromJson(jsonObject)
+        configuration.signUpAttributes.shouldBeEmpty()
+    }
+
+    @Test
+    fun `usernameAttributes is empty if json field is missing`() {
+        getAuthConfig().remove("usernameAttributes")
+        val configuration = AuthConfiguration.fromJson(jsonObject)
+        configuration.usernameAttributes.shouldBeEmpty()
+    }
+
+    @Test
+    fun `verificationMechanisms is empty if json field is missing`() {
+        getAuthConfig().remove("verificationMechanisms")
+        val configuration = AuthConfiguration.fromJson(jsonObject)
+        configuration.verificationMechanisms.shouldBeEmpty()
+    }
+
+    @Test
+    fun `passwordProtectionSettings is null if json field is missing`() {
+        getAuthConfig().remove("passwordProtectionSettings")
+        val configuration = AuthConfiguration.fromJson(jsonObject)
+        configuration.passwordProtectionSettings?.shouldBeNull()
+    }
+
+    @Test
+    fun `password min length defaults to zero if json field is missing`() {
+        getPasswordSettings().remove("passwordPolicyMinLength")
+        val configuration = AuthConfiguration.fromJson(jsonObject)
+        configuration.passwordProtectionSettings?.length shouldBe 0
+    }
+
+    @Test
+    fun `password character requirements are false if json field is missing`() {
+        getPasswordSettings().remove("passwordPolicyCharacters")
+        val configuration = AuthConfiguration.fromJson(jsonObject)
+        configuration.passwordProtectionSettings?.requiresLower?.shouldBeFalse()
+        configuration.passwordProtectionSettings?.requiresUpper?.shouldBeFalse()
+        configuration.passwordProtectionSettings?.requiresNumber?.shouldBeFalse()
+        configuration.passwordProtectionSettings?.requiresSpecial?.shouldBeFalse()
+    }
+
+    private fun getAuthConfig() = jsonObject.getJSONObject("Auth").getJSONObject("Default")
+    private fun getPasswordSettings() = jsonObject.getJSONObject("Auth").getJSONObject("Default")
+        .getJSONObject("passwordProtectionSettings")
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/codegen/data/AuthConfigurationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/codegen/data/AuthConfigurationTest.kt
@@ -1,6 +1,9 @@
 package com.amplifyframework.statemachine.codegen.data
 
 import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthConfiguration
+import com.amplifyframework.auth.cognito.UsernameAttribute
+import com.amplifyframework.auth.cognito.VerificationMechanism
 import com.amplifyframework.auth.cognito.options.AuthFlowType
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Amplify previously exposed raw JSON via `getPluginConfiguration` for Authenticator to consume. This change instead exposed a pre-parsed `AuthConfiguration`.

- Added `signupAttributes`, `usernameAttributes`, `verificationMechanisms`, and `passwordProtectionSettings` to `AuthConfiguration`
- Exposed `AuthConfiguration` and related types with `@InternalAmplifyApi` annotations.
- Deprecated existing `getPluginConfiguration` function.
- Moved `AuthConfiguration` to `com.amplifyframework.auth.cognito` package. This is a more appropriate location for this class.

Equivalent Swift PR is here: https://github.com/aws-amplify/amplify-swift/pull/3566

*How did you test these changes?*
- Tested consuming new internal API in Authenticator 

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
