### PR TITLE
chore: Move to using the Maven Publish DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,12 @@ fun Project.configureAndroid() {
                 )
             )
         }
+
+        publishing {
+            singleVariant("release") {
+                withSourcesJar()
+            }
+        }
     }
 
     dependencies {

--- a/configuration/publishing.gradle
+++ b/configuration/publishing.gradle
@@ -42,12 +42,6 @@ def getRepositoryPassword() {
 }
 
 afterEvaluate { project ->
-    task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
-        from android.sourceSets.main.java.source
-    }
-
-
     publishing {
         publications {
             library(MavenPublication) {
@@ -55,13 +49,7 @@ afterEvaluate { project ->
                 artifactId POM_ARTIFACT_ID
                 version VERSION_NAME
 
-                artifact("${buildDir}/outputs/aar/${artifactId}-release.aar")
-                if (project.getPlugins().hasPlugin('com.android.application') ||
-                        project.getPlugins().hasPlugin('com.android.library')) {
-                    artifact(androidSourcesJar)
-                } else {
-                    artifact(sourcesJar)
-                }
+                from(components.named("release").get())
 
                 pom {
                     name = POM_NAME
@@ -92,16 +80,12 @@ afterEvaluate { project ->
                     }
 
                     withXml {
-                        def dependenciesNode = asNode().appendNode('dependencies')
-                        // Note that this only handles implementation
-                        // dependencies. In the future, may need to add api,
-                        // etc.
-                        configurations.implementation.allDependencies.each {
-                            def dependencyNode = dependenciesNode.appendNode('dependency')
-                            dependencyNode.appendNode('groupId', it.group)
-                            dependencyNode.appendNode('artifactId', it.name)
-                            dependencyNode.appendNode('version', it.version)
-                        }
+                        // Remove the scope information for all dependencies. This puts
+                        // everything at "compile" scope, which matches the way Amplify V2 has been
+                        // published historically. For v3 we should remove this and include the
+                        // scope information for our dependencies.
+                        def dependencies = asNode().get('dependencies').first()
+                        dependencies.each { it.remove(it.get('scope')) }
                     }
                 }
             }
@@ -127,5 +111,11 @@ afterEvaluate { project ->
             useInMemoryPgpKeys(keyId, signingKey, signingPassword)
         }
         sign publishing.publications.library
+    }
+
+    // Turn off Gradle metadata. This is to maintain compatibility with the way Amplify V2 has
+    // been published historically. For v3 we should remove this and publish the gradle metadata.
+    tasks.withType(GenerateModuleMetadata).configureEach {
+        enabled = false
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Migrated publishing to use the [publishing DSL](https://developer.android.com/build/publish-library/configure-pub-variants#single-pub-var). This is a pre-requisite to upgrading to Gradle 8+.

The publishing DSL adds `scope` information and publishes Gradle metadata by default. Although those are beneficial, they could potentially impact customers and should not be added in a minor version, so I've disabled/removed both of those. They can be enabled in a future major version release.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
