### PR TITLE
fix(auth): Fix HostedUI signout cancellation issue

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignOutState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignOutState.kt
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.statemachine.codegen.states
 
+import com.amplifyframework.auth.cognito.exceptions.service.UserCancelledException
 import com.amplifyframework.auth.cognito.isAuthEvent
 import com.amplifyframework.auth.cognito.isSignOutEvent
 import com.amplifyframework.statemachine.State
@@ -86,7 +87,15 @@ internal sealed class SignOutState : State {
                     }
                     is SignOutEvent.EventType.UserCancelled -> {
                         val action = signOutActions.userCancelledAction(signOutEvent)
-                        StateResolution(Error(Exception("User Cancelled")), listOf(action))
+                        StateResolution(
+                            Error(
+                                UserCancelledException(
+                                    "The user cancelled the sign-out attempt, so it did not complete.",
+                                    "To recover: catch this error, and attempt the sign out again."
+                                )
+                            ),
+                            listOf(action)
+                        )
                     }
                     else -> defaultResolution
                 }


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/2598

*Description of changes:*
Prevents `signOut` lockup if a user cancels hosted ui sign out from the browser. The common scenario for this is no internet.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
