### PR TITLE
fix(datastore): List errors that are returned from AppSync

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
@@ -320,8 +321,13 @@ final class SyncProcessor {
         return Single.create(emitter -> {
             Cancelable cancelable = appSync.sync(request, result -> {
                 if (!result.hasData()) {
+                    List<String> errorStrings = result.getErrors().stream()
+                                                    .map(GraphQLResponse.Error::toString)
+                                                    .collect(Collectors.toList());
+                    String errors = String.join(",\n", errorStrings);
+
                     emitter.onError(new DataStoreException.IrRecoverableException(
-                            "Empty response from AppSync.", "Report to AWS team."
+                            "Received errors from AppSync: " + errors, "Report to AWS team."
                     ));
                 } else {
                     if (result.hasErrors()) {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Improve logging of errors returned from AppSync. We previously erroneously reported a response with errors as an "empty response" which limits ability to diagnose the error. We will now include the actual error in the log message.

Before:
```
IrRecoverableException{message=Empty response from AppSync., cause=null, recoverySuggestion=Report to AWS team.}

```

After:
```
IrRecoverableException{message=Received errors from AppSync: GraphQLResponse.Error{message='Not Authorized to access syncGuests on type Query', locations='[GraphQLLocation{line='2', column='3'}]', path='[GraphQLPathSegment{value='syncGuests'}]', extensions='{errorInfo=null, data=null, errorType=Unauthorized}'}, cause=null, recoverySuggestion=Report to AWS team.}
```


*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
