### PR TITLE
feat(storage): Add support to define the S3 Storage Class

### DIFF
--- a/aws-storage-s3/api/aws-storage-s3.api
+++ b/aws-storage-s3/api/aws-storage-s3.api
@@ -240,6 +240,7 @@ public final class com/amplifyframework/storage/s3/options/AWSS3StorageUploadFil
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun from (Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions;)Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions$Builder;
 	public fun getServerSideEncryption ()Lcom/amplifyframework/storage/s3/ServerSideEncryption;
+	public fun getStorageClass ()Laws/sdk/kotlin/services/s3/model/StorageClass;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun useAccelerateEndpoint ()Z
@@ -251,6 +252,7 @@ public final class com/amplifyframework/storage/s3/options/AWSS3StorageUploadFil
 	public fun build ()Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions;
 	public fun serverSideEncryption (Lcom/amplifyframework/storage/s3/ServerSideEncryption;)Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions$Builder;
 	public fun setUseAccelerateEndpoint (Z)Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions$Builder;
+	public fun storageClass (Laws/sdk/kotlin/services/s3/model/StorageClass;)Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions$Builder;
 }
 
 public final class com/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions : com/amplifyframework/storage/options/StorageUploadInputStreamOptions {
@@ -259,6 +261,7 @@ public final class com/amplifyframework/storage/s3/options/AWSS3StorageUploadInp
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun from (Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions;)Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions$Builder;
 	public fun getServerSideEncryption ()Lcom/amplifyframework/storage/s3/ServerSideEncryption;
+	public fun getStorageClass ()Laws/sdk/kotlin/services/s3/model/StorageClass;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun useAccelerateEndpoint ()Z
@@ -270,6 +273,7 @@ public final class com/amplifyframework/storage/s3/options/AWSS3StorageUploadInp
 	public fun build ()Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions;
 	public fun serverSideEncryption (Lcom/amplifyframework/storage/s3/ServerSideEncryption;)Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions$Builder;
 	public fun setUseAccelerateEndpoint (Z)Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions$Builder;
+	public fun storageClass (Laws/sdk/kotlin/services/s3/model/StorageClass;)Lcom/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions$Builder;
 }
 
 public final class com/amplifyframework/storage/s3/request/AWSS3StorageDownloadFileRequest {
@@ -308,13 +312,14 @@ public final class com/amplifyframework/storage/s3/request/AWSS3StorageRemoveReq
 }
 
 public final class com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Lcom/amplifyframework/storage/StorageAccessLevel;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/storage/s3/ServerSideEncryption;Ljava/util/Map;Z)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Lcom/amplifyframework/storage/StorageAccessLevel;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/storage/s3/ServerSideEncryption;Laws/sdk/kotlin/services/s3/model/StorageClass;Ljava/util/Map;Z)V
 	public fun getAccessLevel ()Lcom/amplifyframework/storage/StorageAccessLevel;
 	public fun getContentType ()Ljava/lang/String;
 	public fun getKey ()Ljava/lang/String;
 	public fun getLocal ()Ljava/lang/Object;
 	public fun getMetadata ()Ljava/util/Map;
 	public fun getServerSideEncryption ()Lcom/amplifyframework/storage/s3/ServerSideEncryption;
+	public fun getStorageClass ()Laws/sdk/kotlin/services/s3/model/StorageClass;
 	public fun getTargetIdentityId ()Ljava/lang/String;
 	public fun useAccelerateEndpoint ()Z
 }

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -101,6 +101,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import aws.sdk.kotlin.services.s3.S3Client;
+import aws.sdk.kotlin.services.s3.model.StorageClass;
 
 /**
  * A plugin for the storage category which uses S3 as a storage
@@ -571,6 +572,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
             options instanceof AWSS3StorageUploadFileOptions
                 ? ((AWSS3StorageUploadFileOptions) options).getServerSideEncryption()
                 : ServerSideEncryption.NONE,
+            options instanceof AWSS3StorageUploadFileOptions
+                ? ((AWSS3StorageUploadFileOptions) options).getStorageClass()
+                : StorageClass.Standard.INSTANCE,
             options.getMetadata(),
             useAccelerateEndpoint
         );
@@ -609,6 +613,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
                 options instanceof AWSS3StorageUploadFileOptions
                         ? ((AWSS3StorageUploadFileOptions) options).getServerSideEncryption()
                         : ServerSideEncryption.NONE,
+                options instanceof AWSS3StorageUploadFileOptions
+                        ? ((AWSS3StorageUploadFileOptions) options).getStorageClass()
+                        : StorageClass.Standard.INSTANCE,
                 options.getMetadata(),
                 useAccelerateEndpoint
         );
@@ -699,6 +706,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
             options instanceof AWSS3StorageUploadInputStreamOptions
                 ? ((AWSS3StorageUploadInputStreamOptions) options).getServerSideEncryption()
                 : ServerSideEncryption.NONE,
+            options instanceof AWSS3StorageUploadInputStreamOptions
+                ? ((AWSS3StorageUploadInputStreamOptions) options).getStorageClass()
+                : StorageClass.Standard.INSTANCE,
             options.getMetadata(),
             useAccelerateEndpoint
         );
@@ -737,6 +747,9 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
                 options instanceof AWSS3StorageUploadInputStreamOptions
                         ? ((AWSS3StorageUploadInputStreamOptions) options).getServerSideEncryption()
                         : ServerSideEncryption.NONE,
+                options instanceof AWSS3StorageUploadInputStreamOptions
+                        ? ((AWSS3StorageUploadInputStreamOptions) options).getStorageClass()
+                        : StorageClass.Standard.INSTANCE,
                 options.getMetadata(),
                 useAccelerateEndpoint
         );

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StoragePathUploadFileOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StoragePathUploadFileOperation.kt
@@ -111,6 +111,7 @@ internal class AWSS3StoragePathUploadFileOperation internal constructor(
                     objectMetadata.metaData[ObjectMetadata.SERVER_SIDE_ENCRYPTION] =
                         storageServerSideEncryption.getName()
                 }
+                objectMetadata.metaData[ObjectMetadata.STORAGE_CLASS] = uploadRequest.storageClass.value
                 transferObserver = storageService.uploadFile(
                     transferId,
                     serviceKey,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StoragePathUploadInputStreamOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StoragePathUploadInputStreamOperation.kt
@@ -14,6 +14,7 @@
  */
 package com.amplifyframework.storage.s3.operation
 
+import aws.sdk.kotlin.services.s3.model.StorageClass
 import com.amplifyframework.auth.AuthCredentialsProvider
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.Consumer
@@ -110,6 +111,7 @@ internal class AWSS3StoragePathUploadInputStreamOperation internal constructor(
                     objectMetadata.metaData[ObjectMetadata.SERVER_SIDE_ENCRYPTION] =
                         storageServerSideEncryption.getName()
                 }
+                objectMetadata.metaData[ObjectMetadata.STORAGE_CLASS] = request.storageClass.value
                 transferObserver = storageService.uploadInputStream(
                     transferId,
                     serviceKey,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadFileOperation.kt
@@ -109,6 +109,7 @@ class AWSS3StorageUploadFileOperation @JvmOverloads internal constructor(
                                 objectMetadata.metaData[ObjectMetadata.SERVER_SIDE_ENCRYPTION] =
                                     storageServerSideEncryption.getName()
                             }
+                            objectMetadata.metaData[ObjectMetadata.STORAGE_CLASS] = uploadRequest.storageClass.value
                             transferObserver = storageService.uploadFile(
                                 transferId,
                                 serviceKey,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/operation/AWSS3StorageUploadInputStreamOperation.kt
@@ -116,6 +116,7 @@ class AWSS3StorageUploadInputStreamOperation @JvmOverloads internal constructor(
                                 objectMetadata.metaData[ObjectMetadata.SERVER_SIDE_ENCRYPTION] =
                                     storageServerSideEncryption.getName()
                             }
+                            objectMetadata.metaData[ObjectMetadata.STORAGE_CLASS] = uploadRequest.storageClass.value
                             transferObserver = storageService.uploadInputStream(
                                 transferId,
                                 serviceKey,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageUploadFileOptions.java
@@ -23,16 +23,20 @@ import com.amplifyframework.storage.s3.ServerSideEncryption;
 
 import java.util.Objects;
 
+import aws.sdk.kotlin.services.s3.model.StorageClass;
+
 /**
  * Options to specify attributes of object upload operation to an AWS S3 bucket.
  */
 public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOptions {
     private final ServerSideEncryption serverSideEncryption;
+    private final StorageClass storageClass;
     private final boolean useAccelerationMode;
 
     private AWSS3StorageUploadFileOptions(final Builder builder) {
         super(builder);
         this.serverSideEncryption = builder.getServerSideEncryption();
+        this.storageClass = builder.getStorageClass();
         this.useAccelerationMode = builder.useAccelerateEndpoint;
     }
 
@@ -43,6 +47,15 @@ public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOption
     @NonNull
     public ServerSideEncryption getServerSideEncryption() {
         return serverSideEncryption;
+    }
+
+    /**
+     * Storage class.
+     * @return Storage class
+     */
+    @NonNull
+    public StorageClass getStorageClass() {
+        return storageClass;
     }
 
     /**
@@ -75,6 +88,7 @@ public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOption
             .targetIdentityId(options.getTargetIdentityId())
             .contentType(options.getContentType())
             .serverSideEncryption(options.getServerSideEncryption())
+            .storageClass(options.getStorageClass())
             .metadata(options.getMetadata());
     }
 
@@ -109,6 +123,7 @@ public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOption
                     ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId()) &&
                     ObjectsCompat.equals(getContentType(), that.getContentType()) &&
                     ObjectsCompat.equals(getServerSideEncryption(), that.getServerSideEncryption()) &&
+                    ObjectsCompat.equals(getStorageClass(), that.getStorageClass()) &&
                     ObjectsCompat.equals(getMetadata(), that.getMetadata());
         }
     }
@@ -121,6 +136,7 @@ public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOption
                 getTargetIdentityId(),
                 getContentType(),
                 getServerSideEncryption(),
+                getStorageClass(),
                 getMetadata()
         );
     }
@@ -134,6 +150,7 @@ public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOption
                 ", targetIdentityId=" + getTargetIdentityId() +
                 ", contentType=" + getContentType() +
                 ", serverSideEncryption=" + getServerSideEncryption().getName() +
+                ", storageClass=" + getStorageClass() +
                 ", metadata=" + getMetadata() +
                 '}';
     }
@@ -145,11 +162,13 @@ public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOption
      */
     public static final class Builder extends StorageUploadFileOptions.Builder<Builder> {
         private ServerSideEncryption serverSideEncryption;
+        private StorageClass storageClass;
         private boolean useAccelerateEndpoint;
 
         private Builder() {
             super();
             this.serverSideEncryption = ServerSideEncryption.NONE;
+            this.storageClass = StorageClass.Standard.INSTANCE;
         }
 
         /**
@@ -173,9 +192,25 @@ public final class AWSS3StorageUploadFileOptions extends StorageUploadFileOption
             return this;
         }
 
+        /**
+         * Configures the storage class for a new AWSS3StorageUploadFileOptions instance.
+         * @param storageClass storage class
+         * @return Current Builder instance for fluent chaining
+         */
+        @NonNull
+        public Builder storageClass(@NonNull StorageClass storageClass) {
+            this.storageClass = Objects.requireNonNull(storageClass);
+            return this;
+        }
+
         @NonNull
         ServerSideEncryption getServerSideEncryption() {
             return serverSideEncryption;
+        }
+
+        @NonNull
+        StorageClass getStorageClass() {
+            return storageClass;
         }
 
         @Override

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageUploadInputStreamOptions.java
@@ -23,16 +23,20 @@ import com.amplifyframework.storage.s3.ServerSideEncryption;
 
 import java.util.Objects;
 
+import aws.sdk.kotlin.services.s3.model.StorageClass;
+
 /**
  * Options to specify attributes of object upload operation to an AWS S3 bucket.
  */
 public final class AWSS3StorageUploadInputStreamOptions extends StorageUploadInputStreamOptions {
     private final ServerSideEncryption serverSideEncryption;
+    private final StorageClass storageClass;
     private final boolean useAccelerationMode;
 
     private AWSS3StorageUploadInputStreamOptions(final Builder builder) {
         super(builder);
         this.serverSideEncryption = builder.serverSideEncryption;
+        this.storageClass = builder.storageClass;
         this.useAccelerationMode = builder.useAccelerateEndpoint;
     }
 
@@ -43,6 +47,15 @@ public final class AWSS3StorageUploadInputStreamOptions extends StorageUploadInp
     @NonNull
     public ServerSideEncryption getServerSideEncryption() {
         return serverSideEncryption;
+    }
+
+    /**
+     * Storage class.
+     * @return Storage class
+     */
+    @NonNull
+    public StorageClass getStorageClass() {
+        return storageClass;
     }
 
     /**
@@ -75,6 +88,7 @@ public final class AWSS3StorageUploadInputStreamOptions extends StorageUploadInp
                 .targetIdentityId(options.getTargetIdentityId())
                 .contentType(options.getContentType())
                 .serverSideEncryption(options.getServerSideEncryption())
+                .storageClass(options.getStorageClass())
                 .metadata(options.getMetadata());
     }
 
@@ -109,6 +123,7 @@ public final class AWSS3StorageUploadInputStreamOptions extends StorageUploadInp
                     ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId()) &&
                     ObjectsCompat.equals(getContentType(), that.getContentType()) &&
                     ObjectsCompat.equals(getServerSideEncryption(), that.getServerSideEncryption()) &&
+                    ObjectsCompat.equals(getStorageClass(), that.getStorageClass()) &&
                     ObjectsCompat.equals(getMetadata(), that.getMetadata());
         }
     }
@@ -121,6 +136,7 @@ public final class AWSS3StorageUploadInputStreamOptions extends StorageUploadInp
                 getTargetIdentityId(),
                 getContentType(),
                 getServerSideEncryption(),
+                getStorageClass(),
                 getMetadata()
         );
     }
@@ -134,6 +150,7 @@ public final class AWSS3StorageUploadInputStreamOptions extends StorageUploadInp
                 ", targetIdentityId=" + getTargetIdentityId() +
                 ", contentType=" + getContentType() +
                 ", serverSideEncryption=" + getServerSideEncryption().getName() +
+                ", storageClass=" + getStorageClass() +
                 ", metadata=" + getMetadata() +
                 '}';
     }
@@ -145,11 +162,13 @@ public final class AWSS3StorageUploadInputStreamOptions extends StorageUploadInp
      */
     public static final class Builder extends StorageUploadInputStreamOptions.Builder<Builder> {
         private ServerSideEncryption serverSideEncryption;
+        private StorageClass storageClass;
         private boolean useAccelerateEndpoint;
 
         private Builder() {
             super();
             this.serverSideEncryption = ServerSideEncryption.NONE;
+            this.storageClass = StorageClass.Standard.INSTANCE;
         }
 
         /**
@@ -170,6 +189,17 @@ public final class AWSS3StorageUploadInputStreamOptions extends StorageUploadInp
         @NonNull
         public Builder serverSideEncryption(@NonNull ServerSideEncryption serverSideEncryption) {
             this.serverSideEncryption = Objects.requireNonNull(serverSideEncryption);
+            return this;
+        }
+
+        /**
+         * Configures the storage class for a new AWSS3StorageUploadInputStreamOptions instance.
+         * @param storageClass storage class
+         * @return Current Builder instance for fluent chaining
+         */
+        @NonNull
+        public Builder storageClass(@NonNull StorageClass storageClass) {
+            this.storageClass = Objects.requireNonNull(storageClass);
             return this;
         }
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StoragePathUploadRequest.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StoragePathUploadRequest.kt
@@ -14,6 +14,7 @@
  */
 package com.amplifyframework.storage.s3.request
 
+import aws.sdk.kotlin.services.s3.model.StorageClass
 import com.amplifyframework.storage.StoragePath
 import com.amplifyframework.storage.s3.ServerSideEncryption
 
@@ -26,6 +27,7 @@ internal data class AWSS3StoragePathUploadRequest<L>(
     val local: L,
     val contentType: String?,
     val serverSideEncryption: ServerSideEncryption,
+    val storageClass: StorageClass,
     val metadata: Map<String, String>,
     val useAccelerateEndpoint: Boolean
 )

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/request/AWSS3StorageUploadRequest.java
@@ -24,6 +24,8 @@ import com.amplifyframework.storage.s3.ServerSideEncryption;
 import java.util.HashMap;
 import java.util.Map;
 
+import aws.sdk.kotlin.services.s3.model.StorageClass;
+
 /**
  * Parameters to provide to S3 that describe a request to upload.
  * @param <L> object to upload (e.g. File or InputStream)
@@ -39,6 +41,7 @@ public final class AWSS3StorageUploadRequest<L> {
     private final String targetIdentityId;
     private final String contentType;
     private final ServerSideEncryption serverSideEncryption;
+    private final StorageClass storageClass;
     private final Map<String, String> metadata;
     private final boolean useAccelerateEndpoint;
 
@@ -54,6 +57,7 @@ public final class AWSS3StorageUploadRequest<L> {
      *                         If null, the operation will fetch the current identity ID.
      * @param contentType The standard MIME type describing the format of the object to store
      * @param serverSideEncryption server side encryption type for the current storage bucket
+     * @param storageClass The storage class to use for the object to store
      * @param metadata Metadata for the object to store
      * @param useAccelerateEndpoint flag to use acceleration endpoint.
      */
@@ -65,6 +69,7 @@ public final class AWSS3StorageUploadRequest<L> {
             @Nullable String targetIdentityId,
             @Nullable String contentType,
             @NonNull ServerSideEncryption serverSideEncryption,
+            @NonNull StorageClass storageClass,
             @Nullable Map<String, String> metadata,
             boolean useAccelerateEndpoint
     ) {
@@ -74,6 +79,7 @@ public final class AWSS3StorageUploadRequest<L> {
         this.targetIdentityId = targetIdentityId;
         this.contentType = contentType;
         this.serverSideEncryption = serverSideEncryption;
+        this.storageClass = storageClass;
         this.metadata = new HashMap<>();
         if (metadata != null) {
             this.metadata.putAll(metadata);
@@ -134,6 +140,15 @@ public final class AWSS3StorageUploadRequest<L> {
     @NonNull
     public ServerSideEncryption getServerSideEncryption() {
         return serverSideEncryption;
+    }
+
+    /**
+     * Gets the storage class.
+     * @return storage class
+     */
+    @NonNull
+    public StorageClass getStorageClass() {
+        return storageClass;
     }
 
     /**


### PR DESCRIPTION
Add support to define the S3 Storage Class when uploading files or streams.
Implementation is based on the existing support Server Side Encryption.

See also: https://aws.amazon.com/s3/storage-classes

- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
I didn't see any tests for related functionality. I tested  the storage class is set correctly when uploading to my S3 bucket from my own application.

```
val options = AWSS3StorageUploadInputStreamOptions.builder()
    .storageClass(aws.sdk.kotlin.services.s3.model.StorageClass.GlacierIr)
    .build()

Amplify.Storage.uploadInputStream(
    StoragePath.fromString(key),
    inputStream,
    options,
    { result -> ... },
    { error -> ... }
)
```


*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.