### PR TITLE
fix(api): Add missing JvmStatic annotations

### DIFF
--- a/aws-api/api/aws-api.api
+++ b/aws-api/api/aws-api.api
@@ -262,13 +262,13 @@ public final class com/amplifyframework/api/graphql/model/ModelQuery {
 
 public final class com/amplifyframework/api/graphql/model/ModelSubscription {
 	public static final field INSTANCE Lcom/amplifyframework/api/graphql/model/ModelSubscription;
-	public final fun of (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
-	public final fun of (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun of (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun of (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onCreate (Ljava/lang/Class;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onCreate (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
-	public final fun onDelete (Ljava/lang/Class;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun onDelete (Ljava/lang/Class;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onDelete (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
-	public final fun onUpdate (Ljava/lang/Class;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun onUpdate (Ljava/lang/Class;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onUpdate (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelSubscription.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelSubscription.kt
@@ -33,6 +33,7 @@ object ModelSubscription {
      * @param <M> the concrete type of the model.
      * @return a valid [GraphQLRequest] instance.
      </M> */
+    @JvmStatic
     fun <M : Model> of(
         modelType: Class<M>,
         type: SubscriptionType,
@@ -49,6 +50,7 @@ object ModelSubscription {
      * @param <P> the concrete model path for the M model type
      * @return a valid [GraphQLRequest] instance.
      </M> */
+    @JvmStatic
     fun <M : Model, P : ModelPath<M>> of(
         modelType: Class<M>,
         type: SubscriptionType,
@@ -93,6 +95,7 @@ object ModelSubscription {
      * @return a valid [GraphQLRequest] instance.
      * @see .of
      </M> */
+    @JvmStatic
     fun <M : Model> onDelete(modelType: Class<M>): GraphQLRequest<M> {
         return of(modelType, SubscriptionType.ON_DELETE)
     }
@@ -121,6 +124,7 @@ object ModelSubscription {
      * @return a valid [GraphQLRequest] instance.
      * @see .of
      </M> */
+    @JvmStatic
     fun <M : Model> onUpdate(modelType: Class<M>): GraphQLRequest<M> {
         return of(modelType, SubscriptionType.ON_UPDATE)
     }


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
In conversion of ModelSubscription file from Java to Kotlin, JvmStatic annotations were missed, which make calling from Java more difficult. Adding JvmStatic back to re-introduce calling without requiring `ModelSubscription.INSTANCE`

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
