### PR TITLE
fix(api): Fix the handling of exceptions when subscribing with Kotlin Facade

### DIFF
--- a/core-kotlin/build.gradle.kts
+++ b/core-kotlin/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(libs.test.mockk)
     testImplementation(libs.test.kotlin.coroutines)
     testImplementation(project(":testmodels"))
+    testImplementation(libs.test.kotest.assertions)
 }
 
 android.kotlinOptions {

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/api/KotlinApiFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/api/KotlinApiFacade.kt
@@ -108,7 +108,8 @@ class KotlinApiFacade(private val delegate: Delegate = Amplify.API) : Api {
                 { subscription.completions.tryEmit(Unit) }
             )
         }
-        subscription.cancelable = operation as Cancelable
+        // If subscribe fails it does not return an operation, and instead invokes the onSubscriptionFailure callback
+        operation?.let { subscription.cancelable = operation }
         return subscription.awaitStart()
     }
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
While testing subscription auth modes I found that exceptions during subscription would get replaced with a NPE when using the Kotlin Facade. Resolved the error so that the underlying exception gets propagated to the caller.

*How did you test these changes?*
- Unit test
- Verified issue could not be reproduced after change

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
