### PR TITLE
fix(analytics): Expose a constant for the API name used for Gen2 defineData

### DIFF
--- a/aws-api/api/aws-api.api
+++ b/aws-api/api/aws-api.api
@@ -1,4 +1,5 @@
 public final class com/amplifyframework/api/aws/AWSApiPlugin : com/amplifyframework/api/ApiPlugin {
+	public static final field GEN2_DATA_API_NAME Ljava/lang/String;
 	public fun <init> ()V
 	public fun <init> (Lcom/amplifyframework/api/aws/ApiAuthProviders;)V
 	public static fun builder ()Lcom/amplifyframework/api/aws/AWSApiPlugin$Builder;

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -74,6 +74,12 @@ import okhttp3.Protocol;
  */
 @SuppressWarnings("TypeParameterHidesVisibleType") // <R> shadows >com.amplifyframework.api.aws.R
 public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
+
+    /**
+     * The ApiName used by default for the GraphQL API represented by defineData in Amplify Gen2.
+     */
+    public static final String GEN2_DATA_API_NAME = "gen2DataApiName";
+
     private final Map<String, ClientDetails> apiDetails;
     private final Map<String, OkHttpConfigurator> apiHttpClientConfigurators;
     private final Map<String, OkHttpConfigurator> apiWebsocketUpgradeClientConfigurators;

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPlugin.java
@@ -76,9 +76,10 @@ import okhttp3.Protocol;
 public final class AWSApiPlugin extends ApiPlugin<Map<String, OkHttpClient>> {
 
     /**
-     * The ApiName used by default for the GraphQL API represented by defineData in Amplify Gen2.
+     * The ApiName used by default for the GraphQL API represented by defineData in amplify_outputs. This constant is
+     * not used for APIs present in amplifyconfiguration.json since they always have names.
      */
-    public static final String GEN2_DATA_API_NAME = "gen2DataApiName";
+    public static final String DEFAULT_GRAPHQL_API = "defaultGraphQLApi";
 
     private final Map<String, ClientDetails> apiDetails;
     private final Map<String, OkHttpConfigurator> apiHttpClientConfigurators;

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReader.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReader.java
@@ -35,7 +35,6 @@ import java.util.Set;
  * associated key.
  */
 final class AWSApiPluginConfigurationReader {
-    static final String GEN2_API_NAME = "default";
 
     private AWSApiPluginConfigurationReader() { /* no instances */ }
 
@@ -84,7 +83,7 @@ final class AWSApiPluginConfigurationReader {
             .build();
 
         return AWSApiPluginConfiguration.builder()
-                   .addApi(GEN2_API_NAME, apiConfigBuilder)
+                   .addApi(AWSApiPlugin.GEN2_DATA_API_NAME, apiConfigBuilder)
                    .build();
     }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReader.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReader.java
@@ -83,7 +83,7 @@ final class AWSApiPluginConfigurationReader {
             .build();
 
         return AWSApiPluginConfiguration.builder()
-                   .addApi(AWSApiPlugin.GEN2_DATA_API_NAME, apiConfigBuilder)
+                   .addApi(AWSApiPlugin.DEFAULT_GRAPHQL_API, apiConfigBuilder)
                    .build();
     }
 

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReaderTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReaderTest.kt
@@ -15,7 +15,7 @@
 package com.amplifyframework.api.aws
 
 import com.amplifyframework.api.ApiException
-import com.amplifyframework.api.aws.AWSApiPlugin.GEN2_DATA_API_NAME
+import com.amplifyframework.api.aws.AWSApiPlugin.DEFAULT_GRAPHQL_API
 import com.amplifyframework.core.configuration.AmplifyOutputsData
 import com.amplifyframework.testutils.Resources
 import com.amplifyframework.testutils.configuration.amplifyOutputsData
@@ -80,8 +80,8 @@ class AWSApiPluginConfigurationReaderTest {
 
         val config = AWSApiPluginConfigurationReader.from(outputs)
 
-        config.apis shouldContainKey GEN2_DATA_API_NAME
-        config.apis[GEN2_DATA_API_NAME]!!.run {
+        config.apis shouldContainKey DEFAULT_GRAPHQL_API
+        config.apis[DEFAULT_GRAPHQL_API]!!.run {
             region shouldBe "test-region"
             endpointType shouldBe EndpointType.GRAPHQL
             endpoint shouldBe "https://aws.com"
@@ -100,8 +100,8 @@ class AWSApiPluginConfigurationReaderTest {
 
         val config = AWSApiPluginConfigurationReader.from(outputs)
 
-        config.apis shouldContainKey GEN2_DATA_API_NAME
-        config.apis[GEN2_DATA_API_NAME]!!.run {
+        config.apis shouldContainKey DEFAULT_GRAPHQL_API
+        config.apis[DEFAULT_GRAPHQL_API]!!.run {
             apiKey.shouldBeNull()
         }
     }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReaderTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginConfigurationReaderTest.kt
@@ -15,7 +15,7 @@
 package com.amplifyframework.api.aws
 
 import com.amplifyframework.api.ApiException
-import com.amplifyframework.api.aws.AWSApiPluginConfigurationReader.GEN2_API_NAME
+import com.amplifyframework.api.aws.AWSApiPlugin.GEN2_DATA_API_NAME
 import com.amplifyframework.core.configuration.AmplifyOutputsData
 import com.amplifyframework.testutils.Resources
 import com.amplifyframework.testutils.configuration.amplifyOutputsData
@@ -80,8 +80,8 @@ class AWSApiPluginConfigurationReaderTest {
 
         val config = AWSApiPluginConfigurationReader.from(outputs)
 
-        config.apis shouldContainKey GEN2_API_NAME
-        config.apis[GEN2_API_NAME]!!.run {
+        config.apis shouldContainKey GEN2_DATA_API_NAME
+        config.apis[GEN2_DATA_API_NAME]!!.run {
             region shouldBe "test-region"
             endpointType shouldBe EndpointType.GRAPHQL
             endpoint shouldBe "https://aws.com"
@@ -100,8 +100,8 @@ class AWSApiPluginConfigurationReaderTest {
 
         val config = AWSApiPluginConfigurationReader.from(outputs)
 
-        config.apis shouldContainKey GEN2_API_NAME
-        config.apis[GEN2_API_NAME]!!.run {
+        config.apis shouldContainKey GEN2_DATA_API_NAME
+        config.apis[GEN2_DATA_API_NAME]!!.run {
             apiKey.shouldBeNull()
         }
     }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Gen2 doesn't have a concept of API names when using defineData, so we hardcode a default name to use instead.

We realized that you need to supply an API name to configure okhttp clients, so customers will need to supply this hardcoded default. Exposing this constant will avoid having customers need to copy/paste a string from documentation.

```kotlin
val plugin = AWSApiPlugin.builder()
  .configureClient(GEN2_DATA_API_NAME) { clientBuilder ->
    // ...
  }
  .build()
```

Also aligned the value of the constant with Swift to be `gen2DataApiName`.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
