### PR TITLE
fix(auth): Fix parsing of REQUIRES_UPPERCASE/REQUIRES_LOWERCASE password settings in Gen1

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
@@ -202,16 +202,16 @@ data class AuthConfiguration internal constructor(
                 length = passwordLength,
                 requiresNumber = passwordRequirements.contains("REQUIRES_NUMBERS"),
                 requiresSpecial = passwordRequirements.contains("REQUIRES_SYMBOLS"),
-                requiresLower = passwordRequirements.contains("REQUIRES_LOWER"),
-                requiresUpper = passwordRequirements.contains("REQUIRES_UPPER")
+                requiresLower = passwordRequirements.contains("REQUIRES_LOWERCASE"),
+                requiresUpper = passwordRequirements.contains("REQUIRES_UPPERCASE")
             )
         }
 
         private fun PasswordProtectionSettings.toGen1Json() = JSONObject().apply {
             put("passwordPolicyMinLength", length)
             val characters = JSONArray().apply {
-                if (requiresLower) put("REQUIRES_LOWER")
-                if (requiresUpper) put("REQUIRES_UPPER")
+                if (requiresLower) put("REQUIRES_LOWERCASE")
+                if (requiresUpper) put("REQUIRES_UPPERCASE")
                 if (requiresNumber) put("REQUIRES_NUMBERS")
                 if (requiresSpecial) put("REQUIRES_SYMBOLS")
             }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthConfigurationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthConfigurationTest.kt
@@ -73,7 +73,7 @@ class AuthConfigurationTest {
                         ],
                         "passwordProtectionSettings": {
                             "passwordPolicyMinLength": 10,
-                            "passwordPolicyCharacters": ["REQUIRES_NUMBERS", "REQUIRES_LOWER"]
+                            "passwordPolicyCharacters": ["REQUIRES_NUMBERS", "REQUIRES_LOWERCASE"]
                         },
                         "mfaConfiguration": "OFF",
                         "mfaTypes": [


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
#2835 
https://github.com/aws-amplify/amplify-ui-android/issues/154

*Description of changes:*
The correct values for the Gen1 configuration password settings are `REQUIRES_UPPERCASE`/`REQUIRES_LOWERCASE`.

*How did you test these changes?*
- Verified that all settings were respected with a config generated from the CLI.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
