### PR TITLE
fix(api): Fix connecting to AppSync from China with API category

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/DomainType.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/DomainType.java
@@ -34,7 +34,7 @@ public enum DomainType {
     CUSTOM;
 
     private static final String STANDARD_ENDPOINT_REGEX =
-            "^https:\\/\\/\\w{26}\\.appsync\\-api\\.\\w{2}(?:(?:\\-\\w{2,})+)\\-\\d\\.amazonaws.com\\/graphql$";
+            "^https:\\/\\/\\w{26}\\.appsync\\-api\\.\\w{2}(?:\\-\\w{2,})+\\-\\d\\.amazonaws.com(?:\\.cn)?\\/graphql$";
 
     /**
      * Get Domain type based on defined endpoint.

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/DomainTypeTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/DomainTypeTest.java
@@ -24,6 +24,8 @@ import static com.amplifyframework.api.aws.DomainType.STANDARD;
 public class DomainTypeTest {
     private static final String STANDARD_URL =
             "https://abcdefghijklmnopqrstuvwxyz.appsync-api.us-west-2.amazonaws.com/graphql";
+    private static final String STANDARD_URL_CHINA =
+        "https://abcdefghijklmnopqrstuvwxyz.appsync-api.us-west-2.amazonaws.com.cn/graphql";
     private static final String CUSTOM_URL = "https://something.in.somedomain.com/graphql";
 
     /**
@@ -32,6 +34,14 @@ public class DomainTypeTest {
     @Test
     public void testStandardURLMatch() {
         Assert.assertEquals(STANDARD, DomainType.from(STANDARD_URL));
+    }
+
+    /**
+     * Test that Domain type is {@link DomainType#STANDARD} for generated URL.
+     */
+    @Test
+    public void testStandardURLChinaMatch() {
+        Assert.assertEquals(STANDARD, DomainType.from(STANDARD_URL_CHINA));
     }
 
     /**


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2945

*Description of changes:*
In China the AppSync URL has .cn as a TLD, and we weren't account for that in our standard URL regex. I updated the regex to [match Amplify JS](https://github.com/aws-amplify/amplify-js/blob/7402f607443786750c9b2da63461739f974b594b/packages/api-graphql/src/Providers/AWSWebSocketProvider/appsyncUrl.ts#L13-L16)

*How did you test these changes?*
Unit test

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
