### PR TITLE
fix(analytics): Set start time before generating session ID

### DIFF
--- a/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/Session.kt
+++ b/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/Session.kt
@@ -56,8 +56,8 @@ class Session {
         context: Context,
         uniqueId: String
     ) {
-        this@Session.sessionId = generateSessionId(uniqueId)
         this@Session.startTime = System.currentTimeMillis()
+        this@Session.sessionId = generateSessionId(uniqueId)
         this@Session.stopTime = null
     }
 


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
#2746

*Description of changes:*
startTime should be set before generating a session ID

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
