### PR TITLE
fix(datastore): Add syncExpression field to LastSyncMetadata

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -937,7 +937,7 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     // We only need to do the model migration here because
                     // the current implementation of sqliteStorageHelper.update will drop all existing tables and recreate tables with new schemas,
                     // However, this might be changed in the future
-                    LOG.debug("Database up to date. Checking ModelMetadata.");
+                    LOG.debug("Database up to date. Checking System Models.");
                     new ModelMigrations(databaseConnectionHandle, modelsProvider).apply();
                 }
             }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/SQLiteStorageAdapter.java
@@ -934,6 +934,9 @@ public final class SQLiteStorageAdapter implements LocalStorageAdapter {
                     Objects.requireNonNull(databaseConnectionHandle);
                     sqliteStorageHelper.update(databaseConnectionHandle, oldVersion, newVersion);
                 } else {
+                    // We only need to do the model migration here because
+                    // the current implementation of sqliteStorageHelper.update will drop all existing tables and recreate tables with new schemas,
+                    // However, this might be changed in the future
                     LOG.debug("Database up to date. Checking ModelMetadata.");
                     new ModelMigrations(databaseConnectionHandle, modelsProvider).apply();
                 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/migrations/AddSyncExpressionToLastSyncMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/migrations/AddSyncExpressionToLastSyncMetadata.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.datastore.storage.sqlite.migrations;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.category.CategoryType;
+import com.amplifyframework.core.model.ModelProvider;
+import com.amplifyframework.logging.Logger;
+
+public class AddSyncExpressionToLastSyncMetadata implements ModelMigration{
+    private static final Logger LOG = Amplify.Logging.logger(CategoryType.DATASTORE, "amplify:aws-datastore");
+    private final SQLiteDatabase database;
+    private final ModelProvider modelProvider;
+
+    /**
+     * Constructor for the migration class.
+     * @param database Connection to the SQLite database.
+     * @param modelProvider The model provider.
+     */
+    public AddSyncExpressionToLastSyncMetadata(SQLiteDatabase database, ModelProvider modelProvider) {
+        this.database = database;
+        this.modelProvider = modelProvider;
+    }
+
+    @Override
+    public void apply() {
+        LOG.info("AddSyncExpressionToLastSyncMetadata is applied");
+    }
+}

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/migrations/ModelMigrations.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/storage/sqlite/migrations/ModelMigrations.java
@@ -37,6 +37,7 @@ public class ModelMigrations {
     public ModelMigrations(SQLiteDatabase databaseConnectionHandle, ModelProvider modelsProvider) {
         List<ModelMigration> migrationClasses = new ArrayList<>();
         migrationClasses.add(new AddModelNameToModelMetadataKey(databaseConnectionHandle, modelsProvider));
+        migrationClasses.add(new AddSyncExpressionToLastSyncMetadata(databaseConnectionHandle, modelsProvider));
         this.modelMigrations = Immutable.of(migrationClasses);
     }
 

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/LastSyncMetadata.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/LastSyncMetadata.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * Metadata about the last time that a model class was sync'd with AppSync backend.
+ * Metadata about the last time that a model class was sync'd with AppSync backend using a certain syncExpression.
  * This metadata is persisted locally as a system model. This metadata is inspected
  * whenever the Sync Engine starts up. The system consider the value of
  * {@link LastSyncMetadata#getLastSyncTime()} to decide whether or not it should
@@ -39,13 +39,15 @@ public final class LastSyncMetadata implements Model {
     private final @ModelField(targetType = "String", isRequired = true) String modelClassName;
     private final @ModelField(targetType = "AWSTimestamp", isRequired = true) Long lastSyncTime;
     private final @ModelField(targetType = "String", isRequired = true) String lastSyncType;
+    private final @ModelField(targetType = "String") String syncExpression;
 
     @SuppressWarnings("checkstyle:ParameterName") // The field is named "id" in the model; keep it consistent
-    private LastSyncMetadata(String id, String modelClassName, Long lastSyncTime, SyncType syncType) {
+    private LastSyncMetadata(String id, String modelClassName, Long lastSyncTime, SyncType syncType, @Nullable String syncExpression) {
         this.id = id;
         this.modelClassName = modelClassName;
         this.lastSyncTime = lastSyncTime;
         this.lastSyncType = syncType.name();
+        this.syncExpression = syncExpression;
     }
 
     /**
@@ -57,9 +59,9 @@ public final class LastSyncMetadata implements Model {
      * @return {@link LastSyncMetadata} for the model class
      */
     public static <T extends Model> LastSyncMetadata baseSyncedAt(@NonNull String modelClassName,
-                                                           @Nullable long lastSyncTime) {
+                                                           @Nullable long lastSyncTime, @Nullable String syncExpression) {
         Objects.requireNonNull(modelClassName);
-        return create(modelClassName, lastSyncTime, SyncType.BASE);
+        return create(modelClassName, lastSyncTime, SyncType.BASE, syncExpression);
     }
 
     /**
@@ -70,9 +72,9 @@ public final class LastSyncMetadata implements Model {
      * @return {@link LastSyncMetadata} for the model class
      */
     static <T extends Model> LastSyncMetadata deltaSyncedAt(@NonNull String modelClassName,
-                                                           @Nullable long lastSyncTime) {
+                                                           @Nullable long lastSyncTime, @Nullable String syncExpression) {
         Objects.requireNonNull(modelClassName);
-        return create(modelClassName, lastSyncTime, SyncType.DELTA);
+        return create(modelClassName, lastSyncTime, SyncType.DELTA, syncExpression);
     }
 
     /**
@@ -84,7 +86,7 @@ public final class LastSyncMetadata implements Model {
      */
     public static <T extends Model> LastSyncMetadata neverSynced(@NonNull String modelClassName) {
         Objects.requireNonNull(modelClassName);
-        return create(modelClassName, null, SyncType.BASE);
+        return create(modelClassName, null, SyncType.BASE, null);
     }
 
     /**
@@ -97,9 +99,9 @@ public final class LastSyncMetadata implements Model {
      */
     @SuppressWarnings("WeakerAccess")
     static <T extends Model> LastSyncMetadata create(
-            @NonNull String modelClassName, @Nullable Long lastSyncTime, @NonNull SyncType syncType) {
+            @NonNull String modelClassName, @Nullable Long lastSyncTime, @NonNull SyncType syncType, @Nullable String syncExpression) {
         Objects.requireNonNull(modelClassName);
-        return new LastSyncMetadata(hash(modelClassName), modelClassName, lastSyncTime, syncType);
+        return new LastSyncMetadata(hash(modelClassName), modelClassName, lastSyncTime, syncType, syncExpression);
     }
 
     @NonNull
@@ -145,6 +147,14 @@ public final class LastSyncMetadata implements Model {
     }
 
     /**
+     * Returns the sync expression being used in the last sync
+     * @return A serialized sync expression
+     */
+    public String getSyncExpression() {
+        return this.syncExpression;
+    }
+
+    /**
      * Computes a stable hash for a model class, by its name.
      * Since {@link Model}s have to have unique IDs, we need an ID for this class.
      * However, ideally, we wouldn't use it. Ideally, we'd use the model class name.
@@ -175,6 +185,9 @@ public final class LastSyncMetadata implements Model {
         if (!ObjectsCompat.equals(lastSyncType, that.lastSyncType)) {
             return false;
         }
+        if (!ObjectsCompat.equals(syncExpression, that.syncExpression)) {
+            return false;
+        }
         return ObjectsCompat.equals(lastSyncTime, that.lastSyncTime);
     }
 
@@ -184,6 +197,7 @@ public final class LastSyncMetadata implements Model {
         result = 31 * result + modelClassName.hashCode();
         result = 31 * result + lastSyncTime.hashCode();
         result = 31 * result + lastSyncType.hashCode();
+        result = 31 * result + syncExpression.hashCode();
         return result;
     }
 
@@ -194,6 +208,7 @@ public final class LastSyncMetadata implements Model {
             ", modelClassName='" + modelClassName + '\'' +
             ", lastSyncTime=" + lastSyncTime +
             ", lastSyncType=" + lastSyncType +
+            ", syncExpression" + syncExpression +
             '}';
     }
 }

--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncTimeRegistry.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncTimeRegistry.java
@@ -40,6 +40,7 @@ final class SyncTimeRegistry {
         this.localStorageAdapter = localStorageAdapter;
     }
 
+    //TODO: add the second argument: current sync expression here
     Single<SyncTime> lookupLastSyncTime(@NonNull String modelClassName) {
         return Single.create(emitter -> {
             QueryPredicate hasMatchingModelClassName = QueryField.field("modelClassName").eq(modelClassName);
@@ -47,6 +48,9 @@ final class SyncTimeRegistry {
             localStorageAdapter.query(LastSyncMetadata.class, Where.matches(hasMatchingModelClassName), results -> {
                 try {
                     LastSyncMetadata syncMetadata = extractSingleResult(modelClassName, results);
+                    //TODO: syncMetadata should contain the previous serialized sync expression
+                    //TODO: compare the previous sync expression with the current one
+                    //TODO: emmit SyncTime.never() if different
                     emitter.onSuccess(SyncTime.from(syncMetadata.getLastSyncTime()));
                 } catch (DataStoreException queryResultFailure) {
                     emitter.onError(queryResultFailure);
@@ -55,9 +59,10 @@ final class SyncTimeRegistry {
         });
     }
 
-    Completable saveLastDeltaSyncTime(@NonNull String modelClassName, @Nullable SyncTime syncTime) {
+    //TODO: change the name to saveLastDeltaSync, and add the second argument for sync expression
+    Completable saveLastDeltaSyncTime(@NonNull String modelClassName, @Nullable SyncTime syncTime, @Nullable String syncExpression) {
         LastSyncMetadata metadata = syncTime != null && syncTime.exists() ?
-            LastSyncMetadata.deltaSyncedAt(modelClassName, syncTime.toLong()) :
+            LastSyncMetadata.deltaSyncedAt(modelClassName, syncTime.toLong(), syncExpression) :
             LastSyncMetadata.neverSynced(modelClassName);
 
         return Completable.create(emitter ->
@@ -71,9 +76,10 @@ final class SyncTimeRegistry {
         );
     }
 
-    Completable saveLastBaseSyncTime(@NonNull String modelClassName, @Nullable SyncTime syncTime) {
+    //TODO: change the name to saveLastDeltaSync, and add the second argument for sync expression
+    Completable saveLastBaseSyncTime(@NonNull String modelClassName, @Nullable SyncTime syncTime, @Nullable String syncExpression) {
         LastSyncMetadata metadata = syncTime != null && syncTime.exists() ?
-            LastSyncMetadata.baseSyncedAt(modelClassName, syncTime.toLong()) :
+            LastSyncMetadata.baseSyncedAt(modelClassName, syncTime.toLong(), syncExpression) :
             LastSyncMetadata.neverSynced(modelClassName);
 
         return Completable.create(emitter ->


### PR DESCRIPTION
- [X] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
This is **the first out of two PRs** in an effort to address a current issue customers had reported in our Datastore category.

The issue is that the "changing sync expression in Runtime" doesn't work as expected as described in [our doc](https://docs.amplify.aws/gen1/react/build-a-backend/more-features/datastore/sync-to-cloud/#reevaluate-expressions-at-runtime).

For example, when we initialize the DataStorePlugin with a sync expression for Student model to **only** sync down all the _students who are >= 20-year-old_, even if we change this sync expression to sync down _students who are >= 17-year-old in run-time_ followed by `Amplify.DataStore.stop({},{})` and `Amplify.DataStore.start({}, {})`: the new synced expression will only be applied to the newly-created/updated students, i.e. **existing instances of Students whose ages are in between 17 and 20 in remote database won't get synced, which is not as expected**.

The bug is originated from the `hydrate() method in SyncProcessor.java`, which is being called by the `startApiSync() method in Orchestrator.java`, a component responsible for "Synchronizing changed data between the LocalStorageAdapter and AppSync".
To build a Sync Request (`syncModel(..) method in SyncProcessor.java`), we need to pass in
- a model schema of the Model we want to sync
- last_sync_timestamp of this model
- predicate / sync expression

**In order to achieve this, our implementation persists the last_sync_timestamp of models in `LastSyncMetadata table` whenever the code initiate a sync request, and uses the persisted last_sync_timestamp from LastSyncMetadata to initiate the next sync.** (`createHydrationTasks(..) in SyncProcessor.java`)

This would allow us to initiate either a Delta sync or Base sync based on the `lastSyncTime` parameter we pass in, which is defined by the nature of AppSync's Sync API.

_To further explain the cause of this bug, let's keep using the previous example:_
After we initiate the first sync with sync expression _(age>=20)_, we would add a new row in LastSyncMetadata, which might look like `[Student(model name), 3(last sync timestamp)]`, assuming the current timestamp is 3.
After we change the sync expression in runtime _(age>=17)_, the implementation would:
- retrieve the Student model's last sync time (3) from the database
- use 3 as last sync time and the updated sync expression (age>=17) to build a new sync request for Student model
- update the row in LastSyncMetadata table, which might look like `[Student(model name), 4(last sync timestamp)]`

This will lead to the bug behavior described above, because:
AppSync will use BOTH _updated_sync_expression(age>=17)_ and _last_sync_timestamp(3)_ to initiate a **delta sync** (_base sync will be performed only when _last_sync_timestamp is 0_). **And for delta sync, under the hood, this `last_sync_timestamp` will be used to compare with the metadata `_lastChangedAt` in each rows of Student table in remote database.**

So previous students  who haven't been updated since last_sync_timestamp(3), i.e. _lastChangedAt<3, **won't get synced down, even though they meet the updated sync expression**, e.g. a row in Student table like `[student1(name), 18(age), 2(_lastChangedAt)]`.

But students who are added/updated later **will get synced**, e.g., a row in Student table like `[student2(name), 17(age), 5(_lastChangedAt)]`.

The essence of this problem is that: **the last_sync_timestamp was only associated with the model, but should be associated with the model and the last_sync_expression being used**.

To address this, we need to:
- add a new column in LastSyncMetadata to store the `last_sync_expression` being used
- **store** the last_sync_expression after we request a sync, and **use** last_sync_expression to adjust the retrieved last_sync_timestamp when we try to build a new sync request. To be specific, if the current_sync_expression != last_sync_expression, we return 0 as adjusted last_sync_timestamp to initiate a full sync.

The solution has been broke down into two steps, which would be implemented in two PRs:
1. DB migration for LastSyncMetadata table
2. logic changes to make use of the new field

*How did you test these changes?*
(Please add a line here how the changes were tested)
**[TODO]**

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
