### PR TITLE
feat(api): Pass authorization in header instead of query parameter for API category

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -131,7 +131,7 @@ final class SubscriptionEndpoint {
                                                   .addHeader("Sec-WebSocket-Protocol", "graphql-ws")
                                                   .header("User-Agent", UserAgent.string());
                     // Add all authorization headers
-                    getConnectionAuthorizationHeaders(authType).forEach(builder::addHeader);
+                    getConnectionAuthorizationHeaders(authType).forEach(builder::header);
                     webSocket = okHttpClient.newWebSocket(builder.build(), webSocketListener);
                 } catch (ApiException apiException) {
                     onSubscriptionError.accept(apiException);

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -16,7 +16,6 @@
 package com.amplifyframework.api.aws;
 
 import android.net.Uri;
-import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
@@ -24,6 +23,7 @@ import androidx.core.util.ObjectsCompat;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiException.ApiAuthException;
+import com.amplifyframework.api.aws.utils.JSONObjectExtensionsKt;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.core.Action;
@@ -126,11 +126,13 @@ final class SubscriptionEndpoint {
             if (webSocketListener == null || webSocketListener.isDisconnectedState()) {
                 webSocketListener = new AmplifyWebSocketListener();
                 try {
-                    webSocket = okHttpClient.newWebSocket(new Request.Builder()
-                                                              .url(buildConnectionRequestUrl(authType))
-                                                              .addHeader("Sec-WebSocket-Protocol", "graphql-ws")
-                                                              .header("User-Agent", UserAgent.string())
-                                                              .build(), webSocketListener);
+                    Request.Builder builder = new Request.Builder()
+                                                  .url(buildConnectionRequestUrl())
+                                                  .addHeader("Sec-WebSocket-Protocol", "graphql-ws")
+                                                  .header("User-Agent", UserAgent.string());
+                    // Add all authorization headers
+                    getConnectionAuthorizationHeaders(authType).forEach(builder::addHeader);
+                    webSocket = okHttpClient.newWebSocket(builder.build(), webSocketListener);
                 } catch (ApiException apiException) {
                     onSubscriptionError.accept(apiException);
                     return;
@@ -303,17 +305,17 @@ final class SubscriptionEndpoint {
         }
     }
 
+    private Map<String, String> getConnectionAuthorizationHeaders(AuthorizationType authType) throws ApiException {
+        JSONObject headers = authorizer.createHeadersForConnection(authType);
+        return JSONObjectExtensionsKt.toStringMap(headers);
+    }
+
     /*
      * Discover WebSocket endpoint from the AppSync endpoint.
      * AppSync endpoint : https://xxxxxxxxxxxx.appsync-api.ap-southeast-2.amazonaws.com/graphql
      * Discovered WebSocket endpoint : wss:// xxxxxxxxxxxx.appsync-realtime-api.ap-southeast-2.amazonaws.com/graphql
      */
-    private String buildConnectionRequestUrl(AuthorizationType authType) throws ApiException {
-        // Construct the authorization header for connection request
-        final byte[] rawHeader = authorizer.createHeadersForConnection(authType)
-            .toString()
-            .getBytes();
-
+    private String buildConnectionRequestUrl() throws ApiException {
         URL appSyncEndpoint = null;
         try {
             appSyncEndpoint = new URL(apiConfiguration.getEndpoint());
@@ -343,8 +345,6 @@ final class SubscriptionEndpoint {
             .scheme("wss")
             .authority(authority)
             .path(path)
-            .appendQueryParameter("header", Base64.encodeToString(rawHeader, Base64.DEFAULT))
-            .appendQueryParameter("payload", "e30=")
             .build()
             .toString();
     }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/JSONObjectExtensions.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/JSONObjectExtensions.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws.utils
+
+import org.json.JSONObject
+
+internal fun JSONObject.toStringMap(): Map<String, String> {
+    val map = mutableMapOf<String, String>()
+    this.keys().forEach { key -> map[key] = this.getString(key) }
+    return map
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
AppSync now supports passing the authorization headers as HTTP headers instead of query string parameters when establishing a websocket connection.

This PR migrates the API category to the new, recommended method for passing authorization headers.

*How did you test these changes?*
- Manual test
- Integration tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
