### PR TITLE
fix(DataStore): should not crash on missing version metadata

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSync.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSync.java
@@ -112,7 +112,7 @@ public interface AppSync {
     <T extends Model> Cancelable update(
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
-            @NonNull Integer version,
+            @Nullable Integer version,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure
     );
@@ -132,7 +132,7 @@ public interface AppSync {
     <T extends Model> Cancelable update(
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
-            @NonNull Integer version,
+            @Nullable Integer version,
             @NonNull QueryPredicate predicate,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure
@@ -152,7 +152,7 @@ public interface AppSync {
     <T extends Model> Cancelable delete(
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
-            @NonNull Integer version,
+            @Nullable Integer version,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure
     );
@@ -172,7 +172,7 @@ public interface AppSync {
     <T extends Model> Cancelable delete(
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
-            @NonNull Integer version,
+            @Nullable Integer version,
             @NonNull QueryPredicate predicate,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncClient.java
@@ -159,7 +159,7 @@ public final class AppSyncClient implements AppSync {
     public <T extends Model> Cancelable update(
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
-            @NonNull Integer version,
+            @Nullable Integer version,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
         return update(model, modelSchema, version, QueryPredicates.all(), onResponse, onFailure);
@@ -170,7 +170,7 @@ public final class AppSyncClient implements AppSync {
     public <T extends Model> Cancelable update(
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
-            @NonNull Integer version,
+            @Nullable Integer version,
             @NonNull QueryPredicate predicate,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
@@ -207,7 +207,7 @@ public final class AppSyncClient implements AppSync {
     public <T extends Model> Cancelable delete(
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
-            @NonNull Integer version,
+            @Nullable Integer version,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {
         return delete(model, modelSchema, version, QueryPredicates.all(), onResponse, onFailure);
@@ -218,7 +218,7 @@ public final class AppSyncClient implements AppSync {
     public <T extends Model> Cancelable delete(
             @NonNull T model,
             @NonNull ModelSchema modelSchema,
-            @NonNull Integer version,
+            @Nullable Integer version,
             @NonNull QueryPredicate predicate,
             @NonNull Consumer<GraphQLResponse<ModelWithMetadata<T>>> onResponse,
             @NonNull Consumer<DataStoreException> onFailure) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/appsync/AppSyncRequestFactory.java
@@ -167,7 +167,9 @@ final class AppSyncRequestFactory {
             throws DataStoreException {
         try {
             Map<String, Object> inputMap = new HashMap<>();
-            inputMap.put("_version", version);
+            if (version != null) {
+                inputMap.put("_version", version);
+            }
             inputMap.putAll(GraphQLRequestHelper.getDeleteMutationInputMap(schema, model));
             return buildMutation(schema, inputMap, predicate, MutationType.DELETE, strategyType);
         } catch (AmplifyException amplifyException) {
@@ -184,7 +186,9 @@ final class AppSyncRequestFactory {
             AuthModeStrategyType strategyType) throws DataStoreException {
         try {
             Map<String, Object> inputMap = new HashMap<>();
-            inputMap.put("_version", version);
+            if (version != null) {
+                inputMap.put("_version", version);
+            }
             inputMap.putAll(GraphQLRequestHelper.getMapOfFieldNameAndValues(schema, model, MutationType.UPDATE));
             return buildMutation(schema, inputMap, predicate, MutationType.UPDATE, strategyType);
         } catch (AmplifyException amplifyException) {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -290,7 +290,7 @@ final class MutationProcessor {
             this.schemaRegistry.getModelSchemaForModelClass(updatedItem.getModelName());
         return versionRepository.findModelVersion(updatedItem).flatMap(version ->
             publishWithStrategy(mutation, (model, onSuccess, onError) ->
-                appSync.update(model, updatedItemSchema, version, mutation.getPredicate(), onSuccess, onError)
+                appSync.update(model, updatedItemSchema, version.orElse(null), mutation.getPredicate(), onSuccess, onError)
             )
         );
     }
@@ -312,7 +312,7 @@ final class MutationProcessor {
         return versionRepository.findModelVersion(deletedItem).flatMap(version ->
             publishWithStrategy(mutation, (model, onSuccess, onError) ->
                 appSync.delete(
-                    deletedItem, deletedItemSchema, version, mutation.getPredicate(), onSuccess, onError
+                    deletedItem, deletedItemSchema, version.orElse(null), mutation.getPredicate(), onSuccess, onError
                 )
             )
         );

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java
@@ -290,7 +290,8 @@ final class MutationProcessor {
             this.schemaRegistry.getModelSchemaForModelClass(updatedItem.getModelName());
         return versionRepository.findModelVersion(updatedItem).flatMap(version ->
             publishWithStrategy(mutation, (model, onSuccess, onError) ->
-                appSync.update(model, updatedItemSchema, version.orElse(null), mutation.getPredicate(), onSuccess, onError)
+                appSync.update(
+                    model, updatedItemSchema, version.orElse(null), mutation.getPredicate(), onSuccess, onError)
             )
         );
     }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.kt
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.kt
@@ -138,16 +138,14 @@ internal class VersionRepository(private val localStorageAdapter: LocalStorageAd
         metadataIterator: Iterator<ModelMetadata>
     ): Optional<Int> {
         val results: MutableList<ModelMetadata> =
-                ArrayList()
+            ArrayList()
         while (metadataIterator.hasNext()) {
             results.add(metadataIterator.next())
         }
         // There should be only one metadata for the model....
         if (results.size != 1) {
             LOG.warn(
-                    "Wanted exactly 1 metadata for item with id = " + model.primaryKeyString + ", but had " + results.size +
-                            "." +
-                    "This is likely a bug. please report to AWS."
+                "Wanted 1 metadata for item with id = " + model.primaryKeyString + ", but had " + results.size + "."
             )
             return Optional.empty()
         } else {

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.kt
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.kt
@@ -29,6 +29,7 @@ import com.amplifyframework.datastore.extensions.getMetadataSQLitePrimaryKey
 import com.amplifyframework.datastore.storage.LocalStorageAdapter
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.core.SingleEmitter
+import java.util.Optional
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -48,8 +49,8 @@ internal class VersionRepository(private val localStorageAdapter: LocalStorageAd
      * @param <T> Type of model
      * @return Current version known locally
      </T> */
-    fun <T : Model> findModelVersion(model: T): Single<Int> {
-        return Single.create { emitter: SingleEmitter<Int> ->
+    fun <T : Model> findModelVersion(model: T): Single<Optional<Int>> {
+        return Single.create { emitter: SingleEmitter<Optional<Int>> ->
             // The ModelMetadata for the model uses the same ID as an identifier.
             localStorageAdapter.query(
                 ModelMetadata::class.java,
@@ -129,32 +130,29 @@ internal class VersionRepository(private val localStorageAdapter: LocalStorageAd
      * @param metadataIterator An iterator of ModelMetadata; the metadata is associated with the provided model
      * @param <T> The type of model
      * @return The version of the model, if available
-     * @throws DataStoreException If there is no version for the model, or if the version cannot be obtained
+     * @throws DataStoreException If there is no metadata for the model
      </T> */
     @Throws(DataStoreException::class)
     private fun <T : Model> extractVersion(
         model: T,
         metadataIterator: Iterator<ModelMetadata>
-    ): Int {
+    ): Optional<Int> {
         val results: MutableList<ModelMetadata> =
-            ArrayList()
+                ArrayList()
         while (metadataIterator.hasNext()) {
             results.add(metadataIterator.next())
         }
-
         // There should be only one metadata for the model....
         if (results.size != 1) {
-            throw DataStoreException(
-                "Wanted 1 metadata for item with id = " + model.primaryKeyString + ", but had " + results.size +
-                    ".",
-                "This is likely a bug. please report to AWS."
+            LOG.warn(
+                    "Wanted exactly 1 metadata for item with id = " + model.primaryKeyString + ", but had " + results.size +
+                            "." +
+                    "This is likely a bug. please report to AWS."
             )
+            return Optional.empty()
+        } else {
+            return Optional.ofNullable(results[0].version)
         }
-        return results[0].version
-            ?: throw DataStoreException(
-                "Metadata for item with id = " + model.primaryKeyString + " had null version.",
-                "This is likely a bug. Please report to AWS."
-            )
     }
 
     companion object {

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/VersionRepositoryTest.kt
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/VersionRepositoryTest.kt
@@ -22,6 +22,7 @@ import com.amplifyframework.datastore.storage.InMemoryStorageAdapter
 import com.amplifyframework.datastore.storage.SynchronousStorageAdapter
 import com.amplifyframework.testmodels.commentsblog.BlogOwner
 import java.util.Locale
+import java.util.Optional
 import java.util.Random
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
@@ -55,12 +56,12 @@ class VersionRepositoryTest {
 
     /**
      * When you try to get a model version, but there's no metadata for that model,
-     * this should fail with an [DataStoreException].
+     * this should return empty.
      * @throws InterruptedException If interrupted while awaiting terminal result in test observer
      */
     @Test
     @Throws(InterruptedException::class)
-    fun emitsErrorForNoMetadataInRepo() {
+    fun emitsSuccessWithEmptyValueForNoMetadataInRepo() {
         // Arrange: no metadata is in the repo.
         val blogOwner = BlogOwner.builder()
             .name("Jameson Williams")
@@ -73,33 +74,22 @@ class VersionRepositoryTest {
         val observer = versionRepository.findModelVersion(blogOwner).test()
         assertTrue(observer.await(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS))
 
-        // Assert: this failed. There was no version available.
-        observer.assertError { error: Throwable ->
-            if (error !is DataStoreException) {
-                return@assertError false
-            }
-            val expectedMessage = String.format(
-                Locale.US,
-                "Wanted 1 metadata for item with id = %s, but had 0.",
-                blogOwner.id
-            )
-            expectedMessage == error.message
-        }
+        // Assert: we got a empty version
+        observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValue(Optional.empty())
     }
 
     /**
      * When you try to get the version for a model, and there is metadata for the model
      * in the DataStore, BUT the version info is not populated, this should return an
-     * [DataStoreException].
-     * @throws DataStoreException
-     * NOT EXPECTED. This happens on failure to arrange data before test action.
-     * The expected DataStoreException is communicated via callback, not thrown
-     * on the calling thread. It's a different thing than this.
+     * empty optional.
      * @throws InterruptedException If interrupted while awaiting terminal result in test observer
      */
     @Test
     @Throws(DataStoreException::class, InterruptedException::class)
-    fun emitsErrorWhenMetadataHasNullVersion() {
+    fun emitsSuccessWithEmptyValueWhenMetadataHasNullVersion() {
         // Arrange a model an metadata into the store, but the metadtaa doesn't contain a valid version
         val blogOwner = BlogOwner.builder()
             .name("Jameson")
@@ -114,18 +104,11 @@ class VersionRepositoryTest {
         val observer = versionRepository.findModelVersion(blogOwner).test()
         assertTrue(observer.await(REASONABLE_WAIT_TIME, TimeUnit.MILLISECONDS))
 
-        // Assert: the single emitted a DataStoreException.
-        observer.assertError { error: Throwable ->
-            if (error !is DataStoreException) {
-                return@assertError false
-            }
-            val expectedMessage = String.format(
-                Locale.US,
-                "Metadata for item with id = %s had null version.",
-                blogOwner.id
-            )
-            expectedMessage == error.message
-        }
+        // Assert: we got a empty version
+        observer
+                .assertNoErrors()
+                .assertComplete()
+                .assertValue(Optional.empty())
     }
 
     /**
@@ -142,12 +125,13 @@ class VersionRepositoryTest {
             .name("Jameson")
             .build()
         val maxRandomVersion = 1000
-        val expectedVersion = Random().nextInt(maxRandomVersion)
+        val randomVersion = Random().nextInt(maxRandomVersion)
+        val expectedVersion = Optional.ofNullable(randomVersion)
         storageAdapter.save(
             ModelMetadata(
                 owner.modelName + "|" + owner.id,
                 false,
-                expectedVersion,
+                randomVersion,
                 Temporal.Timestamp.now()
             )
         )

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/VersionRepositoryTest.kt
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/VersionRepositoryTest.kt
@@ -21,7 +21,6 @@ import com.amplifyframework.datastore.appsync.ModelWithMetadata
 import com.amplifyframework.datastore.storage.InMemoryStorageAdapter
 import com.amplifyframework.datastore.storage.SynchronousStorageAdapter
 import com.amplifyframework.testmodels.commentsblog.BlogOwner
-import java.util.Locale
 import java.util.Optional
 import java.util.Random
 import java.util.concurrent.TimeUnit
@@ -76,9 +75,9 @@ class VersionRepositoryTest {
 
         // Assert: we got a empty version
         observer
-                .assertNoErrors()
-                .assertComplete()
-                .assertValue(Optional.empty())
+            .assertNoErrors()
+            .assertComplete()
+            .assertValue(Optional.empty())
     }
 
     /**
@@ -106,9 +105,9 @@ class VersionRepositoryTest {
 
         // Assert: we got a empty version
         observer
-                .assertNoErrors()
-                .assertComplete()
-                .assertValue(Optional.empty())
+            .assertNoErrors()
+            .assertComplete()
+            .assertValue(Optional.empty())
     }
 
     /**


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/2151#issuecomment-2135346064

*Description of changes:*

**The app should not crash when DataStore cannot retrieve the version for update and delete mutations. DataStore should attempt to send the mutation without a version and handle the response.**

This PR is looking to address the following crash that customers are experiencing

```
DataStoreException{message=Wanted 1 metadata for item with id = e7eb4237-c0d4-4ce6-8800-3b9d5fb603b8, but had 0., cause=null, recoverySuggestion=This is likely a bug. please report to AWS.}
     at com.amplifyframework.datastore.syncengine.VersionRepository.extractVersion(VersionRepository.java:91)
    at com.amplifyframework.datastore.syncengine.VersionRepository.lambda$findModelVersion$0$com-amplifyframework-datastore-syncengine-VersionRepository(VersionRepository.java:64)
     at com.amplifyframework.datastore.syncengine.VersionRepository$$ExternalSyntheticLambda0.accept(Unknown Source:8)
     at com.amplifyframework.datastore.storage.sqlite.SQLiteStorageAdapter.lambda$query$4$com-amplifyframework-datastore-storage-sqlite-SQLiteStorageAdapter(SQLiteStorageAdapter.java:407)
     at com.amplifyframework.datastore.storage.sqlite.SQLiteStorageAdapter$$ExternalSyntheticLambda6.run(Unknown Source:10)
     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:463)
     at java.util.concurrent.FutureTask.run(FutureTask.java:264)
     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
     at java.lang.Thread.run(Thread.java:1012)
```

The message 
```
Wanted 1 metadata for item with id = e7eb4237-c0d4-4ce6-8800-3b9d5fb603b8, but had 0.
```
comes from https://github.com/aws-amplify/amplify-android/blob/main/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/VersionRepository.kt#L148

Code paths
```
MutationProcessor.publishToNetwork → 
    MutationProcessor.update → 
        VersionRepository.findModelVersion → 
            VersionRepository.extractVersion

MutationProcessor.publishToNetwork → 
   MutationProcessor.delete → 
        VersionRepository.findModelVersion → 
            VersionRepository.extractVersion
```

The **unexpected behavior** observed by the customer is that DataStore is deciding to crash when publishing mutations requires a version for updates and deletes, but it could not find it.

According to this customer https://github.com/aws-amplify/amplify-android/issues/2151#issuecomment-2135346064 This happens in bad network scenarios during saving and updating a model. 

**The cause of this issue**:

1. `DataStore.save(model)` is called for a new model. This inserts into the local database and queues up a pending create mutation.
2. `DataStore.save(model)` is called for the existing model, performing some updates to the fields. This updates the existing record in the local database, and queues up a pending update mutation. We assume that the MutationProcessor performs (1) process the create mutation, such that it is marked in flight, and the update mutation is not merged into the create mutation when it is inserted into the mutation database, and has to be sent on its own by the MutationProcessor.

MutationProcessor (running in parallel):

1. Process create mutation by publishing it to the network. The network is down. The request times out and fails. MutationProcessor can handle this in two ways: retry indefinitely or drop the mutation event.
    1. Retrying indefinitely will only occur when it accurately classifies the response as a transient network failure.
    2. If the response is classified as a non-retryable error, the error is returned to the customer on the `errorHandler` and the mutation will be dropped. Subsequently there will not be any reconciliation, and no local version will be persisted.
2. Process update mutation. Query the local metadata table for the model’s version, cannot find it, throw exception which crashes the app.

The cause of this issue is the create mutation was dropped, which could happen for a variety of reasons decided by the MutationProcessor’s logic in handling the response of the request, and the subsequent update mutation did not have a version to send with the mutation.

**MutationProcessor error classification**

https://github.com/aws-amplify/amplify-android/blob/main/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java#L353-L355

```
nonRetryableExceptions.add(DataStoreException.GraphQLResponseException.class);
nonRetryableExceptions.add(ApiException.NonRetryableException.class);
```

**`DataStoreException.GraphQLResponseException`**

https://github.com/aws-amplify/amplify-android/blob/main/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/MutationProcessor.java#L387

This exception is thrown when the response is successful with a GraphQL response payload containing errors. If any of the GraphQLError’s do not contain the AppSync “conflictUnhandled” type then throw this.

This means the conditions for classification of non-retryable is as follows:

1. A successful GraphQL response containing errors
2. The error is not ConflictUnhandled, such as 
    * ConditionalCheckFailedException
    * OperationDisabled
    * Unauthorized

Since we are discussing the scenario with bad network conditions, it’s unlikely that it was classified as non-retyable due to this condition since (1) A successful GraphQL response would not have occurred.

**`ApiException.NonRetryableException`**
This exception is thrown when the response is 400 to 499. 
```
private static final int START_OF_CLIENT_ERROR_CODE = 400;
private static final int END_OF_CLIENT_ERROR_CODE = 499;

/// ...
if (response.code() >= START_OF_CLIENT_ERROR_CODE && response.code() <= END_OF_CLIENT_ERROR_CODE) {
    onFailure.accept(new ApiException
            .NonRetryableException("OkHttp client request failed.", "Irrecoverable error")
    );
    return;
}

```

This includes 408 Request Timeout. To be verified by manual testing, but this could be the response being handled as non-retryable even though it was a transient timeout error (bad network conditions).

In summary, there is an existing scenario to be verified: During bad network conditions, DataStore’s MutationProcessor should handle failures as retryable. 

Consider the scenario in which Unauthorized is treated as non-retryable (as seen above in DataStoreException.GraphQLResponseException). Unauthorized is very common when the user is signed out, or their token or session is expired. The mutation is then dropped, and update mutation will attempt to get the version and crash the app. 

This PR looks to address this scenario while another PR independent from this will look into verifying MutationProcessor's classification of transient network errors as retryable. The app should not crash when DataStore cannot retrieve the version for update and delete mutations. DataStore should attempt to send the mutation without a version and handle the response. The response will be handled by DataStore by sending it back to the customer through the `errorHandler` and then dropping it, moving on to the next mutation in the queue.

**What kind of response are we expecting?**

The conflict resolution enabled backend does not enforce version to be a required field. If we cannot get a version locally, we can send the update/delete mutation without a version, AppSync will respond successfully with a GraphQL response. This is inline with Swift DataStore's implementation, as it will also send update/delete mutations without a version if it cannot retrieve it at the time it's processing the mutation event.

Example 1. Update Mutation on existing model
```
mutation UpdateWithNoVersionHelloUpdated {
  updateBlog(input: {id: "f92dfb85-c580-4c3e-9eb4-93e3b76c33b5", name: "hello updated"}) {
    _deleted
    _lastChangedAt
    _version
    createdAt
    id
    name
    owner
    updatedAt
  }
}

// response
{
  "data": {
    "updateBlog": {
      "_deleted": null,
      "_lastChangedAt": 1718203981917,
      "_version": 6,
      "createdAt": "2024-06-12T14:49:26.329Z",
      "id": "f92dfb85-c580-4c3e-9eb4-93e3b76c33b5",
      "name": "hello",
      "owner": "michael",
      "updatedAt": "2024-06-12T14:49:26.329Z"
    }
  }
}
```

In the above example, version is updated, and the name is not. The conflict resolution strategy is enabled is auto-merge. DataStore will then reconcile this response data into the local database as the latest version of this model.

Example 2: Update mutation on model not yet created in AppSync
```
mutation UpdateInvalidIdWithNoVersion {
  updateBlog(input: {id: "notYetCreated", name: "hello updated"}) {
    _deleted
    _lastChangedAt
    _version
    createdAt
    id
    name
    owner
    updatedAt
  }
}
// response
{
  "data": {
    "updateBlog": null
  },
  "errors": [
    {
      "path": [
        "updateBlog"
      ],
      "data": null,
      "errorType": "Unauthorized",
      "errorInfo": null,
      "locations": [
        {
          "line": 27,
          "column": 3,
          "sourceName": null
        }
      ],
      "message": "Not Authorized to access updateBlog on type Mutation"
    }
  ]
}
```
The example above closely resembles the scenario where we continue to send the update mutation without a version. When the create mutation fails, the blog id does not exist in the AppSync. When the id is used for update mutations w/ Cognito User Pool auth, and without version, the response will be unauthorized.

According to the MutationProcessor logic, this will be categorized as a non retryable error, and the error will be returned to the customer through the `errorHandler`, before the update mutation is dropped. Based on their use cases, they can decide to reconcile this themselves or not, however, new devices or cleared devices will not sync this data back down to the app since it does not exist in the remote store.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
