### PR TITLE
fix(notifications): Catch Exception when download icon image of pinpoint notification

### DIFF
--- a/aws-push-notifications-pinpoint-common/src/main/java/com/amplifyframework/pushnotifications/pinpoint/PushNotificationsUtils.kt
+++ b/aws-push-notifications-pinpoint-common/src/main/java/com/amplifyframework/pushnotifications/pinpoint/PushNotificationsUtils.kt
@@ -77,7 +77,9 @@ class PushNotificationsUtils(
     }
 
     private suspend fun downloadImage(url: String): Bitmap? = withContext(Dispatchers.IO) {
-        BitmapFactory.decodeStream(URL(url).openConnection().getInputStream())
+        runCatching {
+            BitmapFactory.decodeStream(URL(url).openConnection().getInputStream())
+        }.getOrNull()
     }
 
     fun isAppInForeground(): Boolean {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
None

*Description of changes:*
Fix to catch exception when icon image download fails from notification payload.
If an exception is thrown, the image data is treated as null.

*How did you test these changes?*
This has not been checked as there is no back-end available.
The following commands were executed, but originally failed.
`./gradlew clean build`

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
