### PR TITLE
chore(all): Create Gen2 canary tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ __pycache__/
 **/credentials.json
 **/google_client_creds.json
 **/amplifyconfiguration*.json
+**/amplify_outputs.json
 
 # IDE files
 .idea/**

--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsCanaryTestGen2.kt
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsCanaryTestGen2.kt
@@ -45,8 +45,10 @@ import org.json.JSONException
 import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore("Backend is configured to require client secret, which is not supported in Gen2")
 class PinpointAnalyticsCanaryTestGen2 {
     companion object {
         private const val CREDENTIALS_RESOURCE_NAME = "credentials"

--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsCanaryTestGen2.kt
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsCanaryTestGen2.kt
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.analytics.pinpoint
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Pair
+import androidx.annotation.RawRes
+import androidx.test.core.app.ApplicationProvider
+import aws.sdk.kotlin.services.pinpoint.PinpointClient
+import aws.sdk.kotlin.services.pinpoint.model.EndpointLocation
+import aws.sdk.kotlin.services.pinpoint.model.EndpointResponse
+import aws.sdk.kotlin.services.pinpoint.model.GetEndpointRequest
+import com.amplifyframework.analytics.AnalyticsEvent
+import com.amplifyframework.analytics.AnalyticsProperties
+import com.amplifyframework.analytics.UserProfile
+import com.amplifyframework.analytics.pinpoint.models.AWSPinpointUserProfile
+import com.amplifyframework.analytics.pinpoint.test.R
+import com.amplifyframework.auth.AuthPlugin
+import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.configuration.AmplifyOutputs
+import com.amplifyframework.hub.HubChannel
+import com.amplifyframework.hub.HubEvent
+import com.amplifyframework.testutils.HubAccumulator
+import com.amplifyframework.testutils.Resources
+import com.amplifyframework.testutils.Sleep
+import com.amplifyframework.testutils.sync.SynchronousAuth
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
+import org.json.JSONException
+import org.junit.Assert
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+
+class PinpointAnalyticsCanaryTestGen2 {
+    companion object {
+        private const val CREDENTIALS_RESOURCE_NAME = "credentials"
+        private const val CONFIGURATION_NAME = "amplifyconfiguration"
+        private const val COGNITO_CONFIGURATION_TIMEOUT = 5 * 1000L
+        private const val PINPOINT_ROUNDTRIP_TIMEOUT = 10 * 1000L
+        private const val TIMEOUT_S = 20
+        private const val UNIQUE_ID_KEY = "UniqueId"
+        private const val PREFERENCES_AND_FILE_MANAGER_SUFFIX = "515d6767-01b7-49e5-8273-c8d11b0f331d"
+        private lateinit var synchronousAuth: SynchronousAuth
+        private lateinit var preferences: SharedPreferences
+        private lateinit var appId: String
+        private lateinit var uniqueId: String
+        private lateinit var pinpointClient: PinpointClient
+
+        @BeforeClass
+        @JvmStatic
+        fun setupBefore() {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+
+            @RawRes val resourceId = Resources.getRawResourceId(context, CONFIGURATION_NAME)
+            appId = readAppIdFromResource(context, resourceId)
+            preferences = context.getSharedPreferences(
+                "${appId}$PREFERENCES_AND_FILE_MANAGER_SUFFIX",
+                Context.MODE_PRIVATE
+            )
+            setUniqueId()
+            Amplify.Auth.addPlugin(AWSCognitoAuthPlugin() as AuthPlugin<*>)
+            Amplify.addPlugin(AWSPinpointAnalyticsPlugin())
+            Amplify.configure(
+                AmplifyOutputs(R.raw.amplify_outputs),
+                context
+            )
+            Sleep.milliseconds(COGNITO_CONFIGURATION_TIMEOUT)
+            synchronousAuth = SynchronousAuth.delegatingTo(Amplify.Auth)
+        }
+
+        private fun setUniqueId() {
+            uniqueId = UUID.randomUUID().toString()
+            preferences.edit().putString(UNIQUE_ID_KEY, uniqueId).commit()
+        }
+
+        private fun readCredentialsFromResource(context: Context, @RawRes resourceId: Int): Pair<String, String>? {
+            val resource = Resources.readAsJson(context, resourceId)
+            var userCredentials: Pair<String, String>? = null
+            return try {
+                val credentials = resource.getJSONArray("credentials")
+                for (index in 0 until credentials.length()) {
+                    val credential = credentials.getJSONObject(index)
+                    val username = credential.getString("username")
+                    val password = credential.getString("password")
+                    userCredentials = Pair(username, password)
+                }
+                userCredentials
+            } catch (jsonReadingFailure: JSONException) {
+                throw RuntimeException(jsonReadingFailure)
+            }
+        }
+
+        private fun readAppIdFromResource(context: Context, @RawRes resourceId: Int): String {
+            val resource = Resources.readAsJson(context, resourceId)
+            return try {
+                val analyticsJson = resource.getJSONObject("analytics")
+                val pluginsJson = analyticsJson.getJSONObject("plugins")
+                val pluginJson = pluginsJson.getJSONObject("awsPinpointAnalyticsPlugin")
+                val pinpointJson = pluginJson.getJSONObject("pinpointAnalytics")
+                pinpointJson.getString("appId")
+            } catch (jsonReadingFailure: JSONException) {
+                throw RuntimeException(jsonReadingFailure)
+            }
+        }
+    }
+
+    @Before
+    fun flushEvents() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        @RawRes val resourceId = Resources.getRawResourceId(context, CREDENTIALS_RESOURCE_NAME)
+        val userAndPasswordPair = readCredentialsFromResource(context, resourceId)
+        synchronousAuth.signOut()
+        synchronousAuth.signIn(
+            userAndPasswordPair!!.first,
+            userAndPasswordPair.second
+        )
+        val hubAccumulator =
+            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsChannelEventName.FLUSH_EVENTS, 1).start()
+        Amplify.Analytics.flushEvents()
+        hubAccumulator.await(10, TimeUnit.SECONDS)
+        pinpointClient = Amplify.Analytics.getPlugin("awsPinpointAnalyticsPlugin").escapeHatch as
+            PinpointClient
+        uniqueId = preferences.getString(UNIQUE_ID_KEY, "error-no-unique-id")!!
+        Assert.assertNotEquals(uniqueId, "error-no-unique-id")
+    }
+
+    @Test
+    fun recordEvent_flushEvent() {
+        val hubAccumulator =
+            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsChannelEventName.FLUSH_EVENTS, 2).start()
+        val eventName = "Amplify-event" + UUID.randomUUID().toString()
+        val event = AnalyticsEvent.builder()
+            .name(eventName)
+            .addProperty("AnalyticsStringProperty", "Pancakes")
+            .addProperty("AnalyticsBooleanProperty", true)
+            .addProperty("AnalyticsDoubleProperty", 3.14)
+            .addProperty("AnalyticsIntegerProperty", 42)
+            .build()
+
+        Amplify.Analytics.recordEvent(event)
+        Amplify.Analytics.flushEvents()
+        val hubEvents = hubAccumulator.await(TIMEOUT_S, TimeUnit.SECONDS)
+        val submittedEvents = combineAndFilterEvents(hubEvents)
+        Assert.assertEquals(1, submittedEvents.size.toLong())
+    }
+
+    @Test
+    fun registerGlobalProperties() {
+        val hubAccumulator =
+            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsChannelEventName.FLUSH_EVENTS, 2).start()
+        val eventName = "Amplify-event" + UUID.randomUUID().toString()
+        val event = AnalyticsEvent.builder()
+            .name(eventName)
+            .addProperty("AnalyticsStringProperty", "Pancakes")
+            .addProperty("AnalyticsBooleanProperty", true)
+            .addProperty("AnalyticsDoubleProperty", 3.14)
+            .addProperty("AnalyticsIntegerProperty", 42)
+            .build()
+
+        Amplify.Analytics.recordEvent(event)
+        Amplify.Analytics.registerGlobalProperties(
+            AnalyticsProperties.builder()
+                .add("AppStyle", "DarkMode")
+                .build()
+        )
+        Amplify.Analytics.flushEvents()
+        val hubEvents = hubAccumulator.await(TIMEOUT_S, TimeUnit.SECONDS)
+        val submittedEvents = combineAndFilterEvents(hubEvents)
+        Assert.assertEquals(1, submittedEvents.size.toLong())
+    }
+
+    @Test
+    fun unregisterGlobalProperties() {
+        val hubAccumulator =
+            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsChannelEventName.FLUSH_EVENTS, 2).start()
+        val eventName = "Amplify-event" + UUID.randomUUID().toString()
+        val event = AnalyticsEvent.builder()
+            .name(eventName)
+            .addProperty("AnalyticsStringProperty", "Pancakes")
+            .addProperty("AnalyticsBooleanProperty", true)
+            .addProperty("AnalyticsDoubleProperty", 3.14)
+            .addProperty("AnalyticsIntegerProperty", 42)
+            .build()
+
+        Amplify.Analytics.recordEvent(event)
+        Amplify.Analytics.unregisterGlobalProperties("AppStyle")
+        Amplify.Analytics.flushEvents()
+        val hubEvents = hubAccumulator.await(TIMEOUT_S, TimeUnit.SECONDS)
+        val submittedEvents = combineAndFilterEvents(hubEvents)
+        Assert.assertEquals(1, submittedEvents.size.toLong())
+    }
+
+    @Test
+    fun identifyUser() {
+        val location = testLocation
+        val properties = endpointProperties
+        val userProfile = AWSPinpointUserProfile.builder()
+            .name("test-user")
+            .email("user@test.com")
+            .plan("test-plan")
+            .location(location)
+            .customProperties(properties)
+            .build()
+        Amplify.Analytics.identifyUser(UUID.randomUUID().toString(), userProfile)
+        Sleep.milliseconds(PINPOINT_ROUNDTRIP_TIMEOUT)
+        val endpointResponse = fetchEndpointResponse()
+        assertCommonEndpointResponseProperties(endpointResponse)
+        assert(null == endpointResponse.user!!.userAttributes)
+    }
+
+    private val endpointProperties: AnalyticsProperties
+        get() {
+            return AnalyticsProperties.builder()
+                .add("TestStringProperty", "TestStringValue")
+                .add("TestDoubleProperty", 1.0)
+                .build()
+        }
+    private val testLocation: UserProfile.Location
+        get() {
+            return UserProfile.Location.builder()
+                .latitude(47.6154086)
+                .longitude(-122.3349685)
+                .postalCode("98122")
+                .city("Seattle")
+                .region("WA")
+                .country("USA")
+                .build()
+        }
+
+    private fun combineAndFilterEvents(hubEvents: List<HubEvent<*>>): MutableList<AnalyticsEvent> {
+        val result = mutableListOf<AnalyticsEvent>()
+        hubEvents.forEach {
+            if ((it.data as List<*>).isNotEmpty()) {
+                (it.data as ArrayList<*>).forEach { event ->
+                    if (!(event as AnalyticsEvent).name.startsWith("_session")) {
+                        result.add(event)
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    private fun assertCommonEndpointResponseProperties(endpointResponse: EndpointResponse) {
+        val attributes = endpointResponse.attributes!!
+        Assert.assertEquals("user@test.com", attributes["email"]!![0])
+        Assert.assertEquals("test-user", attributes["name"]!![0])
+        Assert.assertEquals("test-plan", attributes["plan"]!![0])
+        val endpointProfileLocation: EndpointLocation = endpointResponse.location!!
+        Assert.assertEquals(47.6154086, endpointProfileLocation.latitude ?: 0.0, 0.1)
+        Assert.assertEquals((-122.3349685), endpointProfileLocation.longitude ?: 0.0, 0.1)
+        Assert.assertEquals("98122", endpointProfileLocation.postalCode)
+        Assert.assertEquals("Seattle", endpointProfileLocation.city)
+        Assert.assertEquals("WA", endpointProfileLocation.region)
+        Assert.assertEquals("USA", endpointProfileLocation.country)
+        Assert.assertEquals("TestStringValue", attributes["TestStringProperty"]!![0])
+        Assert.assertEquals(1.0, endpointResponse.metrics!!["TestDoubleProperty"]!!, 0.1)
+    }
+
+    private fun fetchEndpointResponse(): EndpointResponse {
+        var endpointResponse: EndpointResponse? = null
+        runBlocking {
+            endpointResponse = pinpointClient.getEndpoint(
+                GetEndpointRequest.invoke {
+                    this.applicationId = appId
+                    this.endpointId = uniqueId
+                }
+            ).endpointResponse
+        }
+        assert(null != endpointResponse)
+        return endpointResponse!!
+    }
+}

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTestGen2.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTestGen2.kt
@@ -1,0 +1,549 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito
+
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.api.aws.AWSApiPlugin
+import com.amplifyframework.api.rest.RestOptions
+import com.amplifyframework.auth.AuthProvider
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
+import com.amplifyframework.auth.cognito.options.AuthFlowType
+import com.amplifyframework.auth.cognito.result.AWSCognitoAuthSignOutResult
+import com.amplifyframework.auth.cognito.test.R
+import com.amplifyframework.auth.cognito.testutils.Credentials
+import com.amplifyframework.auth.options.AuthFetchSessionOptions
+import com.amplifyframework.auth.options.AuthSignOutOptions
+import com.amplifyframework.auth.options.AuthSignUpOptions
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.AmplifyConfiguration
+import com.amplifyframework.core.configuration.AmplifyOutputs
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Ignore
+import org.junit.Test
+
+class AuthCanaryTestGen2 {
+    companion object {
+        private const val TIMEOUT_S = 20L
+        private val TAG = AuthCanaryTestGen2::class.simpleName
+        private val mainThreadSurrogate = newSingleThreadContext("Main thread")
+        private val attributes = listOf(
+            (AuthUserAttribute(AuthUserAttributeKey.address(), "Sesame Street")),
+            (AuthUserAttribute(AuthUserAttributeKey.name(), "Elmo")),
+            (AuthUserAttribute(AuthUserAttributeKey.gender(), "Male")),
+            (AuthUserAttribute(AuthUserAttributeKey.birthdate(), "February 3")),
+            (AuthUserAttribute(AuthUserAttributeKey.phoneNumber(), "+16268319333")), // Elmo's phone #
+            (AuthUserAttribute(AuthUserAttributeKey.updatedAt(), "${System.currentTimeMillis()}"))
+        )
+
+        private val api = AWSApiPlugin()
+        private val auth = AWSCognitoAuthPlugin()
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            // Gen2 doesn't support REST API as of v1 schema, so for now we will initialize an API plugin with the
+            // Gen1 config json. We can then use this plugin directly instead of calling Amplify.API
+            val amplifyConfiguration = AmplifyConfiguration.fromConfigFile(ApplicationProvider.getApplicationContext())
+            val apiJson = amplifyConfiguration.forCategoryType(api.categoryType).getPluginConfig(api.pluginKey)
+            api.configure(apiJson, ApplicationProvider.getApplicationContext())
+
+            try {
+                Amplify.addPlugin(auth)
+                Amplify.configure(AmplifyOutputs(R.raw.amplify_outputs), ApplicationProvider.getApplicationContext())
+            } catch (error: AmplifyException) {
+                Log.e(TAG, "Could not initialize Amplify", error)
+            }
+        }
+    }
+
+    private lateinit var username: String
+    private lateinit var password: String
+    private lateinit var tempUsername: String
+    private lateinit var tempPassword: String
+    private var signedUpNewUser = false
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun resetAuth() {
+        signOutUser()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        Dispatchers.setMain(mainThreadSurrogate)
+        Credentials.load(context).let {
+            username = it.first
+            password = it.second
+        }
+        tempUsername = UUID.randomUUID().toString()
+        tempPassword = UUID.randomUUID().toString()
+        signedUpNewUser = false
+    }
+
+    @After
+    fun teardown() {
+        if (signedUpNewUser) {
+            signedUpNewUser = false
+            signOutUser()
+            deleteTemporaryUser(tempUsername)
+        }
+    }
+
+    @Test
+    fun signUp() {
+        val latch = CountDownLatch(1)
+        val options = AuthSignUpOptions.builder()
+            .userAttribute(AuthUserAttributeKey.email(), "my@email.com")
+            .build()
+        Amplify.Auth.signUp(
+            tempUsername,
+            tempPassword,
+            options,
+            {
+                signedUpNewUser = true
+                latch.countDown()
+            },
+            { fail("Sign up failed: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    // Test requires confirmation code, testing onError call.
+    @Test
+    fun confirmSignUp() {
+        val latch = CountDownLatch(1)
+        Amplify.Auth.confirmSignUp(
+            "username",
+            "the code you received via email",
+            { fail("Confirm sign up completed successfully, expected confirm sign up to fail") },
+            { latch.countDown() }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    @Ignore("Sending sign up confirmation code is disabled in the user pool.")
+    fun resendSignUpCode() {
+        signUpUser(tempUsername, tempPassword)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.resendSignUpCode(
+            tempUsername,
+            { latch.countDown() },
+            { fail("Failed to confirm sign up: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun signIn() {
+        val latch = CountDownLatch(1)
+        val options = AWSCognitoAuthSignInOptions.builder().authFlowType(AuthFlowType.USER_SRP_AUTH).build()
+        Amplify.Auth.signIn(
+            username,
+            password,
+            options,
+            { result ->
+                if (result.isSignedIn) {
+                    latch.countDown()
+                } else {
+                    fail("Sign in not complete")
+                }
+            },
+            { fail("Failed to sign in: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    @Ignore("Test will require UI. Implementation is TODO.")
+    fun signInWithWebUI() { }
+
+    @Test
+    @Ignore("Test will require UI. Implementation is TODO.")
+    fun signInWithSocialWebUi() { }
+
+    // Test requires confirmation code, testing onError call
+    @Test
+    fun confirmSignIn() {
+        val latch = CountDownLatch(1)
+        Amplify.Auth.confirmSignIn(
+            "confirmation code",
+            { fail("Confirm sign in completed successfully, expected confirm sign in to fail") },
+            { latch.countDown() }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun fetchAuthSession() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.fetchAuthSession(
+            { latch.countDown() },
+            { fail("Failed to fetch session: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun fetchAuthSessionWithRefresh() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        val option = AuthFetchSessionOptions.builder().forceRefresh(true).build()
+        Amplify.Auth.fetchAuthSession(
+            option,
+            { latch.countDown() },
+            { fail("Failed to fetch session: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    @Ignore("Test fails with missing device key error. Ignoring test pending investigation.")
+    fun rememberDevice() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.rememberDevice(
+            { latch.countDown() },
+            { fail("Remember device failed: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    @Ignore("Test fails with missing device key error. Ignoring test pending investigation.")
+    fun forgetDevice() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.forgetDevice(
+            { latch.countDown() },
+            { fail("Forget device failed with error: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun fetchDevices() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.fetchDevices(
+            { latch.countDown() },
+            { fail("Fetch devices failed with error: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    @Ignore("Test requires a temporary user with a confirmed email.")
+    fun resetPassword() {
+        signUpUser(tempUsername, tempPassword)
+        confirmTemporaryUserSignUp(tempUsername)
+        signInUser(tempUsername, tempPassword)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.resetPassword(
+            tempUsername,
+            { latch.countDown() },
+            { fail("Reset password failed: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    // Test requires confirmation code, testing onError call
+    @Test
+    fun confirmResetPassword() {
+        val latch = CountDownLatch(1)
+        try {
+            Amplify.Auth.confirmResetPassword(
+                "username",
+                "NewPassword123",
+                "confirmation code",
+                { fail("New password confirmed, expected confirm reset password to fail") },
+                { latch.countDown() }
+            )
+        } catch (e: Exception) {
+            fail(e.toString())
+        }
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun updatePassword() {
+        signUpUser(tempUsername, tempPassword)
+        confirmTemporaryUserSignUp(tempUsername)
+        signInUser(tempUsername, tempPassword)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.updatePassword(
+            tempPassword,
+            tempPassword + "1",
+            { latch.countDown() },
+            { fail("Password update failed: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun fetchUserAttributes() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.fetchUserAttributes(
+            { latch.countDown() },
+            { fail("Failed to fetch user attributes: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun updateUserAttribute() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.updateUserAttribute(
+            AuthUserAttribute(AuthUserAttributeKey.name(), "apitest"),
+            { latch.countDown() },
+            { fail("Failed to update user attribute: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun updateUserAttributes() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.updateUserAttributes(
+            attributes, // attributes is a list of AuthUserAttribute
+            { latch.countDown() },
+            { fail("Failed to update user attributes: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    // Test requires confirmation code, testing onError call
+    @Test
+    fun confirmUserAttribute() {
+        val latch = CountDownLatch(1)
+        Amplify.Auth.confirmUserAttribute(
+            AuthUserAttributeKey.email(),
+            "344299",
+            { fail("Confirmed user attribute with incorrect code, expected confirm user attribute to fail.") },
+            { latch.countDown() }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    @Ignore("Test fails when run too frequently due to resend confirmation code limit exceeded.")
+    fun resendUserAttributeConfirmationCode() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.resendUserAttributeConfirmationCode(
+            AuthUserAttributeKey.email(),
+            { latch.countDown() },
+            { fail("Failed to resend code: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun getCurrentUser() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.getCurrentUser(
+            { latch.countDown() },
+            { fail("Get current user failed with an exception: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun signOut() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.signOut { signOutResult ->
+            when (signOutResult) {
+                is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
+                    // Sign Out completed fully and without errors.
+                    latch.countDown()
+                }
+                is AWSCognitoAuthSignOutResult.PartialSignOut -> {
+                    // Sign Out completed with some errors. User is signed out of the device.
+                    signOutResult.hostedUIError?.let { fail("HostedUIError while signing out: $it") }
+                    signOutResult.globalSignOutError?.let { fail("GlobalSignOutError while signing out: $it") }
+                    signOutResult.revokeTokenError?.let { fail("RevokeTokenError: $it") }
+                }
+                is AWSCognitoAuthSignOutResult.FailedSignOut -> {
+                    // Sign Out failed with an exception, leaving the user signed in.
+                    fail("Sign out failed: ${signOutResult.exception}")
+                }
+            }
+        }
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun globalSignOut() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        val options = AuthSignOutOptions.builder()
+            .globalSignOut(true)
+            .build()
+        Amplify.Auth.signOut(options) { signOutResult ->
+            when (signOutResult) {
+                is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
+                    // Sign Out completed fully and without errors.
+                    latch.countDown()
+                }
+                is AWSCognitoAuthSignOutResult.PartialSignOut -> {
+                    // Sign Out completed with some errors. User is signed out of the device.
+                    signOutResult.hostedUIError?.let { fail("HostedUIError while signing out: $it") }
+                    signOutResult.globalSignOutError?.let { fail("GlobalSignOutError while signing out: $it") }
+                    signOutResult.revokeTokenError?.let { fail("RevokeTokenError: $it") }
+                }
+                is AWSCognitoAuthSignOutResult.FailedSignOut -> {
+                    // Sign Out failed with an exception, leaving the user signed in.
+                    fail("Sign out failed: ${signOutResult.exception}")
+                }
+            }
+        }
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun deleteUser() {
+        signUpUser(tempUsername, tempPassword)
+        confirmTemporaryUserSignUp(tempUsername)
+        signInUser(tempUsername, tempPassword)
+        val latch = CountDownLatch(1)
+        Amplify.Auth.deleteUser(
+            {
+                signedUpNewUser = false
+                latch.countDown()
+            },
+            { fail("Delete user failed: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    @Ignore("OAuth flows not set up.")
+    fun testFederateToIdentityPool() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        auth.federateToIdentityPool(
+            "YOUR_TOKEN",
+            AuthProvider.facebook(),
+            { latch.countDown() },
+            { fail("Failed to federate to Identity Pool: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    @Ignore("OAuth flows not set up.")
+    fun testClearFederateToIdentityPool() {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        auth.clearFederationToIdentityPool(
+            { latch.countDown() },
+            { fail("Failed to clear federation: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    private fun signUpUser(user: String, pass: String) {
+        val latch = CountDownLatch(1)
+        val options = AuthSignUpOptions.builder()
+            .userAttribute(AuthUserAttributeKey.email(), "my@email.com")
+            .build()
+        auth.signUp(
+            user,
+            pass,
+            options,
+            {
+                signedUpNewUser = true
+                latch.countDown()
+            },
+            {
+                Log.e(TAG, "Sign up failed", it)
+                latch.countDown()
+            }
+        )
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+    }
+
+    private fun signInUser(user: String, pass: String) {
+        val latch = CountDownLatch(1)
+        auth.signIn(user, pass, { latch.countDown() }, { latch.countDown() })
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+    }
+
+    private fun signOutUser() {
+        val latch = CountDownLatch(1)
+        auth.signOut { latch.countDown() }
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+    }
+
+    private fun deleteTemporaryUser(user: String) {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        val request = RestOptions.builder()
+            .addPath("/deleteUser")
+            .addBody("{\"username\":\"$user\"}".toByteArray())
+            .addHeader("Content-Type", "application/json")
+            .build()
+        api.post(
+            request,
+            { latch.countDown() },
+            {
+                Log.e(TAG, "Error deleting user", it)
+                latch.countDown()
+            }
+        )
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+        signOutUser()
+    }
+
+    private fun confirmTemporaryUserSignUp(user: String) {
+        signInUser(username, password)
+        val latch = CountDownLatch(1)
+        val request = RestOptions.builder()
+            .addPath("/confirmUserSignUp")
+            .addBody("{\"username\":\"$user\"}".toByteArray())
+            .addHeader("Content-Type", "application/json")
+            .build()
+        api.post(
+            request,
+            { latch.countDown() },
+            {
+                Log.e(TAG, "Error confirming user", it)
+                latch.countDown()
+            }
+        )
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+        signOutUser()
+    }
+}

--- a/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/DatastoreCanaryTestGen2.kt
+++ b/aws-datastore/src/androidTest/java/com/amplifyframework/datastore/DatastoreCanaryTestGen2.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.datastore
+
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.configuration.AmplifyOutputs
+import com.amplifyframework.datastore.test.R
+import com.amplifyframework.hub.HubChannel
+import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider
+import com.amplifyframework.testmodels.commentsblog.Post
+import com.amplifyframework.testmodels.commentsblog.PostStatus
+import com.amplifyframework.testutils.HubAccumulator
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.BeforeClass
+import org.junit.Test
+
+class DatastoreCanaryTestGen2 {
+    companion object {
+        private const val TIMEOUT_S = 20L
+        private val TAG = DatastoreCanaryTestGen2::class.simpleName
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            try {
+                Amplify.addPlugin(
+                    AWSDataStorePlugin.builder()
+                        .modelProvider(AmplifyModelProvider.getInstance())
+                        .build()
+                )
+                Amplify.configure(AmplifyOutputs(R.raw.amplify_outputs), ApplicationProvider.getApplicationContext())
+            } catch (error: AmplifyException) {
+                Log.e(TAG, "Could not initialize Amplify", error)
+            }
+        }
+    }
+
+    @After
+    fun teardown() {
+        val latch = CountDownLatch(1)
+        Amplify.DataStore.clear(
+            { latch.countDown() },
+            {
+                latch.countDown()
+                Log.e(TAG, "Error clearing DataStore", it)
+            }
+        )
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun save() {
+        val latch = CountDownLatch(1)
+        val post = Post.builder()
+            .title("Post" + UUID.randomUUID().toString())
+            .status(PostStatus.ACTIVE)
+            .rating(3)
+            .build()
+
+        Amplify.DataStore.save(
+            post,
+            { latch.countDown() },
+            { fail("Error creating post: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun query() {
+        val latch = CountDownLatch(1)
+        Amplify.DataStore.query(
+            Post::class.java,
+            { latch.countDown() },
+            { fail("Error retrieving posts: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun delete() {
+        val post = Post.builder()
+            .title("Post" + UUID.randomUUID().toString())
+            .status(PostStatus.ACTIVE)
+            .rating(3)
+            .id(UUID.randomUUID().toString())
+            .build()
+
+        val saveLatch = CountDownLatch(1)
+        val createHub = HubAccumulator.create(
+            HubChannel.DATASTORE,
+            DataStoreHubEventFilters.enqueueOf(Post::class.simpleName, post.id),
+            1
+        ).start()
+
+        Amplify.DataStore.save(
+            post,
+            { saveLatch.countDown() },
+            { fail("Error creating post: $it") }
+        )
+        saveLatch.await(TIMEOUT_S, TimeUnit.SECONDS)
+        createHub.await(TIMEOUT_S.toInt(), TimeUnit.SECONDS)
+
+        val deleteLatch = CountDownLatch(1)
+        Amplify.DataStore.delete(
+            post,
+            { deleteLatch.countDown() },
+            { fail("Failed to delete post: $it") }
+        )
+        // Temporarily prevent https://github.com/aws-amplify/amplify-android/issues/2617
+        Thread.sleep(1000)
+        assertTrue(deleteLatch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun start() {
+        val latch = CountDownLatch(1)
+        Amplify.DataStore.start(
+            { latch.countDown() },
+            { fail("Error starting DataStore: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun observe() {
+        val latch = CountDownLatch(1)
+        Amplify.DataStore.observe(
+            Post::class.java,
+            { latch.countDown() },
+            {
+                val post = it.item()
+                Log.i(TAG, "Post: $post")
+            },
+            { fail("Observation failed: $it") },
+            { Log.i(TAG, "Observation complete") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun stop() {
+        val latch = CountDownLatch(1)
+        Amplify.DataStore.stop(
+            { latch.countDown() },
+            { fail("Error stopping DataStore: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun clear() {
+        val latch = CountDownLatch(1)
+        Amplify.DataStore.clear(
+            { latch.countDown() },
+            { fail("Error clearing DataStore: $it") }
+        )
+        assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+}

--- a/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/GeoCanaryTestGen2.kt
+++ b/aws-geo-location/src/androidTest/java/com/amplifyframework/geo/location/GeoCanaryTestGen2.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.geo.location
+
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.configuration.AmplifyOutputs
+import com.amplifyframework.geo.location.test.R
+import com.amplifyframework.geo.models.Coordinates
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert
+import org.junit.Assert.fail
+import org.junit.BeforeClass
+import org.junit.Test
+
+class GeoCanaryTestGen2 {
+    companion object {
+        private const val TIMEOUT_S = 20L
+        private val TAG = GeoCanaryTestGen2::class.simpleName
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            try {
+                Amplify.addPlugin(AWSCognitoAuthPlugin())
+                Amplify.addPlugin(AWSLocationGeoPlugin())
+                Amplify.configure(AmplifyOutputs(R.raw.amplify_outputs), ApplicationProvider.getApplicationContext())
+            } catch (error: AmplifyException) {
+                Log.e(TAG, "Could not initialize Amplify", error)
+            }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        signOutFromCognito()
+    }
+
+    @Test
+    fun searchByText() {
+        val latch = CountDownLatch(1)
+        signInWithCognito()
+        val searchQuery = "Amazon Go"
+        try {
+            Amplify.Geo.searchByText(
+                searchQuery,
+                {
+                    for (place in it.places) {
+                        Log.i(TAG, place.toString())
+                    }
+                    latch.countDown()
+                },
+                { fail("Failed to search for $searchQuery: $it") }
+            )
+        } catch (e: Exception) {
+            fail(e.toString())
+        }
+        Assert.assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun searchByCoordinates() {
+        val latch = CountDownLatch(1)
+        signInWithCognito()
+        val position = Coordinates(47.6153, -122.3384)
+        try {
+            Amplify.Geo.searchByCoordinates(
+                position,
+                {
+                    for (place in it.places) {
+                        Log.i(TAG, place.toString())
+                    }
+                    latch.countDown()
+                },
+                { fail("Failed to reverse geocode $position: $it") }
+            )
+        } catch (e: Exception) {
+            fail(e.toString())
+        }
+        Assert.assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    private fun signInWithCognito() {
+        val latch = CountDownLatch(1)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val (username, password) = Credentials.load(context)
+        Amplify.Auth.signIn(
+            username,
+            password,
+            { latch.countDown() },
+            { Log.e(TAG, "Failed to sign in", it) }
+        )
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+    }
+
+    private fun signOutFromCognito() {
+        val latch = CountDownLatch(1)
+        Amplify.Auth.signOut {
+            latch.countDown()
+        }
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+    }
+}

--- a/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/StorageCanaryTestGen2.kt
+++ b/aws-storage-s3/src/androidTest/java/com/amplifyframework/storage/s3/StorageCanaryTestGen2.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.storage.s3
+
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.configuration.AmplifyOutputs
+import com.amplifyframework.storage.StorageAccessLevel
+import com.amplifyframework.storage.operation.StorageUploadFileOperation
+import com.amplifyframework.storage.options.StoragePagedListOptions
+import com.amplifyframework.storage.options.StorageUploadFileOptions
+import com.amplifyframework.storage.s3.test.R
+import java.io.File
+import java.io.FileInputStream
+import java.io.RandomAccessFile
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.Assert
+import org.junit.Assert.fail
+import org.junit.BeforeClass
+import org.junit.Test
+
+class StorageCanaryTestGen2 {
+    companion object {
+        private const val TIMEOUT_S = 20L
+        private val TAG = StorageCanaryTestGen2::class.simpleName
+        private const val TEMP_DIR_PROPERTY = "java.io.tmpdir"
+        private val TEMP_DIR = System.getProperty(TEMP_DIR_PROPERTY)
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            try {
+                Amplify.addPlugin(AWSCognitoAuthPlugin())
+                Amplify.addPlugin(AWSS3StoragePlugin())
+                Amplify.configure(AmplifyOutputs(R.raw.amplify_outputs), ApplicationProvider.getApplicationContext())
+            } catch (error: AmplifyException) {
+                Log.e(TAG, "Could not initialize Amplify", error)
+            }
+        }
+    }
+
+    @Test
+    fun uploadInputStream() {
+        val latch = CountDownLatch(1)
+        val raf = createFile(1)
+        val stream = FileInputStream(raf)
+        val fileKey = "ExampleKey"
+        Amplify.Storage.uploadInputStream(
+            fileKey,
+            stream,
+            { latch.countDown() },
+            { fail("Upload failed: $it") }
+        )
+        Assert.assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+        removeFile(fileKey)
+    }
+
+    @Test
+    fun uploadFile() {
+        val latch = CountDownLatch(1)
+        val file = createFile(1)
+        val fileKey = UUID.randomUUID().toString()
+        Amplify.Storage.uploadFile(
+            fileKey,
+            file,
+            { latch.countDown() },
+            { fail("Upload failed: $it") }
+        )
+        Assert.assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+        removeFile(fileKey)
+    }
+
+    @Test
+    fun downloadFile() {
+        val uploadLatch = CountDownLatch(1)
+        val file = createFile(1)
+        val fileName = "ExampleKey${UUID.randomUUID()}"
+        Amplify.Storage.uploadFile(
+            fileName,
+            file,
+            { uploadLatch.countDown() },
+            { fail("Upload failed: $it") }
+        )
+        uploadLatch.await(TIMEOUT_S, TimeUnit.SECONDS)
+
+        val downloadLatch = CountDownLatch(1)
+        Amplify.Storage.downloadFile(
+            fileName,
+            file,
+            { downloadLatch.countDown() },
+            { fail("Download failed: $it") }
+        )
+        Assert.assertTrue(downloadLatch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun getUrl() {
+        val latch = CountDownLatch(1)
+        Amplify.Storage.getUrl(
+            "ExampleKey",
+            {
+                Log.i(TAG, "Successfully generated: ${it.url}")
+                latch.countDown()
+            },
+            { fail("URL generation failure: $it") }
+        )
+        Assert.assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun getTransfer() {
+        val uploadLatch = CountDownLatch(1)
+        val file = createFile(100)
+        val fileName = "ExampleKey${UUID.randomUUID()}"
+        val transferId = AtomicReference<String>()
+        val opContainer = AtomicReference<StorageUploadFileOperation<*>>()
+        val op = Amplify.Storage.uploadFile(
+            fileName,
+            file,
+            StorageUploadFileOptions.builder().accessLevel(StorageAccessLevel.PUBLIC).build(),
+            { progress ->
+                if (progress.currentBytes > 0) {
+                    opContainer.get().pause()
+                }
+                uploadLatch.countDown()
+            },
+            { Log.i(TAG, "Successfully uploaded: ${it.key}") },
+            { fail("Upload failed: $it") }
+        )
+        opContainer.set(op)
+        transferId.set(op.transferId)
+        uploadLatch.await(TIMEOUT_S, TimeUnit.SECONDS)
+
+        val transferLatch = CountDownLatch(1)
+        Amplify.Storage.getTransfer(
+            transferId.get(),
+            { operation ->
+                Log.i(TAG, "Current State" + operation.transferState)
+                transferLatch.countDown()
+            },
+            { fail("Failed to query transfer: $it") }
+        )
+        Assert.assertTrue(transferLatch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun list() {
+        val options = StoragePagedListOptions.builder()
+            .setPageSize(1000)
+            .build()
+        val latch = CountDownLatch(1)
+        Amplify.Storage.list(
+            "",
+            options,
+            { result ->
+                result.items.forEach { item ->
+                    Log.i(TAG, "Item: ${item.key}")
+                }
+                latch.countDown()
+            },
+            { fail("Failed to list items: $it") }
+        )
+        Assert.assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun remove() {
+        val latch = CountDownLatch(1)
+        Amplify.Storage.remove(
+            "myUploadedFileName.txt",
+            {
+                Log.i(TAG, "Successfully removed: ${it.key}")
+                latch.countDown()
+            },
+            { fail("Failed to remove file: $it") }
+        )
+        Assert.assertTrue(latch.await(TIMEOUT_S, TimeUnit.SECONDS))
+    }
+
+    private fun createFile(size: Int): File {
+        val file = File(TEMP_DIR!! + File.separator + "file")
+        file.createNewFile()
+        val raf = RandomAccessFile(file, "rw")
+        raf.setLength((size * 1024 * 1024).toLong())
+        raf.close()
+        file.deleteOnExit()
+        return file
+    }
+
+    private fun removeFile(fileKey: String) {
+        val latch = CountDownLatch(1)
+        Amplify.Storage.remove(
+            fileKey,
+            { latch.countDown() },
+            { Log.e(TAG, "Failed to remove file", it) }
+        )
+        latch.await(TIMEOUT_S, TimeUnit.SECONDS)
+    }
+}

--- a/configuration/instrumentation-tests.gradle
+++ b/configuration/instrumentation-tests.gradle
@@ -14,13 +14,13 @@ def module_backends = [
 ]
 
 def canaryTests = [
-        'aws-datastore'   : ['com.amplifyframework.datastore.DatastoreCanaryTest'],
-        'aws-auth-cognito': ['com.amplifyframework.auth.cognito.AuthCanaryTest'],
-        'aws-analytics-pinpoint': ['com.amplifyframework.analytics.pinpoint.PinpointAnalyticsCanaryTest'],
-        'aws-geo-location': ['com.amplifyframework.geo.location.GeoCanaryTest'],
+        'aws-datastore'   : ['com.amplifyframework.datastore.DatastoreCanaryTest', 'com.amplifyframework.datastore.DatastoreCanaryTestGen2'],
+        'aws-auth-cognito': ['com.amplifyframework.auth.cognito.AuthCanaryTest', 'com.amplifyframework.auth.cognito.AuthCanaryTestGen2'],
+        'aws-analytics-pinpoint': ['com.amplifyframework.analytics.pinpoint.PinpointAnalyticsCanaryTest', 'com.amplifyframework.analytics.pinpoint.PinpointAnalyticsCanaryTestGen2'],
+        'aws-geo-location': ['com.amplifyframework.geo.location.GeoCanaryTest', 'com.amplifyframework.geo.location.GeoCanaryTestGen2'],
         'aws-predictions': ['com.amplifyframework.predictions.aws.PredictionsCanaryTest'],
 //      'aws-push-notifications-pinpoint': ['com.amplifyframework.pushnotifications.pinpoint.NotificationsCanaryTest'],
-        'aws-storage-s3': ['com.amplifyframework.storage.s3.StorageCanaryTest']
+        'aws-storage-s3': ['com.amplifyframework.storage.s3.StorageCanaryTest', 'com.amplifyframework.storage.s3.StorageCanaryTestGen2']
 ]
 
 subprojects {

--- a/scripts/pull_backend_config_from_s3
+++ b/scripts/pull_backend_config_from_s3
@@ -16,6 +16,7 @@ readonly config_files=(
     "aws-analytics-pinpoint/src/androidTest/res/raw/amplifyconfiguration.json"
     "aws-analytics-pinpoint/src/androidTest/res/raw/awsconfiguration.json"
     "aws-analytics-pinpoint/src/androidTest/res/raw/credentials.json"
+    "aws-analytics-pinpoint/src/androidTest/res/raw/amplify_outputs.json"
 
     # API
     "aws-api/src/androidTest/res/raw/amplifyconfiguration.json"
@@ -29,6 +30,7 @@ readonly config_files=(
     "aws-datastore/src/androidTest/res/raw/credentials.json"
     "aws-datastore/src/androidTest/res/raw/google_client_creds.json"
     "aws-datastore/src/androidTest/res/raw/amplifyconfigurationupdated.json"
+    "aws-datastore/src/androidTest/res/raw/amplify_outputs.json"
 
     # DataStore V2
     "aws-datastore/src/androidTest/res/raw/amplifyconfiguration_v2.json"
@@ -41,11 +43,13 @@ readonly config_files=(
     "aws-storage-s3/src/androidTest/res/raw/amplifyconfiguration.json"
     "aws-storage-s3/src/androidTest/res/raw/awsconfiguration.json"
     "aws-storage-s3/src/androidTest/res/raw/credentials.json"
+    "aws-storage-s3/src/androidTest/res/raw/amplify_outputs.json"
 
     # Geo
     "aws-geo-location/src/androidTest/res/raw/amplifyconfiguration.json"
     "aws-geo-location/src/androidTest/res/raw/awsconfiguration.json"
     "aws-geo-location/src/androidTest/res/raw/credentials.json"
+    "aws-geo-location/src/androidTest/res/raw/amplify_outputs.json"
 
     # Maplibre Adapter
     "maplibre-adapter/src/androidTest/res/raw/amplifyconfiguration.json"
@@ -57,6 +61,7 @@ readonly config_files=(
     "aws-auth-cognito/src/androidTest/res/raw/amplifyconfiguration_totp.json"
     "aws-auth-cognito/src/androidTest/res/raw/awsconfiguration.json"
     "aws-auth-cognito/src/androidTest/res/raw/credentials.json"
+    "aws-auth-cognito/src/androidTest/res/raw/amplify_outputs.json"
 )
 
 # Set up output path


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Add a Gen2 version of each Canary Test class. This is a straight copy/paste of the existing Canary Test (with one exception, see below) except the configuration has been replaced with using `amplify_outputs`.

One exception: The Auth canary test used a REST API to use backend functions for confirming and deleting users. This isn't supported in the v1 Gen2 schema, so this Gen2 canary test uses an API plugin directly with a Gen1 config to replicate this behaviour. This can be updated once amplify_outputs schema adds support for REST API.

The Analytics canary test is currently disabled because the auth backend is configured to require a client secret, which is not supported in Gen2 config.

The test classes are duplicated due to their need to run with the default environment we currently use on Device Farm, which has some limitations in the test runner it uses. I am currently working with Device Farm to try to use Test Orchestrator working in a custom environment. If that is successful then we can remove this duplication and use parameterized tests instead.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [x] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
