### PR TITLE
feat(predictions): Add support for a no light freshness challenge

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/exceptions/FaceLivenessUnsupportedChallengeTypeException.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/exceptions/FaceLivenessUnsupportedChallengeTypeException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.predictions.aws.exceptions
+
+import com.amplifyframework.annotations.InternalAmplifyApi
+import com.amplifyframework.predictions.PredictionsException
+
+@InternalAmplifyApi
+class FaceLivenessUnsupportedChallengeTypeException internal constructor(
+    message: String = "Received an unsupported ChallengeType from the backend.",
+    cause: Throwable? = null,
+    recoverySuggestion: String = "Verify that the Challenges configured in your backend are supported by the " +
+        "frontend code (e.g. Amplify UI)"
+) : PredictionsException(message, cause, recoverySuggestion)

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -169,13 +169,12 @@ internal class LivenessWebSocket(
                             }
 
                             // If challengeType hasn't been initialized by this point it's because server sent an
-                            // unsupported challenge type so return an error to the client.
+                            // unsupported challenge type so return an error to the client and close the web socket.
                             val resolvedChallengeType = challengeType
                             if (resolvedChallengeType == null) {
                                 webSocketError = FaceLivenessUnsupportedChallengeTypeException()
                                 destroy(UNSUPPORTED_CHALLENGE_CLOSURE_STATUS_CODE)
                             } else {
-                                // send non-null challenge Type
                                 onSessionResponseReceived.accept(
                                     SessionResponse(
                                         response.serverSessionInformationEvent.sessionInformation,

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/ChallengeEvent.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/ChallengeEvent.kt
@@ -14,12 +14,12 @@
  */
 package com.amplifyframework.predictions.aws.models.liveness
 
-import com.amplifyframework.predictions.models.ChallengeType
+import com.amplifyframework.predictions.models.FaceLivenessChallengeType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class ChallengeEvent(
-    @SerialName("Type") val challengeType: ChallengeType,
+    @SerialName("Type") val challengeType: FaceLivenessChallengeType,
     @SerialName("Version") val version: String
 )

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/ChallengeEvent.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/ChallengeEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  */
 package com.amplifyframework.predictions.aws.models.liveness
 
+import com.amplifyframework.predictions.models.ChallengeType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ClientChallenge(
-    @SerialName("FaceMovementAndLightChallenge") val faceMovementAndLightChallenge:
-        FaceMovementAndLightClientChallenge? = null,
-    @SerialName("FaceMovementChallenge") val faceMovementChallenge: FaceMovementClientChallenge? = null
+internal data class ChallengeEvent(
+    @SerialName("Type") val challengeType: ChallengeType,
+    @SerialName("Version") val version: String
 )

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/FaceMovementClientChallenge.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/FaceMovementClientChallenge.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ClientChallenge(
-    @SerialName("FaceMovementAndLightChallenge") val faceMovementAndLightChallenge:
-        FaceMovementAndLightClientChallenge? = null,
-    @SerialName("FaceMovementChallenge") val faceMovementChallenge: FaceMovementClientChallenge? = null
+internal data class FaceMovementClientChallenge(
+    @SerialName("ChallengeId") val challengeId: String,
+    @SerialName("VideoStartTimestamp") val videoStartTimestamp: Long? = null,
+    @SerialName("VideoEndTimestamp") val videoEndTimestamp: Long? = null,
+    @SerialName("InitialFace") val initialFace: InitialFace? = null,
+    @SerialName("TargetFace") val targetFace: TargetFace? = null,
 )

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/FaceMovementServerChallenge.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/FaceMovementServerChallenge.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -18,8 +18,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ClientChallenge(
-    @SerialName("FaceMovementAndLightChallenge") val faceMovementAndLightChallenge:
-        FaceMovementAndLightClientChallenge? = null,
-    @SerialName("FaceMovementChallenge") val faceMovementChallenge: FaceMovementClientChallenge? = null
+internal data class FaceMovementServerChallenge(
+    @SerialName("OvalParameters") val ovalParameters: OvalParameters,
+    @SerialName("ChallengeConfig") val challengeConfig: ChallengeConfig,
 )

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/LivenessResponseStream.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/LivenessResponseStream.kt
@@ -23,7 +23,8 @@ internal sealed class LivenessResponseStream {
     internal data class Event(
         @SerialName("ServerSessionInformationEvent") val serverSessionInformationEvent:
             ServerSessionInformationEvent? = null,
-        @SerialName("DisconnectionEvent") val disconnectionEvent: DisconnectionEvent? = null
+        @SerialName("DisconnectionEvent") val disconnectionEvent: DisconnectionEvent? = null,
+        @SerialName("ChallengeEvent") val challengeEvent: ChallengeEvent? = null
     ) : LivenessResponseStream()
 
     @Serializable

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/ServerChallenge.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/models/liveness/ServerChallenge.kt
@@ -19,5 +19,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class ServerChallenge(
-    @SerialName("FaceMovementAndLightChallenge") val faceMovementAndLightChallenge: FaceMovementAndLightServerChallenge
+    @SerialName("FaceMovementAndLightChallenge") val faceMovementAndLightChallenge:
+        FaceMovementAndLightServerChallenge? = null,
+    @SerialName("FaceMovementChallenge") val faceMovementChallenge: FaceMovementServerChallenge? = null
 )

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
@@ -36,7 +36,6 @@ import com.amplifyframework.predictions.aws.models.liveness.FreshnessColor
 import com.amplifyframework.predictions.aws.models.liveness.OvalParameters
 import com.amplifyframework.predictions.aws.models.liveness.SessionInformation
 import com.amplifyframework.predictions.models.ChallengeResponseEvent
-import com.amplifyframework.predictions.models.FaceLivenessChallengeType
 import com.amplifyframework.predictions.models.FaceLivenessSession
 import com.amplifyframework.predictions.models.FaceLivenessSessionChallenge
 import com.amplifyframework.predictions.models.FaceLivenessSessionInformation
@@ -58,9 +57,9 @@ internal class RunFaceLivenessSession(
         region = clientSessionInformation.region,
         clientSessionInformation = clientSessionInformation,
         livenessVersion = livenessVersion,
-        onSessionInformationReceived = { serverSessionInformation ->
-            val challenges = processSessionInformation(serverSessionInformation)
-            val challengeType = getChallengeType()
+        onSessionResponseReceived = { serverSessionResponse ->
+            val challenges = processSessionInformation(serverSessionResponse.faceLivenessSession)
+            val challengeType = serverSessionResponse.livenessChallengeType
             val faceLivenessSession = FaceLivenessSession(
                 challengeId = getChallengeId(),
                 challengeType = challengeType,
@@ -127,8 +126,6 @@ internal class RunFaceLivenessSession(
     }
 
     private fun getChallengeId(): String = livenessWebSocket.challengeId
-
-    private fun getChallengeType(): FaceLivenessChallengeType = livenessWebSocket.challengeType!!
 
     private fun getFaceTargetChallenge(
         ovalParameters: OvalParameters,

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
@@ -128,7 +128,7 @@ internal class RunFaceLivenessSession(
 
     private fun getChallengeId(): String = livenessWebSocket.challengeId
 
-    private fun getChallengeType(): FaceLivenessChallengeType = livenessWebSocket.challengeType
+    private fun getChallengeType(): FaceLivenessChallengeType = livenessWebSocket.challengeType!!
 
     private fun getFaceTargetChallenge(
         ovalParameters: OvalParameters,

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
@@ -215,7 +215,7 @@ internal class LivenessWebSocketTest {
     }
 
     @Test
-    fun `test unsupported challengetype`() {
+    fun `unsupported challengetype returns an exception`() {
         val clientSessionInfo = createClientSessionInformation(
             listOf(Challenge.FaceMovementAndLightChallenge("2.0.0"))
         )

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
@@ -222,8 +222,6 @@ internal class LivenessWebSocketTest {
             "3"
         )
         val livenessWebSocket = createLivenessWebSocket(sessionInformation = sessionInfo)
-        assertEquals(FaceLivenessChallengeType.FaceMovementAndLightChallenge, livenessWebSocket.challengeType)
-
         val event = ChallengeEvent(
             challengeType = FaceLivenessChallengeType.FaceMovementAndLightChallenge,
             version = "1.0.0"

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
@@ -37,7 +37,7 @@ import com.amplifyframework.predictions.aws.models.liveness.ServerChallenge
 import com.amplifyframework.predictions.aws.models.liveness.ServerSessionInformationEvent
 import com.amplifyframework.predictions.aws.models.liveness.SessionInformation
 import com.amplifyframework.predictions.aws.models.liveness.ValidationException
-import com.amplifyframework.predictions.models.ChallengeType
+import com.amplifyframework.predictions.models.FaceLivenessChallengeType
 import com.amplifyframework.predictions.models.FaceLivenessSessionInformation
 import io.mockk.every
 import io.mockk.mockk
@@ -215,7 +215,7 @@ internal class LivenessWebSocketTest {
         assertEquals(null, livenessWebSocket.challengeType)
 
         val event = ChallengeEvent(
-            challengeType = ChallengeType.FaceMovementAndLightChallenge,
+            challengeType = FaceLivenessChallengeType.FaceMovementAndLightChallenge,
             version = "2.0.0"
         )
 
@@ -230,7 +230,7 @@ internal class LivenessWebSocketTest {
 
         livenessWebSocket.webSocketListener.onMessage(mockk(), encodedByteString)
 
-        assertEquals(ChallengeType.FaceMovementAndLightChallenge, livenessWebSocket.challengeType)
+        assertEquals(FaceLivenessChallengeType.FaceMovementAndLightChallenge, livenessWebSocket.challengeType)
     }
 
     @Test
@@ -239,7 +239,7 @@ internal class LivenessWebSocketTest {
         assertEquals(null, livenessWebSocket.challengeType)
 
         val event = ChallengeEvent(
-            challengeType = ChallengeType.FaceMovementChallenge,
+            challengeType = FaceLivenessChallengeType.FaceMovementChallenge,
             version = "1.0.0"
         )
 
@@ -254,7 +254,7 @@ internal class LivenessWebSocketTest {
 
         livenessWebSocket.webSocketListener.onMessage(mockk(), encodedByteString)
 
-        assertEquals(ChallengeType.FaceMovementChallenge, livenessWebSocket.challengeType)
+        assertEquals(FaceLivenessChallengeType.FaceMovementChallenge, livenessWebSocket.challengeType)
     }
 
     @Test

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
@@ -70,7 +70,6 @@ import okhttp3.WebSocketListener
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.junit.After
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSessionTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSessionTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.aws.service
+
+import com.amplifyframework.auth.CognitoCredentialsProvider
+import com.amplifyframework.predictions.models.Challenge
+import com.amplifyframework.predictions.models.FaceLivenessSessionInformation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class RunFaceLivenessSessionTest {
+
+    private val region = "us-east-1"
+    private val sessionId = "123456"
+    private val videoWidth = 480f
+    private val videoHeight = 640f
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @After
+    fun shutDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `test websocket endpoint generation using the old liveness library`() {
+        val sessionInformation = FaceLivenessSessionInformation(
+            videoHeight = videoHeight,
+            videoWidth = videoWidth,
+            challenge = "FaceMovementAndLightChallenge_1.0.0",
+            region = region
+        )
+
+        val session = RunFaceLivenessSession(
+            sessionId = sessionId,
+            clientSessionInformation = sessionInformation,
+            credentialsProvider = CognitoCredentialsProvider(),
+            livenessVersion = "1.0.0",
+            onSessionStarted = {},
+            onComplete = {},
+            onError = {}
+        )
+
+        Assert.assertEquals(
+            generateEndpoint("FaceMovementAndLightChallenge_1.0.0"),
+            session.buildWebSocketEndpoint()
+        )
+    }
+
+    @Test
+    fun `test websocket endpoint generation supplying attempt count and enabled start view`() {
+        val attemptCount = 1
+        val preCheckEnabled = true
+        val sessionInformation = FaceLivenessSessionInformation(
+            videoHeight = videoHeight,
+            videoWidth = videoWidth,
+            challengeVersions = listOf(
+                Challenge.FaceMovementAndLightChallenge("2.0.0")
+            ),
+            region = region,
+            preCheckViewEnabled = preCheckEnabled,
+            attemptCount = attemptCount
+        )
+
+        val session = RunFaceLivenessSession(
+            sessionId = sessionId,
+            clientSessionInformation = sessionInformation,
+            credentialsProvider = CognitoCredentialsProvider(),
+            livenessVersion = "1.0.0",
+            onSessionStarted = {},
+            onComplete = {},
+            onError = {}
+        )
+
+        Assert.assertEquals(
+            generateEndpoint("FaceMovementAndLightChallenge_2.0.0", preCheckEnabled, attemptCount),
+            session.buildWebSocketEndpoint()
+        )
+    }
+
+    @Test
+    fun `test websocket endpoint generation supplying different attempt count and enabled start view`() {
+        val attemptCount = 3
+        val preCheckEnabled = true
+        val sessionInformation = FaceLivenessSessionInformation(
+            videoHeight = videoHeight,
+            videoWidth = videoWidth,
+            challengeVersions = listOf(
+                Challenge.FaceMovementAndLightChallenge("2.0.0")
+            ),
+            attemptCount = attemptCount,
+            region = region,
+            preCheckViewEnabled = preCheckEnabled
+        )
+
+        val session = RunFaceLivenessSession(
+            sessionId = sessionId,
+            clientSessionInformation = sessionInformation,
+            credentialsProvider = CognitoCredentialsProvider(),
+            livenessVersion = "1.0.0",
+            onSessionStarted = {},
+            onComplete = {},
+            onError = {}
+        )
+
+        Assert.assertEquals(
+            generateEndpoint("FaceMovementAndLightChallenge_2.0.0", preCheckEnabled, attemptCount),
+            session.buildWebSocketEndpoint()
+        )
+    }
+
+    @Test
+    fun `test websocket endpoint generation supplying attempt count and disabled start view`() {
+        val attemptCount = 3
+        val preCheckEnabled = false
+        val sessionInformation = FaceLivenessSessionInformation(
+            videoHeight = videoHeight,
+            videoWidth = videoWidth,
+            challengeVersions = listOf(
+                Challenge.FaceMovementAndLightChallenge("2.0.0")
+            ),
+            attemptCount = attemptCount,
+            region = region,
+            preCheckViewEnabled = preCheckEnabled
+        )
+
+        val session = RunFaceLivenessSession(
+            sessionId = sessionId,
+            clientSessionInformation = sessionInformation,
+            credentialsProvider = CognitoCredentialsProvider(),
+            livenessVersion = "1.0.0",
+            onSessionStarted = {},
+            onComplete = {},
+            onError = {}
+        )
+
+        Assert.assertEquals(
+            generateEndpoint("FaceMovementAndLightChallenge_2.0.0", preCheckEnabled, attemptCount),
+            session.buildWebSocketEndpoint()
+        )
+    }
+
+    private fun generateEndpoint(
+        challenges: String,
+        preCheckEnabled: Boolean? = null,
+        attemptCount: Int? = null
+    ): String {
+        var endpoint = "wss://streaming-rekognition.$region.amazonaws.com:443/start-face-liveness-session-websocket" +
+            "?session-id=$sessionId&video-width=${videoWidth.toInt()}&video-height=${videoHeight.toInt()}" +
+            "&challenge-versions=$challenges"
+
+        if (preCheckEnabled != null) {
+            val value = if (preCheckEnabled) "1" else "0"
+            endpoint = "$endpoint&precheck-view-enabled=$value"
+        }
+
+        if (attemptCount != null) {
+            endpoint = "$endpoint&attempt-count=$attemptCount"
+        }
+
+        return endpoint
+    }
+}

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessChallengeType.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessChallengeType.kt
@@ -19,6 +19,5 @@ import com.amplifyframework.annotations.InternalAmplifyApi
 @InternalAmplifyApi
 enum class FaceLivenessChallengeType {
     FaceMovementChallenge,
-    FaceMovementAndLightChallenge,
-    Unknown
+    FaceMovementAndLightChallenge
 }

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessChallengeType.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessChallengeType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -17,26 +17,8 @@ package com.amplifyframework.predictions.models
 import com.amplifyframework.annotations.InternalAmplifyApi
 
 @InternalAmplifyApi
-data class FaceLivenessSessionInformation(
-    val videoWidth: Float,
-    val videoHeight: Float,
-    val challenge: String? = null,
-    val region: String,
-    val challengeVersions: List<Challenge>? = null,
-    val preCheckViewEnabled: Boolean? = null,
-    val attemptCount: Int? = null
-)
-
-@InternalAmplifyApi
-data class Challenge(
-    val type: ChallengeType,
-    val version: String
-) {
-    fun toQueryParamString(): String = "${type.name}_$version"
-}
-
-@InternalAmplifyApi
-enum class ChallengeType {
+enum class FaceLivenessChallengeType {
     FaceMovementChallenge,
     FaceMovementAndLightChallenge,
+    Unknown
 }

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSession.kt
@@ -19,6 +19,8 @@ import com.amplifyframework.annotations.InternalAmplifyApi
 
 @InternalAmplifyApi
 class FaceLivenessSession(
+    val challengeId: String,
+    val challengeType: FaceLivenessChallengeType,
     val challenges: List<FaceLivenessSessionChallenge>,
     private val onVideoEvent: (VideoEvent) -> Unit,
     private val onChallengeResponseEvent: (ChallengeResponseEvent) -> Unit,

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSessionInformation.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSessionInformation.kt
@@ -17,26 +17,58 @@ package com.amplifyframework.predictions.models
 import com.amplifyframework.annotations.InternalAmplifyApi
 
 @InternalAmplifyApi
-data class FaceLivenessSessionInformation(
-    val videoWidth: Float,
-    val videoHeight: Float,
-    val challenge: String? = null,
-    val region: String,
-    val challengeVersions: List<Challenge>? = null,
-    val preCheckViewEnabled: Boolean? = null,
-    val attemptCount: Int? = null
-)
+class FaceLivenessSessionInformation {
+    val videoWidth: Float
+    val videoHeight: Float
+    val challengeVersions: List<Challenge>
+    val region: String
+    val preCheckViewEnabled: Boolean?
+    val attemptCount: Int?
 
-@InternalAmplifyApi
-data class Challenge(
-    val type: ChallengeType,
-    val version: String
-) {
-    fun toQueryParamString(): String = "${type.name}_$version"
+    @Deprecated("Keeping compatibility for <= Amplify Liveness 1.2.6")
+    constructor(
+        videoWidth: Float,
+        videoHeight: Float,
+        challenge: String,
+        region: String
+    ) {
+        this.videoWidth = videoWidth
+        this.videoHeight = videoHeight
+        this.challengeVersions = listOf(Challenge.FaceMovementAndLightChallenge("1.0.0"))
+        this.region = region
+        this.preCheckViewEnabled = null
+        this.attemptCount = null
+    }
+
+    constructor(
+        videoWidth: Float,
+        videoHeight: Float,
+        region: String,
+        challengeVersions: List<Challenge>,
+        preCheckViewEnabled: Boolean,
+        attemptCount: Int
+    ) {
+        this.videoWidth = videoWidth
+        this.videoHeight = videoHeight
+        this.region = region
+        this.challengeVersions = challengeVersions
+        this.preCheckViewEnabled = preCheckViewEnabled
+        this.attemptCount = attemptCount
+    }
 }
 
 @InternalAmplifyApi
-enum class ChallengeType {
-    FaceMovementChallenge,
-    FaceMovementAndLightChallenge,
+sealed class Challenge private constructor(val name: String, val version: String) {
+
+    @InternalAmplifyApi
+    class FaceMovementChallenge(version: String) : Challenge("FaceMovementChallenge", version)
+
+    @InternalAmplifyApi
+    class FaceMovementAndLightChallenge(version: String) : Challenge("FaceMovementAndLightChallenge", version)
+
+    fun compareType(challenge: Challenge): Boolean {
+        return this.name == challenge.name && this.version == challenge.version
+    }
+
+    fun toQueryParamString(): String = "${name}_$version"
 }

--- a/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSessionInformation.kt
+++ b/core/src/main/java/com/amplifyframework/predictions/models/FaceLivenessSessionInformation.kt
@@ -58,17 +58,14 @@ class FaceLivenessSessionInformation {
 }
 
 @InternalAmplifyApi
-sealed class Challenge private constructor(val name: String, val version: String) {
+sealed class Challenge private constructor(val name: String, open val version: String) {
 
     @InternalAmplifyApi
-    class FaceMovementChallenge(version: String) : Challenge("FaceMovementChallenge", version)
+    data class FaceMovementChallenge(override val version: String) : Challenge("FaceMovementChallenge", version)
 
     @InternalAmplifyApi
-    class FaceMovementAndLightChallenge(version: String) : Challenge("FaceMovementAndLightChallenge", version)
-
-    fun compareType(challenge: Challenge): Boolean {
-        return this.name == challenge.name && this.version == challenge.version
-    }
+    data class FaceMovementAndLightChallenge(override val version: String) :
+        Challenge("FaceMovementAndLightChallenge", version)
 
     fun toQueryParamString(): String = "${name}_$version"
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:*
This adds support for a no-light challenge to the Prediction plugin's Face LIveness feature and adds telemetry tracking as requested by the Rekognition team. There's no API change to the core plugin API and **additive** changes to the `FaceLivenessSessionInformation` data class that's used as part of the API.

Notable callouts:
- `FaceLivenessSessionInformation`
   - Changed the `String` `challenge` parameter to be nullable. This is required to allow backward compatibility with the existing Liveness UI component library.
   - Added a new parameter `challengeVersions` to replace the previous `challenge` which takes in a `List<Challenge>`. These `Challenge`s represent both the challenge name and the version for that challenge. 
   - Added a new parameter `preCheckViewEnabled` which signifies if the default "Start View" was enabled. Used for telemetry.
   - Added a new parameter `attemptCount` which signifies how many times the user attempted to perform the liveness check. Used for telemetry.
- Added a new supported challenge called `FaceMovementChallenge` that will live alongside the existing supported `FaceMovementAndLightChallenge` 
- Updated the websocket endpoint generation to use a `Uri.Builder()` for code cleanliness
- Added support for a new web socket event called `ChallengeType` which is used for determining what type of challenge is requested from the backend to render to the user. 

*How did you test these changes?*
- Updated and added unit tests for the new ChallengeType event
- Tested with a corresponding Amplify UI change that accepts the new challenge type and renders it
- Tested with the existing version of Amplify UI to ensure backwards compatibility

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
