### PR TITLE
fix(auth): Fix timestamp issue with v1 to v2 migration

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
@@ -182,16 +182,16 @@ internal class AWSCognitoLegacyCredentialStore(
         val accessKey = idAndCredentialsKeyValue.get(namespace(AK_KEY))
         val secretKey = idAndCredentialsKeyValue.get(namespace(SK_KEY))
         val sessionToken = idAndCredentialsKeyValue.get(namespace(ST_KEY))
-        var expiration = idAndCredentialsKeyValue.get(namespace(EXP_KEY))?.toLongOrNull()
 
         // V2 AWSCredential expiration is in epoch seconds whereas legacy expiration may be in epoch milliseconds
         // Session expiration should be within 24 hours so if we see a date in the far future, we can assume the
         // timestamp is encoded in milliseconds.
-        val expirationInstant = expiration?.let { Instant.ofEpochSecond(it) }
-        if (expiration != null &&
-            expirationInstant?.isAfter(Instant.now().plus(365, ChronoUnit.DAYS)) == true
-        ) {
-            expiration /= 1000
+        val expiration = idAndCredentialsKeyValue.get(namespace(EXP_KEY))?.toLongOrNull()?.let {
+            if (Instant.ofEpochSecond(it).isAfter(Instant.now().plus(365, ChronoUnit.DAYS))) {
+                it / 1000
+            } else {
+                it
+            }
         }
 
         return if (accessKey == null && secretKey == null && sessionToken == null) {

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStoreTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStoreTest.kt
@@ -96,7 +96,6 @@ class AWSCognitoLegacyCredentialStoreTest {
 
         private const val expirationTimestampInSec: Long = 1714431706
         private const val expirationTimestampInMs: Long = 1714431706486
-
     }
 
     @Mock

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStoreTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStoreTest.kt
@@ -93,6 +93,10 @@ class AWSCognitoLegacyCredentialStoreTest {
 
         private const val userDeviceDetailsCacheKey = "$deviceCachePrefix.$USER_POOL_ID.%s"
         private val deviceDetailsCacheKey = String.format(userDeviceDetailsCacheKey, userId)
+
+        private const val expirationTimestampInSec: Long = 1714431706
+        private const val expirationTimestampInMs: Long = 1714431706486
+
     }
 
     @Mock
@@ -181,7 +185,7 @@ class AWSCognitoLegacyCredentialStoreTest {
         `when`(mockKeyValue.get(cachedIdTokenKey)).thenReturn("idToken")
         `when`(mockKeyValue.get(cachedAccessTokenKey)).thenReturn(dummyToken)
         `when`(mockKeyValue.get(cachedRefreshTokenKey)).thenReturn("refreshToken")
-        `when`(mockKeyValue.get(cachedTokenExpirationKey)).thenReturn("123123")
+        `when`(mockKeyValue.get(cachedTokenExpirationKey)).thenReturn(expirationTimestampInMs.toString())
 
         // Device Metadata
         `when`(mockKeyValue.get("DeviceKey")).thenReturn("someDeviceKey")
@@ -192,7 +196,7 @@ class AWSCognitoLegacyCredentialStoreTest {
         `when`(mockKeyValue.get("$IDENTITY_POOL_ID.${"accessKey"}")).thenReturn("accessKeyId")
         `when`(mockKeyValue.get("$IDENTITY_POOL_ID.${"secretKey"}")).thenReturn("secretAccessKey")
         `when`(mockKeyValue.get("$IDENTITY_POOL_ID.${"sessionToken"}")).thenReturn("sessionToken")
-        `when`(mockKeyValue.get("$IDENTITY_POOL_ID.${"expirationDate"}")).thenReturn("123123")
+        `when`(mockKeyValue.get("$IDENTITY_POOL_ID.${"expirationDate"}")).thenReturn(expirationTimestampInMs.toString())
 
         // Identity ID
         `when`(mockKeyValue.get("$IDENTITY_POOL_ID.${"identityId"}")).thenReturn("identityPool")
@@ -225,10 +229,10 @@ class AWSCognitoLegacyCredentialStoreTest {
                 "amplify_user",
                 Date(0),
                 SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_SRP_AUTH),
-                CognitoUserPoolTokens("idToken", dummyToken, "refreshToken", 123123)
+                CognitoUserPoolTokens("idToken", dummyToken, "refreshToken", expirationTimestampInSec)
             ),
             "identityPool",
-            AWSCredentials("accessKeyId", "secretAccessKey", "sessionToken", 123123)
+            AWSCredentials("accessKeyId", "secretAccessKey", "sessionToken", expirationTimestampInSec)
         )
     }
 
@@ -249,10 +253,10 @@ class AWSCognitoLegacyCredentialStoreTest {
                 "amplify_user",
                 Date(0),
                 SignInMethod.HostedUI(),
-                CognitoUserPoolTokens("idToken", dummyToken, "refreshToken", 123123)
+                CognitoUserPoolTokens("idToken", dummyToken, "refreshToken", expirationTimestampInSec)
             ),
             "identityPool",
-            AWSCredentials("accessKeyId", "secretAccessKey", "sessionToken", 123123)
+            AWSCredentials("accessKeyId", "secretAccessKey", "sessionToken", expirationTimestampInSec)
         )
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/SessionHelperTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/SessionHelperTests.kt
@@ -17,15 +17,11 @@ package com.amplifyframework.auth.cognito.helpers
 
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import org.junit.After
 import org.junit.Test
 
 class SessionHelperTests {
@@ -42,11 +38,6 @@ class SessionHelperTests {
 
     // Encoded Date Time: April 30, 2024 02:00AM
     private val currentInstant = Instant.ofEpochSecond(1714467600)
-
-    @After
-    fun teardown() {
-        unmockkStatic(Instant::class)
-    }
 
     @Test
     fun testGetExpiration() {
@@ -78,9 +69,6 @@ class SessionHelperTests {
 
     @Test
     fun `Pulling a V1 credential should fail isValidSession check`() {
-        mockkStatic(Instant::class)
-        every { Instant.now() } returns currentInstant
-
         // Expiration is encoded in ms to simulate v1 > v2 migration issue
         assertFalse(
             SessionHelper.isValidSession(
@@ -88,7 +76,7 @@ class SessionHelperTests {
                     accessKeyId = dummyToken,
                     secretAccessKey = dummyToken,
                     sessionToken = dummyToken,
-                    expiration = currentInstant.plus(30, ChronoUnit.MINUTES).toEpochMilli()
+                    expiration = Instant.now().plus(30, ChronoUnit.MINUTES).toEpochMilli()
                 )
             )
         )
@@ -96,16 +84,13 @@ class SessionHelperTests {
 
     @Test
     fun `Session with an expiration in the past should fail isValidSession check`() {
-        mockkStatic(Instant::class)
-        every { Instant.now() } returns currentInstant
-
         assertFalse(
             SessionHelper.isValidSession(
                 AWSCredentials(
                     accessKeyId = dummyToken,
                     secretAccessKey = dummyToken,
                     sessionToken = dummyToken,
-                    expiration = currentInstant.minus(1, ChronoUnit.MINUTES).epochSecond
+                    expiration = Instant.now().minus(1, ChronoUnit.MINUTES).epochSecond
                 )
             )
         )
@@ -113,16 +98,13 @@ class SessionHelperTests {
 
     @Test
     fun `Session with an expiration in the future should pass isValidSession check`() {
-        mockkStatic(Instant::class)
-        every { Instant.now() } returns currentInstant
-
         assertTrue(
             SessionHelper.isValidSession(
                 AWSCredentials(
                     accessKeyId = dummyToken,
                     secretAccessKey = dummyToken,
                     sessionToken = dummyToken,
-                    expiration = currentInstant.plus(1, ChronoUnit.MINUTES).epochSecond
+                    expiration = Instant.now().plus(1, ChronoUnit.MINUTES).epochSecond
                 )
             )
         )

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/SessionHelperTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/SessionHelperTests.kt
@@ -19,7 +19,7 @@ import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import io.mockk.every
 import io.mockk.mockkStatic
-import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.test.assertEquals
@@ -45,7 +45,7 @@ class SessionHelperTests {
 
     @After
     fun teardown() {
-        unmockkAll()
+        unmockkStatic(Instant::class)
     }
 
     @Test

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/SessionHelperTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/SessionHelperTests.kt
@@ -82,12 +82,16 @@ class SessionHelperTests {
         every { Instant.now() } returns currentInstant
 
         // Expiration is encoded in ms to simulate v1 > v2 migration issue
-        assertFalse(SessionHelper.isValidSession(AWSCredentials(
-            accessKeyId = dummyToken,
-            secretAccessKey = dummyToken,
-            sessionToken = dummyToken,
-            expiration = currentInstant.plus(30, ChronoUnit.MINUTES).toEpochMilli()
-        )))
+        assertFalse(
+            SessionHelper.isValidSession(
+                AWSCredentials(
+                    accessKeyId = dummyToken,
+                    secretAccessKey = dummyToken,
+                    sessionToken = dummyToken,
+                    expiration = currentInstant.plus(30, ChronoUnit.MINUTES).toEpochMilli()
+                )
+            )
+        )
     }
 
     @Test
@@ -95,12 +99,16 @@ class SessionHelperTests {
         mockkStatic(Instant::class)
         every { Instant.now() } returns currentInstant
 
-        assertFalse(SessionHelper.isValidSession(AWSCredentials(
-            accessKeyId = dummyToken,
-            secretAccessKey = dummyToken,
-            sessionToken = dummyToken,
-            expiration = currentInstant.minus(1, ChronoUnit.MINUTES).epochSecond
-        )))
+        assertFalse(
+            SessionHelper.isValidSession(
+                AWSCredentials(
+                    accessKeyId = dummyToken,
+                    secretAccessKey = dummyToken,
+                    sessionToken = dummyToken,
+                    expiration = currentInstant.minus(1, ChronoUnit.MINUTES).epochSecond
+                )
+            )
+        )
     }
 
     @Test
@@ -108,11 +116,15 @@ class SessionHelperTests {
         mockkStatic(Instant::class)
         every { Instant.now() } returns currentInstant
 
-        assertTrue(SessionHelper.isValidSession(AWSCredentials(
-            accessKeyId = dummyToken,
-            secretAccessKey = dummyToken,
-            sessionToken = dummyToken,
-            expiration = currentInstant.plus(1, ChronoUnit.MINUTES).epochSecond
-        )))
+        assertTrue(
+            SessionHelper.isValidSession(
+                AWSCredentials(
+                    accessKeyId = dummyToken,
+                    secretAccessKey = dummyToken,
+                    sessionToken = dummyToken,
+                    expiration = currentInstant.plus(1, ChronoUnit.MINUTES).epochSecond
+                )
+            )
+        )
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/SessionHelperTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/SessionHelperTests.kt
@@ -36,9 +36,6 @@ class SessionHelperTests {
         expiration = 0
     )
 
-    // Encoded Date Time: April 30, 2024 02:00AM
-    private val currentInstant = Instant.ofEpochSecond(1714467600)
-
     @Test
     fun testGetExpiration() {
         val expiry = SessionHelper.getExpiration(dummyToken)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* https://github.com/aws-amplify/amplify-android/issues/2789

*Description of changes:* 
V1 was storing session expiration timestamp as epoch milliseconds and V2 was reading/storing it as epoch seconds. The migration code did not account for this and users that migrated would store a session expiration that would be many many years in the future.

This change adds some logic to the migration code to detect this and covert from milli to sec for new users that still need to migrate.

This change also adds a check in the isValidSession function for users who have already migrated and needs a way to fix themselves.

*How did you test these changes?*


*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
