### PR TITLE
fix(storage): Fix multiple instances of TransferDB leading to SQLiteDatabaseLockedException

### DIFF
--- a/aws-storage-s3/build.gradle.kts
+++ b/aws-storage-s3/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     testImplementation(libs.test.mockk)
     testImplementation(libs.test.androidx.workmanager)
     testImplementation(libs.test.kotlin.coroutines)
+    testImplementation(libs.test.kotest.assertions)
     testImplementation(project(":aws-storage-s3"))
 
     androidTestImplementation(project(":testutils"))

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferDBHelper.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferDBHelper.kt
@@ -24,14 +24,16 @@ import android.database.sqlite.SQLiteOpenHelper
 import android.database.sqlite.SQLiteQueryBuilder
 import android.net.Uri
 import android.text.TextUtils
-import androidx.annotation.VisibleForTesting
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.category.CategoryType
 import com.amplifyframework.storage.s3.AWSS3StoragePlugin
 
-@VisibleForTesting
-internal class TransferDBHelper(private val context: Context) :
-    SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+internal class TransferDBHelper(private val context: Context) : SQLiteOpenHelper(
+    context,
+    DATABASE_NAME,
+    null,
+    DATABASE_VERSION
+) {
 
     internal val contentUri: Uri
     private val uriMatcher: UriMatcher

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferManager.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferManager.kt
@@ -43,7 +43,7 @@ import kotlin.math.min
  * download files. It inserts upload and download records into the database and
  * enqueue a WorkRequest for WorkManager to service the transfer
  */
-internal class TransferManager @JvmOverloads constructor(
+internal class TransferManager(
     context: Context,
     s3: S3Client,
     private val pluginKey: String,
@@ -51,7 +51,8 @@ internal class TransferManager @JvmOverloads constructor(
 ) {
 
     private val transferDB: TransferDB = TransferDB.getInstance(context)
-    val transferStatusUpdater: TransferStatusUpdater = TransferStatusUpdater.getInstance(context)
+    val transferStatusUpdater: TransferStatusUpdater = TransferStatusUpdater(transferDB)
+
     private val logger =
         Amplify.Logging.logger(
             CategoryType.STORAGE,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferStatusUpdater.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferStatusUpdater.kt
@@ -15,7 +15,6 @@
 
 package com.amplifyframework.storage.s3.transfer
 
-import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import com.amplifyframework.core.Amplify
@@ -28,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Updates transfer status to observers and to local DB
  **/
-internal class TransferStatusUpdater private constructor(
+internal class TransferStatusUpdater(
     private val transferDB: TransferDB
 ) {
     private val logger =
@@ -64,13 +63,7 @@ internal class TransferStatusUpdater private constructor(
     }
 
     companion object {
-
         internal const val TEMP_FILE_PREFIX = "aws-s3-d861b25a-1edf-11eb-adc1-0242ac120002"
-
-        @JvmStatic
-        fun getInstance(context: Context): TransferStatusUpdater {
-            return TransferStatusUpdater(TransferDB.getInstance(context))
-        }
     }
 
     @Synchronized

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/transfer/TransferDBTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/transfer/TransferDBTest.kt
@@ -1,0 +1,28 @@
+package com.amplifyframework.storage.s3.transfer
+
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class TransferDBTest {
+
+    @After
+    fun teardown() {
+        // Clear instance
+        TransferDB.instance = null
+    }
+
+    @Test
+    fun `getInstance returns the same object`() {
+        val context = RuntimeEnvironment.getApplication()
+
+        val db1 = TransferDB.getInstance(context)
+        val db2 = TransferDB.getInstance(context)
+
+        db1 shouldBeSameInstanceAs db2
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
#2720 

*Description of changes:*
TransferDB is supposed to be a singleton but it was implemented incorrectly. Having multiple instance of this class causes multiple database connections, which can lead to the exception described in the issue.

Also made some minor cleanup in related classes.

*How did you test these changes?*
Unit test to verify the fix.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
