### PR TITLE
fix(analytics): Make Analytics Options Builder build function public for Java to call

### DIFF
--- a/aws-analytics-pinpoint/api/aws-analytics-pinpoint.api
+++ b/aws-analytics-pinpoint/api/aws-analytics-pinpoint.api
@@ -33,6 +33,7 @@ public final class com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsP
 
 public final class com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin$Options$Builder {
 	public final fun autoFlushEventsInterval (J)Lcom/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin$Options$Builder;
+	public final fun build ()Lcom/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin$Options;
 	public final fun getAutoFlushEventsInterval ()J
 	public final fun getTrackLifecycleEvents ()Z
 	public final synthetic fun setAutoFlushEventsInterval (J)V

--- a/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.kt
+++ b/aws-analytics-pinpoint/src/main/java/com/amplifyframework/analytics/pinpoint/AWSPinpointAnalyticsPlugin.kt
@@ -191,7 +191,7 @@ class AWSPinpointAnalyticsPlugin @JvmOverloads constructor(
              */
             fun trackLifecycleEvents(value: Boolean) = apply { trackLifecycleEvents = value }
 
-            internal fun build() = Options(
+            fun build() = Options(
                 autoFlushEventsInterval = autoFlushEventsInterval,
                 trackLifecycleEvents = trackLifecycleEvents
             )


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2802

*Description of changes:*
Analytics Options Builder should have had a public build method. While it's not needed for Kotlin it is needed for Java.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update) - Docs to be updated once released

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
