### PR TITLE
feat(storage): update AWSS3StoragePlugin to support multiple buckets

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -533,13 +533,13 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         );
 
         AWSS3StoragePathDownloadFileOperation operation = new AWSS3StoragePathDownloadFileOperation(
-            request,
-            defaultStorageService,
-            executorService,
-            authCredentialsProvider,
-            onProgress,
-            onSuccess,
-            onError
+                request,
+                defaultStorageService,
+                executorService,
+                authCredentialsProvider,
+                onProgress,
+                onSuccess,
+                onError
         );
         operation.start();
 
@@ -663,13 +663,13 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         );
 
         AWSS3StoragePathUploadFileOperation operation = new AWSS3StoragePathUploadFileOperation(
-            request,
-            defaultStorageService,
-            executorService,
-            authCredentialsProvider,
-            onProgress,
-            onSuccess,
-            onError
+                request,
+                defaultStorageService,
+                executorService,
+                authCredentialsProvider,
+                onProgress,
+                onSuccess,
+                onError
         );
         operation.start();
 
@@ -870,12 +870,12 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
 
         AWSS3StoragePathRemoveOperation operation =
                 new AWSS3StoragePathRemoveOperation(
-                    defaultStorageService,
-                    executorService,
-                    authCredentialsProvider,
-                    request,
-                    onSuccess,
-                    onError);
+                        defaultStorageService,
+                        executorService,
+                        authCredentialsProvider,
+                        request,
+                        onSuccess,
+                        onError);
 
         operation.start();
 
@@ -931,14 +931,14 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
                         case DOWNLOAD:
                             AWSS3StorageDownloadFileOperation
                                 downloadFileOperation = new AWSS3StorageDownloadFileOperation(
-                                    transferId,
-                                    new File(transferRecord.getFile()),
-                                    defaultStorageService,
-                                    executorService,
-                                    authCredentialsProvider,
-                                    awsS3StoragePluginConfiguration,
-                                    null,
-                                    transferObserver);
+                                transferId,
+                                new File(transferRecord.getFile()),
+                                defaultStorageService,
+                                executorService,
+                                authCredentialsProvider,
+                                awsS3StoragePluginConfiguration,
+                                null,
+                                transferObserver);
                             onReceived.accept(downloadFileOperation);
                             break;
                         default:
@@ -1030,12 +1030,12 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
 
         AWSS3StoragePathListOperation operation =
                 new AWSS3StoragePathListOperation(
-                    defaultStorageService,
-                    executorService,
-                    authCredentialsProvider,
-                    request,
-                    onSuccess,
-                    onError);
+                        defaultStorageService,
+                        executorService,
+                        authCredentialsProvider,
+                        request,
+                        onSuccess,
+                        onError);
 
         operation.start();
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/AWSS3StoragePlugin.java
@@ -498,14 +498,14 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         );
 
         AWSS3StorageDownloadFileOperation operation = new AWSS3StorageDownloadFileOperation(
-                defaultStorageService,
-                executorService,
-                authCredentialsProvider,
-                request,
-                awsS3StoragePluginConfiguration,
-                onProgress,
-                onSuccess,
-                onError
+            defaultStorageService,
+            executorService,
+            authCredentialsProvider,
+            request,
+            awsS3StoragePluginConfiguration,
+            onProgress,
+            onSuccess,
+            onError
         );
         operation.start();
 
@@ -533,13 +533,13 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         );
 
         AWSS3StoragePathDownloadFileOperation operation = new AWSS3StoragePathDownloadFileOperation(
-                request,
-                defaultStorageService,
-                executorService,
-                authCredentialsProvider,
-                onProgress,
-                onSuccess,
-                onError
+            request,
+            defaultStorageService,
+            executorService,
+            authCredentialsProvider,
+            onProgress,
+            onSuccess,
+            onError
         );
         operation.start();
 
@@ -625,14 +625,14 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         );
 
         AWSS3StorageUploadFileOperation operation = new AWSS3StorageUploadFileOperation(
-                defaultStorageService,
-                executorService,
-                authCredentialsProvider,
-                request,
-                awsS3StoragePluginConfiguration,
-                onProgress,
-                onSuccess,
-                onError
+            defaultStorageService,
+            executorService,
+            authCredentialsProvider,
+            request,
+            awsS3StoragePluginConfiguration,
+            onProgress,
+            onSuccess,
+            onError
         );
         operation.start();
 
@@ -663,13 +663,13 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         );
 
         AWSS3StoragePathUploadFileOperation operation = new AWSS3StoragePathUploadFileOperation(
-                request,
-                defaultStorageService,
-                executorService,
-                authCredentialsProvider,
-                onProgress,
-                onSuccess,
-                onError
+            request,
+            defaultStorageService,
+            executorService,
+            authCredentialsProvider,
+            onProgress,
+            onSuccess,
+            onError
         );
         operation.start();
 
@@ -753,14 +753,14 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
         );
 
         AWSS3StorageUploadInputStreamOperation operation = new AWSS3StorageUploadInputStreamOperation(
-                defaultStorageService,
-                executorService,
-                authCredentialsProvider,
-                awsS3StoragePluginConfiguration,
-                request,
-                onProgress,
-                onSuccess,
-                onError
+            defaultStorageService,
+            executorService,
+            authCredentialsProvider,
+            awsS3StoragePluginConfiguration,
+            request,
+            onProgress,
+            onSuccess,
+            onError
         );
         operation.start();
 
@@ -845,13 +845,13 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
 
         AWSS3StorageRemoveOperation operation =
             new AWSS3StorageRemoveOperation(
-                    defaultStorageService,
-                    executorService,
-                    authCredentialsProvider,
-                    request,
-                    awsS3StoragePluginConfiguration,
-                    onSuccess,
-                    onError);
+                defaultStorageService,
+                executorService,
+                authCredentialsProvider,
+                request,
+                awsS3StoragePluginConfiguration,
+                onSuccess,
+                onError);
 
         operation.start();
 
@@ -870,12 +870,12 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
 
         AWSS3StoragePathRemoveOperation operation =
                 new AWSS3StoragePathRemoveOperation(
-                        defaultStorageService,
-                        executorService,
-                        authCredentialsProvider,
-                        request,
-                        onSuccess,
-                        onError);
+                    defaultStorageService,
+                    executorService,
+                    authCredentialsProvider,
+                    request,
+                    onSuccess,
+                    onError);
 
         operation.start();
 
@@ -895,36 +895,36 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
                     TransferObserver transferObserver =
                         new TransferObserver(
                             transferRecord.getId(),
-                                defaultStorageService.getTransferManager().getTransferStatusUpdater(),
-                                transferRecord.getBucketName(),
-                                transferRecord.getKey(),
-                                transferRecord.getFile(),
-                                null,
-                                transferRecord.getState() != null ? transferRecord.getState() : TransferState.UNKNOWN);
+                            defaultStorageService.getTransferManager().getTransferStatusUpdater(),
+                            transferRecord.getBucketName(),
+                            transferRecord.getKey(),
+                            transferRecord.getFile(),
+                            null,
+                            transferRecord.getState() != null ? transferRecord.getState() : TransferState.UNKNOWN);
                     TransferType transferType = transferRecord.getType();
                     switch (Objects.requireNonNull(transferType)) {
                         case UPLOAD:
                             if (transferRecord.getFile().startsWith(TransferStatusUpdater.TEMP_FILE_PREFIX)) {
                                 AWSS3StorageUploadInputStreamOperation operation =
                                     new AWSS3StorageUploadInputStreamOperation(
-                                            transferId,
-                                            defaultStorageService,
-                                            executorService,
-                                            authCredentialsProvider,
-                                            awsS3StoragePluginConfiguration,
-                                            null,
-                                            transferObserver);
+                                        transferId,
+                                        defaultStorageService,
+                                        executorService,
+                                        authCredentialsProvider,
+                                        awsS3StoragePluginConfiguration,
+                                        null,
+                                        transferObserver);
                                 onReceived.accept(operation);
                             } else {
                                 AWSS3StorageUploadFileOperation operation =
                                     new AWSS3StorageUploadFileOperation(
-                                            transferId,
-                                            defaultStorageService,
-                                            executorService,
-                                            authCredentialsProvider,
-                                            awsS3StoragePluginConfiguration,
-                                            null,
-                                            transferObserver);
+                                        transferId,
+                                        defaultStorageService,
+                                        executorService,
+                                        authCredentialsProvider,
+                                        awsS3StoragePluginConfiguration,
+                                        null,
+                                        transferObserver);
                                 onReceived.accept(operation);
                             }
                             break;
@@ -1001,13 +1001,13 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
 
         AWSS3StorageListOperation operation =
             new AWSS3StorageListOperation(
-                    defaultStorageService,
-                    executorService,
-                    authCredentialsProvider,
-                    request,
-                    awsS3StoragePluginConfiguration,
-                    onSuccess,
-                    onError);
+                defaultStorageService,
+                executorService,
+                authCredentialsProvider,
+                request,
+                awsS3StoragePluginConfiguration,
+                onSuccess,
+                onError);
 
         operation.start();
 
@@ -1030,12 +1030,12 @@ public final class AWSS3StoragePlugin extends StoragePlugin<S3Client> {
 
         AWSS3StoragePathListOperation operation =
                 new AWSS3StoragePathListOperation(
-                        defaultStorageService,
-                        executorService,
-                        authCredentialsProvider,
-                        request,
-                        onSuccess,
-                        onError);
+                    defaultStorageService,
+                    executorService,
+                    authCredentialsProvider,
+                    request,
+                    onSuccess,
+                    onError);
 
         operation.start();
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageGetPresignedUrlOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageGetPresignedUrlOptions.java
@@ -59,11 +59,12 @@ public final class AWSS3StorageGetPresignedUrlOptions extends StorageGetUrlOptio
     @SuppressWarnings("deprecation")
     public static Builder from(@NonNull AWSS3StorageGetPresignedUrlOptions options) {
         return builder()
-            .accessLevel(options.getAccessLevel())
-            .targetIdentityId(options.getTargetIdentityId())
-            .expires(options.getExpires())
-            .setValidateObjectExistence(options.getValidateObjectExistence())
-            .expires(options.getExpires());
+                .accessLevel(options.getAccessLevel())
+                .targetIdentityId(options.getTargetIdentityId())
+                .expires(options.getExpires())
+                .setValidateObjectExistence(options.getValidateObjectExistence())
+                .expires(options.getExpires())
+                .bucket(options.getBucket());
     }
 
     /**
@@ -106,6 +107,7 @@ public final class AWSS3StorageGetPresignedUrlOptions extends StorageGetUrlOptio
             return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
                     ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId()) &&
                     ObjectsCompat.equals(getExpires(), that.getExpires()) &&
+                    ObjectsCompat.equals(getBucket(), that.getBucket()) &&
                     ObjectsCompat.equals(getValidateObjectExistence(), that.getValidateObjectExistence());
         }
     }
@@ -117,7 +119,8 @@ public final class AWSS3StorageGetPresignedUrlOptions extends StorageGetUrlOptio
                 getAccessLevel(),
                 getTargetIdentityId(),
                 getExpires(),
-                getValidateObjectExistence()
+                getValidateObjectExistence(),
+                getBucket()
         );
     }
 
@@ -130,6 +133,7 @@ public final class AWSS3StorageGetPresignedUrlOptions extends StorageGetUrlOptio
                 ", targetIdentityId=" + getTargetIdentityId() +
                 ", expires=" + getExpires() +
                 ", validateObjectExistence=" + getValidateObjectExistence() +
+                ", bucket=" + getBucket() +
                 '}';
     }
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageGetPresignedUrlOptions.java
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/options/AWSS3StorageGetPresignedUrlOptions.java
@@ -59,12 +59,12 @@ public final class AWSS3StorageGetPresignedUrlOptions extends StorageGetUrlOptio
     @SuppressWarnings("deprecation")
     public static Builder from(@NonNull AWSS3StorageGetPresignedUrlOptions options) {
         return builder()
-                .accessLevel(options.getAccessLevel())
-                .targetIdentityId(options.getTargetIdentityId())
-                .expires(options.getExpires())
-                .setValidateObjectExistence(options.getValidateObjectExistence())
-                .expires(options.getExpires())
-                .bucket(options.getBucket());
+            .accessLevel(options.getAccessLevel())
+            .targetIdentityId(options.getTargetIdentityId())
+            .expires(options.getExpires())
+            .setValidateObjectExistence(options.getValidateObjectExistence())
+            .expires(options.getExpires())
+            .bucket(options.getBucket());
     }
 
     /**

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/AWSS3StoragePluginTest.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/AWSS3StoragePluginTest.kt
@@ -15,11 +15,15 @@
 
 package com.amplifyframework.storage.s3
 
+import com.amplifyframework.storage.BucketInfo
+import com.amplifyframework.storage.InvalidStorageBucketException
+import com.amplifyframework.storage.StorageBucket
 import com.amplifyframework.storage.StorageException
 import com.amplifyframework.storage.s3.service.AWSS3StorageService
 import com.amplifyframework.storage.s3.service.StorageService
 import com.amplifyframework.testutils.configuration.amplifyOutputsData
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -61,6 +65,87 @@ class AWSS3StoragePluginTest {
 
         shouldThrow<StorageException> {
             plugin.configure(data, mockk())
+        }
+    }
+
+    @Test
+    fun `getStorageService returns default storage service if bucket is null`() {
+        val data = amplifyOutputsData {
+            storage {
+                awsRegion = "test-region"
+                bucketName = "test-bucket"
+                buckets {
+                    awsRegion = "test-region"
+                    bucketName = "test-bucket"
+                    name = "test=name"
+                }
+            }
+        }
+
+        plugin.configure(data, mockk())
+        val service = plugin.getStorageService(null)
+        service shouldNotBe null
+    }
+
+    @Test
+    fun `get AWSS3StorageService from BucketInfo`() {
+        val data = amplifyOutputsData {
+            storage {
+                awsRegion = "test-region"
+                bucketName = "test-bucket"
+                buckets {
+                    awsRegion = "test-region"
+                    bucketName = "test-bucket"
+                    name = "test=name"
+                }
+            }
+        }
+
+        plugin.configure(data, mockk())
+        val bucketInfo = BucketInfo("test-bucket", "test-region")
+        val bucket = StorageBucket.fromBucketInfo(bucketInfo)
+        val service = plugin.getStorageService(bucket)
+        service shouldNotBe null
+    }
+
+    @Test
+    fun `get AWSS3StorageService from AmplifyOutputs`() {
+        val data = amplifyOutputsData {
+            storage {
+                awsRegion = "test-region"
+                bucketName = "test-bucket"
+                buckets {
+                    awsRegion = "test-region"
+                    bucketName = "test-bucket"
+                    name = "test=name"
+                }
+            }
+        }
+
+        plugin.configure(data, mockk())
+        val bucket = StorageBucket.fromOutputs("test=name")
+        val service = plugin.getStorageService(bucket)
+        service shouldNotBe null
+    }
+
+    @Test
+    fun `getStorageService throws InvalidStorageBucketException`() {
+        val data = amplifyOutputsData {
+            storage {
+                awsRegion = "test-region"
+                bucketName = "test-bucket"
+                buckets {
+                    awsRegion = "test-region"
+                    bucketName = "test-bucket"
+                    name = "test=name"
+                }
+            }
+        }
+
+        plugin.configure(data, mockk())
+        val bucket = StorageBucket.fromOutputs("myBucket")
+        shouldThrow<InvalidStorageBucketException> {
+            plugin.getStorageService(bucket)
         }
     }
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3952,6 +3952,7 @@ public final class com/amplifyframework/storage/IdentityIdProvidedStoragePath : 
 }
 
 public final class com/amplifyframework/storage/InvalidStorageBucketException : com/amplifyframework/AmplifyException {
+	public fun <init> ()V
 }
 
 public final class com/amplifyframework/storage/ObjectMetadata {
@@ -4005,26 +4006,6 @@ public final class com/amplifyframework/storage/ObjectMetadata {
 }
 
 public final class com/amplifyframework/storage/ObjectMetadata$Companion {
-}
-
-public final class com/amplifyframework/storage/OutputsStorageBucket : com/amplifyframework/storage/StorageBucket {
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/amplifyframework/storage/OutputsStorageBucket;
-	public static synthetic fun copy$default (Lcom/amplifyframework/storage/OutputsStorageBucket;Ljava/lang/String;ILjava/lang/Object;)Lcom/amplifyframework/storage/OutputsStorageBucket;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getName ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/amplifyframework/storage/ResolvedStorageBucket : com/amplifyframework/storage/StorageBucket {
-	public final fun component1 ()Lcom/amplifyframework/storage/BucketInfo;
-	public final fun copy (Lcom/amplifyframework/storage/BucketInfo;)Lcom/amplifyframework/storage/ResolvedStorageBucket;
-	public static synthetic fun copy$default (Lcom/amplifyframework/storage/ResolvedStorageBucket;Lcom/amplifyframework/storage/BucketInfo;ILjava/lang/Object;)Lcom/amplifyframework/storage/ResolvedStorageBucket;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBucketInfo ()Lcom/amplifyframework/storage/BucketInfo;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/amplifyframework/storage/StorageAccessLevel : java/lang/Enum {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3930,12 +3930,28 @@ public final class com/amplifyframework/predictions/result/TranslateTextResult$B
 	public fun translatedText (Ljava/lang/String;)Lcom/amplifyframework/predictions/result/TranslateTextResult$Builder;
 }
 
+public final class com/amplifyframework/storage/BucketInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/amplifyframework/storage/BucketInfo;
+	public static synthetic fun copy$default (Lcom/amplifyframework/storage/BucketInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/amplifyframework/storage/BucketInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getRegion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/amplifyframework/storage/IdentityIdProvidedStoragePath : com/amplifyframework/storage/StoragePath {
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/storage/IdentityIdProvidedStoragePath;
 	public static synthetic fun copy$default (Lcom/amplifyframework/storage/IdentityIdProvidedStoragePath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/amplifyframework/storage/IdentityIdProvidedStoragePath;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplifyframework/storage/InvalidStorageBucketException : com/amplifyframework/AmplifyException {
 }
 
 public final class com/amplifyframework/storage/ObjectMetadata {
@@ -3991,12 +4007,44 @@ public final class com/amplifyframework/storage/ObjectMetadata {
 public final class com/amplifyframework/storage/ObjectMetadata$Companion {
 }
 
+public final class com/amplifyframework/storage/OutputsStorageBucket : com/amplifyframework/storage/StorageBucket {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/amplifyframework/storage/OutputsStorageBucket;
+	public static synthetic fun copy$default (Lcom/amplifyframework/storage/OutputsStorageBucket;Ljava/lang/String;ILjava/lang/Object;)Lcom/amplifyframework/storage/OutputsStorageBucket;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplifyframework/storage/ResolvedStorageBucket : com/amplifyframework/storage/StorageBucket {
+	public final fun component1 ()Lcom/amplifyframework/storage/BucketInfo;
+	public final fun copy (Lcom/amplifyframework/storage/BucketInfo;)Lcom/amplifyframework/storage/ResolvedStorageBucket;
+	public static synthetic fun copy$default (Lcom/amplifyframework/storage/ResolvedStorageBucket;Lcom/amplifyframework/storage/BucketInfo;ILjava/lang/Object;)Lcom/amplifyframework/storage/ResolvedStorageBucket;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBucketInfo ()Lcom/amplifyframework/storage/BucketInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/amplifyframework/storage/StorageAccessLevel : java/lang/Enum {
 	public static final field PRIVATE Lcom/amplifyframework/storage/StorageAccessLevel;
 	public static final field PROTECTED Lcom/amplifyframework/storage/StorageAccessLevel;
 	public static final field PUBLIC Lcom/amplifyframework/storage/StorageAccessLevel;
 	public static fun valueOf (Ljava/lang/String;)Lcom/amplifyframework/storage/StorageAccessLevel;
 	public static fun values ()[Lcom/amplifyframework/storage/StorageAccessLevel;
+}
+
+public abstract class com/amplifyframework/storage/StorageBucket {
+	public static final field Companion Lcom/amplifyframework/storage/StorageBucket$Companion;
+	public fun <init> ()V
+	public static final fun fromBucketInfo (Lcom/amplifyframework/storage/BucketInfo;)Lcom/amplifyframework/storage/StorageBucket;
+	public static final fun fromOutputs (Ljava/lang/String;)Lcom/amplifyframework/storage/StorageBucket;
+}
+
+public final class com/amplifyframework/storage/StorageBucket$Companion {
+	public final fun fromBucketInfo (Lcom/amplifyframework/storage/BucketInfo;)Lcom/amplifyframework/storage/StorageBucket;
+	public final fun fromOutputs (Ljava/lang/String;)Lcom/amplifyframework/storage/StorageBucket;
 }
 
 public final class com/amplifyframework/storage/StorageCategory : com/amplifyframework/core/category/Category, com/amplifyframework/storage/StorageCategoryBehavior {

--- a/core/src/main/java/com/amplifyframework/core/configuration/AmplifyOutputsData.kt
+++ b/core/src/main/java/com/amplifyframework/core/configuration/AmplifyOutputsData.kt
@@ -187,6 +187,14 @@ interface AmplifyOutputsData {
     interface Storage {
         val awsRegion: String
         val bucketName: String
+        val buckets: List<StorageBucket>
+    }
+
+    @InternalAmplifyApi
+    interface StorageBucket {
+        val name: String
+        val awsRegion: String
+        val bucketName: String
     }
 
     @InternalAmplifyApi
@@ -353,8 +361,16 @@ internal data class AmplifyOutputsDataImpl(
     @Serializable
     data class Storage(
         override val awsRegion: String,
-        override val bucketName: String
+        override val bucketName: String,
+        override val buckets: List<StorageBucket> = emptyList()
     ) : AmplifyOutputsData.Storage
+
+    @Serializable
+    data class StorageBucket(
+        override val name: String,
+        override val awsRegion: String,
+        override val bucketName: String
+    ) : AmplifyOutputsData.StorageBucket
 
     @Serializable
     data class AmazonLocationServiceConfig(

--- a/core/src/main/java/com/amplifyframework/storage/BucketInfo.kt
+++ b/core/src/main/java/com/amplifyframework/storage/BucketInfo.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.storage
+
+data class BucketInfo(val name: String, val region: String)

--- a/core/src/main/java/com/amplifyframework/storage/InvalidStorageBucketException.kt
+++ b/core/src/main/java/com/amplifyframework/storage/InvalidStorageBucketException.kt
@@ -15,12 +15,11 @@
 package com.amplifyframework.storage
 
 import com.amplifyframework.AmplifyException
-import com.amplifyframework.annotations.InternalAmplifyApi
 
 /**
  * Exception thrown when an invalid StorageBucket is specified.
  */
-class InvalidStorageBucketException @InternalAmplifyApi constructor(
+class InvalidStorageBucketException internal constructor(
     message: String = "Unable to find bucket from name in Amplify Outputs.",
     recoverySuggestion: String = "Ensure the bucket name used is available in Amplify Outputs."
 ) : AmplifyException(message, recoverySuggestion)

--- a/core/src/main/java/com/amplifyframework/storage/InvalidStorageBucketException.kt
+++ b/core/src/main/java/com/amplifyframework/storage/InvalidStorageBucketException.kt
@@ -17,6 +17,9 @@ package com.amplifyframework.storage
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.annotations.InternalAmplifyApi
 
+/**
+ * Exception thrown when an invalid StorageBucket is specified.
+ */
 class InvalidStorageBucketException @InternalAmplifyApi constructor(
     message: String = "Unable to find bucket from name in Amplify Outputs.",
     recoverySuggestion: String = "Ensure the bucket name used is available in Amplify Outputs."

--- a/core/src/main/java/com/amplifyframework/storage/InvalidStorageBucketException.kt
+++ b/core/src/main/java/com/amplifyframework/storage/InvalidStorageBucketException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.storage
+
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.annotations.InternalAmplifyApi
+
+class InvalidStorageBucketException @InternalAmplifyApi constructor(
+    message: String = "Unable to find bucket from name in Amplify Outputs.",
+    recoverySuggestion: String = "Ensure the bucket name used is available in Amplify Outputs."
+) : AmplifyException(message, recoverySuggestion)

--- a/core/src/main/java/com/amplifyframework/storage/StorageBucket.kt
+++ b/core/src/main/java/com/amplifyframework/storage/StorageBucket.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.storage
+
+abstract class StorageBucket {
+    companion object {
+        @JvmStatic
+        fun fromOutputs(name: String): StorageBucket = OutputsStorageBucket(name)
+        @JvmStatic
+        fun fromBucketInfo(bucketInfo: BucketInfo): StorageBucket = ResolvedStorageBucket(bucketInfo)
+    }
+}
+
+// While class may be technically public, the constructor is internal,
+// Customer is never expected to see or attempt to use this extended class
+data class OutputsStorageBucket internal constructor(val name: String) : StorageBucket()
+
+// While class may be technically public, the constructor is internal,
+// Customer is never expected to see or attempt to use this extended class
+data class ResolvedStorageBucket internal constructor(val bucketInfo: BucketInfo) : StorageBucket()

--- a/core/src/main/java/com/amplifyframework/storage/StorageBucket.kt
+++ b/core/src/main/java/com/amplifyframework/storage/StorageBucket.kt
@@ -14,6 +14,8 @@
  */
 package com.amplifyframework.storage
 
+import com.amplifyframework.annotations.InternalAmplifyApi
+
 abstract class StorageBucket {
     companion object {
         @JvmStatic
@@ -23,10 +25,8 @@ abstract class StorageBucket {
     }
 }
 
-// While class may be technically public, the constructor is internal,
-// Customer is never expected to see or attempt to use this extended class
+@InternalAmplifyApi
 data class OutputsStorageBucket internal constructor(val name: String) : StorageBucket()
 
-// While class may be technically public, the constructor is internal,
-// Customer is never expected to see or attempt to use this extended class
+@InternalAmplifyApi
 data class ResolvedStorageBucket internal constructor(val bucketInfo: BucketInfo) : StorageBucket()

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageGetUrlOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageGetUrlOptions.java
@@ -32,7 +32,7 @@ public class StorageGetUrlOptions extends StorageOptions {
      */
     @SuppressWarnings("deprecation")
     protected StorageGetUrlOptions(final Builder<?> builder) {
-        super(builder.getAccessLevel(), builder.getTargetIdentityId());
+        super(builder.getAccessLevel(), builder.getTargetIdentityId(), builder.getBucket());
         this.expires = builder.getExpires();
     }
 
@@ -69,9 +69,10 @@ public class StorageGetUrlOptions extends StorageOptions {
     @SuppressWarnings("deprecation")
     public static Builder<?> from(@NonNull StorageGetUrlOptions options) {
         return builder()
-            .accessLevel(options.getAccessLevel())
-            .targetIdentityId(options.getTargetIdentityId())
-            .expires(options.getExpires());
+                .accessLevel(options.getAccessLevel())
+                .targetIdentityId(options.getTargetIdentityId())
+                .bucket(options.getBucket())
+                .expires(options.getExpires());
     }
 
     /**
@@ -97,6 +98,7 @@ public class StorageGetUrlOptions extends StorageOptions {
             StorageGetUrlOptions that = (StorageGetUrlOptions) obj;
             return ObjectsCompat.equals(getAccessLevel(), that.getAccessLevel()) &&
                     ObjectsCompat.equals(getTargetIdentityId(), that.getTargetIdentityId()) &&
+                    ObjectsCompat.equals(getBucket(), that.getBucket()) &&
                     ObjectsCompat.equals(getExpires(), that.getExpires());
         }
     }
@@ -110,6 +112,7 @@ public class StorageGetUrlOptions extends StorageOptions {
         return ObjectsCompat.hash(
                 getAccessLevel(),
                 getTargetIdentityId(),
+                getBucket(),
                 getExpires()
         );
     }
@@ -124,6 +127,7 @@ public class StorageGetUrlOptions extends StorageOptions {
         return "StorageGetUrlOptions {" +
                 "accessLevel=" + getAccessLevel() +
                 ", targetIdentityId=" + getTargetIdentityId() +
+                ", bucket=" + getBucket() +
                 ", expires=" + getExpires() +
                 '}';
     }

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageOptions.java
@@ -74,6 +74,10 @@ abstract class StorageOptions {
         return targetIdentityId;
     }
 
+    /**
+     * Gets the storage bucket.
+     * @return storage bucket
+     */
     @Nullable
     public final StorageBucket getBucket() {
         return bucket;
@@ -118,6 +122,11 @@ abstract class StorageOptions {
             return (B) this;
         }
 
+        /**
+         * Configure the storage bucket that will be used on newly built StorageOptions.
+         * @param bucket Storage bucket for new StorageOptions instances
+         * @return Current Builder instance, for fluent method chaining
+         */
         public final B bucket(StorageBucket bucket) {
             this.bucket = bucket;
             return (B) this;
@@ -136,6 +145,10 @@ abstract class StorageOptions {
             return targetIdentityId;
         }
 
+        /**
+         * Gets the storage bucket.
+         * @return storage bucket
+         */
         @Nullable
         public final StorageBucket getBucket() {
             return bucket;

--- a/core/src/main/java/com/amplifyframework/storage/options/StorageOptions.java
+++ b/core/src/main/java/com/amplifyframework/storage/options/StorageOptions.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.amplifyframework.storage.StorageAccessLevel;
+import com.amplifyframework.storage.StorageBucket;
 import com.amplifyframework.storage.StoragePath;
 
 /**
@@ -31,11 +32,23 @@ abstract class StorageOptions {
     private final StorageAccessLevel accessLevel;
     private final String targetIdentityId;
 
+    private final StorageBucket bucket;
+
     @SuppressWarnings("deprecation")
     StorageOptions(StorageAccessLevel accessLevel,
                    String targetIdentityId) {
         this.accessLevel = accessLevel;
         this.targetIdentityId = targetIdentityId;
+        this.bucket = null;
+    }
+
+    @SuppressWarnings("deprecation")
+    StorageOptions(StorageAccessLevel accessLevel,
+                   String targetIdentityId,
+                   StorageBucket bucket) {
+        this.accessLevel = accessLevel;
+        this.targetIdentityId = targetIdentityId;
+        this.bucket = bucket;
     }
 
     /**
@@ -61,6 +74,11 @@ abstract class StorageOptions {
         return targetIdentityId;
     }
 
+    @Nullable
+    public final StorageBucket getBucket() {
+        return bucket;
+    }
+
     /**
      * Builds storage options.
      */
@@ -69,6 +87,7 @@ abstract class StorageOptions {
         @SuppressWarnings("deprecation")
         private StorageAccessLevel accessLevel;
         private String targetIdentityId;
+        private StorageBucket bucket;
 
         /**
          * Configures the storage access level to set on new
@@ -99,6 +118,11 @@ abstract class StorageOptions {
             return (B) this;
         }
 
+        public final B bucket(StorageBucket bucket) {
+            this.bucket = bucket;
+            return (B) this;
+        }
+
         @SuppressWarnings("deprecation")
         @Deprecated
         @Nullable
@@ -110,6 +134,11 @@ abstract class StorageOptions {
         @Nullable
         public final String getTargetIdentityId() {
             return targetIdentityId;
+        }
+
+        @Nullable
+        public final StorageBucket getBucket() {
+            return bucket;
         }
 
         /**

--- a/core/src/test/java/com/amplifyframework/core/configuration/AmplifyOutputsDataTest.kt
+++ b/core/src/test/java/com/amplifyframework/core/configuration/AmplifyOutputsDataTest.kt
@@ -253,6 +253,44 @@ class AmplifyOutputsDataTest {
         outputs.storage?.run {
             awsRegion shouldBe "us-east-1"
             bucketName shouldBe "myBucket"
+            buckets.size shouldBe 0
+        }
+    }
+
+    @Test
+    fun `parses multi-bucket storage configuration`() {
+        val json = createJson(
+            Keys.storage to mapOf(
+                Keys.region to "us-east-1",
+                Keys.bucket to "myBucket",
+                Keys.buckets to listOf(
+                    mapOf(
+                        Keys.region to "us-east-1",
+                        Keys.bucket to "myBucket",
+                        Keys.name to "name1"
+                    ),
+                    mapOf(
+                        Keys.region to "us-east-2",
+                        Keys.bucket to "myBucket2",
+                        Keys.name to "name2"
+                    )
+                )
+            )
+        )
+
+        val outputs = AmplifyOutputsData.deserialize(json)
+
+        outputs.storage.shouldNotBeNull()
+        outputs.storage?.run {
+            awsRegion shouldBe "us-east-1"
+            bucketName shouldBe "myBucket"
+            buckets.size shouldBe 2
+            buckets[0].name shouldBe "name1"
+            buckets[0].awsRegion shouldBe "us-east-1"
+            buckets[0].bucketName shouldBe "myBucket"
+            buckets[1].name shouldBe "name2"
+            buckets[1].awsRegion shouldBe "us-east-2"
+            buckets[1].bucketName shouldBe "myBucket2"
         }
     }
 
@@ -361,6 +399,8 @@ class AmplifyOutputsDataTest {
         // Storage
         const val storage = "storage"
         const val bucket = "bucket_name"
+        const val buckets = "buckets"
+        const val name = "name"
 
         // Custom
         const val custom = "custom"

--- a/core/src/test/java/com/amplifyframework/core/configuration/AmplifyOutputsDataTest.kt
+++ b/core/src/test/java/com/amplifyframework/core/configuration/AmplifyOutputsDataTest.kt
@@ -285,12 +285,17 @@ class AmplifyOutputsDataTest {
             awsRegion shouldBe "us-east-1"
             bucketName shouldBe "myBucket"
             buckets.size shouldBe 2
-            buckets[0].name shouldBe "name1"
-            buckets[0].awsRegion shouldBe "us-east-1"
-            buckets[0].bucketName shouldBe "myBucket"
-            buckets[1].name shouldBe "name2"
-            buckets[1].awsRegion shouldBe "us-east-2"
-            buckets[1].bucketName shouldBe "myBucket2"
+            buckets[0].apply {
+                name shouldBe "name1"
+                awsRegion shouldBe "us-east-1"
+                bucketName shouldBe "myBucket"
+            }
+
+            buckets[1].apply {
+                name shouldBe "name2"
+                awsRegion shouldBe "us-east-2"
+                bucketName shouldBe "myBucket2"
+            }
         }
     }
 

--- a/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/configuration/AmplifyOutputsDataBuilder.kt
@@ -163,4 +163,14 @@ class NotificationsBuilder : AmplifyOutputsData.Notifications {
 class StorageBuilder : AmplifyOutputsData.Storage {
     override var awsRegion: String = "us-east-1"
     override var bucketName: String = "bucket-name"
+    override var buckets: MutableList<AmplifyOutputsData.StorageBucket> = mutableListOf()
+    fun buckets(func: StorageBucketBuilder.() -> Unit) {
+        buckets += StorageBucketBuilder().apply(func)
+    }
+}
+
+class StorageBucketBuilder : AmplifyOutputsData.StorageBucket {
+    override var awsRegion: String = "us-east-1"
+    override var bucketName: String = "bucket-name"
+    override var name: String = "test-name"
 }


### PR DESCRIPTION
**Multi-bucket support part 1**

- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
This the first part of a series of changes/pull request to support multi-bucket in the S3 Storage Plugin.  The series of changes will be reviewed and merged into a feature branch and combined into a single pull request to be reviewed and merged into `main` branch.

Changes in this pull request includes:
* Update `AmplifyOutputsData` to support multi-bucket configuration
* Add new data structures and update `StorageOption` to specify S3 bucket
* Update `AWSS3StoragePlugin` to support interfacing with unique bucket/region by creating and maintaining multiple `AWSS3StorageService` instances.  Creating multiple `AWSS3StorageService` at the plugin level is the least invasive change to support multiple buckets/regions; the alternative is to create and maintain multiple `S3Client` at the operation layer and result in updating every operations in the Storage plugin.
* Update `getUrl` API to support multiple buckets.  The rest of the Storage plugin API will be updated in subsequent pull requests.
* Added unit tests to support new behaviors


Integration tests will be added in a separate pull request.

*How did you test these changes?*
* verified via unit tests and manual testing

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
