### PR TITLE
chore(auth): Add waits to asynchronous tests

### DIFF
--- a/testutils/src/main/java/com/amplifyframework/testutils/CountdownLatchExtensions.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/CountdownLatchExtensions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+
+/**
+ * Await using a [Duration]
+ */
+fun CountDownLatch.await(duration: Duration) = await(duration.inWholeMilliseconds, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
I noticed that unit tests in RealAuthCognitoPluginTest were frequently failing on CI. Inspecting the failing tests show that they were not necessarily waiting for the callbacks to be invoked before proceeding with verification.  Adding additional latches should resolve the issue.

Longer term this area of the codebase should be refactored into usecases.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
