### PR TITLE
fix(storage): Remove unused foreground service permission

### DIFF
--- a/aws-storage-s3/src/main/AndroidManifest.xml
+++ b/aws-storage-s3/src/main/AndroidManifest.xml
@@ -16,8 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.amplifyframework.storage.s3" >
-    <!-- Permission will be merged into the manifest of the hosting app. -->
-    <!-- Is required to launch foreground transfer service for targetSdkVersion 28+. -->
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Noted that storage plugin was requesting foreground service permission. This is a leftover from Amplify V1 and is unused - there is no Service (or foreground Service) used in Storage V2, we use Work Manager instead.

Listing permissions you don't actually use is bad form, so I've removed it.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
