### PR TITLE
fix(analytics): Fix accessing the Analytics category from RxAmplify or Kotlin Facade

### DIFF
--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/core/Amplify.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/core/Amplify.kt
@@ -41,11 +41,11 @@ import com.amplifyframework.logging.LoggingCategory
 @Suppress("unused")
 class Amplify {
     companion object {
-        val Analytics = AnalyticsCategory()
+        val Analytics: AnalyticsCategory = delegate.Analytics
         val API = KotlinApiFacade()
         val Auth = KotlinAuthFacade()
         val Geo = KotlinGeoFacade()
-        val Logging = LoggingCategory()
+        val Logging: LoggingCategory = delegate.Logging
         val Storage = KotlinStorageFacade()
         val Hub = KotlinHubFacade()
         val DataStore = KotlinDataStoreFacade()

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAmplify.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAmplify.java
@@ -34,10 +34,10 @@ public final class RxAmplify {
     private RxAmplify() {}
 
     // Breaking the rules, here. Don't look.
-    @SuppressWarnings({"checkstyle:all"}) public static final AnalyticsCategory Analytics = new AnalyticsCategory();
+    @SuppressWarnings({"checkstyle:all"}) public static final AnalyticsCategory Analytics = Amplify.Analytics;
     @SuppressWarnings({"checkstyle:all"}) public static final RxApiCategoryBehavior API = new RxApiBinding();
     @SuppressWarnings({"checkstyle:all"}) public static final RxAuthCategoryBehavior Auth = new RxAuthBinding();
-    @SuppressWarnings({"checkstyle:all"}) public static final LoggingCategory Logging = new LoggingCategory();
+    @SuppressWarnings({"checkstyle:all"}) public static final LoggingCategory Logging = Amplify.Logging;
     @SuppressWarnings({"checkstyle:all"}) public static final RxStorageCategoryBehavior Storage = new RxStorageBinding();
     @SuppressWarnings({"checkstyle:all"}) public static final RxHubCategoryBehavior Hub = new RxHubBinding();
     @SuppressWarnings({"checkstyle:all"}) public static final RxDataStoreCategoryBehavior DataStore = new RxDataStoreBinding();


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* 
#2943

*Description of changes:*
The `RxAmplify` and the Kotlin Facade version of `Amplify` both instantiate their own versions of the Analytics (and Logging) category. Neither do that for other categories.

This is a problem because they delegate to the main Amplify for all other actions, including adding plugins. Therefore, the Analytics plugin gets added to the "main" instance of the Category (e.g. the one owned by `com.amplifyframework.core.Amplify`) while subsequent API calls get routed to the "new" instance of the category (owned by `com.amplifyframework.rx.RxAmplify` or `com.amplifyframework.kotlin.core.Amplify`). Such API calls always result in a `IllegalStateException` because there is no plugin added to that instance of the category.

The fix is simple, the two facade classes should reference the Analytics/Logging instance owned by the main Amplify class, just as they do for all other categories.

This fixes the crash. Now it does not matter what combination of Amplify/RxAmplify/Kotlin Facade is used, all calls work as expected.

*How did you test these changes?*
- Built app with RxAmplify & Kotlin Facade and verified crash is resolved by using the updated libraries in this PR.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
