### PR TITLE
feat(api): Add AuthMode to ModelSubscription

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
 [*.{kt,kts}]
 #this is to match java checkstyle
 max_line_length=120
+ktlint_code_style=android_studio

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="ENABLE_SECOND_REFORMAT" value="true" />
     <JavaCodeStyleSettings>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>

--- a/aws-api/api/aws-api.api
+++ b/aws-api/api/aws-api.api
@@ -83,7 +83,10 @@ public final class com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory {
 	public static final fun buildQuery (Ljava/lang/Class;Ljava/lang/String;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun buildQuery (Ljava/lang/Class;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun buildSubscription (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun buildSubscription (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lcom/amplifyframework/api/aws/AuthorizationType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun buildSubscription (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lcom/amplifyframework/api/aws/AuthorizationType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun buildSubscription (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static synthetic fun buildSubscription$default (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lcom/amplifyframework/api/aws/AuthorizationType;ILjava/lang/Object;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 }
 
 public final class com/amplifyframework/api/aws/BuildConfig {
@@ -263,12 +266,24 @@ public final class com/amplifyframework/api/graphql/model/ModelQuery {
 public final class com/amplifyframework/api/graphql/model/ModelSubscription {
 	public static final field INSTANCE Lcom/amplifyframework/api/graphql/model/ModelSubscription;
 	public static final fun of (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun of (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lcom/amplifyframework/api/aws/AuthorizationType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun of (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lcom/amplifyframework/api/aws/AuthorizationType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun of (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static synthetic fun of$default (Ljava/lang/Class;Lcom/amplifyframework/api/graphql/SubscriptionType;Lcom/amplifyframework/api/aws/AuthorizationType;ILjava/lang/Object;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onCreate (Ljava/lang/Class;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun onCreate (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun onCreate (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onCreate (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static synthetic fun onCreate$default (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;ILjava/lang/Object;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onDelete (Ljava/lang/Class;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun onDelete (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun onDelete (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onDelete (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static synthetic fun onDelete$default (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;ILjava/lang/Object;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onUpdate (Ljava/lang/Class;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun onUpdate (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static final fun onUpdate (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 	public static final fun onUpdate (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
+	public static synthetic fun onUpdate$default (Ljava/lang/Class;Lcom/amplifyframework/api/aws/AuthorizationType;ILjava/lang/Object;)Lcom/amplifyframework/api/graphql/GraphQLRequest;
 }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelSubscription.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/graphql/model/ModelSubscription.kt
@@ -15,6 +15,7 @@
 package com.amplifyframework.api.graphql.model
 
 import com.amplifyframework.api.aws.AppSyncGraphQLRequestFactory.buildSubscription
+import com.amplifyframework.api.aws.AuthorizationType
 import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.SubscriptionType
 import com.amplifyframework.core.model.Model
@@ -30,16 +31,17 @@ object ModelSubscription {
      * Builds a subscriptions request of a given `type` for a `modelType`.
      * @param modelType the model class.
      * @param type the subscription type.
+     * @param authMode The [AuthorizationType] to use for making the request
      * @param <M> the concrete type of the model.
      * @return a valid [GraphQLRequest] instance.
-     </M> */
+     */
     @JvmStatic
+    @JvmOverloads
     fun <M : Model> of(
         modelType: Class<M>,
         type: SubscriptionType,
-    ): GraphQLRequest<M> {
-        return buildSubscription(modelType, type)
-    }
+        authMode: AuthorizationType? = null
+    ): GraphQLRequest<M> = buildSubscription(modelType, type, authMode)
 
     /**
      * Builds a subscriptions request of a given `type` for a `modelType`.
@@ -49,27 +51,46 @@ object ModelSubscription {
      * @param <M> the concrete type of the model.
      * @param <P> the concrete model path for the M model type
      * @return a valid [GraphQLRequest] instance.
-     </M> */
+     */
     @JvmStatic
     fun <M : Model, P : ModelPath<M>> of(
         modelType: Class<M>,
         type: SubscriptionType,
         includes: ((P) -> List<PropertyContainerPath>)
-    ): GraphQLRequest<M> {
-        return buildSubscription(modelType, type, includes)
-    }
+    ): GraphQLRequest<M> = buildSubscription(modelType, type, includes)
+
+    /**
+     * Builds a subscriptions request of a given `type` for a `modelType`.
+     * @param modelType the model class.
+     * @param type the subscription type.
+     * @param authMode The [AuthorizationType] to use for making the request
+     * @param includes lambda returning list of relationships that should be included in the selection set
+     * @param <M> the concrete type of the model.
+     * @param <P> the concrete model path for the M model type
+     * @return a valid [GraphQLRequest] instance.
+     */
+    @JvmStatic
+    fun <M : Model, P : ModelPath<M>> of(
+        modelType: Class<M>,
+        type: SubscriptionType,
+        authMode: AuthorizationType,
+        includes: ((P) -> List<PropertyContainerPath>)
+    ): GraphQLRequest<M> = buildSubscription(modelType, type, authMode, includes)
 
     /**
      * Creates a subscription request of type [SubscriptionType.ON_CREATE].
      * @param modelType the model class.
+     * @param authMode The [AuthorizationType] to use for making the request
      * @param <M> the concrete type of the model.
      * @return a valid [GraphQLRequest] instance.
      * @see .of
-     </M> */
+     */
     @JvmStatic
-    fun <M : Model> onCreate(modelType: Class<M>): GraphQLRequest<M> {
-        return of(modelType, SubscriptionType.ON_CREATE)
-    }
+    @JvmOverloads
+    fun <M : Model> onCreate(
+        modelType: Class<M>,
+        authMode: AuthorizationType? = null
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_CREATE, authMode)
 
     /**
      * Creates a subscription request of type [SubscriptionType.ON_CREATE].
@@ -79,26 +100,44 @@ object ModelSubscription {
      * @param <P> the concrete model path for the M model type
      * @return a valid [GraphQLRequest] instance.
      * @see .of
-     </M> */
+     */
     @JvmStatic
     fun <M : Model, P : ModelPath<M>> onCreate(
         modelType: Class<M>,
         includes: ((P) -> List<PropertyContainerPath>)
-    ): GraphQLRequest<M> {
-        return of(modelType, SubscriptionType.ON_CREATE, includes)
-    }
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_CREATE, includes)
+
+    /**
+     * Creates a subscription request of type [SubscriptionType.ON_CREATE].
+     * @param modelType the model class.
+     * @param authMode The [AuthorizationType] to use for making the request
+     * @param includes lambda returning list of relationships that should be included in the selection set
+     * @param <M> the concrete type of the model.
+     * @param <P> the concrete model path for the M model type
+     * @return a valid [GraphQLRequest] instance.
+     * @see .of
+     */
+    @JvmStatic
+    fun <M : Model, P : ModelPath<M>> onCreate(
+        modelType: Class<M>,
+        authMode: AuthorizationType,
+        includes: ((P) -> List<PropertyContainerPath>)
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_CREATE, authMode, includes)
 
     /**
      * Creates a subscription request of type [SubscriptionType.ON_DELETE].
      * @param modelType the model class.
+     * @param authMode The [AuthorizationType] to use for making the request
      * @param <M> the concrete type of the model.
      * @return a valid [GraphQLRequest] instance.
      * @see .of
-     </M> */
+     */
     @JvmStatic
-    fun <M : Model> onDelete(modelType: Class<M>): GraphQLRequest<M> {
-        return of(modelType, SubscriptionType.ON_DELETE)
-    }
+    @JvmOverloads
+    fun <M : Model> onDelete(
+        modelType: Class<M>,
+        authMode: AuthorizationType? = null
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_DELETE, authMode)
 
     /**
      * Creates a subscription request of type [SubscriptionType.ON_DELETE].
@@ -108,26 +147,44 @@ object ModelSubscription {
      * @param <P> the concrete model path for the M model type
      * @return a valid [GraphQLRequest] instance.
      * @see .of
-     </M> */
+     */
     @JvmStatic
     fun <M : Model, P : ModelPath<M>> onDelete(
         modelType: Class<M>,
         includes: ((P) -> List<PropertyContainerPath>)
-    ): GraphQLRequest<M> {
-        return of(modelType, SubscriptionType.ON_DELETE, includes)
-    }
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_DELETE, includes)
+
+    /**
+     * Creates a subscription request of type [SubscriptionType.ON_DELETE].
+     * @param modelType the model class.
+     * @param authMode The [AuthorizationType] to use for making the request
+     * @param includes lambda returning list of relationships that should be included in the selection set
+     * @param <M> the concrete type of the model.
+     * @param <P> the concrete model path for the M model type
+     * @return a valid [GraphQLRequest] instance.
+     * @see .of
+     */
+    @JvmStatic
+    fun <M : Model, P : ModelPath<M>> onDelete(
+        modelType: Class<M>,
+        authMode: AuthorizationType,
+        includes: ((P) -> List<PropertyContainerPath>)
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_DELETE, authMode, includes)
 
     /**
      * Creates a subscription request of type [SubscriptionType.ON_UPDATE].
      * @param modelType the model class.
+     * @param authMode The [AuthorizationType] to use for making the request
      * @param <M> the concrete type of the model.
      * @return a valid [GraphQLRequest] instance.
      * @see .of
-     </M> */
+     */
     @JvmStatic
-    fun <M : Model> onUpdate(modelType: Class<M>): GraphQLRequest<M> {
-        return of(modelType, SubscriptionType.ON_UPDATE)
-    }
+    @JvmOverloads
+    fun <M : Model> onUpdate(
+        modelType: Class<M>,
+        authMode: AuthorizationType? = null
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_UPDATE, authMode)
 
     /**
      * Creates a subscription request of type [SubscriptionType.ON_UPDATE].
@@ -137,12 +194,27 @@ object ModelSubscription {
      * @param <P> the concrete model path for the M model type
      * @return a valid [GraphQLRequest] instance.
      * @see .of
-     </M> */
+     */
     @JvmStatic
     fun <M : Model, P : ModelPath<M>> onUpdate(
         modelType: Class<M>,
         includes: ((P) -> List<PropertyContainerPath>)
-    ): GraphQLRequest<M> {
-        return of(modelType, SubscriptionType.ON_UPDATE, includes)
-    }
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_UPDATE, includes)
+
+    /**
+     * Creates a subscription request of type [SubscriptionType.ON_UPDATE].
+     * @param modelType the model class.
+     * @param authMode The [AuthorizationType] to use for making the request
+     * @param includes lambda returning list of relationships that should be included in the selection set
+     * @param <M> the concrete type of the model.
+     * @param <P> the concrete model path for the M model type
+     * @return a valid [GraphQLRequest] instance.
+     * @see .of
+     */
+    @JvmStatic
+    fun <M : Model, P : ModelPath<M>> onUpdate(
+        modelType: Class<M>,
+        authMode: AuthorizationType,
+        includes: ((P) -> List<PropertyContainerPath>)
+    ): GraphQLRequest<M> = of(modelType, SubscriptionType.ON_UPDATE, authMode, includes)
 }

--- a/aws-api/src/test/java/com/amplifyframework/graphql/model/ModelSubscriptionTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/graphql/model/ModelSubscriptionTest.kt
@@ -16,12 +16,14 @@
 package com.amplifyframework.graphql.model
 
 import com.amplifyframework.api.aws.AppSyncGraphQLRequestFactory
+import com.amplifyframework.api.aws.AuthorizationType
 import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.SubscriptionType
 import com.amplifyframework.api.graphql.model.ModelSubscription
 import com.amplifyframework.core.model.includes
 import com.amplifyframework.testmodels.lazy.Post
 import com.amplifyframework.testmodels.lazy.PostPath
+import io.kotest.matchers.shouldBe
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -40,6 +42,23 @@ class ModelSubscriptionTest {
         val actualRequest = ModelSubscription.of(expectedClass, expectedType)
 
         assertEquals(expectedRequest, actualRequest)
+    }
+
+    @Test
+    fun `of with authMode`() {
+        val expectedClass = Post::class.java
+        val expectedType = SubscriptionType.ON_CREATE
+        val expectedAuthMode = AuthorizationType.OPENID_CONNECT
+
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory.buildSubscription(
+            expectedClass,
+            expectedType,
+            expectedAuthMode
+        )
+
+        val actualRequest = ModelSubscription.of(expectedClass, expectedType, expectedAuthMode)
+
+        actualRequest shouldBe expectedRequest
     }
 
     @Test
@@ -63,19 +82,57 @@ class ModelSubscriptionTest {
     }
 
     @Test
+    fun `of with includes and authMode`() {
+        val expectedClass = Post::class.java
+        val expectedType = SubscriptionType.ON_CREATE
+        val expectedAuthMode = AuthorizationType.OPENID_CONNECT
+
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory
+            .buildSubscription<Post, Post, PostPath>(
+                expectedClass,
+                expectedType,
+                expectedAuthMode
+            ) {
+                includes(it.comments, it.blog)
+            }
+
+        val actualRequest = ModelSubscription.of<Post, PostPath>(expectedClass, expectedType, expectedAuthMode) {
+            includes(it.comments, it.blog)
+        }
+
+        actualRequest shouldBe expectedRequest
+    }
+
+    @Test
     fun create() {
         val expectedClass = Post::class.java
         val expectedType = SubscriptionType.ON_CREATE
 
-        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory
-            .buildSubscription(
-                expectedClass,
-                expectedType
-            )
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory.buildSubscription(
+            expectedClass,
+            expectedType
+        )
 
         val actualRequest = ModelSubscription.onCreate(expectedClass)
 
         assertEquals(expectedRequest, actualRequest)
+    }
+
+    @Test
+    fun `create with authMode`() {
+        val expectedClass = Post::class.java
+        val expectedType = SubscriptionType.ON_CREATE
+        val expectedAuthMode = AuthorizationType.OPENID_CONNECT
+
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory.buildSubscription(
+            expectedClass,
+            expectedType,
+            expectedAuthMode
+        )
+
+        val actualRequest = ModelSubscription.onCreate(expectedClass, expectedAuthMode)
+
+        actualRequest shouldBe expectedRequest
     }
 
     @Test
@@ -99,19 +156,57 @@ class ModelSubscriptionTest {
     }
 
     @Test
+    fun `create with includes and authMode`() {
+        val expectedClass = Post::class.java
+        val expectedType = SubscriptionType.ON_CREATE
+        val expectedAuthMode = AuthorizationType.OPENID_CONNECT
+
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory
+            .buildSubscription<Post, Post, PostPath>(
+                expectedClass,
+                expectedType,
+                expectedAuthMode
+            ) {
+                includes(it.comments, it.blog)
+            }
+
+        val actualRequest = ModelSubscription.onCreate<Post, PostPath>(expectedClass, expectedAuthMode) {
+            includes(it.comments, it.blog)
+        }
+
+        actualRequest shouldBe expectedRequest
+    }
+
+    @Test
     fun delete() {
         val expectedClass = Post::class.java
         val expectedType = SubscriptionType.ON_DELETE
 
-        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory
-            .buildSubscription(
-                expectedClass,
-                expectedType
-            )
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory.buildSubscription(
+            expectedClass,
+            expectedType
+        )
 
         val actualRequest = ModelSubscription.onDelete(expectedClass)
 
         assertEquals(expectedRequest, actualRequest)
+    }
+
+    @Test
+    fun `delete with authMode`() {
+        val expectedClass = Post::class.java
+        val expectedType = SubscriptionType.ON_DELETE
+        val expectedAuthMode = AuthorizationType.OPENID_CONNECT
+
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory.buildSubscription(
+            expectedClass,
+            expectedType,
+            expectedAuthMode
+        )
+
+        val actualRequest = ModelSubscription.onDelete(expectedClass, expectedAuthMode)
+
+        actualRequest shouldBe expectedRequest
     }
 
     @Test
@@ -135,19 +230,57 @@ class ModelSubscriptionTest {
     }
 
     @Test
+    fun `delete with includes and authMode`() {
+        val expectedClass = Post::class.java
+        val expectedType = SubscriptionType.ON_DELETE
+        val expectedAuthMode = AuthorizationType.OPENID_CONNECT
+
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory
+            .buildSubscription<Post, Post, PostPath>(
+                expectedClass,
+                expectedType,
+                expectedAuthMode
+            ) {
+                includes(it.comments, it.blog)
+            }
+
+        val actualRequest = ModelSubscription.onDelete<Post, PostPath>(expectedClass, expectedAuthMode) {
+            includes(it.comments, it.blog)
+        }
+
+        actualRequest shouldBe expectedRequest
+    }
+
+    @Test
     fun update() {
         val expectedClass = Post::class.java
         val expectedType = SubscriptionType.ON_UPDATE
 
-        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory
-            .buildSubscription(
-                expectedClass,
-                expectedType
-            )
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory.buildSubscription(
+            expectedClass,
+            expectedType
+        )
 
         val actualRequest = ModelSubscription.onUpdate(expectedClass)
 
         assertEquals(expectedRequest, actualRequest)
+    }
+
+    @Test
+    fun `update with authMode`() {
+        val expectedClass = Post::class.java
+        val expectedType = SubscriptionType.ON_UPDATE
+        val expectedAuthMode = AuthorizationType.OPENID_CONNECT
+
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory.buildSubscription(
+            expectedClass,
+            expectedType,
+            expectedAuthMode
+        )
+
+        val actualRequest = ModelSubscription.onUpdate(expectedClass, authMode = expectedAuthMode)
+
+        actualRequest shouldBe expectedRequest
     }
 
     @Test
@@ -168,5 +301,27 @@ class ModelSubscriptionTest {
         }
 
         assertEquals(expectedRequest, actualRequest)
+    }
+
+    @Test
+    fun `update with includes and authMode`() {
+        val expectedClass = Post::class.java
+        val expectedType = SubscriptionType.ON_UPDATE
+        val expectedAuthMode = AuthorizationType.OPENID_CONNECT
+
+        val expectedRequest: GraphQLRequest<Post> = AppSyncGraphQLRequestFactory
+            .buildSubscription<Post, Post, PostPath>(
+                expectedClass,
+                expectedType,
+                expectedAuthMode
+            ) {
+                includes(it.comments, it.blog)
+            }
+
+        val actualRequest = ModelSubscription.onUpdate<Post, PostPath>(expectedClass, expectedAuthMode) {
+            includes(it.comments, it.blog)
+        }
+
+        actualRequest shouldBe expectedRequest
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Added an `authMode` parameter to the various `ModelSubscription` APIs

*How did you test these changes?*
- Unit test
- Test app

*Documentation update required?*
- [ ] No
- [x] Yes Documentation TODO

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
