### PR TITLE
release: Amplify Android 2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [Release 2.20.0](https://github.com/aws-amplify/amplify-android/releases/tag/release_v2.20.0)
+
+### Features
+- **storage:** add object existence validation option to get presigned url ([#2848](https://github.com/aws-amplify/amplify-android/issues/2848))
+
+### Bug Fixes
+- **notifications:** Prevent notifications text from being truncated ([#2856](https://github.com/aws-amplify/amplify-android/issues/2856))
+- **api:** Don't prevent subscribing with API_KEY when there is also an owner-based rule ([#2828](https://github.com/aws-amplify/amplify-android/issues/2828))
+
+### Miscellaneous
+- **analytics:** Update junit ktx dependency ([#2859](https://github.com/aws-amplify/amplify-android/issues/2859))
+- **auth:** Fix tests by using proper birthdate attribute according to Cognito ([#2865](https://github.com/aws-amplify/amplify-android/issues/2865))
+- **all:** Remove ignored tests ([#2867](https://github.com/aws-amplify/amplify-android/issues/2867))
+
+[See all changes between 2.19.1 and 2.20.0](https://github.com/aws-amplify/amplify-android/compare/release_v2.19.1...release_v2.20.0)
+
 ## [Release 2.19.1](https://github.com/aws-amplify/amplify-android/releases/tag/release_v2.19.1)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ dependencies section:
 ```groovy
 dependencies {
     // Only specify modules that provide functionality your app will use
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:2.19.1'
-    implementation 'com.amplifyframework:aws-api:2.19.1'
-    implementation 'com.amplifyframework:aws-auth-cognito:2.19.1'
-    implementation 'com.amplifyframework:aws-datastore:2.19.1'
-    implementation 'com.amplifyframework:aws-predictions:2.19.1'
-    implementation 'com.amplifyframework:aws-storage-s3:2.19.1'
-    implementation 'com.amplifyframework:aws-geo-location:2.19.1'
-    implementation 'com.amplifyframework:aws-push-notifications-pinpoint:2.19.1'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:2.20.0'
+    implementation 'com.amplifyframework:aws-api:2.20.0'
+    implementation 'com.amplifyframework:aws-auth-cognito:2.20.0'
+    implementation 'com.amplifyframework:aws-datastore:2.20.0'
+    implementation 'com.amplifyframework:aws-predictions:2.20.0'
+    implementation 'com.amplifyframework:aws-storage-s3:2.20.0'
+    implementation 'com.amplifyframework:aws-geo-location:2.20.0'
+    implementation 'com.amplifyframework:aws-push-notifications-pinpoint:2.20.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx4g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-VERSION_NAME=2.19.1
+VERSION_NAME=2.20.0
 
 POM_GROUP=com.amplifyframework
 POM_URL=https://github.com/aws-amplify/amplify-android

--- a/rxbindings/README.md
+++ b/rxbindings/README.md
@@ -24,7 +24,7 @@ library. In your module's `build.gradle`:
 ```gradle
 dependencies {
     // Add this line.
-    implementation 'com.amplifyframework:rxbindings:2.19.1'
+    implementation 'com.amplifyframework:rxbindings:2.20.0'
 }
 ```
 


### PR DESCRIPTION
## Release PR review checklist
- [x] Verify version name in gradle.properties
- [x] Verify CHANGELOG.md


## Module versions

Amplify Android 2.20.0

This is a manual PR because one of the commit messages fails the conventional commits syntax. 

The changelog should call out all of the commits from the last release (2.19.1) to today as listed out here: https://github.com/aws-amplify/amplify-android/commits/main/?since=2024-06-19&until=2024-07-11

Since there's a new feature commit in the changelog, doing a version bump to 2.20.0