### PR TITLE
fix(apollo): Fix using Apollo to connect to AppSync in China

### DIFF
--- a/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/AppSyncEndpoint.kt
+++ b/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/AppSyncEndpoint.kt
@@ -21,7 +21,7 @@ import java.net.URL
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 private val standardEndpointRegex =
-    "^https://\\w{26}\\.appsync-api\\.\\w{2}(?:-\\w{2,})+-\\d\\.amazonaws.com/graphql$".toRegex()
+    "^https://\\w{26}\\.appsync-api\\.\\w{2}(?:-\\w{2,})+-\\d\\.amazonaws.com(?:\\.cn)?/graphql$".toRegex()
 
 /**
  * Class representing the AppSync endpoint. There are multiple URLs associated with each AppSync endpoint: the

--- a/apollo/apollo-appsync/src/test/java/com/amplifyframework/apollo/appsync/AppSyncEndpointTest.kt
+++ b/apollo/apollo-appsync/src/test/java/com/amplifyframework/apollo/appsync/AppSyncEndpointTest.kt
@@ -26,6 +26,8 @@ import org.junit.Test
 
 class AppSyncEndpointTest {
     private val standardAppSyncUrl = "https://example1234567890123456789.appsync-api.us-east-1.amazonaws.com/graphql"
+    private val standardAppSyncUrlChina =
+        "https://example1234567890123456789.appsync-api.us-east-1.amazonaws.com.cn/graphql"
     private val customAppSyncUrl = "https://api.example.com/graphql"
 
     @Test
@@ -46,6 +48,13 @@ class AppSyncEndpointTest {
         val endpoint = AppSyncEndpoint(standardAppSyncUrl)
         endpoint.websocketConnection.toString() shouldBe
             "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com/graphql/connect"
+    }
+
+    @Test
+    fun `uses expected realtime URL for standard endpoint in China`() {
+        val endpoint = AppSyncEndpoint(standardAppSyncUrlChina)
+        endpoint.websocketConnection.toString() shouldBe
+            "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com.cn/graphql/connect"
     }
 
     @Test


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2945

*Description of changes:*
In China the AppSync URL has `.cn` as a TLD, and we weren't account for that in our standard URL regex. I updated the regex to [match Amplify JS](https://github.com/aws-amplify/amplify-js/blob/7402f607443786750c9b2da63461739f974b594b/packages/api-graphql/src/Providers/AWSWebSocketProvider/appsyncUrl.ts#L13-L16)

*How did you test these changes?*
Unit test

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
