### PR TITLE
chore(apollo): Fix publishing errors with apollo-appsync

### DIFF
--- a/apollo/apollo-appsync/build.gradle.kts
+++ b/apollo/apollo-appsync/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
 java {
     withSourcesJar()
+    withJavadocJar()
 }
 
 kotlin {

--- a/configuration/publishing.gradle
+++ b/configuration/publishing.gradle
@@ -57,7 +57,7 @@ afterEvaluate { project ->
                     from(components.named("release").get())
                 }
                 project.pluginManager.withPlugin("java-library") {
-                    from(components["java"])
+                    from(components.named("java").get())
                 }
 
                 pom {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
The signing key was only being set for Android projects, resulting in no signature generating for `apollo-appsync`. You need signature files to publish the artifacts to maven central. Therefore I moved the setting of the required extras outside the check for the Android plugin.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
