### PR TITLE
feat(api): Add authMode support to lazy loaded models

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AWSGraphQLOperation.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AWSGraphQLOperation.kt
@@ -32,8 +32,13 @@ import com.amplifyframework.api.graphql.GraphQLResponse
 abstract class AWSGraphQLOperation<R>(
     graphQLRequest: GraphQLRequest<R>,
     responseFactory: GraphQLResponse.Factory,
-    private val apiName: String?
+    apiName: String?
 ) : GraphQLOperation<R>(graphQLRequest, responseFactory) {
+
+    private val lazyLoadingContext = LazyLoadingContext(
+        apiName = apiName,
+        authMode = (graphQLRequest as? AppSyncGraphQLRequest)?.authorizationType
+    )
 
     @Throws(ApiException::class)
     override fun wrapResponse(jsonResponse: String): GraphQLResponse<R> {
@@ -46,7 +51,7 @@ abstract class AWSGraphQLOperation<R>(
     @Throws(ApiException::class)
     private fun buildResponse(jsonResponse: String): GraphQLResponse<R> {
         return try {
-            (responseFactory as? GsonGraphQLResponseFactory)?.buildResponse(request, jsonResponse, apiName)
+            (responseFactory as? GsonGraphQLResponseFactory)?.buildResponse(request, jsonResponse, lazyLoadingContext)
                 ?: throw ApiException(
                     "Amplify encountered an error while deserializing an object. " +
                         "GraphQLResponse.Factory was not of type GsonGraphQLResponseFactory",

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/ApiLazyModelReference.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/ApiLazyModelReference.kt
@@ -35,9 +35,7 @@ import kotlinx.coroutines.sync.withLock
 internal class ApiLazyModelReference<M : Model> internal constructor(
     private val clazz: Class<M>,
     private val keyMap: Map<String, Any>,
-    // API name is important to provide to future query calls. If a custom API name was used for the original call,
-    // the apiName must be provided to the following lazy call to fetch the value.
-    private val apiName: String? = null,
+    private val lazyContext: LazyLoadingContext,
     private val apiCategory: ApiCategory = Amplify.API
 ) : LazyModelReference<M> {
     private val cachedValue = AtomicReference<LoadedValue<M>?>(null)
@@ -106,15 +104,15 @@ internal class ApiLazyModelReference<M : Model> internal constructor(
 
                 val request: GraphQLRequest<M?> = AppSyncGraphQLRequestFactory.buildQueryInternal(
                     clazz,
-                    null,
-                    null,
+                    authMode = lazyContext.authMode,
+                    includes = null,
                     *variables.toTypedArray()
                 )
 
                 val value = query(
                     apiCategory,
                     request,
-                    apiName
+                    apiName = lazyContext.apiName
                 ).data
                 cachedValue.set(LoadedValue(value))
                 value

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.kt
@@ -332,10 +332,11 @@ object AppSyncGraphQLRequestFactory {
     internal fun <R, T : Model> buildModelPageQuery(
         modelClass: Class<T>,
         predicate: QueryPredicate,
-        pageToken: String?
+        pageToken: String?,
+        authMode: AuthorizationType?
     ): GraphQLRequest<R> {
         val dataType = TypeMaker.getParameterizedType(ApiModelPage::class.java, modelClass)
-        return buildListQueryInternal(modelClass, predicate, DEFAULT_QUERY_LIMIT, dataType, null, null, pageToken)
+        return buildListQueryInternal(modelClass, predicate, DEFAULT_QUERY_LIMIT, dataType, authMode, null, pageToken)
     }
 
     /**

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
@@ -62,7 +62,7 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
     public <T> GraphQLResponse<T> buildResponse(
             @NonNull GraphQLRequest<T> request,
             @Nullable String responseJson,
-            @Nullable String apiName
+            @NonNull LazyLoadingContext lazyLoadingContext
     ) throws ApiException {
         // On empty strings, Gson returns null instead of throwing JsonSyntaxException. See:
         // https://github.com/google/gson/issues/457
@@ -87,12 +87,12 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
                     )
                     .registerTypeAdapter(
                             ModelReference.class,
-                            new ModelReferenceDeserializer<Model>(apiName, schemaRegistry)
+                            new ModelReferenceDeserializer<Model>(lazyLoadingContext, schemaRegistry)
                     )
                     .registerTypeAdapterFactory(
                             // register Model post processing to inject lazy types for fields that
                             // were missing from json response
-                            new ModelPostProcessingTypeAdapter(apiName, schemaRegistry)
+                            new ModelPostProcessingTypeAdapter(lazyLoadingContext, schemaRegistry)
                     )
                     .create();
             return responseGson.fromJson(responseJson, responseType);
@@ -113,7 +113,7 @@ final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
     @Override
     public <T> GraphQLResponse<T> buildResponse(GraphQLRequest<T> request, String responseJson)
             throws ApiException {
-        return buildResponse(request, responseJson, null);
+        return buildResponse(request, responseJson, LazyLoadingContext.Companion.empty());
     }
 
     static final class IterableDeserializer<R> implements JsonDeserializer<Iterable<Object>> {

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/LazyLoadingContext.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/LazyLoadingContext.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws
+
+/**
+ * Holds contextual information about how a lazy model was loaded so that referenced models can be loaded with
+ * the same parameters.
+ */
+internal data class LazyLoadingContext(
+    val apiName: String?,
+    val authMode: AuthorizationType?
+) {
+    companion object {
+        fun empty() = LazyLoadingContext(
+            apiName = null,
+            authMode = null
+        )
+    }
+}

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/LazyTypeDeserializers.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/LazyTypeDeserializers.kt
@@ -32,7 +32,7 @@ const val ITEMS_KEY = "items"
 const val NEXT_TOKEN_KEY = "nextToken"
 
 internal class ModelReferenceDeserializer<M : Model>(
-    val apiName: String?,
+    private val lazyLoadingContext: LazyLoadingContext,
     private val schemaRegistry: AWSApiSchemaRegistry
 ) :
     JsonDeserializer<ModelReference<M>> {
@@ -61,7 +61,7 @@ internal class ModelReferenceDeserializer<M : Model>(
                 // fallback to create lazy
             }
         }
-        return ApiLazyModelReference(type, predicateKeyMap, apiName)
+        return ApiLazyModelReference(type, predicateKeyMap, lazyLoadingContext)
     }
 }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/ModelPostProcessingTypeAdapter.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/ModelPostProcessingTypeAdapter.kt
@@ -37,7 +37,7 @@ import java.io.Serializable
  * We must create the ModelList type, injecting required values such as query keys, api name.
  */
 internal class ModelPostProcessingTypeAdapter(
-    private val apiName: String?,
+    private val lazyLoadingContext: LazyLoadingContext,
     private val schemaRegistry: AWSApiSchemaRegistry
 ) : TypeAdapterFactory {
     override fun <M> create(gson: Gson, type: TypeToken<M>): TypeAdapter<M> {
@@ -87,7 +87,11 @@ internal class ModelPostProcessingTypeAdapter(
                                     name to parentIdentifiers[idx]
                                 }.toMap()
 
-                                val modelList = ApiLazyModelList(lazyFieldModelSchema.modelClass, queryKeys, apiName)
+                                val modelList = ApiLazyModelList(
+                                    lazyFieldModelSchema.modelClass,
+                                    queryKeys,
+                                    lazyLoadingContext
+                                )
 
                                 fieldToUpdate.set(parent, modelList)
                             }
@@ -101,7 +105,7 @@ internal class ModelPostProcessingTypeAdapter(
 
 private fun Model.getSortedIdentifiers(): List<Serializable> {
     return when (val identifier = resolveIdentifier()) {
-        is ModelIdentifier<*> -> { listOf(identifier.key()) + identifier.sortedKeys() }
+        is ModelIdentifier<*> -> listOf(identifier.key()) + identifier.sortedKeys()
         else -> listOf(identifier.toString())
     }
 }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperationTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperationTest.kt
@@ -199,6 +199,7 @@ class MultiAuthSubscriptionOperationTest {
         graphQlRequest: AppSyncGraphQLRequest<String> = mockk {
             every { modelSchema } returns ModelSchema.fromModelClass(ModelWithTwoAuthModes::class.java)
             every { authRuleOperation } returns ModelOperation.READ
+            every { authorizationType } returns null
             every { content } returns ""
         }
     ): MultiAuthSubscriptionOperation<String> {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
When loading a lazy model/list with an authMode we pass that through and use it to also load the referenced models.

*How did you test these changes?*


*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
