### PR TITLE
fix(auth): Remove authenticationFlowType from Gen2 config

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
@@ -177,7 +177,7 @@ data class AuthConfiguration internal constructor(
                 ),
                 identityPool = identityPool,
                 oauth = oauth,
-                authFlowType = auth.authenticationFlowType.toConfigType(),
+                authFlowType = AuthFlowType.USER_SRP_AUTH,
                 signUpAttributes = auth.standardRequiredAttributes,
                 usernameAttributes = auth.usernameAttributes.map { it.toConfigType() },
                 verificationMechanisms = auth.userVerificationTypes.map { it.toConfigType() },
@@ -221,11 +221,6 @@ data class AuthConfiguration internal constructor(
 
         private inline fun <T> JSONArray.map(func: JSONArray.(Int) -> T) = List(length()) {
             func(it)
-        }
-
-        private fun AmplifyOutputsData.Auth.AuthenticationFlowType.toConfigType() = when (this) {
-            AmplifyOutputsData.Auth.AuthenticationFlowType.USER_SRP_AUTH -> AuthFlowType.USER_SRP_AUTH
-            AmplifyOutputsData.Auth.AuthenticationFlowType.CUSTOM_AUTH -> AuthFlowType.CUSTOM_AUTH
         }
 
         private fun AmplifyOutputsData.Auth.UsernameAttributes.toConfigType() = when (this) {

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthConfigurationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthConfigurationTest.kt
@@ -180,7 +180,6 @@ class AuthConfigurationTest {
                 userPoolId = "userpool"
                 userPoolClientId = "userpool-client"
                 identityPoolId = "identity-pool"
-                authenticationFlowType = AmplifyOutputsData.Auth.AuthenticationFlowType.CUSTOM_AUTH
                 passwordPolicy {
                     requireLowercase = true
                     requireSymbols = true
@@ -203,7 +202,7 @@ class AuthConfigurationTest {
 
         val configuration = AuthConfiguration.from(data)
 
-        configuration.authFlowType shouldBe AuthFlowType.CUSTOM_AUTH
+        configuration.authFlowType shouldBe AuthFlowType.USER_SRP_AUTH
         configuration.userPool.shouldNotBeNull().run {
             region shouldBe "test-region"
             poolId shouldBe "userpool"
@@ -243,13 +242,12 @@ class AuthConfigurationTest {
                 awsRegion = "test-region"
                 userPoolId = "userpool"
                 userPoolClientId = "userpool-client"
-                authenticationFlowType = AmplifyOutputsData.Auth.AuthenticationFlowType.CUSTOM_AUTH
             }
         }
 
         val configuration = AuthConfiguration.from(data)
 
-        configuration.authFlowType shouldBe AuthFlowType.CUSTOM_AUTH
+        configuration.authFlowType shouldBe AuthFlowType.USER_SRP_AUTH
         configuration.userPool.shouldNotBeNull().run {
             region shouldBe "test-region"
             poolId shouldBe "userpool"

--- a/core/src/main/java/com/amplifyframework/core/configuration/AmplifyOutputsData.kt
+++ b/core/src/main/java/com/amplifyframework/core/configuration/AmplifyOutputsData.kt
@@ -22,7 +22,6 @@ import com.amplifyframework.AmplifyException
 import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.core.configuration.AmplifyOutputsData.AmazonPinpointChannels
-import com.amplifyframework.core.configuration.AmplifyOutputsData.Auth.AuthenticationFlowType
 import com.amplifyframework.core.configuration.AmplifyOutputsData.Auth.MfaConfiguration
 import com.amplifyframework.core.configuration.AmplifyOutputsData.Auth.MfaMethods
 import com.amplifyframework.core.configuration.AmplifyOutputsData.Auth.Oauth.IdentityProviders
@@ -66,7 +65,6 @@ interface AmplifyOutputsData {
     @InternalAmplifyApi
     interface Auth {
         val awsRegion: String
-        val authenticationFlowType: AuthenticationFlowType
         val userPoolId: String
         val userPoolClientId: String
         val identityPoolId: String?
@@ -113,9 +111,6 @@ interface AmplifyOutputsData {
                 Token
             }
         }
-
-        @InternalAmplifyApi
-        enum class AuthenticationFlowType { USER_SRP_AUTH, CUSTOM_AUTH }
 
         @InternalAmplifyApi
         @Serializable
@@ -282,7 +277,6 @@ internal data class AmplifyOutputsDataImpl(
     @Serializable
     data class Auth(
         override val awsRegion: String,
-        override val authenticationFlowType: AuthenticationFlowType = AuthenticationFlowType.USER_SRP_AUTH,
         override val userPoolId: String,
         override val userPoolClientId: String,
         override val identityPoolId: String?,

--- a/core/src/test/java/com/amplifyframework/core/configuration/AmplifyOutputsDataTest.kt
+++ b/core/src/test/java/com/amplifyframework/core/configuration/AmplifyOutputsDataTest.kt
@@ -58,7 +58,6 @@ class AmplifyOutputsDataTest {
         val json = createJson(
             Keys.auth to mapOf(
                 Keys.region to "us-east-1",
-                Keys.authFlowType to AmplifyOutputsData.Auth.AuthenticationFlowType.USER_SRP_AUTH.name,
                 Keys.userPoolId to "user-pool",
                 Keys.userPoolClientId to "user-pool-client",
                 Keys.identityPoolId to "identity-pool",
@@ -106,7 +105,6 @@ class AmplifyOutputsDataTest {
         outputs.auth.shouldNotBeNull()
         outputs.auth?.run {
             awsRegion shouldBe "us-east-1"
-            authenticationFlowType shouldBe AmplifyOutputsData.Auth.AuthenticationFlowType.USER_SRP_AUTH
             userPoolId shouldBe "user-pool"
             userPoolClientId shouldBe "user-pool-client"
             identityPoolId shouldBe "identity-pool"
@@ -294,7 +292,6 @@ class AmplifyOutputsDataTest {
 
         // Auth
         const val auth = "auth"
-        const val authFlowType = "authentication_flow_type"
         const val userPoolId = "user_pool_id"
         const val userPoolClientId = "user_pool_client_id"
         const val identityPoolId = "identity_pool_id"

--- a/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
@@ -72,8 +72,6 @@ class AmazonPinpointBuilder : AmplifyOutputsData.Analytics.AmazonPinpoint {
 
 class AuthBuilder : AmplifyOutputsData.Auth {
     override var awsRegion: String = "us-east-1"
-    override var authenticationFlowType: AmplifyOutputsData.Auth.AuthenticationFlowType =
-        AmplifyOutputsData.Auth.AuthenticationFlowType.USER_SRP_AUTH
     override var userPoolId: String = "user-pool-id"
     override var userPoolClientId: String = "user-pool-client-id"
     override var identityPoolId: String? = null


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
`authentication_flow_type` is being removed from the Gen2 config. The default will be `USER_SRP_AUTH` unless the customer overrides it.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
