### PR TITLE
chore(auth): Revert cognito/custom domain back to one field

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
@@ -151,8 +151,7 @@ data class AuthConfiguration internal constructor(
                 OauthConfiguration(
                     appClient = auth.userPoolClientId,
                     appSecret = null, // Not supported in Gen2
-                    // Use the custom domain if specified, otherwise use the generated cognito domain
-                    domain = it.customDomain ?: it.cognitoDomain,
+                    domain = it.domain,
                     scopes = it.scopes.toSet(),
                     // Note: Gen2 config gives an array for these values, while Gen1 is just a String. In Gen1
                     // if you specify multiple URIs the CLI will join them to a comma-delimited string in the json.

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthConfigurationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthConfigurationTest.kt
@@ -185,7 +185,7 @@ class AuthConfigurationTest {
                     requireSymbols = true
                 }
                 oauth {
-                    cognitoDomain = "https://test.com"
+                    domain = "https://test.com"
                     identityProviders += AmplifyOutputsData.Auth.Oauth.IdentityProviders.GOOGLE
                     scopes += listOf("myScope", "myScope2")
                     redirectSignInUri += "https://test.com/signin"
@@ -257,22 +257,6 @@ class AuthConfigurationTest {
         configuration.oauth.shouldBeNull()
         configuration.passwordProtectionSettings.shouldBeNull()
         configuration.identityPool.shouldBeNull()
-    }
-
-    @Test
-    fun `uses custom oauth domain if specified`() {
-        val data = amplifyOutputsData {
-            auth {
-                oauth {
-                    cognitoDomain = "cognito"
-                    customDomain = "custom"
-                }
-            }
-        }
-
-        val configuration = AuthConfiguration.from(data)
-
-        configuration.oauth?.domain shouldBe "custom"
     }
 
     @Test

--- a/core/src/main/java/com/amplifyframework/core/configuration/AmplifyOutputsData.kt
+++ b/core/src/main/java/com/amplifyframework/core/configuration/AmplifyOutputsData.kt
@@ -89,8 +89,7 @@ interface AmplifyOutputsData {
         @InternalAmplifyApi
         interface Oauth {
             val identityProviders: List<IdentityProviders>
-            val cognitoDomain: String
-            val customDomain: String?
+            val domain: String
             val scopes: List<String>
             val redirectSignInUri: List<String>
             val redirectSignOutUri: List<String>
@@ -301,8 +300,7 @@ internal data class AmplifyOutputsDataImpl(
         @Serializable
         data class Oauth(
             override val identityProviders: List<IdentityProviders>,
-            override val cognitoDomain: String,
-            override val customDomain: String?,
+            override val domain: String,
             override val scopes: List<String>,
             override val redirectSignInUri: List<String>,
             override val redirectSignOutUri: List<String>,

--- a/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
@@ -103,8 +103,7 @@ class PasswordPolicyBuilder : AmplifyOutputsData.Auth.PasswordPolicy {
 
 class OauthBuilder : AmplifyOutputsData.Auth.Oauth {
     override val identityProviders: MutableList<AmplifyOutputsData.Auth.Oauth.IdentityProviders> = mutableListOf()
-    override var cognitoDomain: String = "domain"
-    override var customDomain: String? = null
+    override var domain: String = "domain"
     override val scopes: MutableList<String> = mutableListOf()
     override val redirectSignInUri: MutableList<String> = mutableListOf()
     override val redirectSignOutUri: MutableList<String> = mutableListOf()


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Backend is reverting back to using a single domain field for oauth configuration.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
