### PR TITLE
feat(all): Add a new API for Flutter to set user agent

### DIFF
--- a/annotations/src/main/java/com/amplifyframework/annotations/AmplifyFlutterApi.kt
+++ b/annotations/src/main/java/com/amplifyframework/annotations/AmplifyFlutterApi.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.annotations
+
+/**
+ * APIs marked with this annotation are visible for usage from the Amplify Flutter library, and are not intended
+ * for external use. They may change or be removed without warning.
+ *
+ * We strongly recommend to not use such API.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is for Amplify Flutter and should not be used elsewhere. " +
+        "It could be removed or changed without notice."
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.CONSTRUCTOR
+)
+annotation class AmplifyFlutterApi

--- a/core/src/androidTest/java/com/amplifyframework/core/util/UserAgentConfigurationTest.java
+++ b/core/src/androidTest/java/com/amplifyframework/core/util/UserAgentConfigurationTest.java
@@ -21,7 +21,6 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.core.AmplifyConfiguration;
 import com.amplifyframework.core.BuildConfig;
-import com.amplifyframework.core.test.R;
 import com.amplifyframework.util.UserAgent;
 
 import org.junit.BeforeClass;
@@ -29,7 +28,6 @@ import org.junit.Test;
 
 import java.util.LinkedHashMap;
 
-import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -44,11 +42,7 @@ public final class UserAgentConfigurationTest {
      */
     @BeforeClass
     public static void setUpOnce() throws AmplifyException {
-        Context context = getApplicationContext();
-        AmplifyConfiguration config = AmplifyConfiguration.builder(context, R.raw.amplifyconfiguration)
-                .addPlatform(UserAgent.Platform.FLUTTER, BuildConfig.VERSION_NAME)
-                .build();
-        Amplify.configure(config, context);
+        Amplify.addUserAgentPlatform(UserAgent.Platform.FLUTTER, BuildConfig.VERSION_NAME);
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/Amplify.java
+++ b/core/src/main/java/com/amplifyframework/core/Amplify.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.analytics.AnalyticsCategory;
+import com.amplifyframework.annotations.AmplifyFlutterApi;
 import com.amplifyframework.api.ApiCategory;
 import com.amplifyframework.auth.AuthCategory;
 import com.amplifyframework.core.category.Category;
@@ -118,6 +119,21 @@ public final class Amplify {
      */
     public static Map<CategoryType, Category<? extends Plugin<?>>> getCategoriesMap() {
         return Immutable.of(CATEGORIES);
+    }
+
+    /**
+     * Appends the given platform information version to the user agent header. This is only for internal use by the
+     * Amplify Flutter library, and is not intended for public consumption.
+     * @param platform The platform identifier
+     * @param version The version string for the platform
+     * @throws AmplifyException If version information has already be configured.
+     */
+    @AmplifyFlutterApi
+    public static void addUserAgentPlatform(
+        @NonNull UserAgent.Platform platform,
+        @NonNull String version
+    ) throws AmplifyException {
+        UserAgent.configure(Map.of(platform, version));
     }
 
     /**

--- a/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
+++ b/core/src/main/java/com/amplifyframework/core/AmplifyConfiguration.java
@@ -280,7 +280,9 @@ public final class AmplifyConfiguration {
          * @param platform Additional platform that uses this library.
          * @param version Version number associated with the additional platform.
          * @return this builder instance.
+         * @deprecated Use Amplify.addUserAgentPlatform instead
          */
+        @Deprecated
         @NonNull
         public Builder addPlatform(@NonNull UserAgent.Platform platform, @NonNull String version) {
             // Do not allow user to specify Android platform to prevent redundancy.


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Add a new API for Flutter to set its user agent string. This is to move away from AmplifyConfiguration for Gen2.
- Add new annotation to mark APIs that are consumed by Flutter.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
