### PR TITLE
feat(all): Configure plugins with AmplifyOutputs

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -22,6 +22,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.annotations.InternalAmplifyApi;
 import com.amplifyframework.api.ApiCategory;
 import com.amplifyframework.api.aws.AuthModeStrategyType;
 import com.amplifyframework.api.graphql.GraphQLBehavior;
@@ -268,6 +269,7 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
     }
 
     @Override
+    @InternalAmplifyApi
     public void configure(@NonNull AmplifyOutputsData configuration, @NonNull Context context) throws AmplifyException {
         // DataStore does not read any values from AmplifyOutputs, just use the programmatically provided
         // configuration values

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/AWSDataStorePlugin.java
@@ -31,6 +31,7 @@ import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.InitializationStatus;
 import com.amplifyframework.core.async.Cancelable;
 import com.amplifyframework.core.category.CategoryType;
+import com.amplifyframework.core.configuration.AmplifyOutputsData;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelIdentifier;
 import com.amplifyframework.core.model.ModelProvider;
@@ -248,9 +249,10 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             @NonNull JSONObject pluginConfiguration,
             @NonNull Context context
     ) throws DataStoreException {
+        DataStoreConfiguration configuration;
         try {
             // Applies user-provided configs on-top-of any values from the file.
-            this.pluginConfiguration = DataStoreConfiguration
+            configuration = DataStoreConfiguration
                 .builder(pluginConfiguration, userProvidedConfiguration)
                 .build();
         } catch (DataStoreException badConfigException) {
@@ -262,6 +264,18 @@ public final class AWSDataStorePlugin extends DataStorePlugin<Void> {
             );
         }
 
+        configure(context, configuration);
+    }
+
+    @Override
+    public void configure(@NonNull AmplifyOutputsData configuration, @NonNull Context context) throws AmplifyException {
+        // DataStore does not read any values from AmplifyOutputs, just use the programmatically provided
+        // configuration values
+        configure(context, userProvidedConfiguration);
+    }
+
+    private void configure(Context context, DataStoreConfiguration configuration) {
+        pluginConfiguration = configuration;
         HubChannel hubChannel = HubChannel.forCategoryType(getCategoryType());
         Amplify.Hub.subscribe(hubChannel,
             event -> InitializationStatus.SUCCEEDED.toString().equals(event.getName()),

--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/TensorFlowPredictionsPlugin.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/TensorFlowPredictionsPlugin.java
@@ -20,7 +20,6 @@ import android.graphics.Bitmap;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
-import com.amplifyframework.AmplifyException;
 import com.amplifyframework.annotations.InternalAmplifyApi;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.configuration.AmplifyOutputsData;

--- a/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/TensorFlowPredictionsPlugin.java
+++ b/aws-predictions-tensorflow/src/main/java/com/amplifyframework/predictions/tensorflow/TensorFlowPredictionsPlugin.java
@@ -21,7 +21,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.annotations.InternalAmplifyApi;
 import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.configuration.AmplifyOutputsData;
 import com.amplifyframework.predictions.PredictionsException;
 import com.amplifyframework.predictions.PredictionsPlugin;
 import com.amplifyframework.predictions.models.IdentifyAction;
@@ -80,8 +82,18 @@ public final class TensorFlowPredictionsPlugin extends PredictionsPlugin<TensorF
     public void configure(
             JSONObject pluginConfiguration,
             @NonNull Context context
-    ) throws AmplifyException {
-        this.predictionsService = new TensorFlowPredictionsService(context);
+    ) {
+        configure(context);
+    }
+
+    @Override
+    @InternalAmplifyApi
+    public void configure(@NonNull AmplifyOutputsData configuration, @NonNull Context context) {
+        configure(context);
+    }
+
+    private void configure(@NonNull Context context) {
+        predictionsService = new TensorFlowPredictionsService(context);
     }
 
     @WorkerThread

--- a/aws-predictions/build.gradle.kts
+++ b/aws-predictions/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation(libs.test.mockwebserver)
     testImplementation(libs.test.mockk)
     testImplementation(libs.test.kotlin.coroutines)
+    testImplementation(libs.test.kotest.assertions)
 
     androidTestImplementation(project(":testutils"))
     androidTestImplementation(project(":aws-auth-cognito"))

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPlugin.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPlugin.java
@@ -113,10 +113,10 @@ public final class AWSPredictionsPlugin extends PredictionsPlugin<AWSPredictions
         @NonNull AmplifyOutputsData configuration,
         @NonNull Context context
     ) throws PredictionsException {
-       throw new PredictionsException(
+        throw new PredictionsException(
            "AWSPredictionsPlugin is not supported when using Amplify Gen2",
            "This plugin is not supported by Amplify Gen2. Remove this plugin to use Gen2."
-       );
+        );
     }
 
     private void configure(AWSPredictionsPluginConfiguration configuration) throws PredictionsException {

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPlugin.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPlugin.java
@@ -109,6 +109,7 @@ public final class AWSPredictionsPlugin extends PredictionsPlugin<AWSPredictions
     }
 
     @Override
+    @InternalAmplifyApi
     public void configure(
         @NonNull AmplifyOutputsData configuration,
         @NonNull Context context

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPlugin.java
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/AWSPredictionsPlugin.java
@@ -28,6 +28,7 @@ import com.amplifyframework.auth.AWSCredentialsProviderKt;
 import com.amplifyframework.auth.CognitoCredentialsProvider;
 import com.amplifyframework.core.Action;
 import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.configuration.AmplifyOutputsData;
 import com.amplifyframework.predictions.PredictionsException;
 import com.amplifyframework.predictions.PredictionsPlugin;
 import com.amplifyframework.predictions.aws.models.AWSVoiceType;
@@ -103,7 +104,23 @@ public final class AWSPredictionsPlugin extends PredictionsPlugin<AWSPredictions
 
     @Override
     public void configure(JSONObject pluginConfiguration, @NonNull Context context) throws PredictionsException {
-        this.configuration = AWSPredictionsPluginConfiguration.fromJson(pluginConfiguration);
+        AWSPredictionsPluginConfiguration config = AWSPredictionsPluginConfiguration.fromJson(pluginConfiguration);
+        configure(config);
+    }
+
+    @Override
+    public void configure(
+        @NonNull AmplifyOutputsData configuration,
+        @NonNull Context context
+    ) throws PredictionsException {
+       throw new PredictionsException(
+           "AWSPredictionsPlugin is not supported when using Amplify Gen2",
+           "This plugin is not supported by Amplify Gen2. Remove this plugin to use Gen2."
+       );
+    }
+
+    private void configure(AWSPredictionsPluginConfiguration configuration) throws PredictionsException {
+        this.configuration = configuration;
 
         CredentialsProvider credentialsProvider;
 
@@ -114,10 +131,10 @@ public final class AWSPredictionsPlugin extends PredictionsPlugin<AWSPredictions
                 credentialsProvider = new CognitoCredentialsProvider();
             } catch (IllegalStateException exception) {
                 throw new PredictionsException(
-                        "AWSPredictionsPlugin depends on AWSCognitoAuthPlugin but it is currently missing",
-                        exception,
-                        "Before configuring Amplify, be sure to add AWSPredictionsPlugin same as you added " +
-                                "AWSPinpointAnalyticsPlugin."
+                    "AWSPredictionsPlugin depends on AWSCognitoAuthPlugin but it is currently missing",
+                    exception,
+                    "Before configuring Amplify, be sure to add AWSPredictionsPlugin same as you added " +
+                        "AWSPinpointAnalyticsPlugin."
                 );
             }
         }

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/AWSPredictionsPluginTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/AWSPredictionsPluginTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.aws
+
+import com.amplifyframework.predictions.PredictionsException
+import com.amplifyframework.testutils.configuration.amplifyOutputsData
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.mockk
+import org.junit.Test
+
+class AWSPredictionsPluginTest {
+    @Test
+    fun `throws exception when trying to configure with AmplifyOutputs`() {
+        val data = amplifyOutputsData {
+            // no predictions configuration supported
+        }
+
+        val plugin = AWSPredictionsPlugin()
+
+        shouldThrow<PredictionsException> {
+            plugin.configure(data, mockk())
+        }
+    }
+}

--- a/aws-push-notifications-pinpoint/build.gradle.kts
+++ b/aws-push-notifications-pinpoint/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
     implementation(libs.kotlin.serializationJson)
 
     testImplementation(libs.test.junit)
+    testImplementation(libs.test.kotest.assertions)
+    testImplementation(project(":testutils"))
 
     androidTestImplementation(project(":aws-auth-cognito"))
     androidTestImplementation(libs.test.androidx.runner)

--- a/aws-push-notifications-pinpoint/src/main/java/com/amplifyframework/pushnotifications/pinpoint/AWSPinpointPushNotificationsConfiguration.kt
+++ b/aws-push-notifications-pinpoint/src/main/java/com/amplifyframework/pushnotifications/pinpoint/AWSPinpointPushNotificationsConfiguration.kt
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.pushnotifications.pinpoint
 
+import com.amplifyframework.core.configuration.AmplifyOutputsData
+import com.amplifyframework.notifications.pushnotifications.PushNotificationsException
 import org.json.JSONObject
 
 class AWSPinpointPushNotificationsConfiguration internal constructor(val appId: String, val region: String) {
@@ -23,6 +25,18 @@ class AWSPinpointPushNotificationsConfiguration internal constructor(val appId: 
             val region = pluginJson?.getString("region")
             val appId = pluginJson?.getString("appId")
             return AWSPinpointPushNotificationsConfiguration(appId!!, region!!)
+        }
+
+        internal fun from(outputs: AmplifyOutputsData): AWSPinpointPushNotificationsConfiguration {
+            val notifications = outputs.notifications ?: throw PushNotificationsException(
+                message = "Missing notifications configuration",
+                recoverySuggestion = "Ensure the notifications category is properly configured"
+            )
+
+            return AWSPinpointPushNotificationsConfiguration(
+                appId = notifications.amazonPinpointAppId,
+                region = notifications.awsRegion
+            )
         }
     }
 }

--- a/aws-push-notifications-pinpoint/src/test/java/com/amplifyframework/pushnotifications/pinpoint/AWSPinpointPushNotificationsConfigurationTest.kt
+++ b/aws-push-notifications-pinpoint/src/test/java/com/amplifyframework/pushnotifications/pinpoint/AWSPinpointPushNotificationsConfigurationTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.pushnotifications.pinpoint
+
+import com.amplifyframework.notifications.NotificationsException
+import com.amplifyframework.testutils.configuration.amplifyOutputsData
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class AWSPinpointPushNotificationsConfigurationTest {
+    @Test
+    fun `extracts values from amplify outputs`() {
+        val data = amplifyOutputsData {
+            notifications {
+                awsRegion = "test-region"
+                amazonPinpointAppId = "test-app-id"
+            }
+        }
+
+        val configuration = AWSPinpointPushNotificationsConfiguration.from(data)
+
+        configuration.appId shouldBe "test-app-id"
+        configuration.region shouldBe "test-region"
+    }
+
+    @Test
+    fun `throws exception if notifications section missing from amplify outputs`() {
+        val data = amplifyOutputsData {
+            // do not set notifications config
+        }
+
+        shouldThrow<NotificationsException> {
+            AWSPinpointPushNotificationsConfiguration.from(data)
+        }
+    }
+}

--- a/aws-storage-s3/build.gradle.kts
+++ b/aws-storage-s3/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     testImplementation(libs.test.mockk)
     testImplementation(libs.test.androidx.workmanager)
     testImplementation(libs.test.kotlin.coroutines)
+    testImplementation(libs.test.kotest.assertions)
     testImplementation(project(":aws-storage-s3"))
 
     androidTestImplementation(project(":testutils"))

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -20,11 +20,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.OptIn;
 import androidx.annotation.VisibleForTesting;
 
+import com.amplifyframework.annotations.InternalAmplifyApi;
 import com.amplifyframework.annotations.InternalApiWarning;
 import com.amplifyframework.auth.AuthCredentialsProvider;
 import com.amplifyframework.auth.CognitoCredentialsProvider;
 import com.amplifyframework.core.Consumer;
 import com.amplifyframework.core.NoOpConsumer;
+import com.amplifyframework.core.configuration.AmplifyOutputsData;
 import com.amplifyframework.storage.StorageAccessLevel;
 import com.amplifyframework.storage.StorageException;
 import com.amplifyframework.storage.StoragePlugin;
@@ -218,6 +220,29 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
             );
         }
 
+        configure(context, region, bucket);
+    }
+
+    @Override
+    @InternalAmplifyApi
+    public void configure(@NonNull AmplifyOutputsData configuration, @NonNull Context context) throws StorageException {
+        AmplifyOutputsData.Storage storage = configuration.getStorage();
+
+        if (storage == null) {
+            throw new StorageException(
+                "Missing storage configuration",
+                "Ensure that storage configuration is present in your Amplify Outputs"
+            );
+        }
+
+        configure(context, storage.getAwsRegion(), storage.getBucketName());
+    }
+
+    private void configure(
+        @NonNull Context context,
+        @NonNull String region,
+        @NonNull String bucket
+    ) throws StorageException {
         try {
             this.storageService = (AWSS3StorageService) storageServiceFactory.create(context, region, bucket);
         } catch (RuntimeException exception) {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -178,7 +178,6 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
     }
 
     @Override
-    @SuppressWarnings("MagicNumber") // TODO: Remove once default values are moved to configuration
     public void configure(
         JSONObject pluginConfiguration,
         @NonNull Context context
@@ -238,6 +237,7 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         configure(context, storage.getAwsRegion(), storage.getBucketName());
     }
 
+    @SuppressWarnings("MagicNumber") // TODO: Remove once default values are moved to configuration
     private void configure(
         @NonNull Context context,
         @NonNull String region,

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/AWSS3StoragePluginTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/AWSS3StoragePluginTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3
+
+import com.amplifyframework.storage.StorageException
+import com.amplifyframework.storage.s3.service.AWSS3StorageService
+import com.amplifyframework.storage.s3.service.StorageService
+import com.amplifyframework.testutils.configuration.amplifyOutputsData
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class AWSS3StoragePluginTest {
+
+    private val storageServiceFactory = mockk<StorageService.Factory> {
+        every { create(any(), any(), any()) } returns mockk<AWSS3StorageService>()
+    }
+
+    private val plugin = AWSS3StoragePlugin(
+        storageServiceFactory,
+        mockk(),
+        mockk()
+    )
+
+    @Test
+    fun `configures with AmplifyOutputs`() {
+        val data = amplifyOutputsData {
+            storage {
+                awsRegion = "test-region"
+                bucketName = "test-bucket"
+            }
+        }
+
+        plugin.configure(data, mockk())
+
+        verify {
+            storageServiceFactory.create(any(), "test-region", "test-bucket")
+        }
+    }
+
+    @Test
+    fun `throws exception if storage configuration is missing`() {
+        val data = amplifyOutputsData {
+            // do not add storage config
+        }
+
+        shouldThrow<StorageException> {
+            plugin.configure(data, mockk())
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,8 @@ tasks.register<Delete>("clean").configure {
 
 val internalApiAnnotations = listOf(
     "com.amplifyframework.annotations.InternalApiWarning",
-    "com.amplifyframework.annotations.InternalAmplifyApi"
+    "com.amplifyframework.annotations.InternalAmplifyApi",
+    "com.amplifyframework.annotations.AmplifyFlutterApi"
 )
 
 subprojects {

--- a/core/src/main/java/com/amplifyframework/logging/LoggingCategory.java
+++ b/core/src/main/java/com/amplifyframework/logging/LoggingCategory.java
@@ -21,6 +21,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.annotations.InternalAmplifyApi;
 import com.amplifyframework.core.Resources;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryConfiguration;
@@ -134,6 +135,7 @@ public final class LoggingCategory extends Category<LoggingPlugin<?>> implements
     }
 
     @Override
+    @InternalAmplifyApi
     public synchronized void configure(@NonNull AmplifyOutputsData configuration, @NonNull Context context)
         throws AmplifyException {
         // Logging plugin config is read from a separate file

--- a/core/src/main/java/com/amplifyframework/logging/LoggingCategory.java
+++ b/core/src/main/java/com/amplifyframework/logging/LoggingCategory.java
@@ -25,6 +25,7 @@ import com.amplifyframework.core.Resources;
 import com.amplifyframework.core.category.Category;
 import com.amplifyframework.core.category.CategoryConfiguration;
 import com.amplifyframework.core.category.CategoryType;
+import com.amplifyframework.core.configuration.AmplifyOutputsData;
 import com.amplifyframework.util.Environment;
 
 import org.json.JSONObject;
@@ -128,6 +129,18 @@ public final class LoggingCategory extends Category<LoggingPlugin<?>> implements
     public synchronized void configure(@NonNull CategoryConfiguration configuration, @NonNull Context context)
         throws AmplifyException {
         super.configure(configuration, context);
+        // Logging plugin config is read from a separate file
+        configure(context);
+    }
+
+    @Override
+    public synchronized void configure(@NonNull AmplifyOutputsData configuration, @NonNull Context context)
+        throws AmplifyException {
+        // Logging plugin config is read from a separate file
+        configure(context);
+    }
+
+    private void configure(@NonNull Context context) throws AmplifyException {
         JSONObject loggingConfiguration = readConfigFile(context);
         Set<LoggingPlugin<?>> loggingPlugins = new HashSet<>(getPlugins());
         loggingPlugins.add(defaultPlugin);

--- a/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
@@ -38,6 +38,10 @@ class AmplifyOutputsDataBuilder : AmplifyOutputsData {
     fun notifications(func: NotificationsBuilder.() -> Unit) {
         notifications = NotificationsBuilder().apply(func)
     }
+
+    fun storage(func: StorageBuilder.() -> Unit) {
+        storage = StorageBuilder().apply(func)
+    }
 }
 
 class AnalyticsBuilder : AmplifyOutputsData.Analytics {
@@ -51,4 +55,9 @@ class NotificationsBuilder : AmplifyOutputsData.Notifications {
     override val channels: MutableList<AmplifyOutputsData.AmazonPinpointChannels> = mutableListOf(
         AmplifyOutputsData.AmazonPinpointChannels.FCM
     )
+}
+
+class StorageBuilder : AmplifyOutputsData.Storage {
+    override var awsRegion: String = "us-east-1"
+    override var bucketName: String = "bucket-name"
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
@@ -25,18 +25,30 @@ class AmplifyOutputsDataBuilder : AmplifyOutputsData {
     override var version = "1"
     override var analytics: AmplifyOutputsData.Analytics? = null
     override var auth: AmplifyOutputsData.Auth? = null
-    override val data: AmplifyOutputsData.Data? = null
-    override val geo: AmplifyOutputsData.Geo? = null
-    override val notifications: AmplifyOutputsData.Notifications? = null
-    override val storage: AmplifyOutputsData.Storage? = null
-    override val custom: JsonObject? = null
+    override var data: AmplifyOutputsData.Data? = null
+    override var geo: AmplifyOutputsData.Geo? = null
+    override var notifications: AmplifyOutputsData.Notifications? = null
+    override var storage: AmplifyOutputsData.Storage? = null
+    override var custom: JsonObject? = null
 
     fun analytics(func: AnalyticsBuilder.() -> Unit) {
         analytics = AnalyticsBuilder().apply(func)
+    }
+
+    fun notifications(func: NotificationsBuilder.() -> Unit) {
+        notifications = NotificationsBuilder().apply(func)
     }
 }
 
 class AnalyticsBuilder : AmplifyOutputsData.Analytics {
     override var awsRegion: String = "us-east-1"
     override var appId: String = "analytics-app-id"
+}
+
+class NotificationsBuilder : AmplifyOutputsData.Notifications {
+    override var awsRegion: String = "us-east-1"
+    override var amazonPinpointAppId: String = "pinpoint-app-id"
+    override val channels: MutableList<AmplifyOutputsData.AmazonPinpointChannels> = mutableListOf(
+        AmplifyOutputsData.AmazonPinpointChannels.FCM
+    )
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Adds configuration code for the following plugins using AmplifyOutputs

- Logging category (no-op, logging configuration is not included in Gen2)
- Storage
- DataStore (no-op, no datastore configuration in Gen2)
- PushNotifications
- Predictions (throws exception, Predictions not supported in Gen2)

The remaining plugins (API, Auth, and Geo) will be separate PRs as they are each more complex than these simple cases.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
