### PR TITLE
chore(auth): Signout before tests start

### DIFF
--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginInstrumentationTests.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginInstrumentationTests.kt
@@ -30,7 +30,6 @@ import com.amplifyframework.testutils.await
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -72,11 +71,6 @@ class AWSCognitoAuthPluginInstrumentationTests {
     fun setup() {
         signOut()
         Thread.sleep(1000) // ensure signout has time to complete
-    }
-
-    @After
-    fun tearDown() {
-        signOut()
     }
 
     @Test

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginInstrumentationTests.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginInstrumentationTests.kt
@@ -26,13 +26,16 @@ import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.InitializationStatus
 import com.amplifyframework.hub.HubChannel
 import com.amplifyframework.testutils.HubAccumulator
+import com.amplifyframework.testutils.await
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -65,6 +68,12 @@ class AWSCognitoAuthPluginInstrumentationTests {
         }
     }
 
+    @Before
+    fun setup() {
+        signOut()
+        Thread.sleep(1000) // ensure signout has time to complete
+    }
+
     @After
     fun tearDown() {
         signOut()
@@ -76,7 +85,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
 
         signInWithCognito()
 
-        hubAccumulator.await(10, TimeUnit.SECONDS)
+        hubAccumulator.await(10.seconds)
         // if we made it this far without timeout, it means hub event was received
     }
 
@@ -87,7 +96,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
         signInWithCognito()
         signOut()
 
-        hubAccumulator.await(10, TimeUnit.SECONDS)
+        hubAccumulator.await(10.seconds)
         // if we made it this far without timeout, it means hub event was received
     }
 
@@ -104,8 +113,8 @@ class AWSCognitoAuthPluginInstrumentationTests {
         signOut()
         signInWithCognito()
 
-        signInAccumulator.await(10, TimeUnit.SECONDS)
-        signOutAccumulator.await(10, TimeUnit.SECONDS)
+        signInAccumulator.await(10.seconds)
+        signOutAccumulator.await(10.seconds)
         // if we made it this far without timeout, it means hub event was received
     }
 
@@ -120,7 +129,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
         signOut()
         signInWithCognito()
 
-        signInAccumulatorExtra.await(10, TimeUnit.SECONDS)
+        signInAccumulatorExtra.await(2.seconds)
         // Execution should not reach here
     }
 
@@ -140,7 +149,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
                 latch.countDown()
             }
         )
-        latch.await(10, TimeUnit.SECONDS)
+        latch.await(10.seconds)
 
         assertTrue(session.isSignedIn)
         with(session as AWSCognitoAuthSession) {
@@ -168,7 +177,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
                 latch.countDown()
             }
         )
-        latch.await(10, TimeUnit.SECONDS)
+        latch.await(10.seconds)
 
         assertFalse(session.isSignedIn)
         with(session as AWSCognitoAuthSession) {
@@ -195,7 +204,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
             }
         )
 
-        rememberLatch.await(10, TimeUnit.SECONDS)
+        rememberLatch.await(10.seconds)
 
         val forgetLatch = CountDownLatch(1)
 
@@ -209,7 +218,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
             }
         )
 
-        forgetLatch.await(10, TimeUnit.SECONDS)
+        forgetLatch.await(10.seconds)
 
         signOut()
         signInWithCognito()
@@ -226,7 +235,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
             }
         )
 
-        rememberLatch2.await(10, TimeUnit.SECONDS)
+        rememberLatch2.await(10.seconds)
 
         val forgetLatch2 = CountDownLatch(1)
 
@@ -240,7 +249,7 @@ class AWSCognitoAuthPluginInstrumentationTests {
             }
         )
 
-        forgetLatch2.await(10, TimeUnit.SECONDS)
+        forgetLatch2.await(10.seconds)
     }
 
     private fun signInWithCognito(synchronous: Boolean = true) {

--- a/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
@@ -197,6 +197,9 @@ public final class HubAccumulator {
         return events.isEmpty() ? null : events.get(0);
     }
 
+    /**
+     * Unsubscribe from the Hub.
+     */
     public void stop() {
         Amplify.Hub.unsubscribe(this.token.get());
     }

--- a/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulator.java
@@ -123,7 +123,7 @@ public final class HubAccumulator {
                     events.add(event);
                     latch.countDown();
                     if (latch.getCount() == 0) {
-                        Amplify.Hub.unsubscribe(this.token.get());
+                        stop();
                     }
                 }
             }
@@ -195,5 +195,9 @@ public final class HubAccumulator {
             Latch.await(latch, unit.toMillis(amount));
         }
         return events.isEmpty() ? null : events.get(0);
+    }
+
+    public void stop() {
+        Amplify.Hub.unsubscribe(this.token.get());
     }
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulatorExtensions.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/HubAccumulatorExtensions.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.testutils
+
+import com.amplifyframework.hub.HubEvent
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Await using a [Duration]
+ */
+fun HubAccumulator.await(timeout: Duration = 2.seconds): List<HubEvent<*>> =
+    await(timeout.inWholeMilliseconds.toInt(), TimeUnit.MILLISECONDS)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
`AWSCognitoAuthPluginInstrumentationTests` fail very frequently on CI.  I've made two changes to try to make this test class more robust:
- Sign out before the test starts and sleep for 1 second before proceeding - this is to ensure we are actually in the correct state before starting the test
- Unsubscribe from the Hub when the test finishes. This prevents the hub from accumulating listeners.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
