### PR TITLE
fix(auth): Fix incorrect statement about when userId is returned in AuthSignUpResult

### DIFF
--- a/core/src/main/java/com/amplifyframework/auth/result/AuthSignUpResult.java
+++ b/core/src/main/java/com/amplifyframework/auth/result/AuthSignUpResult.java
@@ -65,8 +65,8 @@ public final class AuthSignUpResult {
     }
 
     /**
-     * If {@link #isSignUpComplete} is true, this returns the newly registered user's id. Otherwise, null.
-     * @return the newly registered user's id if {@link #isSignUpComplete} is true. Otherwise, null.
+     * Returns the newly registered user's id if available. Otherwise, null.
+     * @return the newly registered user's id if available. Otherwise, null.
      */
     @Nullable
     public String getUserId() {


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.
- [ ] 

*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/2775

*Description of changes:*
userId is not returned in `AuthSignUpResult` for `confirmSignUp` as it is not returned to us from the API. Cognito will only return userId on `signUp` calls. 

We can't be more specific on this class, because `AuthSignUpResult` is in core, and a non-Cognito auth library may have different behavior as to when userId is and isn't returned.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
