### PR TITLE
feat(auth): Add Passwordless features to Amplify

### DIFF
--- a/aws-auth-cognito/api/aws-auth-cognito.api
+++ b/aws-auth-cognito/api/aws-auth-cognito.api
@@ -10,6 +10,9 @@ public final class com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin : com/
 	public static final field AWS_COGNITO_AUTH_LOG_NAMESPACE Ljava/lang/String;
 	public static final field Companion Lcom/amplifyframework/auth/cognito/AWSCognitoAuthPlugin$Companion;
 	public fun <init> ()V
+	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public fun autoSignIn (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public final fun clearFederationToIdentityPool (Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun configure (Lorg/json/JSONObject;Landroid/content/Context;)V
 	public fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmResetPasswordOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
@@ -20,6 +23,8 @@ public final class com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin : com/
 	public fun confirmSignUp (Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun confirmUserAttribute (Lcom/amplifyframework/auth/AuthUserAttributeKey;Ljava/lang/String;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun deleteUser (Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public final fun federateToIdentityPool (Ljava/lang/String;Lcom/amplifyframework/auth/AuthProvider;Lcom/amplifyframework/auth/cognito/options/FederateToIdentityPoolOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public final fun federateToIdentityPool (Ljava/lang/String;Lcom/amplifyframework/auth/AuthProvider;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun fetchAuthSession (Lcom/amplifyframework/auth/options/AuthFetchSessionOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
@@ -36,6 +41,8 @@ public final class com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin : com/
 	public fun getVersion ()Ljava/lang/String;
 	public fun handleWebUISignInResponse (Landroid/content/Intent;)V
 	public fun initialize (Landroid/content/Context;)V
+	public fun listWebAuthnCredentials (Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
+	public fun listWebAuthnCredentials (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun rememberDevice (Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthResendSignUpCodeOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
@@ -238,7 +245,8 @@ public class com/amplifyframework/auth/cognito/exceptions/service/TooManyRequest
 }
 
 public class com/amplifyframework/auth/cognito/exceptions/service/UserCancelledException : com/amplifyframework/auth/exceptions/ServiceException {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public class com/amplifyframework/auth/cognito/exceptions/service/UserLambdaValidationException : com/amplifyframework/auth/exceptions/ServiceException {
@@ -255,6 +263,21 @@ public class com/amplifyframework/auth/cognito/exceptions/service/UserNotFoundEx
 
 public class com/amplifyframework/auth/cognito/exceptions/service/UsernameExistsException : com/amplifyframework/auth/exceptions/ServiceException {
 	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class com/amplifyframework/auth/cognito/exceptions/service/WebAuthnNotEnabledException : com/amplifyframework/auth/exceptions/ServiceException {
+}
+
+public final class com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnCredentialAlreadyExistsException : com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnFailedException {
+}
+
+public class com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnFailedException : com/amplifyframework/auth/AuthException {
+}
+
+public final class com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException : com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnFailedException {
+}
+
+public final class com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnRpMismatchException : com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnFailedException {
 }
 
 public final class com/amplifyframework/auth/cognito/helpers/FlutterFactory {
@@ -295,9 +318,11 @@ public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfi
 	public final fun component1 ()Ljava/util/Map;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/Map;Ljava/util/List;Ljava/lang/String;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions;
-	public static synthetic fun copy$default (Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions;
+	public final fun component4 ()Ljava/lang/ref/WeakReference;
+	public final fun copy (Ljava/util/Map;Ljava/util/List;Ljava/lang/String;Ljava/lang/ref/WeakReference;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions;
+	public static synthetic fun copy$default (Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;Ljava/lang/ref/WeakReference;ILjava/lang/Object;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCallingActivity ()Ljava/lang/ref/WeakReference;
 	public final fun getFriendlyDeviceName ()Ljava/lang/String;
 	public final fun getMetadata ()Ljava/util/Map;
 	public final fun getUserAttributes ()Ljava/util/List;
@@ -309,6 +334,7 @@ public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfi
 	public fun <init> ()V
 	public fun build ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions;
 	public synthetic fun build ()Lcom/amplifyframework/auth/options/AuthConfirmSignInOptions;
+	public final fun callingActivity (Landroid/app/Activity;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions$CognitoBuilder;
 	public final fun friendlyDeviceName (Ljava/lang/String;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions$CognitoBuilder;
 	public fun getThis ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions$CognitoBuilder;
 	public synthetic fun getThis ()Lcom/amplifyframework/auth/options/AuthConfirmSignInOptions$Builder;
@@ -345,6 +371,41 @@ public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfi
 public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignUpOptions$Companion {
 	public final fun builder ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignUpOptions$CognitoBuilder;
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignUpOptions;
+}
+
+public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions : com/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions {
+	public static final field Companion Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions$Companion;
+	public static final fun builder ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions;
+	public static synthetic fun copy$default (Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions;
+	public static final fun defaults ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxResults ()Ljava/lang/Integer;
+	public final fun getNextToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions$Builder : com/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions$Builder {
+	public fun <init> ()V
+	public fun build ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions;
+	public synthetic fun build ()Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;
+	public final fun getMaxResults ()Ljava/lang/Integer;
+	public final fun getNextToken ()Ljava/lang/String;
+	public fun getThis ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions$Builder;
+	public synthetic fun getThis ()Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions$Builder;
+	public final fun maxResults (Ljava/lang/Integer;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions$Builder;
+	public final fun nextToken (Ljava/lang/String;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions$Builder;
+	public final synthetic fun setMaxResults (Ljava/lang/Integer;)V
+	public final synthetic fun setNextToken (Ljava/lang/String;)V
+}
+
+public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions$Companion {
+	public final fun builder ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions$Builder;
+	public final fun defaults ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions;
+	public final synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions;
 }
 
 public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthResendSignUpCodeOptions : com/amplifyframework/auth/options/AuthResendSignUpCodeOptions {
@@ -429,7 +490,9 @@ public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignI
 	public static fun builder ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions$CognitoBuilder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAuthFlowType ()Lcom/amplifyframework/auth/cognito/options/AuthFlowType;
+	public fun getCallingActivity ()Ljava/lang/ref/WeakReference;
 	public fun getMetadata ()Ljava/util/Map;
+	public fun getPreferredFirstFactor ()Lcom/amplifyframework/auth/AuthFactorType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -439,9 +502,11 @@ public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignI
 	public fun authFlowType (Lcom/amplifyframework/auth/cognito/options/AuthFlowType;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions$CognitoBuilder;
 	public fun build ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions;
 	public synthetic fun build ()Lcom/amplifyframework/auth/options/AuthSignInOptions;
+	public fun callingActivity (Landroid/app/Activity;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions$CognitoBuilder;
 	public fun getThis ()Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions$CognitoBuilder;
 	public synthetic fun getThis ()Lcom/amplifyframework/auth/options/AuthSignInOptions$Builder;
 	public fun metadata (Ljava/util/Map;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions$CognitoBuilder;
+	public fun preferredFirstFactor (Lcom/amplifyframework/auth/AuthFactorType;)Lcom/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions$CognitoBuilder;
 }
 
 public final class com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignOutOptions : com/amplifyframework/auth/options/AuthSignOutOptions {
@@ -586,6 +651,7 @@ public final class com/amplifyframework/auth/cognito/options/AuthFlowType : java
 	public static final field CUSTOM_AUTH Lcom/amplifyframework/auth/cognito/options/AuthFlowType;
 	public static final field CUSTOM_AUTH_WITHOUT_SRP Lcom/amplifyframework/auth/cognito/options/AuthFlowType;
 	public static final field CUSTOM_AUTH_WITH_SRP Lcom/amplifyframework/auth/cognito/options/AuthFlowType;
+	public static final field USER_AUTH Lcom/amplifyframework/auth/cognito/options/AuthFlowType;
 	public static final field USER_PASSWORD_AUTH Lcom/amplifyframework/auth/cognito/options/AuthFlowType;
 	public static final field USER_SRP_AUTH Lcom/amplifyframework/auth/cognito/options/AuthFlowType;
 	public static fun valueOf (Ljava/lang/String;)Lcom/amplifyframework/auth/cognito/options/AuthFlowType;
@@ -613,6 +679,19 @@ public final class com/amplifyframework/auth/cognito/options/FederateToIdentityP
 public final class com/amplifyframework/auth/cognito/options/FederateToIdentityPoolOptions$Companion {
 	public final fun builder ()Lcom/amplifyframework/auth/cognito/options/FederateToIdentityPoolOptions$CognitoBuilder;
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/amplifyframework/auth/cognito/options/FederateToIdentityPoolOptions;
+}
+
+public final class com/amplifyframework/auth/cognito/result/AWSCognitoAuthListWebAuthnCredentialsResult : com/amplifyframework/auth/result/AuthListWebAuthnCredentialsResult {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lcom/amplifyframework/auth/cognito/result/AWSCognitoAuthListWebAuthnCredentialsResult;
+	public static synthetic fun copy$default (Lcom/amplifyframework/auth/cognito/result/AWSCognitoAuthListWebAuthnCredentialsResult;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/amplifyframework/auth/cognito/result/AWSCognitoAuthListWebAuthnCredentialsResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCredentials ()Ljava/util/List;
+	public final fun getNextToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class com/amplifyframework/auth/cognito/result/AWSCognitoAuthSignOutResult : com/amplifyframework/auth/result/AuthSignOutResult {

--- a/aws-auth-cognito/build.gradle.kts
+++ b/aws-auth-cognito/build.gradle.kts
@@ -26,6 +26,9 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.auth.cognito"
+    defaultConfig {
+        consumerProguardFiles += file("consumer-rules.pro")
+    }
 }
 
 dependencies {
@@ -37,6 +40,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.security)
     implementation(libs.androidx.browser)
+    implementation(libs.androidx.credentials)
 
     implementation(libs.aws.http)
     implementation(libs.aws.cognitoidentity)
@@ -61,6 +65,7 @@ dependencies {
     testImplementation(libs.test.kotlin.reflection)
     testImplementation(libs.test.kotest.assertions)
     testImplementation(libs.test.kotest.assertions.json)
+    testImplementation(libs.test.turbine)
 
     androidTestImplementation(libs.gson)
     //noinspection GradleDependency

--- a/aws-auth-cognito/consumer-rules.pro
+++ b/aws-auth-cognito/consumer-rules.pro
@@ -1,0 +1,5 @@
+# CredentialManager rules
+-if class androidx.credentials.CredentialManager
+-keep class androidx.credentials.playservices.** {
+  *;
+}

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginEmailMFATests.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginEmailMFATests.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.auth.cognito
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.amplifyframework.api.aws.AWSApiPlugin
+import com.amplifyframework.api.graphql.GraphQLOperation
 import com.amplifyframework.api.graphql.SimpleGraphQLRequest
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
@@ -51,6 +52,7 @@ class AWSCognitoAuthPluginEmailMFATests {
     private var authPlugin = AWSCognitoAuthPlugin()
     private var apiPlugin = AWSApiPlugin()
     private lateinit var synchronousAuth: SynchronousAuth
+    private var subscription: GraphQLOperation<MfaInfo>? = null
     private var mfaCode = ""
     private var latch: CountDownLatch? = null
 
@@ -64,8 +66,8 @@ class AWSCognitoAuthPluginEmailMFATests {
         apiPlugin.configure(config, context)
         synchronousAuth = SynchronousAuth.delegatingTo(authPlugin)
 
-        apiPlugin.subscribe(
-            SimpleGraphQLRequest<MfaInfo>(
+        subscription = apiPlugin.subscribe(
+            SimpleGraphQLRequest(
                 Assets.readAsString("create-mfa-subscription.graphql"),
                 MfaInfo::class.java,
                 null
@@ -83,6 +85,7 @@ class AWSCognitoAuthPluginEmailMFATests {
 
     @After
     fun tearDown() {
+        subscription?.cancel()
         mfaCode = ""
         synchronousAuth.deleteUser()
     }

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginUserAuthTests.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginUserAuthTests.kt
@@ -1,0 +1,668 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.api.aws.AWSApiPlugin
+import com.amplifyframework.api.graphql.GraphQLOperation
+import com.amplifyframework.api.graphql.SimpleGraphQLRequest
+import com.amplifyframework.auth.AuthFactorType
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.exceptions.service.CodeMismatchException
+import com.amplifyframework.auth.cognito.exceptions.service.InvalidParameterException
+import com.amplifyframework.auth.cognito.exceptions.service.UserNotFoundException
+import com.amplifyframework.auth.cognito.exceptions.service.UsernameExistsException
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
+import com.amplifyframework.auth.cognito.options.AuthFlowType
+import com.amplifyframework.auth.cognito.test.R
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.NotAuthorizedException
+import com.amplifyframework.auth.exceptions.SignedOutException
+import com.amplifyframework.auth.options.AuthSignUpOptions
+import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.auth.result.step.AuthSignUpStep
+import com.amplifyframework.core.AmplifyConfiguration
+import com.amplifyframework.core.category.CategoryConfiguration
+import com.amplifyframework.core.category.CategoryType
+import com.amplifyframework.datastore.generated.model.MfaInfo
+import com.amplifyframework.testutils.Assets
+import com.amplifyframework.testutils.sync.SynchronousAuth
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class AWSCognitoAuthPluginUserAuthTests {
+
+    private val password = "${UUID.randomUUID()}BleepBloop1234!"
+    private val userName = "test${Random.nextInt()}"
+    private val email = "$userName@amplify-swift-gamma.awsapps.com"
+    private val phoneNumber = "+1555${Random.nextInt(1000000, 10000000)}"
+
+    private var authPlugin = AWSCognitoAuthPlugin()
+    private var apiPlugin = AWSApiPlugin()
+    private lateinit var synchronousAuth: SynchronousAuth
+    private var subscription: GraphQLOperation<MfaInfo>? = null
+    private var otpCode = ""
+    private var latch: CountDownLatch? = null
+
+    @Before
+    fun initializePlugin() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val config = AmplifyConfiguration.fromConfigFile(context, R.raw.amplifyconfiguration_passwordless)
+        val authConfig: CategoryConfiguration = config.forCategoryType(CategoryType.AUTH)
+        val authConfigJson = authConfig.getPluginConfig("awsCognitoAuthPlugin")
+
+        val apiConfig: CategoryConfiguration = config.forCategoryType(CategoryType.API)
+        val apiConfigJson = apiConfig.getPluginConfig("awsAPIPlugin")
+
+        authPlugin.configure(authConfigJson, context)
+        apiPlugin.configure(apiConfigJson, context)
+        synchronousAuth = SynchronousAuth.delegatingTo(authPlugin)
+
+        subscription = apiPlugin.subscribe(
+            SimpleGraphQLRequest(
+                Assets.readAsString("create-mfa-subscription.graphql"),
+                MfaInfo::class.java,
+                null
+            ),
+            { println("====== Subscription Established ======") },
+            {
+                println("====== Received some MFA Info ======")
+                otpCode = it.data.code
+                latch?.countDown()
+            },
+            { println("====== Subscription Failed $it ======") },
+            { }
+        )
+    }
+
+    @After
+    fun tearDown() {
+        subscription?.cancel()
+        otpCode = ""
+        try {
+            synchronousAuth.deleteUser()
+        } catch (e: SignedOutException) {
+            // Catching this because if an assert fails and the test can't delete a user (because the test failed
+            // before the sign in fully finishes) then deleteUser will always throw an exception because there isn't a
+            // signed in user and that exception will hide the previous, more relevant, exception
+            println("Encountered an exception trying to delete the user: $e")
+        }
+    }
+
+    @Test
+    fun signInWithAnIncompatiblePreferredFirstFactorShowsSelectChallenge() {
+        // Step 1: Sign up a new user with NO phone number and confirm it
+        signUpAndConfirmNewUser(
+            usePhoneNumber = false
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with SMS as the preferred first factor
+        // (Inherently incompatible since the account has no phone number associated with it)
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(AuthFactorType.SMS_OTP)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to select a first factor (since SMS isn't a proper option)
+        assertEquals(AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION, signInResult.nextStep.signInStep)
+
+        // Step 3: Select a proper first factor option
+        signInResult = synchronousAuth.confirmSignIn(AuthFactorType.EMAIL_OTP.name)
+
+        // Validation 2: Validate that the next step is to confirm the emailed OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Step 4: Input the emailed OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 4: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    // Email related tests
+
+    @Test
+    fun signInWithNoFirstFactorPreferenceAndSelectEmailSucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePhoneNumber = true,
+            usePassword = true
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with NO preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(null)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to select a first factor
+        assertEquals(AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION, signInResult.nextStep.signInStep)
+
+        // Step 3: Select a first factor option
+        signInResult = synchronousAuth.confirmSignIn(AuthFactorType.EMAIL_OTP.name)
+
+        // Validation 2: Validate that the next step is to confirm the emailed OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Step 4: Input the emailed OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 4: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun signInWithNoFirstFactorPreferenceAndSelectEmailRetrySucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePhoneNumber = true
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with NO preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(null)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to select a first factor
+        assertEquals(AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION, signInResult.nextStep.signInStep)
+
+        // Step 3: Select a first factor option
+        signInResult = synchronousAuth.confirmSignIn(AuthFactorType.EMAIL_OTP.name)
+
+        // Validation 2: Validate that the next step is to confirm the emailed OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Validation 3: Validate that providing an incorrect OTP code throws the proper exception
+        assertFailsWith<CodeMismatchException> {
+            synchronousAuth.confirmSignIn(otpCode.reversed())
+        }
+
+        // Step 4: Input the emailed OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 4: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun signInWithEmailPreferredSucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser()
+
+        // Step 2: Attempt to sign in with the newly created user with EMAIL preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(AuthFactorType.EMAIL_OTP)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to confirm the emailed OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Step 3: Input the emailed OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 2: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun signInWithEmailPreferredRetrySucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser()
+
+        // Step 2: Attempt to sign in with the newly created user with EMAIL preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(AuthFactorType.EMAIL_OTP)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to confirm the emailed OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Validation 2: Validate that providing an incorrect OTP code throws the proper exception
+        assertFailsWith<CodeMismatchException> {
+            synchronousAuth.confirmSignIn(otpCode.reversed())
+        }
+
+        // Step 3: Input the emailed OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 3: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    // SMS Related Tests
+
+    @Test
+    fun signInWithNoFirstFactorPreferenceAndSelectSmsSucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePhoneNumber = true
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with NO preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(null)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to select a first factor
+        assertEquals(AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION, signInResult.nextStep.signInStep)
+
+        // Step 3: Select a first factor option
+        signInResult = synchronousAuth.confirmSignIn(AuthFactorType.SMS_OTP.name)
+
+        // Validation 2: Validate that the next step is to confirm the texted OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Step 4: Input the texted OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 3: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun signInWithNoFirstFactorPreferenceAndSelectSmsRetrySucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePhoneNumber = true
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with NO preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(null)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to select a first factor
+        assertEquals(AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION, signInResult.nextStep.signInStep)
+
+        // Step 3: Select a first factor option
+        signInResult = synchronousAuth.confirmSignIn(AuthFactorType.SMS_OTP.name)
+
+        // Validation 2: Validate that the next step is to confirm the texted OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Validation 3: Validate that providing an incorrect OTP code throws the proper exception
+        assertFailsWith<CodeMismatchException> {
+            synchronousAuth.confirmSignIn(otpCode.reversed())
+        }
+
+        // Step 4: Input the texted OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 4: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun signInWithSmsPreferredSucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePhoneNumber = true
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with SMS preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(AuthFactorType.SMS_OTP)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to confirm the texted OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Step 4: Input the texted OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 2: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun signInWithSmsPreferredRetrySucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePhoneNumber = true
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with SMS preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(AuthFactorType.SMS_OTP)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to confirm the texted OTP code
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP, signInResult.nextStep.signInStep)
+
+        // Wait until the OTP code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Validation 2: Validate that providing an incorrect OTP code throws the proper exception
+        assertFailsWith<CodeMismatchException> {
+            synchronousAuth.confirmSignIn(otpCode.reversed())
+        }
+
+        // Step 3: Input the texted OTP code for confirmation
+        signInResult = synchronousAuth.confirmSignIn(otpCode)
+
+        // Validation 2: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    // Password Related Tests
+
+    @Test
+    fun signInWithNoFirstFactorPreferenceAndSelectPasswordSucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePassword = true
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with NO preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(null)
+                .build()
+
+        var signInResult = synchronousAuth.signIn(userName, null, options)
+
+        // Validation 1: Validate that the next step is to select a first factor
+        assertEquals(AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION, signInResult.nextStep.signInStep)
+
+        // Step 3: Select a first factor option
+        signInResult = synchronousAuth.confirmSignIn(AuthFactorType.PASSWORD.name)
+
+        // Validation 2: Validate that the user needs to input their password
+        assertEquals(AuthSignInStep.CONFIRM_SIGN_IN_WITH_PASSWORD, signInResult.nextStep.signInStep)
+
+        // Step 4: Input the password
+        signInResult = synchronousAuth.confirmSignIn(password)
+
+        // Validation 3: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun signInWithPasswordPreferredRetrySucceeds() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePassword = true
+        )
+
+        // Step 2: Attempt to sign in with the newly created user with PASSWORD preferred first factor
+        val options =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(AuthFactorType.PASSWORD)
+                .build()
+
+        // Validation 1: Validate that an incorrect password returns the proper exception
+        assertFailsWith<NotAuthorizedException> {
+            synchronousAuth.signIn(userName, password.reversed(), options)
+        }
+
+        // Step 3: Sign in with the correct password
+        val signInResult = synchronousAuth.signIn(userName, password, options)
+
+        // Validation 2: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    // Sign Up
+
+    @Test
+    fun signUpWithEmptyUsernameFails() {
+        // Step 1: Try to sign up a new user with an invalid/empty username
+        val options = AuthSignUpOptions.builder()
+            .userAttributes(listOf(AuthUserAttribute(AuthUserAttributeKey.email(), email)))
+            .build()
+
+        // Validation 1: Validate that sign up fails because a username is required
+        assertFailsWith<InvalidParameterException> {
+            synchronousAuth.signUp("", null, options)
+        }
+    }
+
+    @Test
+    fun signUpWithSameUsernameFails() {
+        // Step 1: Sign up a new user and confirm it
+        signUpAndConfirmNewUser(
+            usePassword = true
+        )
+
+        // Step 2: Try to sign up a user with the same username
+        val signUpOptions = AuthSignUpOptions.builder()
+            .userAttributes(listOf(AuthUserAttribute(AuthUserAttributeKey.email(), email)))
+            .build()
+
+        // Validation 1: Validate that sign up fails because the username was already taken
+        assertFailsWith<UsernameExistsException> {
+            synchronousAuth.signUp(userName, password, signUpOptions)
+        }
+
+        // Step 3: Sign in so that we can delete the user in the tear down
+        val signInOptions =
+            AWSCognitoAuthSignInOptions
+                .builder()
+                .authFlowType(AuthFlowType.USER_AUTH)
+                .preferredFirstFactor(AuthFactorType.PASSWORD)
+                .build()
+
+        // Step 3: Sign in with the correct password
+        val signInResult = synchronousAuth.signIn(userName, password, signInOptions)
+
+        // Validation 2: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    // Confirm Sign Up and Auto Sign In
+
+    @Test
+    fun confirmSignUpAndAutoSignInSucceeds() {
+        // Step 1: Sign up a passwordless user with just an email address
+        val options = AuthSignUpOptions.builder()
+            .userAttributes(listOf(AuthUserAttribute(AuthUserAttributeKey.email(), email)))
+            .build()
+        var signUpResult = synchronousAuth.signUp(userName, null, options)
+
+        // Validation 1: Validate that the user is currently in the Confirm Sign Up state
+        assertEquals(AuthSignUpStep.CONFIRM_SIGN_UP_STEP, signUpResult.nextStep.signUpStep)
+
+        // Validation 2: Validate that calling auto sign in before the user is confirmed fails
+        assertFailsWith<InvalidStateException> {
+            synchronousAuth.autoSignIn()
+        }
+
+        // Wait until the confirmation code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Step 2: Confirm sign up with the correct OTP code
+        signUpResult = synchronousAuth.confirmSignUp(userName, otpCode)
+
+        // Validation 3: Validate that the user confirmation is complete and that auto sign in can be completed
+        assertEquals(AuthSignUpStep.COMPLETE_AUTO_SIGN_IN, signUpResult.nextStep.signUpStep)
+
+        // Step 3: Sign in so that we can delete the user in the tear down
+        val signInResult = synchronousAuth.autoSignIn()
+
+        // Validation 4: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun confirmSignUpRetryAndAutoSignInSucceeds() {
+        // Step 1: Sign up a passwordless user with just an email address
+        val options = AuthSignUpOptions.builder()
+            .userAttributes(listOf(AuthUserAttribute(AuthUserAttributeKey.email(), email)))
+            .build()
+        var signUpResult = synchronousAuth.signUp(userName, null, options)
+
+        // Validation 1: Validate that the user is currently in the Confirm Sign Up state
+        assertEquals(AuthSignUpStep.CONFIRM_SIGN_UP_STEP, signUpResult.nextStep.signUpStep)
+
+        // Validation 2: Validate that calling auto sign in before the user is confirmed fails
+        assertFailsWith<InvalidStateException> {
+            synchronousAuth.autoSignIn()
+        }
+
+        // Wait until the confirmation code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        // Validation 3: Validate that confirm sign up fails the OTP code is incorrect
+        assertFailsWith<CodeMismatchException> {
+            synchronousAuth.confirmSignUp(userName, otpCode.reversed())
+        }
+
+        // Step 2: Confirm sign up with the correct OTP code
+        signUpResult = synchronousAuth.confirmSignUp(userName, otpCode)
+
+        // Validation 4: Validate that the user confirmation is complete and that auto sign in can be completed
+        assertEquals(AuthSignUpStep.COMPLETE_AUTO_SIGN_IN, signUpResult.nextStep.signUpStep)
+
+        // Step 3: Sign in so that we can delete the user in the tear down
+        val signInResult = synchronousAuth.autoSignIn()
+
+        // Validation 5: Validate that user is signed in
+        assertEquals(AuthSignInStep.DONE, signInResult.nextStep.signInStep)
+    }
+
+    @Test
+    fun confirmSignUpFailsForUnregisteredUser() {
+        // Validation 1: Validate that confirm sign up fails on an unregistered user
+        assertFailsWith<UserNotFoundException> {
+            synchronousAuth.confirmSignUp(userName, "123456")
+        }
+    }
+
+    @Test
+    fun confirmSignUpFailsForEmptyUser() {
+        // Validation 1: Validate that confirm sign up fails on an invalid username
+        assertFailsWith<InvalidParameterException> {
+            synchronousAuth.confirmSignUp("", "123456")
+        }
+    }
+
+    private fun signUpAndConfirmNewUser(usePhoneNumber: Boolean = false, usePassword: Boolean = false) {
+        val signUpPassword = if (usePassword) {
+            password
+        } else {
+            null
+        }
+        val attributes = if (usePhoneNumber) {
+            listOf(
+                AuthUserAttribute(AuthUserAttributeKey.email(), email),
+                AuthUserAttribute(AuthUserAttributeKey.phoneNumber(), phoneNumber)
+            )
+        } else {
+            listOf(AuthUserAttribute(AuthUserAttributeKey.email(), email))
+        }
+
+        val options = AuthSignUpOptions.builder()
+            .userAttributes(attributes).build()
+        synchronousAuth.signUp(userName, signUpPassword, options)
+
+        // Wait until the confirmation code has been received
+        latch = CountDownLatch(1)
+        latch?.await(20, TimeUnit.SECONDS)
+
+        synchronousAuth.confirmSignUp(userName, otpCode)
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
@@ -19,6 +19,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import com.amplifyframework.auth.cognito.asf.UserContextDataProvider
 import com.amplifyframework.auth.cognito.helpers.SRPHelper
+import com.amplifyframework.auth.exceptions.InvalidStateException
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.Environment
 import com.amplifyframework.statemachine.StateMachineEvent
@@ -30,6 +31,7 @@ import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.AuthorizationEvent
 import com.amplifyframework.statemachine.codegen.events.DeleteUserEvent
 import com.amplifyframework.statemachine.codegen.events.SignOutEvent
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
 import java.util.Date
 import java.util.UUID
 
@@ -96,7 +98,9 @@ internal class AuthEnvironment internal constructor(
             val newASFDevice = AmplifyCredential.ASFDevice(newDeviceId)
             credentialStoreClient.storeCredentials(CredentialType.ASF, newASFDevice)
             newDeviceId
-        } else asfDevice.id
+        } else {
+            asfDevice.id
+        }
 
         return userContextDataProvider?.getEncodedContextData(username, deviceId)
     }
@@ -112,22 +116,19 @@ internal class AuthEnvironment internal constructor(
     }
 }
 
-internal fun StateMachineEvent.isAuthEvent(): AuthEvent.EventType? {
-    return (this as? AuthEvent)?.eventType
-}
+internal fun AuthEnvironment.requireIdentityProviderClient() = cognitoAuthService.cognitoIdentityProviderClient
+    ?: throw InvalidStateException("No Cognito identity provider client available")
 
-internal fun StateMachineEvent.isAuthenticationEvent(): AuthenticationEvent.EventType? {
-    return (this as? AuthenticationEvent)?.eventType
-}
+internal fun StateMachineEvent.isAuthEvent(): AuthEvent.EventType? = (this as? AuthEvent)?.eventType
 
-internal fun StateMachineEvent.isAuthorizationEvent(): AuthorizationEvent.EventType? {
-    return (this as? AuthorizationEvent)?.eventType
-}
+internal fun StateMachineEvent.isAuthenticationEvent(): AuthenticationEvent.EventType? =
+    (this as? AuthenticationEvent)?.eventType
 
-internal fun StateMachineEvent.isSignOutEvent(): SignOutEvent.EventType? {
-    return (this as? SignOutEvent)?.eventType
-}
+internal fun StateMachineEvent.isAuthorizationEvent(): AuthorizationEvent.EventType? =
+    (this as? AuthorizationEvent)?.eventType
 
-internal fun StateMachineEvent.isDeleteUserEvent(): DeleteUserEvent.EventType? {
-    return (this as? DeleteUserEvent)?.eventType
-}
+internal fun StateMachineEvent.isSignOutEvent(): SignOutEvent.EventType? = (this as? SignOutEvent)?.eventType
+
+internal fun StateMachineEvent.isDeleteUserEvent(): DeleteUserEvent.EventType? = (this as? DeleteUserEvent)?.eventType
+
+internal fun StateMachineEvent.isSignUpEvent(): SignUpEvent.EventType? = (this as? SignUpEvent)?.eventType

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CognitoAuthExceptionConverter.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/CognitoAuthExceptionConverter.kt
@@ -34,6 +34,7 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserLambdaValidatio
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserNotConfirmedException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserNotFoundException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UsernameExistsException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.WebAuthnNotEnabledException
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.cognito.exceptions.service.CodeExpiredException
 import com.amplifyframework.auth.cognito.exceptions.service.FailedAttemptsLimitExceededException
@@ -54,51 +55,54 @@ internal class CognitoAuthExceptionConverter {
          * @param fallbackMessage Fallback message to inform failure
          * @return AuthException Specific exception for Amplify Auth
          */
-        fun lookup(error: Exception, fallbackMessage: String): AuthException {
-            return when (error) {
-                is UserNotFoundException -> com.amplifyframework.auth.cognito.exceptions.service.UserNotFoundException(
+        fun lookup(error: Exception, fallbackMessage: String): AuthException = when (error) {
+            is AuthException -> error
+            is UserNotFoundException -> com.amplifyframework.auth.cognito.exceptions.service.UserNotFoundException(
+                error
+            )
+            is UserNotConfirmedException ->
+                com.amplifyframework.auth.cognito.exceptions.service.UserNotConfirmedException(error)
+            is UsernameExistsException ->
+                com.amplifyframework.auth.cognito.exceptions.service.UsernameExistsException(error)
+            is AliasExistsException -> com.amplifyframework.auth.cognito.exceptions.service.AliasExistsException(
+                error
+            )
+            is InvalidPasswordException ->
+                com.amplifyframework.auth.cognito.exceptions.service.InvalidPasswordException(error)
+            is InvalidParameterException ->
+                com.amplifyframework.auth.cognito.exceptions.service.InvalidParameterException(cause = error)
+            is ExpiredCodeException -> CodeExpiredException(error)
+            is CodeMismatchException -> com.amplifyframework.auth.cognito.exceptions.service.CodeMismatchException(
+                error
+            )
+            is CodeDeliveryFailureException ->
+                com.amplifyframework.auth.cognito.exceptions.service.CodeDeliveryFailureException(error)
+            is LimitExceededException ->
+                com.amplifyframework.auth.cognito.exceptions.service.LimitExceededException(error)
+            is MfaMethodNotFoundException -> MFAMethodNotFoundException(error)
+            is NotAuthorizedException -> com.amplifyframework.auth.exceptions.NotAuthorizedException(cause = error)
+            is ResourceNotFoundException ->
+                com.amplifyframework.auth.cognito.exceptions.service.ResourceNotFoundException(error)
+            is SoftwareTokenMfaNotFoundException ->
+                SoftwareTokenMFANotFoundException(error)
+            is TooManyFailedAttemptsException ->
+                FailedAttemptsLimitExceededException(error)
+            is TooManyRequestsException ->
+                com.amplifyframework.auth.cognito.exceptions.service.TooManyRequestsException(error)
+            is PasswordResetRequiredException ->
+                com.amplifyframework.auth.cognito.exceptions.service.PasswordResetRequiredException(error)
+            is EnableSoftwareTokenMfaException ->
+                com.amplifyframework.auth.cognito.exceptions.service.EnableSoftwareTokenMFAException(error)
+            is UserLambdaValidationException ->
+                com.amplifyframework.auth.cognito.exceptions.service.UserLambdaValidationException(
+                    error.message,
                     error
                 )
-                is UserNotConfirmedException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.UserNotConfirmedException(error)
-                is UsernameExistsException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.UsernameExistsException(error)
-                is AliasExistsException -> com.amplifyframework.auth.cognito.exceptions.service.AliasExistsException(
-                    error
+            is WebAuthnNotEnabledException ->
+                com.amplifyframework.auth.cognito.exceptions.service.WebAuthnNotEnabledException(
+                    cause = error
                 )
-                is InvalidPasswordException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.InvalidPasswordException(error)
-                is InvalidParameterException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.InvalidParameterException(cause = error)
-                is ExpiredCodeException -> CodeExpiredException(error)
-                is CodeMismatchException -> com.amplifyframework.auth.cognito.exceptions.service.CodeMismatchException(
-                    error
-                )
-                is CodeDeliveryFailureException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.CodeDeliveryFailureException(error)
-                is LimitExceededException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.LimitExceededException(error)
-                is MfaMethodNotFoundException -> MFAMethodNotFoundException(error)
-                is NotAuthorizedException -> com.amplifyframework.auth.exceptions.NotAuthorizedException(cause = error)
-                is ResourceNotFoundException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.ResourceNotFoundException(error)
-                is SoftwareTokenMfaNotFoundException ->
-                    SoftwareTokenMFANotFoundException(error)
-                is TooManyFailedAttemptsException ->
-                    FailedAttemptsLimitExceededException(error)
-                is TooManyRequestsException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.TooManyRequestsException(error)
-                is PasswordResetRequiredException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.PasswordResetRequiredException(error)
-                is EnableSoftwareTokenMfaException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.EnableSoftwareTokenMFAException(error)
-                is UserLambdaValidationException ->
-                    com.amplifyframework.auth.cognito.exceptions.service.UserLambdaValidationException(
-                        error.message,
-                        error
-                    )
-                else -> UnknownException(fallbackMessage, error)
-            }
+            else -> UnknownException(fallbackMessage, error)
         }
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -54,7 +54,7 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
 
     suspend fun signUp(
         username: String,
-        password: String,
+        password: String?,
         options: AuthSignUpOptions
     ): AuthSignUpResult {
         return suspendCoroutine { continuation ->
@@ -562,6 +562,15 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 totp,
                 email,
                 { continuation.resume(Unit) },
+                { continuation.resumeWithException(it) }
+            )
+        }
+    }
+
+    suspend fun autoSignIn(): AuthSignInResult {
+        return suspendCoroutine { continuation ->
+            delegate.autoSignIn(
+                { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
             )
         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -20,7 +20,6 @@ import android.content.Intent
 import androidx.annotation.WorkerThread
 import aws.sdk.kotlin.services.cognitoidentityprovider.associateSoftwareToken
 import aws.sdk.kotlin.services.cognitoidentityprovider.confirmForgotPassword
-import aws.sdk.kotlin.services.cognitoidentityprovider.confirmSignUp
 import aws.sdk.kotlin.services.cognitoidentityprovider.getUser
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.AnalyticsMetadataType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
@@ -41,18 +40,17 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifySoftwareToken
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifyUserAttributeRequest
 import aws.sdk.kotlin.services.cognitoidentityprovider.resendConfirmationCode
 import aws.sdk.kotlin.services.cognitoidentityprovider.setUserMfaPreference
-import aws.sdk.kotlin.services.cognitoidentityprovider.signUp
 import aws.sdk.kotlin.services.cognitoidentityprovider.verifySoftwareToken
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.auth.AWSCognitoAuthMetadataType
 import com.amplifyframework.auth.AWSCredentials
 import com.amplifyframework.auth.AWSTemporaryCredentials
-import com.amplifyframework.auth.AuthCategoryBehavior
 import com.amplifyframework.auth.AuthChannelEventName
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthDevice
 import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.AuthFactorType
 import com.amplifyframework.auth.AuthProvider
 import com.amplifyframework.auth.AuthSession
 import com.amplifyframework.auth.AuthUser
@@ -72,6 +70,7 @@ import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.cognito.helpers.HostedUIHelper
 import com.amplifyframework.auth.cognito.helpers.SessionHelper
 import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
+import com.amplifyframework.auth.cognito.helpers.collectWhile
 import com.amplifyframework.auth.cognito.helpers.getAllowedMFATypesFromChallengeParameters
 import com.amplifyframework.auth.cognito.helpers.getMFASetupTypeOrNull
 import com.amplifyframework.auth.cognito.helpers.getMFAType
@@ -126,10 +125,8 @@ import com.amplifyframework.auth.result.AuthSignOutResult
 import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult
 import com.amplifyframework.auth.result.step.AuthNextSignInStep
-import com.amplifyframework.auth.result.step.AuthNextSignUpStep
 import com.amplifyframework.auth.result.step.AuthNextUpdateAttributeStep
 import com.amplifyframework.auth.result.step.AuthSignInStep
-import com.amplifyframework.auth.result.step.AuthSignUpStep
 import com.amplifyframework.auth.result.step.AuthUpdateAttributeStep
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Amplify
@@ -145,6 +142,9 @@ import com.amplifyframework.statemachine.codegen.data.HostedUIErrorData
 import com.amplifyframework.statemachine.codegen.data.SignInData
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
 import com.amplifyframework.statemachine.codegen.data.SignOutData
+import com.amplifyframework.statemachine.codegen.data.SignUpData
+import com.amplifyframework.statemachine.codegen.data.WebAuthnSignInContext
+import com.amplifyframework.statemachine.codegen.data.challengeNameType
 import com.amplifyframework.statemachine.codegen.errors.SessionError
 import com.amplifyframework.statemachine.codegen.events.AuthEvent
 import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
@@ -153,7 +153,9 @@ import com.amplifyframework.statemachine.codegen.events.DeleteUserEvent
 import com.amplifyframework.statemachine.codegen.events.HostedUIEvent
 import com.amplifyframework.statemachine.codegen.events.SetupTOTPEvent
 import com.amplifyframework.statemachine.codegen.events.SignInChallengeEvent
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
 import com.amplifyframework.statemachine.codegen.events.SignOutEvent
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
 import com.amplifyframework.statemachine.codegen.states.AuthState
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.AuthorizationState
@@ -164,6 +166,9 @@ import com.amplifyframework.statemachine.codegen.states.SetupTOTPState
 import com.amplifyframework.statemachine.codegen.states.SignInChallengeState
 import com.amplifyframework.statemachine.codegen.states.SignInState
 import com.amplifyframework.statemachine.codegen.states.SignOutState
+import com.amplifyframework.statemachine.codegen.states.SignUpState
+import com.amplifyframework.statemachine.codegen.states.WebAuthnSignInState
+import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -173,6 +178,10 @@ import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 
 internal class RealAWSCognitoAuthPlugin(
@@ -180,7 +189,7 @@ internal class RealAWSCognitoAuthPlugin(
     private val authEnvironment: AuthEnvironment,
     private val authStateMachine: AuthStateMachine,
     private val logger: Logger
-) : AuthCategoryBehavior {
+) {
 
     private val lastPublishedHubEventName = AtomicReference<String>()
 
@@ -222,24 +231,12 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     internal suspend fun suspendWhileConfiguring() {
-        return suspendCoroutine { continuation ->
-            val token = StateChangeListenerToken()
-            authStateMachine.listen(
-                token,
-                {
-                    if (it is AuthState.Configured || it is AuthState.Error) {
-                        authStateMachine.cancel(token)
-                        continuation.resume(Unit)
-                    }
-                },
-                { }
-            )
-        }
+        authStateMachine.state.takeWhile { it !is AuthState.Configured && it !is AuthState.Error }.collect()
     }
 
-    override fun signUp(
+    fun signUp(
         username: String,
-        password: String,
+        password: String?,
         options: AuthSignUpOptions,
         onSuccess: Consumer<AuthSignUpResult>,
         onError: Consumer<AuthException>
@@ -259,92 +256,39 @@ internal class RealAWSCognitoAuthPlugin(
 
     private suspend fun _signUp(
         username: String,
-        password: String,
+        password: String?,
         options: AuthSignUpOptions,
         onSuccess: Consumer<AuthSignUpResult>,
         onError: Consumer<AuthException>
     ) {
-        logger.verbose("SignUp Starting execution")
-        try {
-            val userAttributes = options.userAttributes.map {
-                AttributeType {
-                    name = it.key.keyString
-                    value = it.value
+        authStateMachine.state.onStart {
+            val validationData = (options as? AWSCognitoAuthSignUpOptions)?.validationData
+            val clientMetadata = (options as? AWSCognitoAuthSignUpOptions)?.clientMetadata
+            val signupData = SignUpData(username, validationData, clientMetadata)
+            val event = SignUpEvent(SignUpEvent.EventType.InitiateSignUp(signupData, password, options.userAttributes))
+            authStateMachine.send(event)
+        }.drop(1).collectWhile { authState ->
+            when (val signUpState = authState.authSignUpState) {
+                is SignUpState.AwaitingUserConfirmation -> {
+                    onSuccess.accept(signUpState.signUpResult)
+                    false
                 }
-            }
-
-            val encodedContextData = authEnvironment.getUserContextData(username)
-            val pinpointEndpointId = authEnvironment.getPinpointEndpointId()
-
-            val response = authEnvironment.cognitoAuthService.cognitoIdentityProviderClient?.signUp {
-                this.username = username
-                this.password = password
-                this.userAttributes = userAttributes
-                this.clientId = configuration.userPool?.appClient
-                this.secretHash = AuthHelper.getSecretHash(
-                    username,
-                    configuration.userPool?.appClient,
-                    configuration.userPool?.appClientSecret
-                )
-                pinpointEndpointId?.let {
-                    this.analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = it }
+                is SignUpState.SignedUp -> {
+                    onSuccess.accept(signUpState.signUpResult)
+                    false
                 }
-                encodedContextData?.let { this.userContextData { encodedData = it } }
-
-                (options as? AWSCognitoAuthSignUpOptions)?.let {
-                    this.validationData = it.validationData.mapNotNull { option ->
-                        AttributeType {
-                            name = option.key
-                            value = option.value
-                        }
-                    }
-                    this.clientMetadata = it.clientMetadata
+                is SignUpState.Error -> {
+                    onError.accept(
+                        CognitoAuthExceptionConverter.lookup(signUpState.exception, "Sign up failed.")
+                    )
+                    false
                 }
+                else -> true
             }
-
-            val deliveryDetails = response?.codeDeliveryDetails?.let { details ->
-                mapOf(
-                    "DESTINATION" to details.destination,
-                    "MEDIUM" to details.deliveryMedium?.value,
-                    "ATTRIBUTE" to details.attributeName
-                )
-            }
-
-            val authSignUpResult = if (response?.userConfirmed == true) {
-                AuthSignUpResult(
-                    true,
-                    AuthNextSignUpStep(
-                        AuthSignUpStep.DONE,
-                        mapOf(),
-                        null
-                    ),
-                    response.userSub
-                )
-            } else {
-                AuthSignUpResult(
-                    false,
-                    AuthNextSignUpStep(
-                        AuthSignUpStep.CONFIRM_SIGN_UP_STEP,
-                        mapOf(),
-                        AuthCodeDeliveryDetails(
-                            deliveryDetails?.getValue("DESTINATION") ?: "",
-                            AuthCodeDeliveryDetails.DeliveryMedium.fromString(
-                                deliveryDetails?.getValue("MEDIUM")
-                            ),
-                            deliveryDetails?.getValue("ATTRIBUTE")
-                        )
-                    ),
-                    response?.userSub
-                )
-            }
-            onSuccess.accept(authSignUpResult)
-            logger.verbose("SignUp Execution complete")
-        } catch (exception: Exception) {
-            onError.accept(CognitoAuthExceptionConverter.lookup(exception, "Sign up failed."))
         }
     }
 
-    override fun confirmSignUp(
+    fun confirmSignUp(
         username: String,
         confirmationCode: String,
         onSuccess: Consumer<AuthSignUpResult>,
@@ -353,7 +297,7 @@ internal class RealAWSCognitoAuthPlugin(
         confirmSignUp(username, confirmationCode, AuthConfirmSignUpOptions.defaults(), onSuccess, onError)
     }
 
-    override fun confirmSignUp(
+    fun confirmSignUp(
         username: String,
         confirmationCode: String,
         options: AuthConfirmSignUpOptions,
@@ -366,7 +310,7 @@ internal class RealAWSCognitoAuthPlugin(
                     InvalidUserPoolConfigurationException()
                 )
                 is AuthenticationState.SignedIn, is AuthenticationState.SignedOut -> GlobalScope.launch {
-                    _confirmSignUp(username, confirmationCode, options, onSuccess, onError)
+                    _confirmSignUp(username, confirmationCode, authState.authSignUpState, options, onSuccess, onError)
                 }
                 else -> onError.accept(InvalidStateException())
             }
@@ -376,49 +320,129 @@ internal class RealAWSCognitoAuthPlugin(
     private suspend fun _confirmSignUp(
         username: String,
         confirmationCode: String,
+        authSignUpState: SignUpState?,
         options: AuthConfirmSignUpOptions,
         onSuccess: Consumer<AuthSignUpResult>,
         onError: Consumer<AuthException>
     ) {
-        logger.verbose("ConfirmSignUp Starting execution")
-        try {
-            val encodedContextData = authEnvironment.getUserContextData(username)
-            val pinpointEndpointId = authEnvironment.getPinpointEndpointId()
-
-            authEnvironment.cognitoAuthService.cognitoIdentityProviderClient?.confirmSignUp {
-                this.username = username
-                this.confirmationCode = confirmationCode
-                this.clientId = configuration.userPool?.appClient
-                this.secretHash = AuthHelper.getSecretHash(
-                    username,
-                    configuration.userPool?.appClient,
-                    configuration.userPool?.appClientSecret
-                )
-                pinpointEndpointId?.let {
-                    this.analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = it }
+        val token = StateChangeListenerToken()
+        authStateMachine.listen(
+            token,
+            { authState ->
+                when (val signUpState = authState.authSignUpState) {
+                    // Only process error if new. Existing errors have already been passed to customer
+                    is SignUpState.Error -> {
+                        if (signUpState.hasNewResponse) {
+                            signUpState.hasNewResponse = false
+                            authStateMachine.cancel(token)
+                            onError.accept(
+                                CognitoAuthExceptionConverter.lookup(signUpState.exception, "Sign up failed.")
+                            )
+                        }
+                    }
+                    is SignUpState.SignedUp -> {
+                        authStateMachine.cancel(token)
+                        onSuccess.accept(signUpState.signUpResult)
+                    }
+                    else -> Unit
                 }
-                encodedContextData?.let { this.userContextData { encodedData = it } }
-
-                (options as? AWSCognitoAuthConfirmSignUpOptions)?.let {
-                    this.clientMetadata = it.clientMetadata
+            },
+            {
+                var userId: String? = null
+                var session: String? = null
+                if (authSignUpState is SignUpState.AwaitingUserConfirmation &&
+                    authSignUpState.signUpData.username == username
+                ) {
+                    session = authSignUpState.signUpData.session
+                    userId = authSignUpState.signUpResult.userId
                 }
+                val clientMetadata = (options as? AWSCognitoAuthConfirmSignUpOptions)?.clientMetadata
+                val signupData = SignUpData(username, null, clientMetadata, session, userId)
+                val event = SignUpEvent(SignUpEvent.EventType.ConfirmSignUp(signupData, confirmationCode))
+                authStateMachine.send(event)
             }
+        )
+    }
 
-            val authSignUpResult = AuthSignUpResult(
-                true,
-                AuthNextSignUpStep(AuthSignUpStep.DONE, mapOf(), null),
-                null
-            )
-            onSuccess.accept(authSignUpResult)
-            logger.verbose("ConfirmSignUp Execution complete")
-        } catch (exception: Exception) {
-            onError.accept(
-                CognitoAuthExceptionConverter.lookup(exception, "Confirm sign up failed.")
-            )
+    fun autoSignIn(onSuccess: Consumer<AuthSignInResult>, onError: Consumer<AuthException>) {
+        authStateMachine.getCurrentState { authState ->
+            when (authState.authNState) {
+                is AuthenticationState.NotConfigured -> onError.accept(
+                    InvalidUserPoolConfigurationException()
+                )
+                is AuthenticationState.SignedIn -> {
+                    onError.accept(InvalidStateException())
+                }
+                is AuthenticationState.SignedOut -> GlobalScope.launch {
+                    when (val signUpState = authState.authSignUpState) {
+                        is SignUpState.SignedUp -> {
+                            _autoSignIn(signUpState.signUpData, onSuccess, onError)
+                        }
+                        else -> onError.accept(InvalidStateException())
+                    }
+                }
+                else -> onError.accept(InvalidStateException())
+            }
         }
     }
 
-    override fun resendSignUpCode(
+    private suspend fun _autoSignIn(
+        signUpData: SignUpData,
+        onSuccess: Consumer<AuthSignInResult>,
+        onError: Consumer<AuthException>
+    ) {
+        val token = StateChangeListenerToken()
+        authStateMachine.listen(
+            token,
+            { authState ->
+                val authNState = authState.authNState
+                val authZState = authState.authZState
+                when {
+                    authNState is AuthenticationState.SigningIn -> {
+                        val signInState = authNState.signInState
+                        when {
+                            signInState is SignInState.Error -> {
+                                authStateMachine.cancel(token)
+                                onError.accept(
+                                    CognitoAuthExceptionConverter.lookup(signInState.exception, "Sign in failed.")
+                                )
+                            }
+                        }
+                    }
+                    authNState is AuthenticationState.SignedIn &&
+                        authZState is AuthorizationState.SessionEstablished -> {
+                        authStateMachine.cancel(token)
+                        val authSignInResult = AuthSignInResult(
+                            true,
+                            AuthNextSignInStep(
+                                AuthSignInStep.DONE,
+                                mapOf(),
+                                null,
+                                null,
+                                null,
+                                null
+                            )
+                        )
+                        onSuccess.accept(authSignInResult)
+                        sendHubEvent(AuthChannelEventName.SIGNED_IN.toString())
+                    }
+                    else -> Unit
+                }
+            },
+            {
+                val signInData = SignInData.AutoSignInData(
+                    signUpData.username,
+                    signUpData.session,
+                    signUpData.clientMetadata ?: mapOf(),
+                    signUpData.userId
+                )
+                val event = AuthenticationEvent(AuthenticationEvent.EventType.SignInRequested(signInData))
+                authStateMachine.send(event)
+            }
+        )
+    }
+
+    fun resendSignUpCode(
         username: String,
         onSuccess: Consumer<AuthCodeDeliveryDetails>,
         onError: Consumer<AuthException>
@@ -426,7 +450,7 @@ internal class RealAWSCognitoAuthPlugin(
         resendSignUpCode(username, AuthResendSignUpCodeOptions.defaults(), onSuccess, onError)
     }
 
-    override fun resendSignUpCode(
+    fun resendSignUpCode(
         username: String,
         options: AuthResendSignUpCodeOptions,
         onSuccess: Consumer<AuthCodeDeliveryDetails>,
@@ -494,7 +518,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun signIn(
+    fun signIn(
         username: String?,
         password: String?,
         onSuccess: Consumer<AuthSignInResult>,
@@ -503,7 +527,7 @@ internal class RealAWSCognitoAuthPlugin(
         signIn(username, password, AuthSignInOptions.defaults(), onSuccess, onError)
     }
 
-    override fun signIn(
+    fun signIn(
         username: String?,
         password: String?,
         options: AuthSignInOptions,
@@ -567,6 +591,7 @@ internal class RealAWSCognitoAuthPlugin(
                         val srpSignInState = (signInState as? SignInState.SigningInWithSRP)?.srpSignInState
                         val challengeState = (signInState as? SignInState.ResolvingChallenge)?.challengeState
                         val totpSetupState = (signInState as? SignInState.ResolvingTOTPSetup)?.setupTOTPState
+                        val webAuthnState = (signInState as? SignInState.SigningInWithWebAuthn)?.webAuthnSignInState
                         when {
                             srpSignInState is SRPSignInState.Error -> {
                                 authStateMachine.cancel(token)
@@ -583,6 +608,12 @@ internal class RealAWSCognitoAuthPlugin(
                             challengeState is SignInChallengeState.WaitingForAnswer -> {
                                 authStateMachine.cancel(token)
                                 SignInChallengeHelper.getNextStep(challengeState.challenge, onSuccess, onError)
+                            }
+                            webAuthnState is WebAuthnSignInState.Error -> {
+                                authStateMachine.cancel(token)
+                                onError.accept(
+                                    CognitoAuthExceptionConverter.lookup(webAuthnState.exception, "Sign in failed")
+                                )
                             }
 
                             totpSetupState is SetupTOTPState.WaitingForAnswer -> {
@@ -607,10 +638,19 @@ internal class RealAWSCognitoAuthPlugin(
                         authStateMachine.cancel(token)
                         val authSignInResult = AuthSignInResult(
                             true,
-                            AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null, null, null)
+                            AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null, null, null, null)
                         )
                         onSuccess.accept(authSignInResult)
                         sendHubEvent(AuthChannelEventName.SIGNED_IN.toString())
+                    }
+                    authNState is AuthenticationState.Error -> {
+                        authStateMachine.cancel(token)
+                        val exception = if (authNState.exception is AuthException) {
+                            authNState.exception
+                        } else {
+                            UnknownException(cause = authNState.exception)
+                        }
+                        onError.accept(exception)
                     }
                     else -> Unit
                 }
@@ -618,7 +658,7 @@ internal class RealAWSCognitoAuthPlugin(
             {
                 val signInData = when (options.authFlowType ?: configuration.authFlowType) {
                     AuthFlowType.USER_SRP_AUTH -> {
-                        SignInData.SRPSignInData(username, password, options.metadata)
+                        SignInData.SRPSignInData(username, password, options.metadata, AuthFlowType.USER_SRP_AUTH)
                     }
                     AuthFlowType.CUSTOM_AUTH, AuthFlowType.CUSTOM_AUTH_WITHOUT_SRP -> {
                         SignInData.CustomAuthSignInData(username, options.metadata)
@@ -627,7 +667,35 @@ internal class RealAWSCognitoAuthPlugin(
                         SignInData.CustomSRPAuthSignInData(username, password, options.metadata)
                     }
                     AuthFlowType.USER_PASSWORD_AUTH -> {
-                        SignInData.MigrationAuthSignInData(username, password, options.metadata)
+                        SignInData.MigrationAuthSignInData(
+                            username = username,
+                            password = password,
+                            metadata = options.metadata,
+                            authFlowType = AuthFlowType.USER_PASSWORD_AUTH
+                        )
+                    }
+                    AuthFlowType.USER_AUTH -> {
+                        when (options.preferredFirstFactor) {
+                            AuthFactorType.PASSWORD -> {
+                                SignInData.MigrationAuthSignInData(
+                                    username = username,
+                                    password = password,
+                                    metadata = options.metadata,
+                                    authFlowType = AuthFlowType.USER_AUTH
+                                )
+                            }
+                            AuthFactorType.PASSWORD_SRP -> {
+                                SignInData.SRPSignInData(username, password, options.metadata, AuthFlowType.USER_AUTH)
+                            }
+                            else -> {
+                                SignInData.UserAuthSignInData(
+                                    username = username,
+                                    preferredChallenge = options.preferredFirstFactor,
+                                    callingActivity = options.callingActivity,
+                                    metadata = options.metadata
+                                )
+                            }
+                        }
                     }
                 }
                 val event = AuthenticationEvent(AuthenticationEvent.EventType.SignInRequested(signInData))
@@ -636,7 +704,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun confirmSignIn(
+    fun confirmSignIn(
         challengeResponse: String,
         onSuccess: Consumer<AuthSignInResult>,
         onError: Consumer<AuthException>
@@ -644,7 +712,7 @@ internal class RealAWSCognitoAuthPlugin(
         confirmSignIn(challengeResponse, AuthConfirmSignInOptions.defaults(), onSuccess, onError)
     }
 
-    override fun confirmSignIn(
+    fun confirmSignIn(
         challengeResponse: String,
         options: AuthConfirmSignInOptions,
         onSuccess: Consumer<AuthSignInResult>,
@@ -667,6 +735,18 @@ internal class RealAWSCognitoAuthPlugin(
                     is SetupTOTPState.WaitingForAnswer, is SetupTOTPState.Error -> {
                         _confirmSignIn(signInState, challengeResponse, options, onSuccess, onError)
                     }
+
+                    else -> onError.accept(InvalidStateException())
+                }
+            } else if (signInState is SignInState.SigningInWithWebAuthn) {
+                when (signInState.webAuthnSignInState) {
+                    is WebAuthnSignInState.Error -> _confirmSignIn(
+                        signInState,
+                        challengeResponse,
+                        options,
+                        onSuccess,
+                        onError
+                    )
                     else -> onError.accept(InvalidStateException())
                 }
             } else {
@@ -696,7 +776,7 @@ internal class RealAWSCognitoAuthPlugin(
                         authStateMachine.cancel(token)
                         val authSignInResult = AuthSignInResult(
                             true,
-                            AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null, null, null)
+                            AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null, null, null, null)
                         )
                         onSuccess.accept(authSignInResult)
                         sendHubEvent(AuthChannelEventName.SIGNED_IN.toString())
@@ -717,9 +797,11 @@ internal class RealAWSCognitoAuthPlugin(
                         authStateMachine.cancel(token)
                         val signInChallengeState = signInState.challengeState as SignInChallengeState.WaitingForAnswer
                         var allowedMFATypes: Set<MFAType>? = null
+                        var codeDeliveryDetails: AuthCodeDeliveryDetails? = null
 
-                        if (signInChallengeState.challenge.challengeName == ChallengeNameType.MfaSetup.value ||
-                            signInChallengeState.challenge.challengeName == ChallengeNameType.EmailOtp.value
+                        if (signInChallengeState.challenge.challengeNameType == ChallengeNameType.MfaSetup ||
+                            signInChallengeState.challenge.challengeNameType == ChallengeNameType.EmailOtp ||
+                            signInChallengeState.challenge.challengeNameType == ChallengeNameType.SmsOtp
                         ) {
                             SignInChallengeHelper.getNextStep(
                                 signInChallengeState.challenge,
@@ -730,14 +812,31 @@ internal class RealAWSCognitoAuthPlugin(
                             return@listen
                         }
 
-                        val signInStep = when (signInChallengeState.challenge.challengeName) {
-                            "SMS_MFA" -> AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE
-                            "NEW_PASSWORD_REQUIRED" -> AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD
-                            "SOFTWARE_TOKEN_MFA" -> AuthSignInStep.CONFIRM_SIGN_IN_WITH_TOTP_CODE
-                            "SELECT_MFA_TYPE" -> {
+                        val signInStep = when (signInChallengeState.challenge.challengeNameType) {
+                            ChallengeNameType.SmsMfa -> AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE
+                            ChallengeNameType.NewPasswordRequired -> AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD
+                            ChallengeNameType.SoftwareTokenMfa -> AuthSignInStep.CONFIRM_SIGN_IN_WITH_TOTP_CODE
+                            ChallengeNameType.SelectMfaType -> {
                                 allowedMFATypes =
                                     getAllowedMFATypesFromChallengeParameters(signInChallengeState.challenge.parameters)
                                 AuthSignInStep.CONTINUE_SIGN_IN_WITH_MFA_SELECTION
+                            }
+                            ChallengeNameType.EmailOtp, ChallengeNameType.SmsOtp -> {
+                                signInChallengeState.challenge.parameters?.get(
+                                    "CODE_DELIVERY_DELIVERY_MEDIUM"
+                                )?.let { medium ->
+                                    signInChallengeState.challenge.parameters["CODE_DELIVERY_DESTINATION"]
+                                        ?.let { destination ->
+                                            codeDeliveryDetails = AuthCodeDeliveryDetails(
+                                                destination,
+                                                AuthCodeDeliveryDetails.DeliveryMedium.fromString(medium)
+                                            )
+                                        }
+                                }
+                                AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP
+                            }
+                            ChallengeNameType.Password, ChallengeNameType.PasswordSrp -> {
+                                AuthSignInStep.CONFIRM_SIGN_IN_WITH_PASSWORD
                             }
                             else -> AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE
                         }
@@ -746,9 +845,10 @@ internal class RealAWSCognitoAuthPlugin(
                             AuthNextSignInStep(
                                 signInStep,
                                 signInChallengeState.challenge.parameters ?: mapOf(),
+                                codeDeliveryDetails,
                                 null,
-                                null,
-                                allowedMFATypes
+                                allowedMFATypes,
+                                null
                             )
                         )
                         onSuccess.accept(authSignInResult)
@@ -800,6 +900,17 @@ internal class RealAWSCognitoAuthPlugin(
                         )
                         (signInState.challengeState as SignInChallengeState.Error).hasNewResponse = false
                     }
+
+                    signInState is SignInState.SigningInWithWebAuthn &&
+                        signInState.webAuthnSignInState is WebAuthnSignInState.Error &&
+                        (signInState.webAuthnSignInState as WebAuthnSignInState.Error).hasNewResponse -> {
+                        val errorState = signInState.webAuthnSignInState as WebAuthnSignInState.Error
+                        authStateMachine.cancel(token)
+                        onError.accept(
+                            CognitoAuthExceptionConverter.lookup(errorState.exception, "Confirm Sign in failed.")
+                        )
+                        errorState.hasNewResponse = false
+                    }
                 }
             },
             {
@@ -810,7 +921,7 @@ internal class RealAWSCognitoAuthPlugin(
                     is SignInState.ResolvingChallenge -> {
                         val challengeState = signInState.challengeState
                         if (challengeState is SignInChallengeState.WaitingForAnswer &&
-                            challengeState.challenge.challengeName == "SELECT_MFA_TYPE" &&
+                            challengeState.challenge.challengeNameType == ChallengeNameType.SelectMfaType &&
                             getMFATypeOrNull(challengeResponse) == null
                         ) {
                             val error = InvalidParameterException(
@@ -818,6 +929,7 @@ internal class RealAWSCognitoAuthPlugin(
                                     "SMS_MFA, EMAIL_OTP or SOFTWARE_TOKEN_MFA"
                             )
                             onError.accept(error)
+                            authStateMachine.cancel(token)
                         } else if (challengeState is SignInChallengeState.WaitingForAnswer &&
                             isMfaSetupSelectionChallenge(challengeState.challenge) &&
                             getMFASetupTypeOrNull(challengeResponse) == null
@@ -827,6 +939,87 @@ internal class RealAWSCognitoAuthPlugin(
                             )
                             onError.accept(error)
                             authStateMachine.cancel(token)
+                        } else if (challengeState is SignInChallengeState.WaitingForAnswer &&
+                            challengeState.challenge.challengeNameType == ChallengeNameType.SelectChallenge &&
+                            challengeResponse == AuthFactorType.WEB_AUTHN.challengeResponse
+                        ) {
+                            val username = challengeState.challenge.username!!
+                            val session = challengeState.challenge.session
+                            val signInContext = WebAuthnSignInContext(
+                                username = username,
+                                callingActivity = awsCognitoConfirmSignInOptions?.callingActivity ?: WeakReference(
+                                    null
+                                ),
+                                session = session
+                            )
+                            val event = SignInEvent(SignInEvent.EventType.InitiateWebAuthnSignIn(signInContext))
+                            authStateMachine.send(event)
+                        } else if (challengeState is SignInChallengeState.WaitingForAnswer &&
+                            challengeState.challenge.challengeNameType == ChallengeNameType.SelectChallenge &&
+                            challengeResponse == ChallengeNameType.Password.value
+                        ) {
+                            val event = SignInEvent(
+                                SignInEvent.EventType.ReceivedChallenge(
+                                    AuthChallenge(
+                                        challengeName = ChallengeNameType.Password.value,
+                                        username = challengeState.challenge.username,
+                                        session = challengeState.challenge.session,
+                                        parameters = challengeState.challenge.parameters
+                                    )
+                                )
+                            )
+                            authStateMachine.send(event)
+                        } else if (challengeState is SignInChallengeState.WaitingForAnswer &&
+                            challengeState.challenge.challengeNameType == ChallengeNameType.SelectChallenge &&
+                            challengeResponse == ChallengeNameType.PasswordSrp.value
+                        ) {
+                            val event = SignInEvent(
+                                SignInEvent.EventType.ReceivedChallenge(
+                                    AuthChallenge(
+                                        challengeName = ChallengeNameType.PasswordSrp.value,
+                                        username = challengeState.challenge.username,
+                                        session = challengeState.challenge.session,
+                                        parameters = challengeState.challenge.parameters
+                                    )
+                                )
+                            )
+                            authStateMachine.send(event)
+                        } else if (challengeState is SignInChallengeState.WaitingForAnswer &&
+                            challengeState.challenge.challengeNameType == ChallengeNameType.Password
+                        ) {
+                            val event = SignInEvent(
+                                SignInEvent.EventType.InitiateMigrateAuth(
+                                    username = challengeState.challenge.username!!,
+                                    password = challengeResponse,
+                                    metadata = metadata,
+                                    authFlowType = AuthFlowType.USER_AUTH,
+                                    respondToAuthChallenge = AuthChallenge(
+                                        challengeName = ChallengeNameType.SelectChallenge.value,
+                                        username = challengeState.challenge.username,
+                                        session = challengeState.challenge.session!!,
+                                        parameters = null
+                                    )
+                                )
+                            )
+                            authStateMachine.send(event)
+                        } else if (challengeState is SignInChallengeState.WaitingForAnswer &&
+                            challengeState.challenge.challengeNameType == ChallengeNameType.PasswordSrp
+                        ) {
+                            val event = SignInEvent(
+                                SignInEvent.EventType.InitiateSignInWithSRP(
+                                    username = challengeState.challenge.username!!,
+                                    password = challengeResponse,
+                                    metadata = metadata,
+                                    authFlowType = AuthFlowType.USER_AUTH,
+                                    respondToAuthChallenge = AuthChallenge(
+                                        challengeName = ChallengeNameType.SelectChallenge.value,
+                                        username = challengeState.challenge.username,
+                                        session = challengeState.challenge.session!!,
+                                        parameters = null
+                                    )
+                                )
+                            )
+                            authStateMachine.send(event)
                         } else {
                             val event = SignInChallengeEvent(
                                 SignInChallengeEvent.EventType.VerifyChallengeAnswer(
@@ -872,17 +1065,36 @@ internal class RealAWSCognitoAuthPlugin(
                                 authStateMachine.send(event)
                             }
 
-                            else -> onError.accept(InvalidStateException())
+                            else -> {
+                                onError.accept(InvalidStateException())
+                                authStateMachine.cancel(token)
+                            }
                         }
                     }
 
-                    else -> onError.accept(InvalidStateException())
+                    is SignInState.SigningInWithWebAuthn -> {
+                        if (signInState.webAuthnSignInState is WebAuthnSignInState.Error &&
+                            challengeResponse == AuthFactorType.WEB_AUTHN.challengeResponse
+                        ) {
+                            val signInContext = (signInState.webAuthnSignInState as WebAuthnSignInState.Error).context
+                            val event = SignInEvent(SignInEvent.EventType.InitiateWebAuthnSignIn(signInContext))
+                            authStateMachine.send(event)
+                        } else {
+                            onError.accept(InvalidStateException())
+                            authStateMachine.cancel(token)
+                        }
+                    }
+
+                    else -> {
+                        onError.accept(InvalidStateException())
+                        authStateMachine.cancel(token)
+                    }
                 }
             }
         )
     }
 
-    override fun signInWithSocialWebUI(
+    fun signInWithSocialWebUI(
         provider: AuthProvider,
         callingActivity: Activity,
         onSuccess: Consumer<AuthSignInResult>,
@@ -897,7 +1109,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun signInWithSocialWebUI(
+    fun signInWithSocialWebUI(
         provider: AuthProvider,
         callingActivity: Activity,
         options: AuthWebUISignInOptions,
@@ -913,7 +1125,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun signInWithWebUI(
+    fun signInWithWebUI(
         callingActivity: Activity,
         onSuccess: Consumer<AuthSignInResult>,
         onError: Consumer<AuthException>
@@ -921,7 +1133,7 @@ internal class RealAWSCognitoAuthPlugin(
         signInWithWebUI(callingActivity, AuthWebUISignInOptions.builder().build(), onSuccess, onError)
     }
 
-    override fun signInWithWebUI(
+    fun signInWithWebUI(
         callingActivity: Activity,
         options: AuthWebUISignInOptions,
         onSuccess: Consumer<AuthSignInResult>,
@@ -1027,7 +1239,7 @@ internal class RealAWSCognitoAuthPlugin(
                         val authSignInResult =
                             AuthSignInResult(
                                 true,
-                                AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null, null, null)
+                                AuthNextSignInStep(AuthSignInStep.DONE, mapOf(), null, null, null, null)
                             )
                         onSuccess.accept(authSignInResult)
                         sendHubEvent(AuthChannelEventName.SIGNED_IN.toString())
@@ -1048,13 +1260,14 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun handleWebUISignInResponse(intent: Intent?) {
+    fun handleWebUISignInResponse(intent: Intent?) {
         authStateMachine.getCurrentState {
             val callbackUri = intent?.data
             when (val authNState = it.authNState) {
                 is AuthenticationState.SigningOut -> {
                     (authNState.signOutState as? SignOutState.SigningOutHostedUI)?.let { signOutState ->
-                        if (callbackUri == null && !signOutState.bypassCancel &&
+                        if (callbackUri == null &&
+                            !signOutState.bypassCancel &&
                             signOutState.signedInData.signInMethod !=
                             SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.UNKNOWN)
                         ) {
@@ -1121,30 +1334,28 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    private suspend fun getSession(): AWSCognitoAuthSession {
-        return suspendCoroutine { continuation ->
-            fetchAuthSession(
-                { authSession ->
-                    if (authSession is AWSCognitoAuthSession) {
-                        continuation.resume(authSession)
-                    } else {
-                        continuation.resumeWithException(
-                            UnknownException(
-                                message = "fetchAuthSession did not return a type of AWSCognitoAuthSession"
-                            )
+    private suspend fun getSession(): AWSCognitoAuthSession = suspendCoroutine { continuation ->
+        fetchAuthSession(
+            { authSession ->
+                if (authSession is AWSCognitoAuthSession) {
+                    continuation.resume(authSession)
+                } else {
+                    continuation.resumeWithException(
+                        UnknownException(
+                            message = "fetchAuthSession did not return a type of AWSCognitoAuthSession"
                         )
-                    }
-                },
-                { continuation.resumeWithException(it) }
-            )
-        }
+                    )
+                }
+            },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    override fun fetchAuthSession(onSuccess: Consumer<AuthSession>, onError: Consumer<AuthException>) {
+    fun fetchAuthSession(onSuccess: Consumer<AuthSession>, onError: Consumer<AuthException>) {
         fetchAuthSession(AuthFetchSessionOptions.defaults(), onSuccess, onError)
     }
 
-    override fun fetchAuthSession(
+    fun fetchAuthSession(
         options: AuthFetchSessionOptions,
         onSuccess: Consumer<AuthSession>,
         onError: Consumer<AuthException>
@@ -1208,9 +1419,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    private fun _fetchAuthSession(
-        onSuccess: Consumer<AuthSession>
-    ) {
+    private fun _fetchAuthSession(onSuccess: Consumer<AuthSession>) {
         val token = StateChangeListenerToken()
         authStateMachine.listen(
             token,
@@ -1261,7 +1470,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun rememberDevice(onSuccess: Action, onError: Consumer<AuthException>) {
+    fun rememberDevice(onSuccess: Action, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (val state = authState.authNState) {
                 is AuthenticationState.SignedIn -> {
@@ -1284,7 +1493,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun forgetDevice(onSuccess: Action, onError: Consumer<AuthException>) {
+    fun forgetDevice(onSuccess: Action, onError: Consumer<AuthException>) {
         forgetDevice(AuthDevice.fromId(""), onSuccess, onError)
     }
 
@@ -1311,11 +1520,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun forgetDevice(
-        device: AuthDevice,
-        onSuccess: Action,
-        onError: Consumer<AuthException>
-    ) {
+    fun forgetDevice(device: AuthDevice, onSuccess: Action, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (val authNState = authState.authNState) {
                 is AuthenticationState.SignedIn -> {
@@ -1354,10 +1559,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun fetchDevices(
-        onSuccess: Consumer<List<AuthDevice>>,
-        onError: Consumer<AuthException>
-    ) {
+    fun fetchDevices(onSuccess: Consumer<List<AuthDevice>>, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (authState.authNState) {
                 is AuthenticationState.SignedIn -> {
@@ -1398,7 +1600,7 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    override fun resetPassword(
+    fun resetPassword(
         username: String,
         options: AuthResetPasswordOptions,
         onSuccess: Consumer<AuthResetPasswordResult>,
@@ -1432,7 +1634,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun resetPassword(
+    fun resetPassword(
         username: String,
         onSuccess: Consumer<AuthResetPasswordResult>,
         onError: Consumer<AuthException>
@@ -1440,7 +1642,7 @@ internal class RealAWSCognitoAuthPlugin(
         resetPassword(username, AuthResetPasswordOptions.defaults(), onSuccess, onError)
     }
 
-    override fun confirmResetPassword(
+    fun confirmResetPassword(
         username: String,
         newPassword: String,
         confirmationCode: String,
@@ -1490,7 +1692,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun confirmResetPassword(
+    fun confirmResetPassword(
         username: String,
         newPassword: String,
         confirmationCode: String,
@@ -1507,12 +1709,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun updatePassword(
-        oldPassword: String,
-        newPassword: String,
-        onSuccess: Action,
-        onError: Consumer<AuthException>
-    ) {
+    fun updatePassword(oldPassword: String, newPassword: String, onSuccess: Action, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (authState.authNState) {
                 // Check if user signed in
@@ -1550,10 +1747,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun fetchUserAttributes(
-        onSuccess: Consumer<List<AuthUserAttribute>>,
-        onError: Consumer<AuthException>
-    ) {
+    fun fetchUserAttributes(onSuccess: Consumer<List<AuthUserAttribute>>, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (authState.authNState) {
                 // Check if user signed in
@@ -1589,7 +1783,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun updateUserAttribute(
+    fun updateUserAttribute(
         attribute: AuthUserAttribute,
         options: AuthUpdateUserAttributeOptions,
         onSuccess: Consumer<AuthUpdateAttributeResult>,
@@ -1609,7 +1803,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun updateUserAttribute(
+    fun updateUserAttribute(
         attribute: AuthUserAttribute,
         onSuccess: Consumer<AuthUpdateAttributeResult>,
         onError: Consumer<AuthException>
@@ -1617,7 +1811,7 @@ internal class RealAWSCognitoAuthPlugin(
         updateUserAttribute(attribute, AuthUpdateUserAttributeOptions.defaults(), onSuccess, onError)
     }
 
-    override fun updateUserAttributes(
+    fun updateUserAttributes(
         attributes: List<AuthUserAttribute>,
         options: AuthUpdateUserAttributesOptions,
         onSuccess: Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>,
@@ -1635,7 +1829,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun updateUserAttributes(
+    fun updateUserAttributes(
         attributes: List<AuthUserAttribute>,
         onSuccess: Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>,
         onError: Consumer<AuthException>
@@ -1646,47 +1840,45 @@ internal class RealAWSCognitoAuthPlugin(
     private suspend fun updateUserAttributes(
         attributes: List<AuthUserAttribute>,
         userAttributesOptionsMetadata: Map<String, String>?
-    ): MutableMap<AuthUserAttributeKey, AuthUpdateAttributeResult> {
-        return suspendCoroutine { continuation ->
+    ): MutableMap<AuthUserAttributeKey, AuthUpdateAttributeResult> = suspendCoroutine { continuation ->
 
-            authStateMachine.getCurrentState { authState ->
-                when (authState.authNState) {
-                    // Check if user signed in
-                    is AuthenticationState.SignedIn -> {
-                        GlobalScope.launch {
-                            try {
-                                val accessToken = getSession().userPoolTokensResult.value?.accessToken
-                                accessToken?.let {
-                                    var userAttributes = attributes.map {
-                                        AttributeType.invoke {
-                                            name = it.key.keyString
-                                            value = it.value
-                                        }
+        authStateMachine.getCurrentState { authState ->
+            when (authState.authNState) {
+                // Check if user signed in
+                is AuthenticationState.SignedIn -> {
+                    GlobalScope.launch {
+                        try {
+                            val accessToken = getSession().userPoolTokensResult.value?.accessToken
+                            accessToken?.let {
+                                var userAttributes = attributes.map {
+                                    AttributeType.invoke {
+                                        name = it.key.keyString
+                                        value = it.value
                                     }
-                                    val userAttributesRequest = UpdateUserAttributesRequest.invoke {
-                                        this.accessToken = accessToken
-                                        this.userAttributes = userAttributes
-                                        this.clientMetadata = userAttributesOptionsMetadata
-                                    }
-                                    val userAttributeResponse = authEnvironment.cognitoAuthService
-                                        .cognitoIdentityProviderClient?.updateUserAttributes(
-                                            userAttributesRequest
-                                        )
-
-                                    continuation.resume(
-                                        getUpdateUserAttributeResult(userAttributeResponse, userAttributes)
+                                }
+                                val userAttributesRequest = UpdateUserAttributesRequest.invoke {
+                                    this.accessToken = accessToken
+                                    this.userAttributes = userAttributes
+                                    this.clientMetadata = userAttributesOptionsMetadata
+                                }
+                                val userAttributeResponse = authEnvironment.cognitoAuthService
+                                    .cognitoIdentityProviderClient?.updateUserAttributes(
+                                        userAttributesRequest
                                     )
-                                } ?: continuation.resumeWithException(
-                                    InvalidUserPoolConfigurationException()
+
+                                continuation.resume(
+                                    getUpdateUserAttributeResult(userAttributeResponse, userAttributes)
                                 )
-                            } catch (e: Exception) {
-                                continuation.resumeWithException(CognitoAuthExceptionConverter.lookup(e, e.toString()))
-                            }
+                            } ?: continuation.resumeWithException(
+                                InvalidUserPoolConfigurationException()
+                            )
+                        } catch (e: Exception) {
+                            continuation.resumeWithException(CognitoAuthExceptionConverter.lookup(e, e.toString()))
                         }
                     }
-                    is AuthenticationState.SignedOut -> continuation.resumeWithException(SignedOutException())
-                    else -> continuation.resumeWithException(InvalidStateException())
                 }
+                is AuthenticationState.SignedOut -> continuation.resumeWithException(SignedOutException())
+                else -> continuation.resumeWithException(InvalidStateException())
             }
         }
     }
@@ -1733,7 +1925,7 @@ internal class RealAWSCognitoAuthPlugin(
         return finalResult
     }
 
-    override fun resendUserAttributeConfirmationCode(
+    fun resendUserAttributeConfirmationCode(
         attributeKey: AuthUserAttributeKey,
         options: AuthResendUserAttributeConfirmationCodeOptions,
         onSuccess: Consumer<AuthCodeDeliveryDetails>,
@@ -1790,7 +1982,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun resendUserAttributeConfirmationCode(
+    fun resendUserAttributeConfirmationCode(
         attributeKey: AuthUserAttributeKey,
         onSuccess: Consumer<AuthCodeDeliveryDetails>,
         onError: Consumer<AuthException>
@@ -1803,7 +1995,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun confirmUserAttribute(
+    fun confirmUserAttribute(
         attributeKey: AuthUserAttributeKey,
         confirmationCode: String,
         onSuccess: Action,
@@ -1839,10 +2031,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun getCurrentUser(
-        onSuccess: Consumer<AuthUser>,
-        onError: Consumer<AuthException>
-    ) {
+    fun getCurrentUser(onSuccess: Consumer<AuthUser>, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (authState.authNState) {
                 is AuthenticationState.SignedIn -> {
@@ -1871,11 +2060,11 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun signOut(onComplete: Consumer<AuthSignOutResult>) {
+    fun signOut(onComplete: Consumer<AuthSignOutResult>) {
         signOut(AuthSignOutOptions.builder().build(), onComplete)
     }
 
-    override fun signOut(options: AuthSignOutOptions, onComplete: Consumer<AuthSignOutResult>) {
+    fun signOut(options: AuthSignOutOptions, onComplete: Consumer<AuthSignOutResult>) {
         authStateMachine.getCurrentState { authState ->
             when (authState.authNState) {
                 is AuthenticationState.NotConfigured ->
@@ -1979,7 +2168,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    override fun deleteUser(onSuccess: Action, onError: Consumer<AuthException>) {
+    fun deleteUser(onSuccess: Action, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (authState.authNState) {
                 is AuthenticationState.SignedIn -> {
@@ -2086,11 +2275,12 @@ internal class RealAWSCognitoAuthPlugin(
                         authNState is AuthenticationState.Error ||
                         authNState is AuthenticationState.NotConfigured ||
                         authNState is AuthenticationState.FederatedToIdentityPool
-                    ) && (
-                    authZState is AuthorizationState.Configured ||
-                        authZState is AuthorizationState.SessionEstablished ||
-                        authZState is AuthorizationState.Error
-                    ) -> {
+                    ) &&
+                    (
+                        authZState is AuthorizationState.Configured ||
+                            authZState is AuthorizationState.SessionEstablished ||
+                            authZState is AuthorizationState.Error
+                        ) -> {
                     val existingCredential = when (authZState) {
                         is AuthorizationState.SessionEstablished -> authZState.amplifyCredential
                         is AuthorizationState.Error -> {
@@ -2171,10 +2361,7 @@ internal class RealAWSCognitoAuthPlugin(
         )
     }
 
-    fun clearFederationToIdentityPool(
-        onSuccess: Action,
-        onError: Consumer<AuthException>
-    ) {
+    fun clearFederationToIdentityPool(onSuccess: Action, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             val authNState = authState.authNState
             val authZState = authState.authZState
@@ -2183,11 +2370,12 @@ internal class RealAWSCognitoAuthPlugin(
                     (
                         authNState is AuthenticationState.FederatedToIdentityPool &&
                             authZState is AuthorizationState.SessionEstablished
-                        ) || (
-                    authZState is AuthorizationState.Error &&
-                        authZState.exception is SessionError &&
-                        authZState.exception.amplifyCredential is AmplifyCredential.IdentityPoolFederated
-                    ) -> {
+                        ) ||
+                    (
+                        authZState is AuthorizationState.Error &&
+                            authZState.exception is SessionError &&
+                            authZState.exception.amplifyCredential is AmplifyCredential.IdentityPoolFederated
+                        ) -> {
                     val event = AuthenticationEvent(AuthenticationEvent.EventType.ClearFederationToIdentityPool())
                     authStateMachine.send(event)
                     _clearFederationToIdentityPool(onSuccess, onError)
@@ -2199,7 +2387,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun setUpTOTP(onSuccess: Consumer<TOTPSetupDetails>, onError: Consumer<AuthException>) {
+    fun setUpTOTP(onSuccess: Consumer<TOTPSetupDetails>, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (authState.authNState) {
                 is AuthenticationState.SignedIn -> {
@@ -2239,15 +2427,7 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
-    override fun verifyTOTPSetup(
-        code: String,
-        onSuccess: Action,
-        onError: Consumer<AuthException>
-    ) {
-        verifyTotp(code, null, onSuccess, onError)
-    }
-
-    override fun verifyTOTPSetup(
+    fun verifyTOTPSetup(
         code: String,
         options: AuthVerifyTOTPSetupOptions,
         onSuccess: Action,
@@ -2257,10 +2437,7 @@ internal class RealAWSCognitoAuthPlugin(
         verifyTotp(code, cognitoOptions?.friendlyDeviceName, onSuccess, onError)
     }
 
-    fun fetchMFAPreference(
-        onSuccess: Consumer<UserMFAPreference>,
-        onError: Consumer<AuthException>
-    ) {
+    fun fetchMFAPreference(onSuccess: Consumer<UserMFAPreference>, onError: Consumer<AuthException>) {
         authStateMachine.getCurrentState { authState ->
             when (authState.authNState) {
                 is AuthenticationState.SignedIn -> {
@@ -2314,8 +2491,7 @@ internal class RealAWSCognitoAuthPlugin(
             return
         }
         // If either of the params have preferred setting set then ignore fetched preference preferred property
-        val overridePreferredSetting =
-            !(sms?.mfaPreferred == true || totp?.mfaPreferred == true || email?.mfaPreferred == true)
+        val overridePreferredSetting: Boolean = !(sms?.mfaPreferred == true || totp?.mfaPreferred == true)
         fetchMFAPreference({ userPreference ->
             authStateMachine.getCurrentState { authState ->
                 when (authState.authNState) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthenticationCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthenticationCognitoActions.kt
@@ -72,7 +72,12 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                 is SignInData.SRPSignInData -> {
                     if (data.username != null && data.password != null) {
                         SignInEvent(
-                            SignInEvent.EventType.InitiateSignInWithSRP(data.username, data.password, data.metadata)
+                            SignInEvent.EventType.InitiateSignInWithSRP(
+                                data.username,
+                                data.password,
+                                data.metadata,
+                                data.authFlowType
+                            )
                         )
                     } else {
                         AuthenticationEvent(
@@ -118,7 +123,12 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                 is SignInData.MigrationAuthSignInData -> {
                     if (data.username != null && data.password != null) {
                         SignInEvent(
-                            SignInEvent.EventType.InitiateMigrateAuth(data.username, data.password, data.metadata)
+                            SignInEvent.EventType.InitiateMigrateAuth(
+                                username = data.username,
+                                password = data.password,
+                                metadata = data.metadata,
+                                authFlowType = data.authFlowType
+                            )
                         )
                     } else {
                         AuthenticationEvent(
@@ -127,6 +137,28 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                             )
                         )
                     }
+                }
+                is SignInData.UserAuthSignInData -> {
+                    if (data.username != null) {
+                        SignInEvent(
+                            SignInEvent.EventType.InitiateUserAuth(
+                                data.username,
+                                data.preferredChallenge,
+                                data.callingActivity,
+                                data.metadata
+                            )
+                        )
+                    } else {
+                        AuthenticationEvent(
+                            AuthenticationEvent.EventType.ThrowError(
+                                ValidationException("Sign in failed.", "username cannot be empty")
+                            )
+                        )
+                    }
+                }
+
+                is SignInData.AutoSignInData -> {
+                    SignInEvent(SignInEvent.EventType.InitiateAutoSignIn(data))
                 }
             }
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/MigrateAuthCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/MigrateAuthCognitoActions.kt
@@ -16,14 +16,19 @@
 package com.amplifyframework.auth.cognito.actions
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.initiateAuth
-import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.respondToAuthChallenge
+import aws.smithy.kotlin.runtime.util.type
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
+import com.amplifyframework.auth.cognito.helpers.toCognitoType
+import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.auth.exceptions.ServiceException
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.MigrateAuthActions
+import com.amplifyframework.statemachine.codegen.data.SignInMethod
 import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.SignInEvent
 
@@ -32,6 +37,8 @@ internal object MigrateAuthCognitoActions : MigrateAuthActions {
     private const val KEY_PASSWORD = "PASSWORD"
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
+    private const val KEY_ANSWER = "ANSWER"
+    private const val KEY_PREFERRED_CHALLENGE = "PREFERRED_CHALLENGE"
 
     override fun initiateMigrateAuthAction(event: SignInEvent.EventType.InitiateMigrateAuth) =
         Action<AuthEnvironment>("InitMigrateAuth") { id, dispatcher ->
@@ -49,32 +56,64 @@ internal object MigrateAuthCognitoActions : MigrateAuthActions {
                 val encodedContextData = getUserContextData(event.username)
                 val pinpointEndpointId = getPinpointEndpointId()
 
-                val response = cognitoAuthService.cognitoIdentityProviderClient?.initiateAuth {
-                    authFlow = AuthFlowType.UserPasswordAuth
-                    clientId = configuration.userPool?.appClient
-                    authParameters = authParams
-                    clientMetadata = event.metadata
-                    pinpointEndpointId?.let { analyticsMetadata { analyticsEndpointId = it } }
-                    encodedContextData?.let { userContextData { encodedData = it } }
-                }
+                if (event.respondToAuthChallenge?.session != null) {
+                    authParams[KEY_ANSWER] = ChallengeNameType.Password.value
 
-                if (response != null) {
-                    val username = AuthHelper.getActiveUsername(
-                        username = event.username,
-                        alternateUsername = response.challengeParameters?.get(KEY_USERNAME),
-                        userIDForSRP = response.challengeParameters?.get(
-                            KEY_USERID_FOR_SRP
+                    val response = cognitoAuthService.cognitoIdentityProviderClient?.respondToAuthChallenge {
+                        clientId = configuration.userPool?.appClient
+                        challengeName = ChallengeNameType.SelectChallenge
+                        this.challengeResponses = authParams
+                        session = event.respondToAuthChallenge.session
+                        clientMetadata = event.metadata
+                        pinpointEndpointId?.let { analyticsMetadata { analyticsEndpointId = it } }
+                        encodedContextData?.let { this.userContextData { encodedData = it } }
+                    }
+
+                    response?.let {
+                        SignInChallengeHelper.evaluateNextStep(
+                            username = event.username,
+                            challengeNameType = response.challengeName,
+                            session = response.session,
+                            challengeParameters = response.challengeParameters,
+                            authenticationResult = response.authenticationResult,
+                            signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
                         )
-                    )
-                    SignInChallengeHelper.evaluateNextStep(
-                        username,
-                        response.challengeName,
-                        response.session,
-                        response.challengeParameters,
-                        response.authenticationResult
-                    )
+                    } ?: throw ServiceException("Sign in failed", AmplifyException.TODO_RECOVERY_SUGGESTION)
                 } else {
-                    throw ServiceException("Sign in failed", AmplifyException.TODO_RECOVERY_SUGGESTION)
+                    if (event.authFlowType == AuthFlowType.USER_AUTH) {
+                        authParams[KEY_PREFERRED_CHALLENGE] = KEY_PASSWORD
+                    }
+                    val response = cognitoAuthService.cognitoIdentityProviderClient?.initiateAuth {
+                        authFlow = event.authFlowType.toCognitoType()
+                        clientId = configuration.userPool?.appClient
+                        authParameters = authParams
+                        clientMetadata = event.metadata
+                        pinpointEndpointId?.let { analyticsMetadata { analyticsEndpointId = it } }
+                        encodedContextData?.let { userContextData { encodedData = it } }
+                    }
+
+                    response?.let {
+                        val username = AuthHelper.getActiveUsername(
+                            username = event.username,
+                            alternateUsername = response.challengeParameters?.get(KEY_USERNAME),
+                            userIDForSRP = response.challengeParameters?.get(
+                                KEY_USERID_FOR_SRP
+                            )
+                        )
+                        val signInMethod = if (event.authFlowType == AuthFlowType.USER_AUTH) {
+                            SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+                        } else {
+                            SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_SRP_AUTH)
+                        }
+                        SignInChallengeHelper.evaluateNextStep(
+                            username = username,
+                            challengeNameType = response.challengeName,
+                            session = response.session,
+                            challengeParameters = response.challengeParameters,
+                            authenticationResult = response.authenticationResult,
+                            signInMethod = signInMethod
+                        )
+                    } ?: throw ServiceException("Sign in failed", AmplifyException.TODO_RECOVERY_SUGGESTION)
                 }
             } catch (e: Exception) {
                 val errorEvent = SignInEvent(SignInEvent.EventType.ThrowError(e))

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCognitoActions.kt
@@ -16,17 +16,22 @@
 package com.amplifyframework.auth.cognito.actions
 
 import android.os.Build
+import aws.sdk.kotlin.services.cognitoidentityprovider.initiateAuth
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ConfirmDeviceRequest
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeviceSecretVerifierConfigType
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.cognito.helpers.CognitoDeviceHelper
+import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
 import com.amplifyframework.auth.exceptions.ServiceException
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.SignInActions
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.CredentialType
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
+import com.amplifyframework.statemachine.codegen.data.SignInMethod
 import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.CustomSignInEvent
 import com.amplifyframework.statemachine.codegen.events.DeviceSRPSignInEvent
@@ -35,12 +40,24 @@ import com.amplifyframework.statemachine.codegen.events.SRPEvent
 import com.amplifyframework.statemachine.codegen.events.SetupTOTPEvent
 import com.amplifyframework.statemachine.codegen.events.SignInChallengeEvent
 import com.amplifyframework.statemachine.codegen.events.SignInEvent
+import com.amplifyframework.statemachine.codegen.events.WebAuthnEvent
 
 internal object SignInCognitoActions : SignInActions {
+    private const val KEY_SECRET_HASH = "SECRET_HASH"
+    private const val KEY_USERNAME = "USERNAME"
+
     override fun startSRPAuthAction(event: SignInEvent.EventType.InitiateSignInWithSRP) =
         Action<AuthEnvironment>("StartSRPAuth") { id, dispatcher ->
             logger.verbose("$id Starting execution")
-            val evt = SRPEvent(SRPEvent.EventType.InitiateSRP(event.username, event.password, event.metadata))
+            val evt = SRPEvent(
+                SRPEvent.EventType.InitiateSRP(
+                    username = event.username,
+                    password = event.password,
+                    metadata = event.metadata,
+                    authFlowType = event.authFlowType,
+                    respondToAuthChallenge = event.respondToAuthChallenge
+                )
+            )
             logger.verbose("$id Sending event ${evt.type}")
             dispatcher.send(evt)
         }
@@ -59,7 +76,12 @@ internal object SignInCognitoActions : SignInActions {
         Action<AuthEnvironment>("StartMigrationAuth") { id, dispatcher ->
             logger.verbose("$id Starting execution")
             val evt = SignInEvent(
-                SignInEvent.EventType.InitiateMigrateAuth(event.username, event.password, event.metadata)
+                SignInEvent.EventType.InitiateMigrateAuth(
+                    username = event.username,
+                    password = event.password,
+                    metadata = event.metadata,
+                    authFlowType = event.authFlowType
+                )
             )
             logger.verbose("$id Sending event ${evt.type}")
             dispatcher.send(evt)
@@ -148,6 +170,77 @@ internal object SignInCognitoActions : SignInActions {
                     challengeParams = event.challengeParams
                 )
             )
+            logger.verbose("$id Sending event ${evt.type}")
+            dispatcher.send(evt)
+        }
+
+    override fun initiateWebAuthnSignInAction(event: SignInEvent.EventType.InitiateWebAuthnSignIn) =
+        Action<AuthEnvironment>("initiateWebAuthnSignIn") { id, dispatcher ->
+            logger.verbose("$id Starting excution")
+            val signInContext = event.signInContext
+            val requestJson = signInContext.requestJson
+            val evt = if (requestJson == null) {
+                // If we don't already have the request JSON then fetch it
+                WebAuthnEvent(WebAuthnEvent.EventType.FetchCredentialOptions(signInContext))
+            } else {
+                // We do have the request JSON so go directly to asserting it
+                WebAuthnEvent(WebAuthnEvent.EventType.AssertCredentialOptions(signInContext))
+            }
+            logger.verbose("$id sending event ${evt.type}")
+            dispatcher.send(evt)
+        }
+
+    override fun autoSignInAction(event: SignInEvent.EventType.InitiateAutoSignIn): Action =
+        Action<AuthEnvironment>("AutoSignIn") { id, dispatcher ->
+            logger.verbose("$id Starting execution")
+            val evt = try {
+                val username = event.signInData.username
+                val secretHash = AuthHelper.getSecretHash(
+                    username,
+                    configuration.userPool?.appClient,
+                    configuration.userPool?.appClientSecret
+                )
+
+                val authParams = mutableMapOf(
+                    KEY_USERNAME to username,
+                )
+                secretHash?.let { authParams[KEY_SECRET_HASH] = it }
+
+                val encodedContextData = getUserContextData(username)
+                val pinpointEndpointId = getPinpointEndpointId()
+
+                val response = cognitoAuthService.cognitoIdentityProviderClient?.initiateAuth {
+                    authFlow = AuthFlowType.UserAuth
+                    clientId = configuration.userPool?.appClient
+                    authParameters = authParams
+                    clientMetadata = event.signInData.metadata
+                    pinpointEndpointId?.let { analyticsMetadata { analyticsEndpointId = it } }
+                    encodedContextData?.let { userContextData { encodedData = it } }
+                    session = event.signInData.session
+                }
+
+                if (response != null) {
+                    SignInChallengeHelper.evaluateNextStep(
+                        username = username,
+                        challengeNameType = response.challengeName,
+                        session = response.session,
+                        challengeParameters = response.challengeParameters,
+                        authenticationResult = response.authenticationResult,
+                        signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+                    )
+                } else {
+                    throw ServiceException(
+                        "Sign in failed",
+                        AmplifyException.TODO_RECOVERY_SUGGESTION
+                    )
+                }
+            } catch (e: Exception) {
+                val signInError = SignInEvent(SignInEvent.EventType.ThrowError(e))
+                logger.verbose("$id Sending event ${signInError.type}")
+                dispatcher.send(signInError)
+
+                AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+            }
             logger.verbose("$id Sending event ${evt.type}")
             dispatcher.send(evt)
         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignUpCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignUpCognitoActions.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.actions
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.confirmSignUp
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AnalyticsMetadataType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.signUp
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.helpers.AuthHelper
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.auth.result.step.AuthNextSignUpStep
+import com.amplifyframework.auth.result.step.AuthSignUpStep
+import com.amplifyframework.statemachine.Action
+import com.amplifyframework.statemachine.codegen.actions.SignUpActions
+import com.amplifyframework.statemachine.codegen.data.SignUpData
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
+
+internal object SignUpCognitoActions : SignUpActions {
+
+    override fun initiateSignUpAction(event: SignUpEvent.EventType.InitiateSignUp): Action =
+        Action<AuthEnvironment>("InitiatingSignUp") { id, dispatcher ->
+            logger.verbose("$id Starting execution")
+            val evt = try {
+                val username = event.signUpData.username
+                val encodedContextData = getUserContextData(username)
+                val pinpointEndpointId = getPinpointEndpointId()
+
+                val response = cognitoAuthService.cognitoIdentityProviderClient?.signUp {
+                    this.username = username
+                    this.password = event.password
+                    this.userAttributes = event.userAttributes?.map {
+                        AttributeType {
+                            name = it.key.keyString
+                            value = it.value
+                        }
+                    }
+                    this.clientId = configuration.userPool?.appClient
+                    this.secretHash = AuthHelper.getSecretHash(
+                        username,
+                        configuration.userPool?.appClient,
+                        configuration.userPool?.appClientSecret
+                    )
+                    pinpointEndpointId?.let {
+                        this.analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = it }
+                    }
+                    encodedContextData?.let { this.userContextData { encodedData = it } }
+                    this.clientMetadata = event.signUpData.clientMetadata
+                    this.validationData = event.signUpData.validationData?.mapNotNull { option ->
+                        AttributeType {
+                            name = option.key
+                            value = option.value
+                        }
+                    }
+                }
+
+                val codeDeliveryDetails = AuthCodeDeliveryDetails(
+                    response?.codeDeliveryDetails?.destination ?: "",
+                    AuthCodeDeliveryDetails.DeliveryMedium.fromString(
+                        response?.codeDeliveryDetails?.deliveryMedium?.value
+                    ),
+                    response?.codeDeliveryDetails?.attributeName
+                )
+                val signUpData = SignUpData(
+                    username,
+                    event.signUpData.validationData,
+                    event.signUpData.clientMetadata,
+                    response?.session,
+                    response?.userSub
+                )
+                if (response?.userConfirmed == true) {
+                    var signUpStep = AuthSignUpStep.DONE
+                    if (response.session != null) {
+                        signUpStep = AuthSignUpStep.COMPLETE_AUTO_SIGN_IN
+                    }
+                    val signUpResult =
+                        AuthSignUpResult(
+                            true,
+                            AuthNextSignUpStep(
+                                signUpStep,
+                                mapOf(),
+                                codeDeliveryDetails
+                            ),
+                            response.userSub
+                        )
+                    SignUpEvent(SignUpEvent.EventType.SignedUp(signUpData, signUpResult))
+                } else {
+                    val signUpResult =
+                        AuthSignUpResult(
+                            false,
+                            AuthNextSignUpStep(
+                                AuthSignUpStep.CONFIRM_SIGN_UP_STEP,
+                                mapOf(),
+                                codeDeliveryDetails
+                            ),
+                            response?.userSub
+                        )
+                    SignUpEvent(SignUpEvent.EventType.InitiateSignUpComplete(signUpData, signUpResult))
+                }
+            } catch (e: Exception) {
+                SignUpEvent(SignUpEvent.EventType.ThrowError(e))
+            }
+            logger.verbose("$id Sending event ${evt.type}")
+            dispatcher.send(evt)
+        }
+
+    override fun confirmSignUpAction(event: SignUpEvent.EventType.ConfirmSignUp): Action =
+        Action<AuthEnvironment>("ConfirmSignUp") { id, dispatcher ->
+            logger.verbose("$id Starting execution")
+            val evt = try {
+                val username = event.signUpData.username
+                val encodedContextData = getUserContextData(username)
+                val pinpointEndpointId = getPinpointEndpointId()
+
+                val response = cognitoAuthService.cognitoIdentityProviderClient?.confirmSignUp {
+                    this.username = username
+                    this.confirmationCode = event.confirmationCode
+                    this.clientId = configuration.userPool?.appClient
+                    this.secretHash = AuthHelper.getSecretHash(
+                        username,
+                        configuration.userPool?.appClient,
+                        configuration.userPool?.appClientSecret
+                    )
+                    pinpointEndpointId?.let {
+                        this.analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = it }
+                    }
+                    encodedContextData?.let { this.userContextData { encodedData = it } }
+                    this.clientMetadata = event.signUpData.clientMetadata
+                    this.session = event.signUpData.session
+                }
+                val signUpData = SignUpData(
+                    username,
+                    event.signUpData.validationData,
+                    event.signUpData.clientMetadata,
+                    response?.session,
+                    event.signUpData.userId
+                )
+                var signUpStep = AuthSignUpStep.DONE
+                if (response?.session != null) {
+                    signUpStep = AuthSignUpStep.COMPLETE_AUTO_SIGN_IN
+                }
+                val signUpResult =
+                    AuthSignUpResult(
+                        true,
+                        AuthNextSignUpStep(
+                            signUpStep,
+                            mapOf(),
+                            null
+                        ),
+                        event.signUpData.userId
+                    )
+                SignUpEvent(SignUpEvent.EventType.SignedUp(signUpData, signUpResult))
+            } catch (e: Exception) {
+                SignUpEvent(SignUpEvent.EventType.ThrowError(e))
+            }
+            logger.verbose("$id Sending event ${evt.type}")
+            dispatcher.send(evt)
+        }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/UserAuthSignInCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/UserAuthSignInCognitoActions.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.actions
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.initiateAuth
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.helpers.AuthHelper
+import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
+import com.amplifyframework.auth.exceptions.ServiceException
+import com.amplifyframework.statemachine.Action
+import com.amplifyframework.statemachine.codegen.actions.UserAuthSignInActions
+import com.amplifyframework.statemachine.codegen.data.SignInMethod
+import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
+
+internal object UserAuthSignInCognitoActions : UserAuthSignInActions {
+    private const val KEY_SECRET_HASH = "SECRET_HASH"
+    private const val KEY_USERNAME = "USERNAME"
+    private const val KEY_DEVICE_KEY = "DEVICE_KEY"
+    private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
+    private const val KEY_PREFERRED_CHALLENGE = "PREFERRED_CHALLENGE"
+
+    override fun initiateUserAuthSignIn(event: SignInEvent.EventType.InitiateUserAuth): Action =
+        Action<AuthEnvironment>("InitUserAuth") { id, dispatcher ->
+            logger.verbose("$id Starting execution")
+            val evt = try {
+                val secretHash = AuthHelper.getSecretHash(
+                    event.username,
+                    configuration.userPool?.appClient,
+                    configuration.userPool?.appClientSecret
+                )
+
+                val authParams = mutableMapOf(KEY_USERNAME to event.username)
+
+                secretHash?.let { authParams[KEY_SECRET_HASH] = it }
+
+                event.preferredChallenge?.let { authParams[KEY_PREFERRED_CHALLENGE] = it.toString() }
+
+                val encodedContextData = getUserContextData(event.username)
+                val deviceMetadata = getDeviceMetadata(event.username)
+                deviceMetadata?.let { authParams[KEY_DEVICE_KEY] = it.deviceKey }
+                val pinpointEndpointId = getPinpointEndpointId()
+
+                val initiateAuthResponse = cognitoAuthService.cognitoIdentityProviderClient?.initiateAuth {
+                    authFlow = AuthFlowType.UserAuth
+                    clientId = configuration.userPool?.appClient
+                    authParameters = authParams
+                    clientMetadata = event.metadata
+                    pinpointEndpointId?.let { analyticsMetadata { analyticsEndpointId = it } }
+                    encodedContextData?.let { userContextData { encodedData = it } }
+                }
+
+                val resolvedSession = initiateAuthResponse?.session
+                val resolvedChallenges = initiateAuthResponse?.availableChallenges
+                if (initiateAuthResponse?.challengeName == ChallengeNameType.SelectChallenge &&
+                    resolvedSession != null &&
+                    resolvedChallenges != null
+                ) {
+                    val activeUserName = AuthHelper.getActiveUsername(
+                        username = event.username,
+                        alternateUsername = initiateAuthResponse.challengeParameters?.get(KEY_USERNAME),
+                        userIDForSRP = initiateAuthResponse.challengeParameters?.get(
+                            KEY_USERID_FOR_SRP
+                        )
+                    )
+
+                    val listOfChallenges = resolvedChallenges.map { it.value }
+
+                    SignInChallengeHelper.evaluateNextStep(
+                        username = activeUserName,
+                        challengeNameType = ChallengeNameType.SelectChallenge,
+                        session = resolvedSession,
+                        availableChallenges = listOfChallenges,
+                        authenticationResult = initiateAuthResponse.authenticationResult,
+                        callingActivity = event.callingActivity,
+                        signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+                    )
+                } else if (isSupportedChallenge(initiateAuthResponse?.challengeName) &&
+                    initiateAuthResponse?.challengeParameters != null &&
+                    resolvedSession != null
+                ) {
+                    val activeUserName = AuthHelper.getActiveUsername(
+                        username = event.username,
+                        alternateUsername = initiateAuthResponse.challengeParameters?.get(KEY_USERNAME),
+                        userIDForSRP = initiateAuthResponse.challengeParameters?.get(
+                            KEY_USERID_FOR_SRP
+                        )
+                    )
+
+                    SignInChallengeHelper.evaluateNextStep(
+                        username = activeUserName,
+                        challengeNameType = initiateAuthResponse.challengeName,
+                        session = resolvedSession,
+                        challengeParameters = initiateAuthResponse.challengeParameters,
+                        authenticationResult = initiateAuthResponse.authenticationResult,
+                        callingActivity = event.callingActivity,
+                        signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+                    )
+                } else {
+                    throw ServiceException("Sign in failed", AmplifyException.TODO_RECOVERY_SUGGESTION)
+                }
+            } catch (e: Exception) {
+                val errorEvent = SignInEvent(SignInEvent.EventType.ThrowError(e))
+                logger.verbose("$id Sending event ${errorEvent.type}")
+                dispatcher.send(errorEvent)
+
+                AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+            }
+            logger.verbose("$id Sending event ${evt.type}")
+            dispatcher.send(evt)
+        }
+
+    private fun isSupportedChallenge(challengeName: ChallengeNameType?): Boolean = challengeName != null &&
+        (
+            challengeName is ChallengeNameType.EmailOtp ||
+                challengeName is ChallengeNameType.SmsOtp ||
+                challengeName is ChallengeNameType.WebAuthn
+            )
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/WebAuthnSignInCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/WebAuthnSignInCognitoActions.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.actions
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.respondToAuthChallenge
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
+import com.amplifyframework.auth.cognito.helpers.WebAuthnHelper
+import com.amplifyframework.auth.cognito.requireIdentityProviderClient
+import com.amplifyframework.statemachine.Action
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.actions.WebAuthnSignInActions
+import com.amplifyframework.statemachine.codegen.data.SignInMethod
+import com.amplifyframework.statemachine.codegen.data.WebAuthnSignInContext
+import com.amplifyframework.statemachine.codegen.data.requireRequestJson
+import com.amplifyframework.statemachine.codegen.data.requireResponseJson
+import com.amplifyframework.statemachine.codegen.events.WebAuthnEvent
+
+internal object WebAuthnSignInCognitoActions : WebAuthnSignInActions {
+    private enum class ChallengeResponse(val key: String) {
+        USERNAME("USERNAME"),
+        CREDENTIAL("CREDENTIAL"),
+        ANSWER("ANSWER")
+    }
+
+    override fun fetchCredentialOptions(event: WebAuthnEvent.EventType.FetchCredentialOptions): Action =
+        safeAction(event.signInContext) {
+            val signInContext = event.signInContext
+            val client = requireIdentityProviderClient()
+            val encodedContextData = getUserContextData(signInContext.username)
+            val pinpointEndpointId = getPinpointEndpointId()
+
+            val response = client.respondToAuthChallenge {
+                challengeName = ChallengeNameType.SelectChallenge
+                clientId = configuration.userPool?.appClient
+                challengeResponses = mapOf(
+                    ChallengeResponse.USERNAME.key to signInContext.username,
+                    ChallengeResponse.ANSWER.key to ChallengeNameType.WebAuthn.value
+                )
+                session = signInContext.session
+                pinpointEndpointId?.let { analyticsMetadata { analyticsEndpointId = it } }
+                encodedContextData?.let { userContextData { encodedData = it } }
+            }
+
+            SignInChallengeHelper.evaluateNextStep(
+                username = signInContext.username,
+                challengeNameType = response.challengeName,
+                session = response.session,
+                challengeParameters = response.challengeParameters,
+                authenticationResult = response.authenticationResult,
+                callingActivity = signInContext.callingActivity
+            )
+        }
+
+    override fun assertCredentials(event: WebAuthnEvent.EventType.AssertCredentialOptions): Action =
+        safeAction(event.signInContext) {
+            val helper = WebAuthnHelper(context)
+            val responseJson = helper.getCredential(
+                requestJson = event.signInContext.requireRequestJson(),
+                callingActivity = event.signInContext.callingActivity
+            )
+            val newContext = event.signInContext.copy(responseJson = responseJson)
+            WebAuthnEvent(WebAuthnEvent.EventType.VerifyCredentialsAndSignIn(newContext))
+        }
+
+    override fun verifyCredentialAndSignIn(event: WebAuthnEvent.EventType.VerifyCredentialsAndSignIn): Action =
+        safeAction(event.signInContext) {
+            val signInContext = event.signInContext
+            val client = requireIdentityProviderClient()
+            val encodedContextData = getUserContextData(signInContext.username)
+            val pinpointEndpointId = getPinpointEndpointId()
+
+            val response = client.respondToAuthChallenge {
+                challengeName = ChallengeNameType.WebAuthn
+                clientId = configuration.userPool?.appClient
+                challengeResponses = mapOf(
+                    ChallengeResponse.USERNAME.key to signInContext.username,
+                    ChallengeResponse.CREDENTIAL.key to signInContext.requireResponseJson()
+                )
+                session = signInContext.session
+                pinpointEndpointId?.let { analyticsMetadata { analyticsEndpointId = it } }
+                encodedContextData?.let { userContextData { encodedData = it } }
+            }
+
+            SignInChallengeHelper.evaluateNextStep(
+                username = signInContext.username,
+                challengeNameType = ChallengeNameType.WebAuthn,
+                session = signInContext.session,
+                challengeParameters = response.challengeParameters,
+                authenticationResult = response.authenticationResult,
+                callingActivity = signInContext.callingActivity,
+                signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+            )
+        }
+
+    private fun safeAction(context: WebAuthnSignInContext, block: suspend AuthEnvironment.() -> StateMachineEvent) =
+        Action<AuthEnvironment> { _, dispatcher ->
+            val evt = try {
+                block()
+            } catch (e: Exception) {
+                WebAuthnEvent(WebAuthnEvent.EventType.ThrowError(e, context))
+            }
+            dispatcher.send(evt)
+        }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/UserCancelledException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/UserCancelledException.kt
@@ -20,6 +20,7 @@ import com.amplifyframework.auth.exceptions.ServiceException
  * Could not complete an action because it was cancelled by the user.
  * @param message An error message describing why this exception was thrown
  * @param recoverySuggestion Text suggesting a way to recover from the error being described
+ * @param cause The cause of the cancellation, if any
  */
-open class UserCancelledException(message: String, recoverySuggestion: String) :
-    ServiceException(message, recoverySuggestion)
+open class UserCancelledException(message: String, recoverySuggestion: String, cause: Throwable? = null) :
+    ServiceException(message, recoverySuggestion, cause)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/WebAuthnNotEnabledException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/service/WebAuthnNotEnabledException.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.exceptions.service
+
+import com.amplifyframework.auth.exceptions.ServiceException
+
+/**
+ * Could not perform the action because WebAuthn is not enabled in the Cognito user pool
+ */
+class WebAuthnNotEnabledException internal constructor(cause: Throwable?) :
+    ServiceException(
+        message = "WebAuthn is not enabled for this userpool",
+        recoverySuggestion = "Ensure that your userpool is setup to have WebAuthn enabled",
+        cause = cause
+    )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnCredentialAlreadyExistsException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnCredentialAlreadyExistsException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.exceptions.webauthn
+
+/**
+ * This exception occurs if associateWebAuthnCredential is invoked on a device that was already associated for the user
+ */
+class WebAuthnCredentialAlreadyExistsException internal constructor(cause: Throwable?) :
+    WebAuthnFailedException(
+        message = "The credential is already associated with this user",
+        recoverySuggestion = "Remove the old WebAuthn credential and try again",
+        cause = cause
+    )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnFailedException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnFailedException.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.exceptions.webauthn
+
+import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.exceptions.UnknownException
+
+/**
+ * A non-specific exception that indicates a failure interacting with Android's CredentialManager APIs
+ */
+open class WebAuthnFailedException internal constructor(
+    message: String,
+    recoverySuggestion: String? = null,
+    cause: Throwable? = null
+) : AuthException(
+    message = message,
+    recoverySuggestion = recoverySuggestion
+        ?: if (cause == null) {
+            UnknownException.RECOVERY_SUGGESTION_WITHOUT_THROWABLE
+        } else {
+            UnknownException.RECOVERY_SUGGESTION_WITH_THROWABLE
+        },
+    cause = cause
+)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.exceptions.webauthn
+
+/**
+ * Exception that is thrown because WebAuthn is not supported on the device. This indicates that either the device
+ * did not ship with WebAuthn support, or that your application is missing a required dependency or service.
+ */
+class WebAuthnNotSupportedException internal constructor(cause: Throwable?) :
+    WebAuthnFailedException(
+        message = "WebAuthn is not supported on this device",
+        recoverySuggestion = TODO_RECOVERY_SUGGESTION,
+        cause = cause
+    )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnRpMismatchException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnRpMismatchException.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.exceptions.webauthn
+
+/**
+ * This Exception indicates that there is was a problem verifying your application against the configured relying party
+ * in your User Pool. This could be because your application has a different package or signing key than the ones
+ * specified in the deployed assetlinks.json file. For more details about this file please refer to the
+ * Android documentation here: https://developer.android.com/identity/sign-in/credential-manager#add-support-dal
+ */
+class WebAuthnRpMismatchException internal constructor(cause: Throwable?) :
+    WebAuthnFailedException(
+        message = "Unable to verify Relying Party data",
+        recoverySuggestion =
+        "Check that you have a valid assetlinks.json file deployed to your RP that specifies the " +
+            "correct package name, signing key fingerprints, and grants permission for " +
+            "delegate_permission/common.get_login_creds. See Android Credential Manager documentation for details.",
+        cause = cause
+    )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthFactorTypeHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthFactorTypeHelper.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.helpers
+
+import com.amplifyframework.auth.AuthFactorType
+
+internal fun String.toAuthFactorTypeOrNull() = AuthFactorType.entries.firstOrNull { it.challengeResponse == this }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthFlowTypeHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthFlowTypeHelper.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.auth.cognito.helpers
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType as CognitoAuthFlowType
+import com.amplifyframework.auth.cognito.options.AuthFlowType
+
+internal fun AuthFlowType.toCognitoType() = when (this) {
+    AuthFlowType.USER_SRP_AUTH -> CognitoAuthFlowType.UserSrpAuth
+    AuthFlowType.CUSTOM_AUTH -> CognitoAuthFlowType.CustomAuth
+    AuthFlowType.CUSTOM_AUTH_WITH_SRP -> CognitoAuthFlowType.CustomAuth
+    AuthFlowType.CUSTOM_AUTH_WITHOUT_SRP -> CognitoAuthFlowType.CustomAuth
+    AuthFlowType.USER_PASSWORD_AUTH -> CognitoAuthFlowType.UserPasswordAuth
+    AuthFlowType.USER_AUTH -> CognitoAuthFlowType.UserAuth
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthLogger.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/AuthLogger.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+@file:JvmName("AuthLogger")
+
+package com.amplifyframework.auth.cognito.helpers
+
+import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin.Companion.AWS_COGNITO_AUTH_LOG_NAMESPACE
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.category.CategoryType
+
+internal fun Any.authLogger() =
+    Amplify.Logging.logger(CategoryType.AUTH, AWS_COGNITO_AUTH_LOG_NAMESPACE.format(this::class.java.simpleName))

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/FlowExtensions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/FlowExtensions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.auth.cognito.helpers
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.takeWhile
+
+internal suspend fun <T> Flow<T>.collectWhile(collector: (T) -> Boolean) {
+    this.takeWhile {
+        collector(it)
+    }.collect()
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/MFAHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/MFAHelper.kt
@@ -15,9 +15,12 @@
 
 package com.amplifyframework.auth.cognito.helpers
 
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
 import com.amplifyframework.auth.MFAType
 import com.amplifyframework.auth.exceptions.UnknownException
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
+import com.amplifyframework.statemachine.codegen.data.ChallengeParameter
+import com.amplifyframework.statemachine.codegen.data.challengeNameType
 
 @Throws(IllegalArgumentException::class)
 internal fun getMFAType(value: String) = when (value) {
@@ -48,15 +51,15 @@ internal val MFAType.value: String
     }
 
 internal fun isMfaSetupSelectionChallenge(challenge: AuthChallenge) =
-    challenge.challengeName == "MFA_SETUP" &&
+    challenge.challengeNameType == ChallengeNameType.MfaSetup &&
         getAllowedMFASetupTypesFromChallengeParameters(challenge.parameters).size > 1
 
 internal fun isEmailMfaSetupChallenge(challenge: AuthChallenge) =
-    challenge.challengeName == "MFA_SETUP" &&
+    challenge.challengeNameType == ChallengeNameType.MfaSetup &&
         getAllowedMFASetupTypesFromChallengeParameters(challenge.parameters) == setOf(MFAType.EMAIL)
 
 internal fun getAllowedMFATypesFromChallengeParameters(challengeParameters: Map<String, String>?): Set<MFAType> {
-    val mfasCanChoose = challengeParameters?.get("MFAS_CAN_CHOOSE") ?: return emptySet()
+    val mfasCanChoose = challengeParameters?.get(ChallengeParameter.MfasCanChoose.key) ?: return emptySet()
     val result = mutableSetOf<MFAType>()
     mfasCanChoose.replace(Regex("\\[|\\]|\""), "").split(",").forEach {
         when (it) {
@@ -71,7 +74,7 @@ internal fun getAllowedMFATypesFromChallengeParameters(challengeParameters: Map<
 
 // We exclude SMS as a setup type
 internal fun getAllowedMFASetupTypesFromChallengeParameters(challengeParameters: Map<String, String>?): Set<MFAType> {
-    val mfasCanSetup = challengeParameters?.get("MFAS_CAN_SETUP") ?: return emptySet()
+    val mfasCanSetup = challengeParameters?.get(ChallengeParameter.MfasCanSetup.key) ?: return emptySet()
 
     val result = mutableSetOf<MFAType>()
     mfasCanSetup.replace(Regex("\\[|\\]|\""), "").split(",").forEach {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/SignInChallengeHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/SignInChallengeHelper.kt
@@ -15,12 +15,14 @@
 
 package com.amplifyframework.auth.cognito.helpers
 
+import android.app.Activity
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthenticationResultType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
 import aws.smithy.kotlin.runtime.time.Instant
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthCodeDeliveryDetails.DeliveryMedium
 import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.AuthFactorType
 import com.amplifyframework.auth.MFAType
 import com.amplifyframework.auth.TOTPSetupDetails
 import com.amplifyframework.auth.exceptions.UnknownException
@@ -30,13 +32,17 @@ import com.amplifyframework.auth.result.step.AuthSignInStep
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.statemachine.StateMachineEvent
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
+import com.amplifyframework.statemachine.codegen.data.ChallengeParameter
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
 import com.amplifyframework.statemachine.codegen.data.SignInTOTPSetupData
 import com.amplifyframework.statemachine.codegen.data.SignedInData
+import com.amplifyframework.statemachine.codegen.data.WebAuthnSignInContext
+import com.amplifyframework.statemachine.codegen.data.challengeNameType
 import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.SignInEvent
+import java.lang.ref.WeakReference
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
 
@@ -45,73 +51,97 @@ internal object SignInChallengeHelper {
         username: String,
         challengeNameType: ChallengeNameType?,
         session: String?,
-        challengeParameters: Map<String, String>?,
+        challengeParameters: Map<String, String>? = null,
+        availableChallenges: List<String>? = null,
         authenticationResult: AuthenticationResultType?,
+        callingActivity: WeakReference<Activity> = WeakReference(null),
         signInMethod: SignInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_SRP_AUTH)
-    ): StateMachineEvent {
-        return when {
-            authenticationResult != null -> {
-                authenticationResult.let {
-                    val userId = it.accessToken?.let { token -> SessionHelper.getUserSub(token) } ?: ""
-                    val expiresIn = Instant.now().plus(it.expiresIn.seconds).epochSeconds
-                    val tokens = CognitoUserPoolTokens(it.idToken, it.accessToken, it.refreshToken, expiresIn)
-                    val signedInData = SignedInData(
-                        userId,
-                        username,
-                        Date(),
-                        signInMethod,
-                        tokens
-                    )
-                    it.newDeviceMetadata?.let { metadata ->
-                        SignInEvent(
-                            SignInEvent.EventType.ConfirmDevice(
-                                DeviceMetadata.Metadata(
-                                    metadata.deviceKey ?: "",
-                                    metadata.deviceGroupKey ?: ""
-                                ),
-                                signedInData
-                            )
-                        )
-                    } ?: AuthenticationEvent(
-                        AuthenticationEvent.EventType.SignInCompleted(
-                            signedInData,
-                            DeviceMetadata.Empty
-                        )
-                    )
-                }
-            }
-            challengeNameType is ChallengeNameType.SmsMfa ||
-                challengeNameType is ChallengeNameType.CustomChallenge ||
-                challengeNameType is ChallengeNameType.NewPasswordRequired ||
-                challengeNameType is ChallengeNameType.SoftwareTokenMfa ||
-                challengeNameType is ChallengeNameType.EmailOtp ||
-                challengeNameType is ChallengeNameType.SelectMfaType -> {
-                val challenge =
-                    AuthChallenge(challengeNameType.value, username, session, challengeParameters)
-                SignInEvent(SignInEvent.EventType.ReceivedChallenge(challenge))
-            }
-            challengeNameType is ChallengeNameType.MfaSetup -> {
-                val allowedMFASetupTypes = getAllowedMFASetupTypesFromChallengeParameters(challengeParameters)
-                val challenge = AuthChallenge(challengeNameType.value, username, session, challengeParameters)
-
-                if (allowedMFASetupTypes.contains(MFAType.EMAIL)) {
-                    SignInEvent(SignInEvent.EventType.ReceivedChallenge(challenge))
-                } else if (allowedMFASetupTypes.contains(MFAType.TOTP)) {
-                    val setupTOTPData = SignInTOTPSetupData("", session, username)
-                    SignInEvent(SignInEvent.EventType.InitiateTOTPSetup(setupTOTPData, challenge.parameters))
-                } else {
+    ): StateMachineEvent = when {
+        authenticationResult != null -> {
+            authenticationResult.let {
+                val userId = it.accessToken?.let { token -> SessionHelper.getUserSub(token) } ?: ""
+                val expiresIn = Instant.now().plus(it.expiresIn.seconds).epochSeconds
+                val tokens = CognitoUserPoolTokens(it.idToken, it.accessToken, it.refreshToken, expiresIn)
+                val signedInData = SignedInData(
+                    userId,
+                    username,
+                    Date(),
+                    signInMethod,
+                    tokens
+                )
+                it.newDeviceMetadata?.let { metadata ->
                     SignInEvent(
-                        SignInEvent.EventType.ThrowError(
-                            Exception("Cannot initiate MFA setup from available Types: $allowedMFASetupTypes")
+                        SignInEvent.EventType.ConfirmDevice(
+                            DeviceMetadata.Metadata(
+                                metadata.deviceKey ?: "",
+                                metadata.deviceGroupKey ?: ""
+                            ),
+                            signedInData
                         )
                     )
-                }
+                } ?: AuthenticationEvent(
+                    AuthenticationEvent.EventType.SignInCompleted(
+                        signedInData,
+                        DeviceMetadata.Empty
+                    )
+                )
             }
-            challengeNameType is ChallengeNameType.DeviceSrpAuth -> {
-                SignInEvent(SignInEvent.EventType.InitiateSignInWithDeviceSRP(username, mapOf()))
-            }
-            else -> SignInEvent(SignInEvent.EventType.ThrowError(Exception("Response did not contain sign in info.")))
         }
+        challengeNameType is ChallengeNameType.SmsMfa ||
+            challengeNameType is ChallengeNameType.CustomChallenge ||
+            challengeNameType is ChallengeNameType.NewPasswordRequired ||
+            challengeNameType is ChallengeNameType.SoftwareTokenMfa ||
+            challengeNameType is ChallengeNameType.SelectMfaType ||
+            challengeNameType is ChallengeNameType.SmsOtp ||
+            challengeNameType is ChallengeNameType.EmailOtp -> {
+            val challenge =
+                AuthChallenge(challengeNameType.value, username, session, challengeParameters)
+            SignInEvent(SignInEvent.EventType.ReceivedChallenge(challenge))
+        }
+        challengeNameType is ChallengeNameType.MfaSetup -> {
+            val allowedMFASetupTypes = getAllowedMFASetupTypesFromChallengeParameters(challengeParameters)
+            val challenge = AuthChallenge(challengeNameType.value, username, session, challengeParameters)
+
+            if (allowedMFASetupTypes.contains(MFAType.EMAIL)) {
+                SignInEvent(SignInEvent.EventType.ReceivedChallenge(challenge))
+            } else if (allowedMFASetupTypes.contains(MFAType.TOTP)) {
+                val setupTOTPData = SignInTOTPSetupData("", session, username)
+                SignInEvent(SignInEvent.EventType.InitiateTOTPSetup(setupTOTPData, challenge.parameters))
+            } else {
+                SignInEvent(
+                    SignInEvent.EventType.ThrowError(
+                        Exception("Cannot initiate MFA setup from available Types: $allowedMFASetupTypes")
+                    )
+                )
+            }
+        }
+        challengeNameType is ChallengeNameType.DeviceSrpAuth -> {
+            SignInEvent(SignInEvent.EventType.InitiateSignInWithDeviceSRP(username, mapOf()))
+        }
+        challengeNameType is ChallengeNameType.SelectChallenge -> {
+            SignInEvent(
+                SignInEvent.EventType.ReceivedChallenge(
+                    AuthChallenge(
+                        challengeName = ChallengeNameType.SelectChallenge.value,
+                        username = username,
+                        session = session,
+                        parameters = null,
+                        availableChallenges = availableChallenges
+                    )
+                )
+            )
+        }
+        challengeNameType is ChallengeNameType.WebAuthn -> {
+            val requestOptions = challengeParameters?.get(ChallengeParameter.CredentialRequestOptions.key)
+            val signInContext = WebAuthnSignInContext(
+                username = username,
+                callingActivity = callingActivity,
+                session = session,
+                requestJson = requestOptions
+            )
+            SignInEvent(SignInEvent.EventType.InitiateWebAuthnSignIn(signInContext))
+        }
+        else -> SignInEvent(SignInEvent.EventType.ThrowError(Exception("Response did not contain sign in info.")))
     }
 
     fun getNextStep(
@@ -121,22 +151,28 @@ internal object SignInChallengeHelper {
         signInTOTPSetupData: SignInTOTPSetupData? = null,
         allowedMFAType: Set<MFAType>? = null
     ) {
-        val challengeParams = challenge.parameters?.toMutableMap() ?: mapOf()
+        val challengeParams = challenge.parameters ?: emptyMap()
 
-        when (ChallengeNameType.fromValue(challenge.challengeName)) {
-            is ChallengeNameType.SmsMfa -> {
+        when (challenge.challengeNameType) {
+            is ChallengeNameType.SmsMfa,
+            ChallengeNameType.EmailOtp,
+            ChallengeNameType.SmsOtp -> {
                 val deliveryDetails = AuthCodeDeliveryDetails(
-                    challengeParams.getValue("CODE_DELIVERY_DESTINATION"),
-                    DeliveryMedium.fromString(
-                        challengeParams.getValue("CODE_DELIVERY_DELIVERY_MEDIUM")
-                    )
+                    challengeParams.getValue(ChallengeParameter.CodeDeliveryDestination.key),
+                    DeliveryMedium.fromString(challengeParams.getValue(ChallengeParameter.CodeDeliveryMedium.key))
                 )
+                val signInStep = if (challenge.challengeNameType == ChallengeNameType.SmsMfa) {
+                    AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE
+                } else {
+                    AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP
+                }
                 val authSignInResult = AuthSignInResult(
                     false,
                     AuthNextSignInStep(
-                        AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE,
+                        signInStep,
                         mapOf(),
                         deliveryDetails,
+                        null,
                         null,
                         null
                     )
@@ -149,6 +185,7 @@ internal object SignInChallengeHelper {
                     AuthNextSignInStep(
                         AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD,
                         challengeParams,
+                        null,
                         null,
                         null,
                         null
@@ -164,6 +201,7 @@ internal object SignInChallengeHelper {
                         challengeParams,
                         null,
                         null,
+                        null,
                         null
                     )
                 )
@@ -175,6 +213,7 @@ internal object SignInChallengeHelper {
                     AuthNextSignInStep(
                         AuthSignInStep.CONFIRM_SIGN_IN_WITH_TOTP_CODE,
                         emptyMap(),
+                        null,
                         null,
                         null,
                         null
@@ -193,7 +232,8 @@ internal object SignInChallengeHelper {
                             emptyMap(),
                             null,
                             null,
-                            allowedMFASetupTypes
+                            allowedMFASetupTypes,
+                            null
                         )
                     )
                     onSuccess.accept(authSignInResult)
@@ -205,7 +245,8 @@ internal object SignInChallengeHelper {
                             challengeParams,
                             null,
                             TOTPSetupDetails(signInTOTPSetupData.secretCode, signInTOTPSetupData.username),
-                            allowedMFAType
+                            allowedMFAType,
+                            null
                         )
                     )
                     onSuccess.accept(authSignInResult)
@@ -217,7 +258,8 @@ internal object SignInChallengeHelper {
                             emptyMap(),
                             null,
                             null,
-                            allowedMFAType
+                            allowedMFAType,
+                            null
                         )
                     )
                     onSuccess.accept(authSignInResult)
@@ -233,35 +275,43 @@ internal object SignInChallengeHelper {
                         mapOf(),
                         null,
                         null,
-                        getAllowedMFATypesFromChallengeParameters(challengeParams)
+                        getAllowedMFATypesFromChallengeParameters(challengeParams),
+                        null
                     )
                 )
                 onSuccess.accept(authSignInResult)
             }
-            is ChallengeNameType.EmailOtp -> {
-                val codeDeliveryMedium = DeliveryMedium.fromString(
-                    challengeParams["CODE_DELIVERY_DELIVERY_MEDIUM"] ?: DeliveryMedium.UNKNOWN.value
-                )
-                val codeDeliveryDestination = challengeParams["CODE_DELIVERY_DESTINATION"]
-                val deliveryDetails = if (codeDeliveryDestination != null) {
-                    AuthCodeDeliveryDetails(codeDeliveryDestination, codeDeliveryMedium)
-                } else {
-                    null
-                }
-
+            is ChallengeNameType.SelectChallenge -> {
                 val authSignInResult = AuthSignInResult(
                     false,
                     AuthNextSignInStep(
-                        AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP,
+                        AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION,
                         mapOf(),
-                        deliveryDetails,
                         null,
-                        null
+                        null,
+                        null,
+                        getAvailableFactors(challenge.availableChallenges)
                     )
                 )
                 onSuccess.accept(authSignInResult)
             }
             else -> onError.accept(UnknownException(cause = Exception("Challenge type not supported.")))
         }
+    }
+
+    private fun getAvailableFactors(possibleFactors: List<String>?): Set<AuthFactorType> {
+        val result = mutableSetOf<AuthFactorType>()
+        if (possibleFactors == null) {
+            throw UnknownException(cause = Exception("Tried to parse available factors but found none."))
+        } else {
+            possibleFactors.forEach {
+                try {
+                    result.add(AuthFactorType.valueOf(it))
+                } catch (exception: IllegalArgumentException) {
+                    throw UnknownException(cause = Exception("Tried to parse an unrecognized AuthFactorType"))
+                }
+            }
+        }
+        return result
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelper.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.helpers
+
+import android.app.Activity
+import android.content.Context
+import androidx.credentials.CreateCredentialResponse
+import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.CreatePublicKeyCredentialResponse
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.PublicKeyCredential
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
+import androidx.credentials.exceptions.CreateCredentialUnsupportedException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
+import androidx.credentials.exceptions.GetCredentialUnsupportedException
+import androidx.credentials.exceptions.domerrors.DataError
+import androidx.credentials.exceptions.domerrors.InvalidStateError
+import androidx.credentials.exceptions.domerrors.NotAllowedError
+import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
+import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialException
+import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.cognito.exceptions.service.UserCancelledException
+import com.amplifyframework.auth.cognito.exceptions.webauthn.WebAuthnCredentialAlreadyExistsException
+import com.amplifyframework.auth.cognito.exceptions.webauthn.WebAuthnFailedException
+import com.amplifyframework.auth.cognito.exceptions.webauthn.WebAuthnNotSupportedException
+import com.amplifyframework.auth.cognito.exceptions.webauthn.WebAuthnRpMismatchException
+import java.lang.ref.WeakReference
+
+internal class WebAuthnHelper(
+    private val context: Context,
+    private val credentialManager: CredentialManager = CredentialManager.create(context)
+) {
+
+    private val logger = authLogger()
+
+    suspend fun getCredential(requestJson: String, callingActivity: WeakReference<Activity>): String {
+        try {
+            // Construct the request for CredentialManager. We're only interested in PublicKey credentials
+            val options = GetPublicKeyCredentialOption(requestJson = requestJson)
+            val request = GetCredentialRequest(credentialOptions = listOf(options))
+
+            logger.verbose("Prompting user for PassKey authorization")
+            val result = credentialManager.getCredential(context = callingActivity.resolveContext(), request = request)
+
+            // Extract the Public Key credential response. This is what we send to Cognito.
+            val publicKeyResult = result.credential as? PublicKeyCredential ?: throw WebAuthnFailedException(
+                "Android returned wrong credential type",
+                AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+            )
+            return publicKeyResult.authenticationResponseJson
+        } catch (e: GetCredentialException) {
+            throw e.toAuthException()
+        }
+    }
+
+    suspend fun createCredential(requestJson: String, callingActivity: Activity): String {
+        try {
+            // Create the request for CredentialManager
+            val request = CreatePublicKeyCredentialRequest(requestJson)
+
+            // Create the credential
+            logger.verbose("Prompting user to create a PassKey")
+            val result: CreateCredentialResponse = credentialManager.createCredential(callingActivity, request)
+
+            // Extract the Public Key registration response. This is what we send to Cognito.
+            val publicKeyResult = result as? CreatePublicKeyCredentialResponse ?: throw WebAuthnFailedException(
+                "Android created wrong credential type",
+                AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+            )
+            return publicKeyResult.registrationResponseJson
+        } catch (e: CreateCredentialException) {
+            throw e.toAuthException()
+        }
+    }
+
+    private fun WeakReference<Activity>.resolveContext(): Context {
+        // Use the Activity context if provided. The Activity context will allow the authorization UI to be shown
+        // in the same Task instance - if we use the Application context instead it will launch a new Task.
+        // Customers should always provide a calling activity when using WebAuthn for the best user experience.
+        val activity = get()
+        if (activity == null) {
+            logger.warn(
+                "No Activity context available when accessing device PassKey. This will result in the system " +
+                    "UI appearing in a new Task. We recommend setting the callingActivity option when invoking " +
+                    "Amplify Auth APIs if you are using WebAuthn."
+            )
+        }
+        return activity ?: context
+    }
+
+    private fun CreateCredentialException.toAuthException(): AuthException = when (this) {
+        is CreateCredentialCancellationException -> userCancelledException()
+        is CreateCredentialProviderConfigurationException -> notSupported()
+        is CreateCredentialUnsupportedException -> notSupported()
+        is CreatePublicKeyCredentialDomException -> {
+            when (this.domError) {
+                is NotAllowedError -> userCancelledException()
+                is InvalidStateError -> alreadyExists()
+                is DataError -> rpMismatch()
+                else -> unknownException()
+            }
+        }
+        else -> unknownException()
+    }
+
+    private fun GetCredentialException.toAuthException(): AuthException = when (this) {
+        is GetCredentialCancellationException -> userCancelledException()
+        is GetCredentialProviderConfigurationException -> notSupported()
+        is GetCredentialUnsupportedException -> notSupported()
+        is GetPublicKeyCredentialDomException -> {
+            when (this.domError) {
+                is NotAllowedError -> userCancelledException()
+                is DataError -> rpMismatch()
+                else -> unknownException()
+            }
+        }
+        else -> unknownException()
+    }
+
+    // The exception returned when user cancels
+    private fun Exception.userCancelledException() = UserCancelledException(
+        message = "User cancelled granting access to PassKey",
+        recoverySuggestion = "Re-show the previous UI and allow user to try again",
+        cause = this
+    ).also { logger.verbose("User cancelled the PassKey authorization UI") }
+
+    private fun CreatePublicKeyCredentialException.alreadyExists() = WebAuthnCredentialAlreadyExistsException(this)
+    private fun Exception.notSupported() = WebAuthnNotSupportedException(this)
+    private fun Exception.rpMismatch() = WebAuthnRpMismatchException(this)
+
+    // The default exception returned when fetching credentials
+    private fun CreateCredentialException.unknownException() =
+        WebAuthnFailedException("Unable to create the passkey using the Androidx CredentialManager", cause = this)
+    private fun GetCredentialException.unknownException() =
+        WebAuthnFailedException("Unable to retrieve the passkey from the Androidx CredentialManager", cause = this)
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthConfirmSignInOptions.kt
@@ -15,8 +15,10 @@
 
 package com.amplifyframework.auth.cognito.options
 
+import android.app.Activity
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
+import java.lang.ref.WeakReference
 
 /**
  * Cognito extension of confirm sign in options to add the platform specific fields.
@@ -36,7 +38,12 @@ data class AWSCognitoAuthConfirmSignInOptions internal constructor(
      * Get the friendly device name used to setup TOTP.
      * @return friendly device name
      */
-    val friendlyDeviceName: String?
+    val friendlyDeviceName: String?,
+    /**
+     * Get the Activity instance, if any.
+     * @return A WeakReference to the Activity
+     */
+    val callingActivity: WeakReference<Activity>
 ) : AuthConfirmSignInOptions() {
 
     companion object {
@@ -45,9 +52,7 @@ data class AWSCognitoAuthConfirmSignInOptions internal constructor(
          * @return a builder object.
          */
         @JvmStatic
-        fun builder(): CognitoBuilder {
-            return CognitoBuilder()
-        }
+        fun builder(): CognitoBuilder = CognitoBuilder()
 
         inline operator fun invoke(block: CognitoBuilder.() -> Unit) = CognitoBuilder().apply(block).build()
     }
@@ -59,14 +64,13 @@ data class AWSCognitoAuthConfirmSignInOptions internal constructor(
         private var metadata: Map<String, String> = mapOf()
         private var userAttributes: List<AuthUserAttribute> = listOf()
         private var friendlyDeviceName: String? = null
+        private var callingActivity: WeakReference<Activity> = WeakReference(null)
 
         /**
          * Returns the type of builder this is to support proper flow with it being an extended class.
          * @return the type of builder this is to support proper flow with it being an extended class.
          */
-        override fun getThis(): CognitoBuilder {
-            return this
-        }
+        override fun getThis(): CognitoBuilder = this
 
         /**
          * Set the metadata field for the object being built.
@@ -91,9 +95,20 @@ data class AWSCognitoAuthConfirmSignInOptions internal constructor(
         fun friendlyDeviceName(friendlyDeviceName: String) = apply { this.friendlyDeviceName = friendlyDeviceName }
 
         /**
+         * Set the callingActivity field for the object being built. This should be set when using WebAuthn to ensure
+         * the optimal user experience.
+         * @param callingActivity The current Activity.
+         * @return the instance of the builder.
+         */
+        fun callingActivity(callingActivity: Activity) = apply {
+            this.callingActivity = WeakReference(callingActivity)
+        }
+
+        /**
          * Construct and return the object with the values set in the builder.
          * @return a new instance of AWSCognitoAuthConfirmSignInOptions with the values specified in the builder.
          */
-        override fun build() = AWSCognitoAuthConfirmSignInOptions(metadata, userAttributes, friendlyDeviceName)
+        override fun build() =
+            AWSCognitoAuthConfirmSignInOptions(metadata, userAttributes, friendlyDeviceName, callingActivity)
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthListWebAuthnCredentialsOptions.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.options
+
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult
+
+/**
+ * Options for the listWebAuthnCredentials API that are specific to Cognito.
+ * @param nextToken The token returned the [AuthListWebAuthnCredentialsResult] that will load the next page of results.
+ *      Should be null to load the first page.
+ * @param maxResults The maximum number of results to return per page. Set to null to use the default max.
+ */
+data class AWSCognitoAuthListWebAuthnCredentialsOptions internal constructor(
+    val nextToken: String?,
+    val maxResults: Int?
+) : AuthListWebAuthnCredentialsOptions() {
+    companion object {
+        /**
+         * Create a [Builder] for this class
+         */
+        @JvmStatic
+        fun builder() = Builder()
+
+        /**
+         * Construct using a DSL syntax
+         */
+        @JvmSynthetic
+        inline operator fun invoke(func: Builder.() -> Unit) = Builder().apply(func).build()
+
+        /**
+         * Return the default options
+         */
+        @JvmStatic
+        fun defaults() = builder().build()
+
+        private fun AuthListWebAuthnCredentialsOptions.asCognitoOptions() =
+            this as? AWSCognitoAuthListWebAuthnCredentialsOptions
+        internal val AuthListWebAuthnCredentialsOptions.nextToken: String?
+            get() = this.asCognitoOptions()?.nextToken
+        internal val AuthListWebAuthnCredentialsOptions.maxResults: Int?
+            get() = this.asCognitoOptions()?.maxResults
+    }
+
+    /**
+     * Builder for cognito-specific [AuthListWebAuthnCredentialsOptions].
+     */
+    class Builder : AuthListWebAuthnCredentialsOptions.Builder<Builder>() {
+        /**
+         *The next token that was returned in the prior page of results. Set to null to load the first page.
+         */
+        var nextToken: String? = null
+            @JvmSynthetic set
+
+        /**
+         * The maximum number of results to return. Set to null to use the service-default max value.
+         */
+        var maxResults: Int? = null
+            @JvmSynthetic set
+
+        /**
+         * Returns this instance for typesafe chaining from the parent class
+         */
+        override fun getThis() = this
+
+        /**
+         * Set the next token to load a further page of results
+         * @param nextToken The next token that was returned in the prior page of results. Set to null to load the
+         * first page.
+         * @return This instance for chaining calls
+         */
+        fun nextToken(nextToken: String?) = apply { this.nextToken = nextToken }
+
+        /**
+         * Set the maximum number of results to return per page
+         * @param maxResults The maximum number of results to return. Set to null to use the service-default max
+         * value.
+         * @return This instance for chaining calls
+         */
+        fun maxResults(maxResults: Int?) = apply { this.maxResults = maxResults }
+
+        /**
+         * Builds the options object
+         * @return The constructed [AWSCognitoAuthListWebAuthnCredentialsOptions] objects
+         */
+        override fun build() = AWSCognitoAuthListWebAuthnCredentialsOptions(
+            nextToken = nextToken,
+            maxResults = maxResults
+        )
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AWSCognitoAuthSignInOptions.java
@@ -15,13 +15,16 @@
 
 package com.amplifyframework.auth.cognito.options;
 
+import android.app.Activity;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
+import com.amplifyframework.auth.AuthFactorType;
 import com.amplifyframework.auth.options.AuthSignInOptions;
 import com.amplifyframework.util.Immutable;
 
+import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -32,19 +35,30 @@ import java.util.Objects;
 public final class AWSCognitoAuthSignInOptions extends AuthSignInOptions {
     private final Map<String, String> metadata;
     private final AuthFlowType authFlowType;
+    private final AuthFactorType preferredFirstFactor;
+    private final WeakReference<Activity> callingActivity;
 
     /**
      * Advanced options for signing in.
      *
      * @param metadata Additional custom attributes to be sent to the service such as information about the client
      * @param authFlowType AuthFlowType to be used by signIn API
+     * @param preferredFirstFactor The preferred authentication factor to use, if available.
+     *                             This is only used if authFlowType is USER_AUTH.
+     * @param callingActivity The Activity reference to use when showing the PassKey UI.
+     *                        This is only used if authFlowType is USER_AUTH and WebAuthn is
+     *                        used to sign in.
      */
     protected AWSCognitoAuthSignInOptions(
             @NonNull Map<String, String> metadata,
-            AuthFlowType authFlowType
+            AuthFlowType authFlowType,
+            AuthFactorType preferredFirstFactor,
+            WeakReference<Activity> callingActivity
     ) {
         this.metadata = metadata;
         this.authFlowType = authFlowType;
+        this.preferredFirstFactor = preferredFirstFactor;
+        this.callingActivity = callingActivity;
     }
 
     /**
@@ -68,6 +82,28 @@ public final class AWSCognitoAuthSignInOptions extends AuthSignInOptions {
     }
 
     /**
+     * Get the preferred {@link AuthFactorType} to use when signing in with USER_AUTH. If that
+     * AuthFactorType is available for the user signing in then it will be used to authenticate
+     * the user, otherwise another factor may be used or the user may be prompted to select a
+     * factor.
+     * @return The preferred {@link AuthFactorType} to use, if available.
+     */
+    @Nullable
+    public AuthFactorType getPreferredFirstFactor() {
+        return preferredFirstFactor;
+    }
+
+    /**
+     * Get the Activity reference to use when showing the PassKey UI. This is only used if
+     * authFlowType is USER_AUTH and WebAuthn is used to sign in.
+     * @return The Activity reference
+     */
+    @NonNull
+    public WeakReference<Activity> getCallingActivity() {
+        return callingActivity;
+    }
+
+    /**
      * Get a builder object.
      *
      * @return a builder object.
@@ -79,7 +115,7 @@ public final class AWSCognitoAuthSignInOptions extends AuthSignInOptions {
 
     @Override
     public int hashCode() {
-        return ObjectsCompat.hash(getMetadata(), getAuthFlowType());
+        return ObjectsCompat.hash(getMetadata(), getAuthFlowType(), getPreferredFirstFactor(), getCallingActivity());
     }
 
     @Override
@@ -91,7 +127,10 @@ public final class AWSCognitoAuthSignInOptions extends AuthSignInOptions {
         } else {
             AWSCognitoAuthSignInOptions authSignInOptions = (AWSCognitoAuthSignInOptions) obj;
             return ObjectsCompat.equals(getMetadata(), authSignInOptions.getMetadata()) &&
-                    ObjectsCompat.equals(getAuthFlowType(), authSignInOptions.getAuthFlowType());
+                    ObjectsCompat.equals(getAuthFlowType(), authSignInOptions.getAuthFlowType()) &&
+                    ObjectsCompat.equals(getPreferredFirstFactor(),
+                            authSignInOptions.getPreferredFirstFactor()) &&
+                    ObjectsCompat.equals(getCallingActivity(), authSignInOptions.getCallingActivity());
         }
     }
 
@@ -100,6 +139,8 @@ public final class AWSCognitoAuthSignInOptions extends AuthSignInOptions {
         return "AWSCognitoAuthSignInOptions{" +
                 "metadata=" + getMetadata() +
                 ", authFlowType=" + getAuthFlowType() +
+                ", preferredFirstFactor=" + getPreferredFirstFactor() +
+                ", callingActivity=" + getCallingActivity() +
                 '}';
     }
 
@@ -109,6 +150,8 @@ public final class AWSCognitoAuthSignInOptions extends AuthSignInOptions {
     public static final class CognitoBuilder extends Builder<CognitoBuilder> {
         private final Map<String, String> metadata;
         private AuthFlowType authFlowType;
+        private AuthFactorType preferredFirstFactor;
+        private WeakReference<Activity> callingActivity = new WeakReference<>(null);
 
         /**
          * Constructor for the builder.
@@ -155,13 +198,47 @@ public final class AWSCognitoAuthSignInOptions extends AuthSignInOptions {
         }
 
         /**
+         * Set the preferred {@link AuthFactorType} to use when signing in with USER_AUTH. If that
+         * AuthFactorType is available for the user signing in then it will be used to authenticate
+         * the user. If this option is not set or is not available for the user then another factor
+         * may be used or the user may be prompted to select a factor.
+         * @param factorType The preferred factor.
+         * @return The builder object to continue building.
+         */
+        @NonNull
+        public CognitoBuilder preferredFirstFactor(@Nullable AuthFactorType factorType) {
+            this.preferredFirstFactor = factorType;
+            return getThis();
+        }
+
+        /**
+         * Set the Activity reference to use when showing the PassKey UI. This is only used if
+         * authFlowType is USER_AUTH and WebAuthn is used to sign in. This option should always be
+         * set if your app may be expecting to use WebAuthn, as not setting this option will lead
+         * to a sub-optimal user experience when authenticating via WebAuthn.
+         * @param callingActivity The Activity instance. This is stored in a WeakReference so that
+         *                        it will not be leaked.
+         * @return The builder object to continue building.
+         */
+        @NonNull
+        public CognitoBuilder callingActivity(@NonNull Activity callingActivity) {
+            this.callingActivity = new WeakReference<>(callingActivity);
+            return getThis();
+        }
+
+        /**
          * Construct and return the object with the values set in the builder.
          *
          * @return a new instance of AWSCognitoAuthSignInOptions with the values specified in the builder.
          */
         @NonNull
         public AWSCognitoAuthSignInOptions build() {
-            return new AWSCognitoAuthSignInOptions(Immutable.of(metadata), authFlowType);
+            return new AWSCognitoAuthSignInOptions(
+                    Immutable.of(metadata),
+                    authFlowType,
+                    preferredFirstFactor,
+                    callingActivity
+            );
         }
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AuthFlowType.java
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/options/AuthFlowType.java
@@ -44,7 +44,13 @@ public enum AuthFlowType {
     /**
      * type for USER_PASSWORD_AUTH.
      */
-    USER_PASSWORD_AUTH("USER_PASSWORD_AUTH");
+    USER_PASSWORD_AUTH("USER_PASSWORD_AUTH"),
+
+    /**
+     * type for USER_AUTH.
+     */
+    USER_AUTH("USER_AUTH");
+
     private String value;
 
     AuthFlowType(String value) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/result/AWSCognitoAuthListWebAuthnCredentialsResult.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/result/AWSCognitoAuthListWebAuthnCredentialsResult.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.result
+
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult
+import com.amplifyframework.auth.result.AuthWebAuthnCredential
+import java.time.Instant
+
+/**
+ * The cognito-specific result to the listWebAuthnCredentials API.
+ * @param credentials The returned credentials
+ * @param nextToken If there are multiple pages of results this will be non-null, and can be passed in the
+ * options object to fetch the next page.
+ */
+data class AWSCognitoAuthListWebAuthnCredentialsResult(
+    override val credentials: List<AuthWebAuthnCredential>,
+    val nextToken: String?
+) : AuthListWebAuthnCredentialsResult
+
+internal data class CognitoWebAuthnCredential(
+    override val credentialId: String,
+    override val friendlyName: String?,
+    override val relyingPartyId: String,
+    override val createdAt: Instant
+) : AuthWebAuthnCredential

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AssociateWebAuthnCredentialUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AssociateWebAuthnCredentialUseCase.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import android.app.Activity
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.completeWebAuthnRegistration
+import aws.sdk.kotlin.services.cognitoidentityprovider.startWebAuthnRegistration
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.helpers.WebAuthnHelper
+import com.amplifyframework.auth.cognito.helpers.authLogger
+import com.amplifyframework.auth.cognito.requireAuthenticationState
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState.SignedIn
+import com.amplifyframework.statemachine.util.mask
+import com.amplifyframework.util.JsonDocument
+import com.amplifyframework.util.toJsonString
+
+internal class AssociateWebAuthnCredentialUseCase(
+    private val client: CognitoIdentityProviderClient,
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val stateMachine: AuthStateMachine,
+    private val webAuthnHelper: WebAuthnHelper
+) {
+    private val logger = authLogger()
+
+    @Suppress("UNUSED_PARAMETER")
+    suspend fun execute(callingActivity: Activity, options: AuthAssociateWebAuthnCredentialsOptions) {
+        // User must be signed in to call this API
+        stateMachine.requireAuthenticationState<SignedIn>()
+
+        val accessToken = fetchAuthSession.execute().accessToken
+
+        // Step 1: Get the credential request JSON from Cognito
+        val requestJson = getCredentialRequestJson(accessToken)
+        logger.debug("Received credential request: ${requestJson.mask()}")
+
+        // Step 2: Create the credential with Android and get the response JSON
+        val responseJson = webAuthnHelper.createCredential(requestJson, callingActivity)
+        logger.debug("Sending credential response: ${responseJson.mask()}")
+
+        // Step 3: Send the response JSON back to Cognito to complete the registration
+        associateCredential(responseJson, accessToken)
+    }
+
+    private suspend fun getCredentialRequestJson(accessToken: String?): String {
+        val response = client.startWebAuthnRegistration {
+            this.accessToken = accessToken
+        }
+        return response.credentialCreationOptions!!.toJsonString()
+    }
+
+    private suspend fun associateCredential(credentialResponseJson: String, accessToken: String?) {
+        client.completeWebAuthnRegistration {
+            this.credential = JsonDocument(credentialResponseJson)
+            this.accessToken = accessToken
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.RealAWSCognitoAuthPlugin
+import com.amplifyframework.auth.cognito.helpers.WebAuthnHelper
+import com.amplifyframework.auth.cognito.requireIdentityProviderClient
+
+internal class AuthUseCaseFactory(
+    private val plugin: RealAWSCognitoAuthPlugin,
+    private val authEnvironment: AuthEnvironment,
+    private val stateMachine: AuthStateMachine
+) {
+
+    fun fetchAuthSession() = FetchAuthSessionUseCase(plugin)
+
+    fun associateWebAuthnCredential() = AssociateWebAuthnCredentialUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine,
+        webAuthnHelper = WebAuthnHelper(authEnvironment.context)
+    )
+
+    fun listWebAuthnCredentials() = ListWebAuthnCredentialsUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
+
+    fun deleteWebAuthnCredential() = DeleteWebAuthnCredentialUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/DeleteWebAuthnCredentialUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/DeleteWebAuthnCredentialUseCase.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.deleteWebAuthnCredential
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.requireAuthenticationState
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState.SignedIn
+
+internal class DeleteWebAuthnCredentialUseCase(
+    private val client: CognitoIdentityProviderClient,
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val stateMachine: AuthStateMachine
+) {
+    @Suppress("UNUSED_PARAMETER")
+    suspend fun execute(credentialId: String, options: AuthDeleteWebAuthnCredentialOptions) {
+        // User must be signed in to call this API
+        stateMachine.requireAuthenticationState<SignedIn>()
+
+        val accessToken = fetchAuthSession.execute().accessToken
+        client.deleteWebAuthnCredential {
+            this.accessToken = accessToken
+            this.credentialId = credentialId
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCase.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import com.amplifyframework.auth.cognito.AWSCognitoAuthSession
+import com.amplifyframework.auth.cognito.RealAWSCognitoAuthPlugin
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+internal class FetchAuthSessionUseCase(
+    private val plugin: RealAWSCognitoAuthPlugin
+) {
+    suspend fun execute(): AWSCognitoAuthSession {
+        // TODO - we should migrate the fetch auth session business logic to this class
+        val session = suspendCoroutine { continuation ->
+            plugin.fetchAuthSession(
+                onSuccess = { continuation.resume(it) },
+                onError = { continuation.resumeWithException(it) }
+            )
+        }
+        return session as AWSCognitoAuthSession
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ListWebAuthnCredentialsUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ListWebAuthnCredentialsUseCase.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.listWebAuthnCredentials
+import aws.smithy.kotlin.runtime.time.toJvmInstant
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthListWebAuthnCredentialsOptions.Companion.maxResults
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthListWebAuthnCredentialsOptions.Companion.nextToken
+import com.amplifyframework.auth.cognito.requireAuthenticationState
+import com.amplifyframework.auth.cognito.result.AWSCognitoAuthListWebAuthnCredentialsResult
+import com.amplifyframework.auth.cognito.result.CognitoWebAuthnCredential
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState.SignedIn
+
+internal class ListWebAuthnCredentialsUseCase(
+    private val client: CognitoIdentityProviderClient,
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val stateMachine: AuthStateMachine
+) {
+    suspend fun execute(options: AuthListWebAuthnCredentialsOptions): AWSCognitoAuthListWebAuthnCredentialsResult {
+        // User must be SignedIn to call this API
+        stateMachine.requireAuthenticationState<SignedIn>()
+
+        val token = fetchAuthSession.execute().accessToken
+
+        val response = client.listWebAuthnCredentials {
+            accessToken = token
+            nextToken = options.nextToken
+            maxResults = options.maxResults
+        }
+
+        val credentials = response.credentials.map { credential ->
+            CognitoWebAuthnCredential(
+                credentialId = credential.credentialId,
+                friendlyName = credential.friendlyCredentialName,
+                relyingPartyId = credential.relyingPartyId,
+                createdAt = credential.createdAt.toJvmInstant()
+            )
+        }
+
+        return AWSCognitoAuthListWebAuthnCredentialsResult(
+            credentials = credentials,
+            nextToken = response.nextToken
+        )
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/SignInActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/SignInActions.kt
@@ -28,4 +28,6 @@ internal interface SignInActions {
     fun confirmDevice(event: SignInEvent.EventType.ConfirmDevice): Action
     fun startHostedUIAuthAction(event: SignInEvent.EventType.InitiateHostedUISignIn): Action
     fun initiateTOTPSetupAction(event: SignInEvent.EventType.InitiateTOTPSetup): Action
+    fun initiateWebAuthnSignInAction(event: SignInEvent.EventType.InitiateWebAuthnSignIn): Action
+    fun autoSignInAction(event: SignInEvent.EventType.InitiateAutoSignIn): Action
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/SignUpActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/SignUpActions.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.actions
+
+import com.amplifyframework.statemachine.Action
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
+
+internal interface SignUpActions {
+    fun initiateSignUpAction(event: SignUpEvent.EventType.InitiateSignUp): Action
+    fun confirmSignUpAction(event: SignUpEvent.EventType.ConfirmSignUp): Action
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/UserAuthSignInActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/UserAuthSignInActions.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.actions
+
+import com.amplifyframework.statemachine.Action
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
+
+internal interface UserAuthSignInActions {
+    fun initiateUserAuthSignIn(event: SignInEvent.EventType.InitiateUserAuth): Action
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/WebAuthnSignInActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/WebAuthnSignInActions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.actions
+
+import com.amplifyframework.statemachine.Action
+import com.amplifyframework.statemachine.codegen.events.WebAuthnEvent
+
+internal interface WebAuthnSignInActions {
+    fun fetchCredentialOptions(event: WebAuthnEvent.EventType.FetchCredentialOptions): Action
+    fun assertCredentials(event: WebAuthnEvent.EventType.AssertCredentialOptions): Action
+    fun verifyCredentialAndSignIn(event: WebAuthnEvent.EventType.VerifyCredentialsAndSignIn): Action
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AuthChallenge.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AuthChallenge.kt
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.statemachine.codegen.data
 
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import com.amplifyframework.statemachine.util.mask
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -22,5 +24,24 @@ internal data class AuthChallenge(
     val challengeName: String,
     val username: String? = null,
     val session: String?,
-    val parameters: Map<String, String>?
+    val parameters: Map<String, String>?,
+    val availableChallenges: List<String>? = null
+) {
+    override fun toString(): String = "AuthChallenge(" +
+        "challengeName='$challengeName', " +
+        "username=$username, " +
+        "session=${session.mask()}, " +
+        "parameters=${parameters?.maskSensitiveChallengeParameters()}, " +
+        "availableChallenges=$availableChallenges" +
+        ")"
+}
+
+internal val AuthChallenge.challengeNameType
+    get() = ChallengeNameType.fromValue(challengeName)
+
+internal fun AuthChallenge.getParameter(parameter: ChallengeParameter) = parameters?.get(parameter.key)
+
+internal fun Map<String, String>.maskSensitiveChallengeParameters() = mask(
+    ChallengeParameter.CodeDeliveryDestination.key,
+    ChallengeParameter.CredentialRequestOptions.key
 )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/ChallengeParameter.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/ChallengeParameter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.data
+
+/**
+ * Enumeration of possible challenge parameter keys
+ */
+internal enum class ChallengeParameter(val key: String) {
+    CodeDeliveryDestination("CODE_DELIVERY_DESTINATION"),
+    CodeDeliveryMedium("CODE_DELIVERY_DELIVERY_MEDIUM"),
+    CredentialRequestOptions("CREDENTIAL_REQUEST_OPTIONS"),
+    MfasCanChoose("MFAS_CAN_CHOOSE"),
+    MfasCanSetup("MFAS_CAN_SETUP")
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignInData.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignInData.kt
@@ -15,12 +15,18 @@
 
 package com.amplifyframework.statemachine.codegen.data
 
+import android.app.Activity
+import com.amplifyframework.auth.AuthFactorType
+import com.amplifyframework.auth.cognito.options.AuthFlowType
+import java.lang.ref.WeakReference
+
 internal sealed class SignInData {
 
     data class SRPSignInData(
         val username: String?,
         val password: String?,
-        val metadata: Map<String, String>
+        val metadata: Map<String, String>,
+        val authFlowType: AuthFlowType
     ) : SignInData()
 
     data class CustomAuthSignInData(
@@ -31,7 +37,8 @@ internal sealed class SignInData {
     data class MigrationAuthSignInData(
         val username: String?,
         val password: String?,
-        val metadata: Map<String, String>
+        val metadata: Map<String, String>,
+        val authFlowType: AuthFlowType
     ) : SignInData()
 
     data class CustomSRPAuthSignInData(
@@ -42,5 +49,19 @@ internal sealed class SignInData {
 
     data class HostedUISignInData(
         val hostedUIOptions: HostedUIOptions
+    ) : SignInData()
+
+    data class UserAuthSignInData(
+        val username: String?,
+        val preferredChallenge: AuthFactorType?,
+        val callingActivity: WeakReference<Activity>,
+        val metadata: Map<String, String>
+    ) : SignInData()
+
+    data class AutoSignInData(
+        val username: String,
+        val session: String?,
+        val metadata: Map<String, String>,
+        val userId: String?
     ) : SignInData()
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignInMethod.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignInMethod.kt
@@ -30,6 +30,7 @@ internal sealed class SignInMethod {
             USER_SRP_AUTH,
             CUSTOM_AUTH,
             USER_PASSWORD_AUTH,
+            USER_AUTH,
             UNKNOWN
         }
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignInTOTPSetupData.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignInTOTPSetupData.kt
@@ -14,6 +14,8 @@
  */
 package com.amplifyframework.statemachine.codegen.data
 
+import com.amplifyframework.statemachine.util.mask
+
 internal data class SignInTOTPSetupData(
     val secretCode: String,
     val session: String?,
@@ -21,17 +23,9 @@ internal data class SignInTOTPSetupData(
 ) {
     override fun toString(): String {
         return "SignInTOTPSetupData(" +
-            "secretCode = ${mask(secretCode)}, " +
-            "session = ${mask(session)}, " +
+            "secretCode = ${secretCode.mask()}, " +
+            "session = ${session.mask()}, " +
             "username = $username}" +
             ")"
-    }
-
-    private fun mask(value: String?): String {
-        return if (value == null || value.length <= 4) {
-            "***"
-        } else {
-            "${value.substring(0 until 4)}***"
-        }
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignUpData.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignUpData.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.data
+
+import com.amplifyframework.statemachine.util.mask
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class SignUpData(
+    val username: String,
+    val validationData: Map<String, String>? = null,
+    val clientMetadata: Map<String, String>? = null,
+    val session: String? = null,
+    val userId: String? = null
+) {
+    override fun toString(): String = "SignUpData(" +
+        "username='$username', " +
+        "validationData=$validationData, " +
+        "clientMetadata=$clientMetadata, " +
+        "session=${session.mask()}, " +
+        "userId=$userId" +
+        ")"
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/WebAuthnSignInContext.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/WebAuthnSignInContext.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.data
+
+import android.app.Activity
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.statemachine.util.mask
+import java.lang.ref.WeakReference
+
+/**
+ * Class that accumulates the information needed to sign in via WebAuthn. The data may be built up over time.
+ */
+internal data class WebAuthnSignInContext(
+    val username: String,
+    val callingActivity: WeakReference<Activity>,
+    val session: String?,
+    val requestJson: String? = null,
+    val responseJson: String? = null
+) {
+    override fun toString() = "WebAuthnSignInContext(" +
+        "username='$username', " +
+        "callingActivity='$callingActivity', " +
+        "session='${session.mask()}', " +
+        "requestJson='${requestJson.mask()}', " +
+        "responseJson='${responseJson.mask()}'" +
+        ")"
+}
+
+internal fun WebAuthnSignInContext.requireRequestJson(): String =
+    requestJson ?: throw InvalidStateException("Missing request json")
+internal fun WebAuthnSignInContext.requireResponseJson(): String =
+    responseJson ?: throw InvalidStateException("Missing response json")

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SRPEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SRPEvent.kt
@@ -15,7 +15,9 @@
 
 package com.amplifyframework.statemachine.codegen.events
 
+import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.AuthChallenge
 import java.util.Date
 
 internal class SRPEvent(val eventType: EventType, override val time: Date? = null) :
@@ -24,7 +26,9 @@ internal class SRPEvent(val eventType: EventType, override val time: Date? = nul
         data class InitiateSRP(
             val username: String,
             val password: String,
-            val metadata: Map<String, String>
+            val metadata: Map<String, String>,
+            val authFlowType: AuthFlowType,
+            val respondToAuthChallenge: AuthChallenge? = null
         ) : EventType()
         data class InitiateSRPWithCustom(
             val username: String,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignInEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignInEvent.kt
@@ -15,12 +15,17 @@
 
 package com.amplifyframework.statemachine.codegen.events
 
+import android.app.Activity
+import com.amplifyframework.auth.AuthFactorType
+import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.statemachine.StateMachineEvent
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.SignInData
 import com.amplifyframework.statemachine.codegen.data.SignInTOTPSetupData
 import com.amplifyframework.statemachine.codegen.data.SignedInData
+import com.amplifyframework.statemachine.codegen.data.WebAuthnSignInContext
+import java.lang.ref.WeakReference
 import java.util.Date
 
 internal class SignInEvent(val eventType: EventType, override val time: Date? = null) : StateMachineEvent {
@@ -28,13 +33,12 @@ internal class SignInEvent(val eventType: EventType, override val time: Date? = 
         data class InitiateSignInWithSRP(
             val username: String,
             val password: String,
-            val metadata: Map<String, String>
+            val metadata: Map<String, String>,
+            val authFlowType: AuthFlowType,
+            val respondToAuthChallenge: AuthChallenge? = null
         ) : EventType()
 
-        data class InitiateSignInWithCustom(
-            val username: String,
-            val metadata: Map<String, String>
-        ) : EventType()
+        data class InitiateSignInWithCustom(val username: String, val metadata: Map<String, String>) : EventType()
 
         data class InitiateCustomSignInWithSRP(
             val username: String,
@@ -45,20 +49,17 @@ internal class SignInEvent(val eventType: EventType, override val time: Date? = 
         data class InitiateMigrateAuth(
             val username: String,
             val password: String,
-            val metadata: Map<String, String>
+            val metadata: Map<String, String>,
+            val authFlowType: AuthFlowType,
+            val respondToAuthChallenge: AuthChallenge? = null
         ) : EventType()
 
         data class InitiateHostedUISignIn(val hostedUISignInData: SignInData.HostedUISignInData) : EventType()
         data class SignedIn(val id: String = "") : EventType()
-        data class InitiateSignInWithDeviceSRP(
-            val username: String,
-            val metadata: Map<String, String>
-        ) : EventType()
+        data class InitiateSignInWithDeviceSRP(val username: String, val metadata: Map<String, String>) : EventType()
 
-        data class ConfirmDevice(
-            val deviceMetadata: DeviceMetadata.Metadata,
-            val signedInData: SignedInData
-        ) : EventType()
+        data class ConfirmDevice(val deviceMetadata: DeviceMetadata.Metadata, val signedInData: SignedInData) :
+            EventType()
         data class FinalizeSignIn(val id: String = "") : EventType()
         data class ReceivedChallenge(val challenge: AuthChallenge) : EventType()
         data class ThrowError(val exception: Exception) : EventType()
@@ -66,6 +67,15 @@ internal class SignInEvent(val eventType: EventType, override val time: Date? = 
             val signInTOTPSetupData: SignInTOTPSetupData,
             val challengeParams: Map<String, String>?
         ) : EventType()
+
+        data class InitiateUserAuth(
+            val username: String,
+            val preferredChallenge: AuthFactorType?,
+            val callingActivity: WeakReference<Activity>,
+            val metadata: Map<String, String>
+        ) : EventType()
+        data class InitiateWebAuthnSignIn(val signInContext: WebAuthnSignInContext) : EventType()
+        data class InitiateAutoSignIn(val signInData: SignInData.AutoSignInData) : EventType()
     }
 
     override val type: String = eventType.javaClass.simpleName

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignUpEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignUpEvent.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.events
+
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.SignUpData
+import java.util.Date
+
+internal class SignUpEvent(
+    val eventType: EventType,
+    override val time: Date? = null,
+) : StateMachineEvent {
+    sealed class EventType {
+        data class InitiateSignUp(
+            val signUpData: SignUpData,
+            val password: String? = null,
+            val userAttributes: List<AuthUserAttribute>? = null
+        ) : EventType()
+
+        data class InitiateSignUpComplete(val signUpData: SignUpData, val signUpResult: AuthSignUpResult) : EventType()
+
+        data class ConfirmSignUp(val signUpData: SignUpData, val confirmationCode: String) : EventType()
+
+        data class SignedUp(val signUpData: SignUpData, val signUpResult: AuthSignUpResult) : EventType()
+
+        data class ThrowError(val exception: Exception) : EventType()
+    }
+
+    override val type: String = eventType.javaClass.simpleName
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/WebAuthnEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/WebAuthnEvent.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.events
+
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.WebAuthnSignInContext
+import com.amplifyframework.statemachine.codegen.events.SignInEvent.EventType
+import java.util.Date
+
+internal class WebAuthnEvent(val eventType: EventType, override val time: Date? = null) : StateMachineEvent {
+
+    sealed class EventType {
+        data class FetchCredentialOptions(val signInContext: WebAuthnSignInContext) : EventType()
+        data class AssertCredentialOptions(val signInContext: WebAuthnSignInContext) : EventType()
+        data class VerifyCredentialsAndSignIn(val signInContext: WebAuthnSignInContext) : EventType()
+        data class ThrowError(val exception: Exception, val signInContext: WebAuthnSignInContext) : EventType()
+    }
+
+    override val type: String = eventType.javaClass.simpleName
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthenticationState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthenticationState.kt
@@ -80,6 +80,10 @@ internal sealed class AuthenticationState : State {
                     is AuthenticationEvent.EventType.InitializedSignedOut -> StateResolution(
                         SignedOut(authenticationEvent.signedOutData)
                     )
+                    is AuthenticationEvent.EventType.SignInRequested -> {
+                        val action = authenticationActions.initiateSignInAction(authenticationEvent)
+                        StateResolution(SigningIn(), listOf(action))
+                    }
                     else -> defaultResolution
                 }
                 is SigningIn -> when (authenticationEvent) {
@@ -91,6 +95,9 @@ internal sealed class AuthenticationState : State {
                             StateResolution(Error(authenticationEvent.error))
                         }
                         StateResolution(SignedOut(SignedOutData()))
+                    }
+                    is AuthenticationEvent.EventType.ThrowError -> {
+                        StateResolution(Error(authenticationEvent.exception))
                     }
                     else -> {
                         val resolution = signInResolver.resolve(oldState.signInState, event)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
@@ -84,6 +84,15 @@ internal sealed class AuthorizationState : State {
             val authorizationEvent = event.isAuthorizationEvent()
             val deleteUserEvent = event.isDeleteUserEvent()
             val defaultResolution = StateResolution(oldState)
+
+            if (authenticationEvent is AuthenticationEvent.EventType.SignInCompleted) {
+                val action = authorizationActions.initializeFetchAuthSession(authenticationEvent.signedInData)
+                return StateResolution(
+                    FetchingAuthSession(authenticationEvent.signedInData, FetchAuthSessionState.NotStarted()),
+                    listOf(action)
+                )
+            }
+
             return when (oldState) {
                 is NotConfigured -> when (authorizationEvent) {
                     is AuthorizationEvent.EventType.Configure -> {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignInChallengeState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignInChallengeState.kt
@@ -58,6 +58,25 @@ internal sealed class SignInChallengeState : State {
                     else -> defaultResolution
                 }
                 is WaitingForAnswer -> when (challengeEvent) {
+                    is SignInChallengeEvent.EventType.WaitForAnswer -> {
+                        /**
+                         * This sends out a second WaitingForAnswer because it requires an additional user-response
+                         * before calling RespondToAuth. e.g. the first WaitingForAnswer asks the user to select
+                         * a first-factor challenge and the user selects password. The user needs to supply the password
+                         * so that the answer *and* the password can be sent in one RespondToAuth call.
+                         **/
+                        StateResolution(
+                            WaitingForAnswer(
+                                challenge = AuthChallenge(
+                                    challengeName = challengeEvent.challenge.challengeName,
+                                    username = oldState.challenge.username,
+                                    session = oldState.challenge.session,
+                                    parameters = oldState.challenge.parameters
+                                ),
+                                hasNewResponse = true
+                            )
+                        )
+                    }
                     is SignInChallengeEvent.EventType.VerifyChallengeAnswer -> {
                         val action = challengeActions.verifyChallengeAuthAction(
                             challengeEvent.answer,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignInState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignInState.kt
@@ -20,6 +20,8 @@ import com.amplifyframework.statemachine.StateMachineEvent
 import com.amplifyframework.statemachine.StateMachineResolver
 import com.amplifyframework.statemachine.StateResolution
 import com.amplifyframework.statemachine.codegen.actions.SignInActions
+import com.amplifyframework.statemachine.codegen.actions.UserAuthSignInActions
+import com.amplifyframework.statemachine.codegen.data.SignInData
 import com.amplifyframework.statemachine.codegen.events.SignInEvent
 
 internal sealed class SignInState : State {
@@ -29,6 +31,8 @@ internal sealed class SignInState : State {
     data class SigningInWithCustom(override var customSignInState: CustomSignInState?) : SignInState()
     data class SigningInWithSRPCustom(override var srpSignInState: SRPSignInState?) : SignInState()
     data class SigningInViaMigrateAuth(override var migrateSignInState: MigrateSignInState?) : SignInState()
+    data class SigningInWithUserAuth(val id: String = "") : SignInState()
+    data class SigningInWithWebAuthn(override var webAuthnSignInState: WebAuthnSignInState?) : SignInState()
     data class ResolvingDeviceSRP(override var deviceSRPSignInState: DeviceSRPSignInState?) : SignInState()
     data class ResolvingChallenge(override var challengeState: SignInChallengeState?) : SignInState()
     data class ResolvingTOTPSetup(override var setupTOTPState: SetupTOTPState?) : SignInState()
@@ -36,6 +40,7 @@ internal sealed class SignInState : State {
     data class Done(val id: String = "") : SignInState()
     data class Error(val exception: Exception) : SignInState()
     data class SignedIn(val id: String = "") : SignInState()
+    data class AutoSigningIn(val signInEventData: SignInData.AutoSignInData) : SignInState()
 
     open var srpSignInState: SRPSignInState? = SRPSignInState.NotStarted()
     open var challengeState: SignInChallengeState? = SignInChallengeState.NotStarted()
@@ -44,6 +49,7 @@ internal sealed class SignInState : State {
     open var hostedUISignInState: HostedUISignInState? = HostedUISignInState.NotStarted()
     open var deviceSRPSignInState: DeviceSRPSignInState? = DeviceSRPSignInState.NotStarted()
     open var setupTOTPState: SetupTOTPState? = SetupTOTPState.NotStarted()
+    open var webAuthnSignInState: WebAuthnSignInState? = WebAuthnSignInState.NotStarted()
 
     class Resolver(
         private val srpSignInResolver: StateMachineResolver<SRPSignInState>,
@@ -53,14 +59,13 @@ internal sealed class SignInState : State {
         private val hostedUISignInResolver: StateMachineResolver<HostedUISignInState>,
         private val deviceSRPSignInResolver: StateMachineResolver<DeviceSRPSignInState>,
         private val setupTOTPResolver: StateMachineResolver<SetupTOTPState>,
+        private val webAuthnSignInResolver: StateMachineResolver<WebAuthnSignInState>,
+        private val userAuthSignInActions: UserAuthSignInActions,
         private val signInActions: SignInActions
-    ) :
-        StateMachineResolver<SignInState> {
+    ) : StateMachineResolver<SignInState> {
         override val defaultState = NotStarted()
 
-        private fun asSignInEvent(event: StateMachineEvent): SignInEvent.EventType? {
-            return (event as? SignInEvent)?.eventType
-        }
+        private fun asSignInEvent(event: StateMachineEvent): SignInEvent.EventType? = (event as? SignInEvent)?.eventType
 
         override fun resolve(oldState: SignInState, event: StateMachineEvent): StateResolution<SignInState> {
             val resolution = resolveSignInEvent(oldState, event)
@@ -101,13 +106,16 @@ internal sealed class SignInState : State {
                 builder.setupTOTPState = it.newState
                 actions += it.actions
             }
+
+            oldState.webAuthnSignInState?.let { webAuthnSignInResolver.resolve(it, event) }?.let {
+                builder.webAuthnSignInState = it.newState
+                actions += it.actions
+            }
+
             return StateResolution(builder.build(), actions)
         }
 
-        private fun resolveSignInEvent(
-            oldState: SignInState,
-            event: StateMachineEvent
-        ): StateResolution<SignInState> {
+        private fun resolveSignInEvent(oldState: SignInState, event: StateMachineEvent): StateResolution<SignInState> {
             val signInEvent = asSignInEvent(event)
             val defaultResolution = StateResolution(oldState)
             return when (oldState) {
@@ -137,11 +145,22 @@ internal sealed class SignInState : State {
                         listOf(signInActions.startCustomAuthWithSRPAction(signInEvent))
                     )
 
+                    is SignInEvent.EventType.InitiateUserAuth -> {
+                        StateResolution(
+                            SigningInWithUserAuth(),
+                            listOf(userAuthSignInActions.initiateUserAuthSignIn(signInEvent))
+                        )
+                    }
+
+                    is SignInEvent.EventType.InitiateAutoSignIn -> StateResolution(
+                        AutoSigningIn(signInEvent.signInData),
+                        listOf(signInActions.autoSignInAction(signInEvent))
+                    )
                     else -> defaultResolution
                 }
 
                 is SigningInWithSRP, is SigningInWithCustom, is SigningInViaMigrateAuth,
-                is SigningInWithSRPCustom
+                is SigningInWithSRPCustom, is SigningInWithUserAuth, is SigningInWithWebAuthn
                 -> when (signInEvent) {
                     is SignInEvent.EventType.ReceivedChallenge -> {
                         val action = signInActions.initResolveChallenge(signInEvent)
@@ -163,6 +182,11 @@ internal sealed class SignInState : State {
                         listOf(signInActions.initiateTOTPSetupAction(signInEvent))
                     )
 
+                    is SignInEvent.EventType.InitiateWebAuthnSignIn -> StateResolution(
+                        newState = SigningInWithWebAuthn(WebAuthnSignInState.NotStarted()),
+                        actions = listOf(signInActions.initiateWebAuthnSignInAction(signInEvent))
+                    )
+
                     is SignInEvent.EventType.ThrowError -> StateResolution(Error(signInEvent.exception))
                     else -> defaultResolution
                 }
@@ -181,6 +205,16 @@ internal sealed class SignInState : State {
                     is SignInEvent.EventType.InitiateTOTPSetup -> StateResolution(
                         ResolvingTOTPSetup(oldState.setupTOTPState),
                         listOf(signInActions.initiateTOTPSetupAction(signInEvent))
+                    )
+
+                    is SignInEvent.EventType.InitiateWebAuthnSignIn -> StateResolution(
+                        newState = SigningInWithWebAuthn(WebAuthnSignInState.NotStarted()),
+                        actions = listOf(signInActions.initiateWebAuthnSignInAction(signInEvent))
+                    )
+
+                    is SignInEvent.EventType.InitiateSignInWithSRP -> StateResolution(
+                        SigningInWithSRP(oldState.srpSignInState),
+                        listOf(signInActions.startSRPAuthAction(signInEvent))
                     )
 
                     is SignInEvent.EventType.ThrowError -> StateResolution(Error(signInEvent.exception))
@@ -240,7 +274,14 @@ internal sealed class SignInState : State {
                     is SignInEvent.EventType.ThrowError -> StateResolution(Error(signInEvent.exception))
                     else -> defaultResolution
                 }
+                is AutoSigningIn -> when (signInEvent) {
+                    is SignInEvent.EventType.FinalizeSignIn -> {
+                        StateResolution(SignedIn())
+                    }
+                    is SignInEvent.EventType.ThrowError -> StateResolution(Error(signInEvent.exception))
 
+                    else -> defaultResolution
+                }
                 else -> defaultResolution
             }
         }
@@ -255,6 +296,7 @@ internal sealed class SignInState : State {
         var hostedUISignInState: HostedUISignInState? = null
         var deviceSRPSignInState: DeviceSRPSignInState? = null
         var setupTOTPState: SetupTOTPState? = null
+        var webAuthnSignInState: WebAuthnSignInState? = null
 
         override fun build(): SignInState = when (signInState) {
             is SigningInWithSRP -> SigningInWithSRP(srpSignInState)
@@ -265,6 +307,8 @@ internal sealed class SignInState : State {
             is SigningInWithSRPCustom -> SigningInWithSRPCustom(srpSignInState)
             is ResolvingDeviceSRP -> ResolvingDeviceSRP(deviceSRPSignInState)
             is ResolvingTOTPSetup -> ResolvingTOTPSetup(setupTOTPState)
+            is SigningInWithUserAuth -> SigningInWithUserAuth()
+            is SigningInWithWebAuthn -> SigningInWithWebAuthn(webAuthnSignInState)
             else -> signInState
         }
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignUpState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignUpState.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.states
+
+import com.amplifyframework.auth.cognito.isSignUpEvent
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.statemachine.State
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.StateMachineResolver
+import com.amplifyframework.statemachine.StateResolution
+import com.amplifyframework.statemachine.codegen.actions.SignUpActions
+import com.amplifyframework.statemachine.codegen.data.SignUpData
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
+
+internal sealed class SignUpState : State {
+    data class NotStarted(val id: String = "") : SignUpState()
+    data class InitiatingSignUp(val signUpData: SignUpData) : SignUpState()
+    data class AwaitingUserConfirmation(val signUpData: SignUpData, val signUpResult: AuthSignUpResult) : SignUpState()
+    data class ConfirmingSignUp(val signUpData: SignUpData) : SignUpState()
+    data class SignedUp(val signUpData: SignUpData, val signUpResult: AuthSignUpResult) : SignUpState()
+    data class Error(val exception: Exception, var hasNewResponse: Boolean = true) : SignUpState()
+
+    class Resolver(private val signUpActions: SignUpActions) :
+        StateMachineResolver<SignUpState> {
+        override val defaultState = NotStarted("")
+
+        override fun resolve(oldState: SignUpState, event: StateMachineEvent): StateResolution<SignUpState> {
+            val defaultResolution = StateResolution(oldState)
+            val signUpEvent = event.isSignUpEvent()
+
+            return when (oldState) {
+                is NotStarted, is SignedUp -> when (signUpEvent) {
+                    is SignUpEvent.EventType.InitiateSignUp -> {
+                        StateResolution(
+                            InitiatingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.initiateSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.ConfirmSignUp -> {
+                        StateResolution(
+                            ConfirmingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.confirmSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.ThrowError -> {
+                        StateResolution(Error(signUpEvent.exception))
+                    }
+                    else -> defaultResolution
+                }
+                is InitiatingSignUp -> when (signUpEvent) {
+                    is SignUpEvent.EventType.InitiateSignUp -> {
+                        StateResolution(
+                            InitiatingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.initiateSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.InitiateSignUpComplete -> {
+                        StateResolution(AwaitingUserConfirmation(signUpEvent.signUpData, signUpEvent.signUpResult))
+                    }
+                    is SignUpEvent.EventType.ConfirmSignUp -> {
+                        StateResolution(
+                            ConfirmingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.confirmSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.SignedUp -> {
+                        StateResolution(
+                            SignedUp(signUpEvent.signUpData, signUpEvent.signUpResult)
+                        )
+                    }
+                    is SignUpEvent.EventType.ThrowError -> {
+                        StateResolution(Error(signUpEvent.exception))
+                    }
+                    else -> defaultResolution
+                }
+                is AwaitingUserConfirmation -> when (signUpEvent) {
+                    is SignUpEvent.EventType.InitiateSignUp -> {
+                        StateResolution(
+                            InitiatingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.initiateSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.ConfirmSignUp -> {
+                        StateResolution(
+                            ConfirmingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.confirmSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.ThrowError -> {
+                        StateResolution(Error(signUpEvent.exception))
+                    }
+                    else -> defaultResolution
+                }
+                is ConfirmingSignUp -> when (signUpEvent) {
+                    is SignUpEvent.EventType.InitiateSignUp -> {
+                        StateResolution(
+                            InitiatingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.initiateSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.ConfirmSignUp -> {
+                        StateResolution(
+                            ConfirmingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.confirmSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.SignedUp -> {
+                        StateResolution(SignedUp(signUpEvent.signUpData, signUpEvent.signUpResult))
+                    }
+                    is SignUpEvent.EventType.ThrowError -> {
+                        StateResolution(Error(signUpEvent.exception))
+                    }
+                    else -> defaultResolution
+                }
+                is Error -> when (signUpEvent) {
+                    is SignUpEvent.EventType.InitiateSignUp -> {
+                        StateResolution(
+                            InitiatingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.initiateSignUpAction(signUpEvent))
+                        )
+                    }
+                    is SignUpEvent.EventType.ConfirmSignUp -> {
+                        StateResolution(
+                            ConfirmingSignUp(signUpEvent.signUpData),
+                            listOf(signUpActions.confirmSignUpAction(signUpEvent))
+                        )
+                    }
+                    else -> defaultResolution
+                }
+            }
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/WebAuthnSignInState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/WebAuthnSignInState.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.states
+
+import com.amplifyframework.statemachine.State
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.StateMachineResolver
+import com.amplifyframework.statemachine.StateResolution
+import com.amplifyframework.statemachine.codegen.actions.SignInActions
+import com.amplifyframework.statemachine.codegen.actions.WebAuthnSignInActions
+import com.amplifyframework.statemachine.codegen.data.WebAuthnSignInContext
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
+import com.amplifyframework.statemachine.codegen.events.WebAuthnEvent
+
+internal sealed class WebAuthnSignInState : State {
+    data class NotStarted(val id: String = "") : WebAuthnSignInState()
+    data class FetchingCredentialOptions(val id: String = "") : WebAuthnSignInState()
+    data class AssertingCredentials(val id: String = "") : WebAuthnSignInState()
+    data class VerifyingCredentialsAndSigningIn(val id: String = "") : WebAuthnSignInState()
+    data class SignedIn(val id: String = "") : WebAuthnSignInState()
+    data class Error(val exception: Exception, val context: WebAuthnSignInContext, var hasNewResponse: Boolean) :
+        WebAuthnSignInState()
+
+    class Resolver(private val actions: WebAuthnSignInActions, private val signInActions: SignInActions) :
+        StateMachineResolver<WebAuthnSignInState> {
+        override val defaultState = NotStarted()
+
+        override fun resolve(
+            oldState: WebAuthnSignInState,
+            event: StateMachineEvent
+        ): StateResolution<WebAuthnSignInState> {
+            val defaultResolution = StateResolution(oldState)
+            val webAuthnEvent = event.asWebAuthnSignInEvent()
+
+            // Thrown errors always result in the error state
+            if (webAuthnEvent is WebAuthnEvent.EventType.ThrowError) {
+                return StateResolution(
+                    Error(webAuthnEvent.exception, webAuthnEvent.signInContext, hasNewResponse = true)
+                )
+            }
+
+            return when (oldState) {
+                is NotStarted -> when (webAuthnEvent) {
+                    is WebAuthnEvent.EventType.AssertCredentialOptions -> StateResolution(
+                        newState = AssertingCredentials(),
+                        actions = listOf(actions.assertCredentials(webAuthnEvent))
+                    )
+                    is WebAuthnEvent.EventType.FetchCredentialOptions -> StateResolution(
+                        newState = FetchingCredentialOptions(),
+                        actions = listOf(actions.fetchCredentialOptions(webAuthnEvent))
+                    )
+                    else -> defaultResolution
+                }
+                is FetchingCredentialOptions -> when (webAuthnEvent) {
+                    is WebAuthnEvent.EventType.AssertCredentialOptions -> StateResolution(
+                        newState = AssertingCredentials(),
+                        actions = listOf(actions.assertCredentials(webAuthnEvent))
+                    )
+                    else -> defaultResolution
+                }
+                is AssertingCredentials -> when (webAuthnEvent) {
+                    is WebAuthnEvent.EventType.VerifyCredentialsAndSignIn -> StateResolution(
+                        newState = VerifyingCredentialsAndSigningIn(),
+                        actions = listOf(actions.verifyCredentialAndSignIn(webAuthnEvent))
+                    )
+                    else -> defaultResolution
+                }
+                is VerifyingCredentialsAndSigningIn -> defaultResolution
+                is SignedIn -> defaultResolution
+                is Error -> when {
+                    event is SignInEvent && event.eventType is SignInEvent.EventType.InitiateWebAuthnSignIn ->
+                        StateResolution(
+                            newState = NotStarted(),
+                            actions = listOf(signInActions.initiateWebAuthnSignInAction(event.eventType))
+                        )
+                    else -> defaultResolution
+                }
+            }
+        }
+
+        private fun StateMachineEvent.asWebAuthnSignInEvent() = (this as? WebAuthnEvent)?.eventType
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/util/MaskUtil.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/util/MaskUtil.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.statemachine.util
+
+internal fun String?.mask() = if (this == null || this.length <= 4) {
+    "***"
+} else {
+    "${this.substring(0 until 4)}***"
+}
+
+/**
+ * Masks the values of the given keys in the map, while leaving other values unmasked
+ */
+internal fun Map<String, String>.mask(vararg keys: String): Map<String, String> = mapValues { (key, value) ->
+    if (keys.contains(key)) value.mask() else value
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -26,13 +26,17 @@ import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.TOTPSetupDetails
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthListWebAuthnCredentialsOptions
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthVerifyTOTPSetupOptions
 import com.amplifyframework.auth.cognito.options.FederateToIdentityPoolOptions
 import com.amplifyframework.auth.cognito.result.FederateToIdentityPoolResult
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions
 import com.amplifyframework.auth.options.AuthFetchSessionOptions
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions
 import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions
 import com.amplifyframework.auth.options.AuthResetPasswordOptions
@@ -49,6 +53,7 @@ import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -69,6 +74,7 @@ class AWSCognitoAuthPluginTest {
     fun setup() {
         authPlugin = AWSCognitoAuthPlugin()
         authPlugin.realPlugin = realPlugin
+        authPlugin.useCaseFactory = mockk(relaxed = true)
     }
 
     @Test
@@ -740,6 +746,69 @@ class AWSCognitoAuthPluginTest {
         authPlugin.updateMFAPreference(smsPreference, totpPreference, emailPreference, onSuccess, onError)
         verify(timeout = CHANNEL_TIMEOUT) {
             realPlugin.updateMFAPreference(smsPreference, totpPreference, emailPreference, any(), any())
+        }
+    }
+
+    @Test
+    fun associateWebAuthnCredential() {
+        val useCase = authPlugin.useCaseFactory.associateWebAuthnCredential()
+
+        val activity: Activity = mockk()
+        authPlugin.associateWebAuthnCredential(activity, {}, {})
+        coVerify(timeout = CHANNEL_TIMEOUT) {
+            useCase.execute(activity, AuthAssociateWebAuthnCredentialsOptions.defaults())
+        }
+    }
+
+    @Test
+    fun associateWebAuthnCredentialWithOptions() {
+        val useCase = authPlugin.useCaseFactory.associateWebAuthnCredential()
+
+        val activity: Activity = mockk()
+        val options: AuthAssociateWebAuthnCredentialsOptions = mockk()
+        authPlugin.associateWebAuthnCredential(activity, options, {}, {})
+        coVerify(timeout = CHANNEL_TIMEOUT) {
+            useCase.execute(activity, options)
+        }
+    }
+
+    @Test
+    fun listWebAuthnCredentials() {
+        val useCase = authPlugin.useCaseFactory.listWebAuthnCredentials()
+        authPlugin.listWebAuthnCredentials({}, {})
+        coVerify {
+            useCase.execute(AuthListWebAuthnCredentialsOptions.defaults())
+        }
+    }
+
+    @Test
+    fun listWebAuthnCredentialsWithOptions() {
+        val useCase = authPlugin.useCaseFactory.listWebAuthnCredentials()
+        val options = AWSCognitoAuthListWebAuthnCredentialsOptions.builder().build()
+        authPlugin.listWebAuthnCredentials(options, {}, {})
+        coVerify {
+            useCase.execute(options)
+        }
+    }
+
+    @Test
+    fun deleteWebAuthnCredential() {
+        val useCase = authPlugin.useCaseFactory.deleteWebAuthnCredential()
+        val credentialId = "someId"
+        authPlugin.deleteWebAuthnCredential(credentialId, {}, {})
+        coVerify {
+            useCase.execute(credentialId, AuthDeleteWebAuthnCredentialOptions.defaults())
+        }
+    }
+
+    @Test
+    fun deleteWebAuthnCredentialWithOptions() {
+        val useCase = authPlugin.useCaseFactory.deleteWebAuthnCredential()
+        val options: AuthDeleteWebAuthnCredentialOptions = mockk()
+        val credentialId = "someId"
+        authPlugin.deleteWebAuthnCredential(credentialId, options, {}, {})
+        coVerify {
+            useCase.execute(credentialId, options)
         }
     }
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
@@ -36,6 +36,7 @@ import com.amplifyframework.statemachine.codegen.data.SignedOutData
 import com.amplifyframework.statemachine.codegen.states.AuthState
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.AuthorizationState
+import com.amplifyframework.statemachine.codegen.states.SignUpState
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.every
@@ -121,7 +122,8 @@ class AuthValidationTest {
         environment,
         initialState = AuthState.Configured(
             authNState = AuthenticationState.SignedOut(signedOutData = SignedOutData()),
-            authZState = AuthorizationState.Configured()
+            authZState = AuthorizationState.Configured(),
+            authSignUpState = SignUpState.NotStarted()
         )
     )
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/MockData.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/MockData.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.WebAuthnCredentialDescription
+import aws.smithy.kotlin.runtime.time.Instant
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
+import com.amplifyframework.auth.AuthFactorType
+import com.amplifyframework.auth.MFAType
+import com.amplifyframework.auth.TOTPSetupDetails
+import com.amplifyframework.auth.result.step.AuthNextSignInStep
+import com.amplifyframework.auth.result.step.AuthSignInStep
+
+fun mockWebAuthnCredentialDescription(
+    credentialId: String = "id",
+    friendlyName: String = "name",
+    relyingParty: String = "relyingParty",
+    createdAt: Instant = Instant.now()
+) = WebAuthnCredentialDescription {
+    this.credentialId = credentialId
+    this.createdAt = createdAt
+    this.relyingPartyId = relyingParty
+    friendlyCredentialName = friendlyName
+    authenticatorTransports = emptyList()
+}
+
+fun mockAuthNextSignInStep(
+    authSignInStep: AuthSignInStep = AuthSignInStep.DONE,
+    additionalInfo: Map<String, String> = emptyMap(),
+    authCodeDeliveryDetails: AuthCodeDeliveryDetails? = null,
+    totpSetupDetails: TOTPSetupDetails? = null,
+    allowedMFATypes: Set<MFAType>? = null,
+    availableFactors: Set<AuthFactorType>? = null
+) = AuthNextSignInStep(
+    authSignInStep,
+    additionalInfo,
+    authCodeDeliveryDetails,
+    totpSetupDetails,
+    allowedMFATypes,
+    availableFactors
+)

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTestBase.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/StateTransitionTestBase.kt
@@ -17,6 +17,7 @@ package com.amplifyframework.auth.cognito
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
 import com.amplifyframework.auth.cognito.actions.DeleteUserCognitoActions
+import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.AuthActions
 import com.amplifyframework.statemachine.codegen.actions.AuthenticationActions
@@ -31,6 +32,9 @@ import com.amplifyframework.statemachine.codegen.actions.SetupTOTPActions
 import com.amplifyframework.statemachine.codegen.actions.SignInActions
 import com.amplifyframework.statemachine.codegen.actions.SignInChallengeActions
 import com.amplifyframework.statemachine.codegen.actions.SignOutActions
+import com.amplifyframework.statemachine.codegen.actions.SignUpActions
+import com.amplifyframework.statemachine.codegen.actions.UserAuthSignInActions
+import com.amplifyframework.statemachine.codegen.actions.WebAuthnSignInActions
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
@@ -119,6 +123,15 @@ open class StateTransitionTestBase {
 
     @Mock
     internal lateinit var mockSetupTOTPActions: SetupTOTPActions
+
+    @Mock
+    internal lateinit var mockSignUpActions: SignUpActions
+
+    @Mock
+    internal lateinit var mockUserAuthSignInActions: UserAuthSignInActions
+
+    @Mock
+    internal lateinit var mockWebAuthnSignInActions: WebAuthnSignInActions
 
     private val dummyCredential = AmplifyCredential.UserAndIdentityPool(
         SignedInData(
@@ -269,7 +282,8 @@ open class StateTransitionTestBase {
                             SRPEvent.EventType.InitiateSRP(
                                 "username",
                                 "password",
-                                mapOf()
+                                mapOf(),
+                                AuthFlowType.USER_SRP_AUTH
                             )
                         )
                     )

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/AutoSignInCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/AutoSignInCognitoActionsTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.auth.cognito.actions
+
+import androidx.test.core.app.ApplicationProvider
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthenticationResultType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InitiateAuthResponse
+import com.amplifyframework.auth.cognito.AWSCognitoAuthService
+import com.amplifyframework.auth.cognito.AuthConfiguration
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.StoreClientBehavior
+import com.amplifyframework.logging.Logger
+import com.amplifyframework.statemachine.EventDispatcher
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
+import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
+import com.amplifyframework.statemachine.codegen.data.CredentialType
+import com.amplifyframework.statemachine.codegen.data.SignInData
+import com.amplifyframework.statemachine.codegen.data.SignInMethod
+import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
+import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AutoSignInCognitoActionsTest {
+
+    private val pool = mockk<UserPoolConfiguration> {
+        every { appClient } returns "client"
+        every { appClientSecret } returns null
+        every { pinpointAppId } returns null
+    }
+    private val configuration = mockk<AuthConfiguration> {
+        every { userPool } returns pool
+    }
+    private val cognitoAuthService = mockk<AWSCognitoAuthService>()
+    private val credentialStoreClient = mockk<StoreClientBehavior> {
+        coEvery { loadCredentials(CredentialType.ASF) } returns AmplifyCredential.ASFDevice("asf_id")
+    }
+    private val logger = mockk<Logger>(relaxed = true)
+    private val cognitoIdentityProviderClientMock = mockk<CognitoIdentityProviderClient>()
+
+    private val capturedEvent = slot<StateMachineEvent>()
+    private val dispatcher = mockk<EventDispatcher> {
+        every { send(capture(capturedEvent)) } just Runs
+    }
+
+    private lateinit var authEnvironment: AuthEnvironment
+
+    @Before
+    fun setup() {
+        every { cognitoAuthService.cognitoIdentityProviderClient }.answers { cognitoIdentityProviderClientMock }
+        authEnvironment = AuthEnvironment(
+            ApplicationProvider.getApplicationContext(),
+            configuration,
+            cognitoAuthService,
+            credentialStoreClient,
+            null,
+            null,
+            logger
+        )
+    }
+
+    @Test
+    fun `auto sign in succeeds with signed in state`() = runTest {
+        val username = "USERNAME"
+        val userSub = "userId"
+        val session = "SESSION"
+        val accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiw" +
+            "iZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU"
+        val idToken = "ID_TOKEN"
+        val refreshToken = "REFRESH_TOKEN"
+        coEvery { cognitoIdentityProviderClientMock.initiateAuth(any()) } returns InitiateAuthResponse {
+            this.session = session
+            this.authenticationResult = AuthenticationResultType.invoke {
+                this.accessToken = accessToken
+                this.idToken = idToken
+                this.refreshToken = refreshToken
+                this.expiresIn = 100
+            }
+        }
+
+        val signInData = SignInData.AutoSignInData(username, session, mapOf(), userSub)
+        val initiateAutoSignInEvent = SignInEvent.EventType.InitiateAutoSignIn(signInData)
+        SignInCognitoActions.autoSignInAction(initiateAutoSignInEvent).execute(dispatcher, authEnvironment)
+
+        val cognitoUserPoolTokens = CognitoUserPoolTokens(idToken, accessToken, refreshToken, 100)
+        val signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<AuthenticationEvent>()
+        val data = event.eventType.shouldBeInstanceOf<AuthenticationEvent.EventType.SignInCompleted>().signedInData
+
+        data.username shouldBe username
+        data.userId shouldBe userSub
+        data.signInMethod shouldBe signInMethod
+        data.cognitoUserPoolTokens shouldBe cognitoUserPoolTokens
+    }
+
+    @Test
+    fun `auto sign in fails with error when user pool tokens are invalid`() = runTest {
+        val username = "USERNAME"
+        val userSub = "123"
+        val session = "SESSION"
+        val accessToken = "INVALID_JSON"
+        coEvery { cognitoIdentityProviderClientMock.initiateAuth(any()) } returns InitiateAuthResponse {
+            this.session = session
+            this.authenticationResult = AuthenticationResultType.invoke {
+                this.accessToken = accessToken
+                this.idToken = null
+                this.refreshToken = null
+                this.expiresIn = 100
+            }
+        }
+
+        val signInData = SignInData.AutoSignInData(username, session, mapOf(), userSub)
+        val initiateAutoSignInEvent = SignInEvent.EventType.InitiateAutoSignIn(signInData)
+        SignInCognitoActions.autoSignInAction(initiateAutoSignInEvent).execute(dispatcher, authEnvironment)
+
+        val expectedEvent = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+
+        capturedEvent.captured.type shouldBe expectedEvent.type
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/MigrateAuthCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/MigrateAuthCognitoActionsTest.kt
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.actions
+
+import androidx.test.core.app.ApplicationProvider
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InitiateAuthRequest
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InitiateAuthResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.RespondToAuthChallengeRequest
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.RespondToAuthChallengeResponse
+import com.amplifyframework.auth.cognito.AWSCognitoAuthService
+import com.amplifyframework.auth.cognito.AuthConfiguration
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.StoreClientBehavior
+import com.amplifyframework.auth.cognito.options.AuthFlowType
+import com.amplifyframework.logging.Logger
+import com.amplifyframework.statemachine.EventDispatcher
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
+import com.amplifyframework.statemachine.codegen.data.AuthChallenge
+import com.amplifyframework.statemachine.codegen.data.CredentialType
+import com.amplifyframework.statemachine.codegen.data.SignInMethod
+import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
+import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MigrateAuthCognitoActionsTest {
+    private val pool = mockk<UserPoolConfiguration> {
+        every { appClient } returns "client"
+        every { appClientSecret } returns null
+        every { pinpointAppId } returns null
+    }
+    private val configuration = mockk<AuthConfiguration> {
+        every { userPool } returns pool
+    }
+    private val cognitoAuthService = mockk<AWSCognitoAuthService>()
+    private val credentialStoreClient = mockk<StoreClientBehavior> {
+        coEvery { loadCredentials(CredentialType.ASF) } returns AmplifyCredential.ASFDevice("asf_id")
+    }
+    private val logger = mockk<Logger>(relaxed = true)
+    private val cognitoIdentityProviderClientMock = mockk<CognitoIdentityProviderClient>()
+
+    private val capturedEvent = slot<StateMachineEvent>()
+    private val dispatcher = mockk<EventDispatcher> {
+        every { send(capture(capturedEvent)) } just Runs
+    }
+
+    private lateinit var authEnvironment: AuthEnvironment
+
+    private val username = "username"
+    private val password = "password"
+    private val userId = "1234567890"
+    private val dummyToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4g" +
+        "RG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
+    private val dummyIdToken = "id-token"
+    private val dummyRefreshToken = "refreshToken"
+    private val bearerToken = "Bearer"
+    private val dummySession = "session"
+    private val dummyDeviceKey = "device-key"
+    private val dummyDeviceGroup = "device-group-key"
+
+    @Before
+    fun setup() {
+        every { cognitoAuthService.cognitoIdentityProviderClient }.answers { cognitoIdentityProviderClientMock }
+        authEnvironment = AuthEnvironment(
+            ApplicationProvider.getApplicationContext(),
+            configuration,
+            cognitoAuthService,
+            credentialStoreClient,
+            null,
+            null,
+            logger
+        )
+    }
+
+    @Test
+    fun `Initiate USER_AUTH with correct password`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = null
+                this.challengeName = null
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = bearerToken
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        MigrateAuthCognitoActions.initiateMigrateAuthAction(
+            SignInEvent.EventType.InitiateMigrateAuth(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_AUTH,
+                metadata = mapOf("KEY" to "VALUE")
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignInEvent>()
+        val data = event.eventType.shouldBeInstanceOf<SignInEvent.EventType.ConfirmDevice>().signedInData
+
+        data.userId shouldBe userId
+        data.username shouldBe username
+        data.signInMethod shouldBe SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+    }
+
+    @Test
+    fun `Initiate USER_AUTH with incorrect password`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.throws(NotAuthorizedException.invoke { })
+
+        MigrateAuthCognitoActions.initiateMigrateAuthAction(
+            SignInEvent.EventType.InitiateMigrateAuth(
+                username = username,
+                password = dummySession,
+                authFlowType = AuthFlowType.USER_AUTH,
+                metadata = mapOf("KEY" to "VALUE")
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<AuthenticationEvent>()
+        event.eventType.shouldBeInstanceOf<AuthenticationEvent.EventType.CancelSignIn>()
+    }
+
+    @Test
+    fun `RespondToAuth USER_AUTH with incorrect password`() = runTest {
+        val capturedRequest = slot<RespondToAuthChallengeRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.respondToAuthChallenge(capture(capturedRequest))
+        }.throws(NotAuthorizedException.invoke { })
+
+        MigrateAuthCognitoActions.initiateMigrateAuthAction(
+            SignInEvent.EventType.InitiateMigrateAuth(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_AUTH,
+                metadata = mapOf("KEY" to "VALUE"),
+                respondToAuthChallenge = AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    session = dummySession,
+                    parameters = null
+                )
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<AuthenticationEvent>()
+        event.eventType.shouldBeInstanceOf<AuthenticationEvent.EventType.CancelSignIn>()
+    }
+
+    @Test
+    fun `RespondToAuth USER_AUTH with correct password`() = runTest {
+        val capturedRequest = slot<RespondToAuthChallengeRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.respondToAuthChallenge(capture(capturedRequest))
+        }.answers {
+            RespondToAuthChallengeResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = null
+                this.challengeName = null
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = "Bearer"
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        MigrateAuthCognitoActions.initiateMigrateAuthAction(
+            SignInEvent.EventType.InitiateMigrateAuth(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_AUTH,
+                metadata = mapOf("KEY" to "VALUE"),
+                respondToAuthChallenge = AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    session = dummySession,
+                    parameters = null
+                )
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignInEvent>()
+        val data = event.eventType.shouldBeInstanceOf<SignInEvent.EventType.ConfirmDevice>().signedInData
+
+        data.userId shouldBe userId
+        data.username shouldBe username
+        data.signInMethod shouldBe SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+    }
+
+    @Test
+    fun `Initiate USER_PASSWORD_AUTH with correct password`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = null
+                this.challengeName = null
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = bearerToken
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        MigrateAuthCognitoActions.initiateMigrateAuthAction(
+            SignInEvent.EventType.InitiateMigrateAuth(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_PASSWORD_AUTH,
+                metadata = mapOf("KEY" to "VALUE")
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignInEvent>()
+        val data = event.eventType.shouldBeInstanceOf<SignInEvent.EventType.ConfirmDevice>().signedInData
+
+        data.userId shouldBe userId
+        data.username shouldBe username
+        data.signInMethod shouldBe SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_SRP_AUTH)
+    }
+
+    @Test
+    fun `Initiate USER_PASSWORD_AUTH with incorrect password`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.throws(NotAuthorizedException.invoke { })
+
+        val expectedEvent = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+
+        MigrateAuthCognitoActions.initiateMigrateAuthAction(
+            SignInEvent.EventType.InitiateMigrateAuth(
+                username = username,
+                password = dummySession,
+                authFlowType = AuthFlowType.USER_PASSWORD_AUTH,
+                metadata = mapOf("KEY" to "VALUE")
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<AuthenticationEvent>()
+        event.eventType.shouldBeInstanceOf<AuthenticationEvent.EventType.CancelSignIn>()
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActionsTest.kt
@@ -1,0 +1,478 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.actions
+
+import androidx.test.core.app.ApplicationProvider
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InitiateAuthRequest
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InitiateAuthResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.RespondToAuthChallengeRequest
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.RespondToAuthChallengeResponse
+import com.amplifyframework.auth.cognito.AWSCognitoAuthService
+import com.amplifyframework.auth.cognito.AuthConfiguration
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.StoreClientBehavior
+import com.amplifyframework.auth.cognito.options.AuthFlowType
+import com.amplifyframework.logging.Logger
+import com.amplifyframework.statemachine.EventDispatcher
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
+import com.amplifyframework.statemachine.codegen.data.AuthChallenge
+import com.amplifyframework.statemachine.codegen.data.CredentialType
+import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
+import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
+import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
+import com.amplifyframework.statemachine.codegen.events.SRPEvent
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SRPCognitoActionsTest {
+    private val username = "username"
+    private val password = "password"
+    private val dummyToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4g" +
+        "RG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
+    private val dummyIdToken = "id-token"
+    private val dummyRefreshToken = "refreshToken"
+    private val bearerToken = "Bearer"
+    private val dummySession = "session"
+    private val dummyDeviceKey = "device-key"
+    private val dummyDeviceGroup = "device-group-key"
+
+    private val pool = mockk<UserPoolConfiguration> {
+        every { appClient } returns "client"
+        every { appClientSecret } returns null
+        every { pinpointAppId } returns null
+    }
+    private val configuration = mockk<AuthConfiguration> {
+        every { userPool } returns pool
+    }
+    private val cognitoAuthService = mockk<AWSCognitoAuthService>()
+    private val credentialStoreClient = mockk<StoreClientBehavior> {
+        coEvery { loadCredentials(CredentialType.ASF) } returns AmplifyCredential.ASFDevice("asf_id")
+        coEvery { loadCredentials(CredentialType.Device(username)) } returns AmplifyCredential.DeviceData(
+            DeviceMetadata.Metadata(
+                deviceKey = dummyDeviceKey,
+                deviceGroupKey = dummyDeviceGroup
+            )
+        )
+    }
+    private val logger = mockk<Logger>(relaxed = true)
+    private val cognitoIdentityProviderClientMock = mockk<CognitoIdentityProviderClient>()
+
+    private val capturedEvent = slot<StateMachineEvent>()
+    private val dispatcher = mockk<EventDispatcher> {
+        every { send(capture(capturedEvent)) }.answers { }
+    }
+
+    private lateinit var authEnvironment: AuthEnvironment
+
+    private val challengeParams = mapOf(
+        "SALT" to "salt",
+        "SECRET_BLOCK" to "secret-block",
+        "SRP_B" to "srp-b",
+        "USERNAME" to username,
+        "USER_ID_FOR_SRP" to username
+    )
+
+    @Before
+    fun setup() {
+        every { cognitoAuthService.cognitoIdentityProviderClient }.answers { cognitoIdentityProviderClientMock }
+        authEnvironment = AuthEnvironment(
+            ApplicationProvider.getApplicationContext(),
+            configuration,
+            cognitoAuthService,
+            credentialStoreClient,
+            null,
+            null,
+            logger
+        )
+    }
+
+    @Test
+    fun `Initiate USER_SRP_AUTH with correct password`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = challengeParams
+                this.challengeName = ChallengeNameType.PasswordVerifier
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = bearerToken
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        val expectedEvent = SRPEvent(
+            SRPEvent.EventType.RespondPasswordVerifier(
+                challengeParams.plus(mapOf("DEVICE_KEY" to dummyDeviceKey)),
+                emptyMap(),
+                dummySession
+            )
+        )
+
+        SRPCognitoActions.initiateSRPAuthAction(
+            SRPEvent.EventType.InitiateSRP(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_SRP_AUTH,
+                metadata = mapOf("KEY" to "VALUE")
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+        assertEquals(
+            dummySession,
+            ((capturedEvent.captured as SRPEvent).eventType as SRPEvent.EventType.RespondPasswordVerifier).session
+        )
+        assertEquals(
+            challengeParams.plus(mapOf("DEVICE_KEY" to dummyDeviceKey)),
+            ((capturedEvent.captured as SRPEvent).eventType as SRPEvent.EventType.RespondPasswordVerifier)
+                .challengeParameters
+        )
+        assertEquals(
+            mapOf("KEY" to "VALUE"),
+            ((capturedEvent.captured as SRPEvent).eventType as SRPEvent.EventType.RespondPasswordVerifier)
+                .metadata
+        )
+    }
+
+    @Test
+    fun `Initiate USER_SRP_AUTH with incorrect password`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.throws(NotAuthorizedException.invoke { })
+
+        val expectedEvent = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+
+        SRPCognitoActions.initiateSRPAuthAction(
+            SRPEvent.EventType.InitiateSRP(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_SRP_AUTH,
+                metadata = mapOf("KEY" to "VALUE")
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+    }
+
+    @Test
+    fun `RespondToAuth USER_AUTH with correct password`() = runTest {
+        val capturedRequest = slot<RespondToAuthChallengeRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.respondToAuthChallenge(capture(capturedRequest))
+        }.answers {
+            RespondToAuthChallengeResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = challengeParams
+                this.challengeName = ChallengeNameType.PasswordVerifier
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = bearerToken
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        val expectedEvent = SRPEvent(
+            SRPEvent.EventType.RespondPasswordVerifier(
+                challengeParams.plus(mapOf("DEVICE_KEY" to dummyDeviceKey)),
+                emptyMap(),
+                dummySession
+            )
+        )
+
+        SRPCognitoActions.initiateSRPAuthAction(
+            SRPEvent.EventType.InitiateSRP(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_AUTH,
+                metadata = mapOf("KEY" to "VALUE"),
+                respondToAuthChallenge = AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    session = dummySession,
+                    parameters = emptyMap()
+                )
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+        assertEquals(
+            dummySession,
+            ((capturedEvent.captured as SRPEvent).eventType as SRPEvent.EventType.RespondPasswordVerifier).session
+        )
+        assertEquals(
+            challengeParams.plus(mapOf("DEVICE_KEY" to dummyDeviceKey)),
+            ((capturedEvent.captured as SRPEvent).eventType as SRPEvent.EventType.RespondPasswordVerifier)
+                .challengeParameters
+        )
+        assertEquals(
+            mapOf("KEY" to "VALUE"),
+            ((capturedEvent.captured as SRPEvent).eventType as SRPEvent.EventType.RespondPasswordVerifier)
+                .metadata
+        )
+    }
+
+    @Test
+    fun `RespondToAuth USER_AUTH with incorrect password`() = runTest {
+        val capturedRequest = slot<RespondToAuthChallengeRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.respondToAuthChallenge(capture(capturedRequest))
+        }.throws(NotAuthorizedException.invoke { })
+
+        val expectedEvent = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+
+        SRPCognitoActions.initiateSRPAuthAction(
+            SRPEvent.EventType.InitiateSRP(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_AUTH,
+                metadata = mapOf("KEY" to "VALUE"),
+                respondToAuthChallenge = AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    session = dummySession,
+                    parameters = emptyMap()
+                )
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+    }
+
+    @Test
+    fun `InitAuth response with no challenge params cancels sign in`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = null
+                this.challengeName = ChallengeNameType.PasswordVerifier
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = bearerToken
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        val expectedEvent = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+
+        SRPCognitoActions.initiateSRPAuthAction(
+            SRPEvent.EventType.InitiateSRP(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_SRP_AUTH,
+                metadata = mapOf("KEY" to "VALUE"),
+                respondToAuthChallenge = AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    session = dummySession,
+                    parameters = emptyMap()
+                )
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+    }
+
+    @Test
+    fun `RespondToAuth response with no challenge params cancels sign in`() = runTest {
+        val capturedRequest = slot<RespondToAuthChallengeRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.respondToAuthChallenge(capture(capturedRequest))
+        }.answers {
+            RespondToAuthChallengeResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = null
+                this.challengeName = ChallengeNameType.PasswordVerifier
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = bearerToken
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        val expectedEvent = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+
+        SRPCognitoActions.initiateSRPAuthAction(
+            SRPEvent.EventType.InitiateSRP(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_AUTH,
+                metadata = mapOf("KEY" to "VALUE"),
+                respondToAuthChallenge = AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    session = dummySession,
+                    parameters = emptyMap()
+                )
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+    }
+
+    @Test
+    fun `InitAuth response with unexpected challenge name cancels sign in`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = null
+                this.challengeName = ChallengeNameType.SelectChallenge
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = bearerToken
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        val expectedEvent = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+
+        SRPCognitoActions.initiateSRPAuthAction(
+            SRPEvent.EventType.InitiateSRP(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_SRP_AUTH,
+                metadata = mapOf("KEY" to "VALUE"),
+                respondToAuthChallenge = AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    session = dummySession,
+                    parameters = emptyMap()
+                )
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+    }
+
+    @Test
+    fun `RespondToAuth response with unexpected challenge name cancels sign in`() = runTest {
+        val capturedRequest = slot<RespondToAuthChallengeRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.respondToAuthChallenge(capture(capturedRequest))
+        }.answers {
+            RespondToAuthChallengeResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = null
+                this.challengeName = ChallengeNameType.SelectChallenge
+                this.authenticationResult {
+                    this.accessToken = dummyToken
+                    this.expiresIn = 3600
+                    this.idToken = dummyIdToken
+                    this.refreshToken = dummyRefreshToken
+                    this.tokenType = bearerToken
+                    newDeviceMetadata {
+                        this.deviceGroupKey = dummyDeviceGroup
+                        this.deviceKey = dummyDeviceKey
+                    }
+                }
+            }
+        }
+
+        val expectedEvent = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
+
+        SRPCognitoActions.initiateSRPAuthAction(
+            SRPEvent.EventType.InitiateSRP(
+                username = username,
+                password = password,
+                authFlowType = AuthFlowType.USER_AUTH,
+                metadata = mapOf("KEY" to "VALUE"),
+                respondToAuthChallenge = AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    session = dummySession,
+                    parameters = emptyMap()
+                )
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/SignUpCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/SignUpCognitoActionsTest.kt
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.auth.cognito.actions
+
+import androidx.test.core.app.ApplicationProvider
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.CodeDeliveryDetailsType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ConfirmSignUpResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeliveryMediumType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.SignUpResponse
+import com.amplifyframework.auth.cognito.AWSCognitoAuthService
+import com.amplifyframework.auth.cognito.AuthConfiguration
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.StoreClientBehavior
+import com.amplifyframework.auth.cognito.usecases.toAuthCodeDeliveryDetails
+import com.amplifyframework.auth.result.step.AuthSignUpStep
+import com.amplifyframework.logging.Logger
+import com.amplifyframework.statemachine.EventDispatcher
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
+import com.amplifyframework.statemachine.codegen.data.CredentialType
+import com.amplifyframework.statemachine.codegen.data.SignUpData
+import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SignUpCognitoActionsTest {
+
+    private val pool = mockk<UserPoolConfiguration> {
+        every { appClient } returns "client"
+        every { appClientSecret } returns null
+        every { pinpointAppId } returns null
+    }
+    private val configuration = mockk<AuthConfiguration> {
+        every { userPool } returns pool
+    }
+    private val cognitoAuthService = mockk<AWSCognitoAuthService>()
+    private val credentialStoreClient = mockk<StoreClientBehavior> {
+        coEvery { loadCredentials(CredentialType.ASF) } returns AmplifyCredential.ASFDevice("asf_id")
+    }
+    private val logger = mockk<Logger>(relaxed = true)
+    private val cognitoIdentityProviderClientMock = mockk<CognitoIdentityProviderClient>()
+
+    private val capturedEvent = slot<StateMachineEvent>()
+    private val dispatcher = mockk<EventDispatcher> {
+        every { send(capture(capturedEvent)) } just Runs
+    }
+
+    private lateinit var authEnvironment: AuthEnvironment
+
+    @Before
+    fun setup() {
+        every { cognitoAuthService.cognitoIdentityProviderClient }.answers { cognitoIdentityProviderClientMock }
+        authEnvironment = AuthEnvironment(
+            ApplicationProvider.getApplicationContext(),
+            configuration,
+            cognitoAuthService,
+            credentialStoreClient,
+            null,
+            null,
+            logger
+        )
+    }
+
+    @Test
+    fun `sign up succeeds with sign up initiated state`() = runTest {
+        val session = "SESSION"
+        val username = "USERNAME"
+        val userSub = "123"
+        val codeDeliveryDetails = CodeDeliveryDetailsType.invoke {
+            this.destination = "DESTINATION"
+            this.deliveryMedium = DeliveryMediumType.Email
+            this.attributeName = "ATTRIBUTE"
+        }
+        coEvery { cognitoIdentityProviderClientMock.signUp(any()) } returns SignUpResponse {
+            this.codeDeliveryDetails = codeDeliveryDetails
+            this.userSub = userSub
+            this.session = session
+            this.userConfirmed = false
+        }
+
+        val signUpData = SignUpData(username, mapOf(), mapOf(), null, null)
+        SignUpCognitoActions.initiateSignUpAction(
+            SignUpEvent.EventType.InitiateSignUp(signUpData)
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignUpEvent>()
+        val eventType = event.eventType.shouldBeInstanceOf<SignUpEvent.EventType.InitiateSignUpComplete>()
+
+        eventType.signUpData.should {
+            it.username shouldBe username
+            it.session shouldBe session
+            it.userId shouldBe userSub
+        }
+
+        eventType.signUpResult.should {
+            it.nextStep.signUpStep shouldBe AuthSignUpStep.CONFIRM_SIGN_UP_STEP
+            it.nextStep.codeDeliveryDetails shouldBe codeDeliveryDetails.toAuthCodeDeliveryDetails()
+            it.isSignUpComplete.shouldBeFalse()
+            it.userId shouldBe userSub
+        }
+    }
+
+    @Test
+    fun `sign up succeeds with confirm sign up state`() = runTest {
+        val session = "SESSION"
+        val username = "USERNAME"
+        val userSub = "123"
+        val codeDeliveryDetails = CodeDeliveryDetailsType.invoke {
+            this.destination = "DESTINATION"
+            this.deliveryMedium = DeliveryMediumType.Email
+            this.attributeName = "ATTRIBUTE"
+        }
+        coEvery { cognitoIdentityProviderClientMock.signUp(any()) } returns SignUpResponse {
+            this.codeDeliveryDetails = codeDeliveryDetails
+            this.userSub = userSub
+            this.session = session
+            this.userConfirmed = false
+        }
+
+        val signUpData = SignUpData(username, mapOf(), mapOf(), null, null)
+        SignUpCognitoActions.initiateSignUpAction(
+            SignUpEvent.EventType.InitiateSignUp(signUpData)
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignUpEvent>()
+        val eventType = event.eventType.shouldBeInstanceOf<SignUpEvent.EventType.InitiateSignUpComplete>()
+
+        eventType.signUpData.should {
+            it.username shouldBe username
+            it.session shouldBe session
+            it.userId shouldBe userSub
+        }
+
+        eventType.signUpResult.should {
+            it.nextStep.signUpStep shouldBe AuthSignUpStep.CONFIRM_SIGN_UP_STEP
+            it.nextStep.codeDeliveryDetails shouldBe codeDeliveryDetails.toAuthCodeDeliveryDetails()
+            it.isSignUpComplete.shouldBeFalse()
+            it.userId shouldBe userSub
+        }
+    }
+
+    @Test
+    fun `sign up succeeds with auto sign in state`() = runTest {
+        val session = "SESSION"
+        val username = "USERNAME"
+        val userSub = "123"
+        coEvery { cognitoIdentityProviderClientMock.signUp(any()) } returns SignUpResponse {
+            this.userSub = userSub
+            this.session = session
+            this.userConfirmed = true
+        }
+
+        val signUpData = SignUpData(username, mapOf(), mapOf(), null, null)
+        SignUpCognitoActions.initiateSignUpAction(
+            SignUpEvent.EventType.InitiateSignUp(signUpData)
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignUpEvent>()
+        val eventType = event.eventType.shouldBeInstanceOf<SignUpEvent.EventType.SignedUp>()
+
+        eventType.signUpData.should {
+            it.username shouldBe username
+            it.session shouldBe session
+            it.userId shouldBe userSub
+        }
+
+        eventType.signUpResult.should {
+            it.nextStep.signUpStep shouldBe AuthSignUpStep.COMPLETE_AUTO_SIGN_IN
+            it.isSignUpComplete.shouldBeTrue()
+            it.userId shouldBe userSub
+        }
+    }
+
+    @Test
+    fun `sign up succeeds with done state`() = runTest {
+        val username = "USERNAME"
+        val userSub = "123"
+        coEvery { cognitoIdentityProviderClientMock.signUp(any()) } returns SignUpResponse {
+            this.userSub = userSub
+            this.userConfirmed = true
+        }
+
+        val signUpData = SignUpData(username, mapOf(), mapOf(), null, null)
+        SignUpCognitoActions.initiateSignUpAction(
+            SignUpEvent.EventType.InitiateSignUp(signUpData)
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignUpEvent>()
+        val eventType = event.eventType.shouldBeInstanceOf<SignUpEvent.EventType.SignedUp>()
+
+        eventType.signUpData.should {
+            it.username shouldBe username
+            it.session.shouldBeNull()
+            it.userId shouldBe userSub
+        }
+
+        eventType.signUpResult.should {
+            it.nextStep.signUpStep shouldBe AuthSignUpStep.DONE
+            it.isSignUpComplete.shouldBeTrue()
+            it.userId shouldBe userSub
+        }
+    }
+
+    @Test
+    fun `confirm sign up succeeds with done state`() = runTest {
+        val username = "USERNAME"
+        val userSub = "123"
+        val confirmationCode = "456"
+        coEvery { cognitoIdentityProviderClientMock.confirmSignUp(any()) } returns ConfirmSignUpResponse {
+            this.session = null
+        }
+
+        val signUpData = SignUpData(username, mapOf(), mapOf(), null, userSub)
+        SignUpCognitoActions.confirmSignUpAction(
+            SignUpEvent.EventType.ConfirmSignUp(signUpData, confirmationCode)
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignUpEvent>()
+        val eventType = event.eventType.shouldBeInstanceOf<SignUpEvent.EventType.SignedUp>()
+
+        eventType.signUpData.should {
+            it.username shouldBe username
+            it.session.shouldBeNull()
+            it.userId shouldBe userSub
+        }
+
+        eventType.signUpResult.should {
+            it.nextStep.signUpStep shouldBe AuthSignUpStep.DONE
+            it.isSignUpComplete.shouldBeTrue()
+            it.userId shouldBe userSub
+        }
+    }
+
+    @Test
+    fun `confirm sign up succeeds with auto sign in state`() = runTest {
+        val username = "USERNAME"
+        val userSub = "123"
+        val confirmationCode = "456"
+        val session = "SESSION"
+        coEvery { cognitoIdentityProviderClientMock.confirmSignUp(any()) } returns ConfirmSignUpResponse {
+            this.session = session
+        }
+
+        val signUpData = SignUpData(username, mapOf(), mapOf(), null, userSub)
+        SignUpCognitoActions.confirmSignUpAction(
+            SignUpEvent.EventType.ConfirmSignUp(signUpData, confirmationCode)
+        ).execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<SignUpEvent>()
+        val eventType = event.eventType.shouldBeInstanceOf<SignUpEvent.EventType.SignedUp>()
+
+        eventType.signUpData.should {
+            it.username shouldBe username
+            it.session shouldBe session
+            it.userId shouldBe userSub
+        }
+
+        eventType.signUpResult.should {
+            it.nextStep.signUpStep shouldBe AuthSignUpStep.COMPLETE_AUTO_SIGN_IN
+            it.isSignUpComplete.shouldBeTrue()
+            it.userId shouldBe userSub
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/UserAuthSignInCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/UserAuthSignInCognitoActionsTest.kt
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.actions
+
+import android.app.Activity
+import androidx.test.core.app.ApplicationProvider
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InitiateAuthRequest
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InitiateAuthResponse
+import com.amplifyframework.auth.AuthFactorType
+import com.amplifyframework.auth.cognito.AWSCognitoAuthService
+import com.amplifyframework.auth.cognito.AuthConfiguration
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.StoreClientBehavior
+import com.amplifyframework.logging.Logger
+import com.amplifyframework.statemachine.EventDispatcher
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
+import com.amplifyframework.statemachine.codegen.data.AuthChallenge
+import com.amplifyframework.statemachine.codegen.data.CredentialType
+import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
+import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
+import com.amplifyframework.statemachine.codegen.data.WebAuthnSignInContext
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.lang.ref.WeakReference
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UserAuthSignInCognitoActionsTest {
+    private val username = "USERNAME"
+    private val dummySession = "session"
+    private val dummyDeviceKey = "device-key"
+    private val dummyDeviceGroup = "device-group-key"
+
+    private val pool = mockk<UserPoolConfiguration> {
+        every { appClient } returns "client"
+        every { appClientSecret } returns null
+        every { pinpointAppId } returns null
+    }
+    private val configuration = mockk<AuthConfiguration> {
+        every { userPool } returns pool
+    }
+    private val cognitoAuthService = mockk<AWSCognitoAuthService>()
+    private val credentialStoreClient = mockk<StoreClientBehavior> {
+        coEvery { loadCredentials(CredentialType.ASF) } returns AmplifyCredential.ASFDevice("asf_id")
+        coEvery { loadCredentials(CredentialType.Device(username)) } returns AmplifyCredential.DeviceData(
+            DeviceMetadata.Metadata(
+                deviceKey = dummyDeviceKey,
+                deviceGroupKey = dummyDeviceGroup
+            )
+        )
+    }
+    private val logger = mockk<Logger>(relaxed = true)
+    private val cognitoIdentityProviderClientMock = mockk<CognitoIdentityProviderClient>()
+
+    private val capturedEvent = slot<StateMachineEvent>()
+    private val dispatcher = mockk<EventDispatcher> {
+        every { send(capture(capturedEvent)) }.answers { }
+    }
+
+    private val callingActivity = mockk<Activity>()
+
+    private lateinit var authEnvironment: AuthEnvironment
+
+    @Before
+    fun setup() {
+        every { cognitoAuthService.cognitoIdentityProviderClient }.answers { cognitoIdentityProviderClientMock }
+        authEnvironment = AuthEnvironment(
+            ApplicationProvider.getApplicationContext(),
+            configuration,
+            cognitoAuthService,
+            credentialStoreClient,
+            null,
+            null,
+            logger
+        )
+    }
+
+    @Test
+    fun `Test no preferred preference and receive SELECT_CHALLENGE`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = emptyMap()
+                this.challengeName = ChallengeNameType.SelectChallenge
+                this.availableChallenges = listOf(
+                    ChallengeNameType.EmailOtp,
+                    ChallengeNameType.WebAuthn,
+                    ChallengeNameType.Password
+                )
+            }
+        }
+
+        val availableChallenges = listOf(
+            ChallengeNameType.EmailOtp.value,
+            ChallengeNameType.WebAuthn.value,
+            ChallengeNameType.Password.value
+        )
+
+        val expectedEvent = SignInEvent(
+            SignInEvent.EventType.ReceivedChallenge(
+                AuthChallenge(
+                    challengeName = ChallengeNameType.SelectChallenge.value,
+                    username = username,
+                    session = dummySession,
+                    parameters = null,
+                    availableChallenges = availableChallenges
+                )
+            )
+        )
+
+        UserAuthSignInCognitoActions.initiateUserAuthSignIn(
+            SignInEvent.EventType.InitiateUserAuth(
+                username = username,
+                preferredChallenge = null,
+                callingActivity = WeakReference(callingActivity),
+                metadata = emptyMap()
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+
+        assertEquals(
+            dummySession,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.session
+        )
+        assertEquals(
+            ChallengeNameType.SelectChallenge.value,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.challengeName
+        )
+        assertEquals(
+            username,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.username
+        )
+        assertNull(
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.parameters
+        )
+        assertEquals(
+            availableChallenges,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.availableChallenges
+        )
+    }
+
+    @Test
+    fun `Test preferred preference of EMAIL_OTP and receive RECEIVED_CHALLENGE`() = runTest {
+        val challengeParams = mapOf(
+            "CODE_DELIVERY_DELIVERY_MEDIUM" to "EMAIL",
+            "CODE_DELIVERY_DESTINATION" to "a***@a***"
+        )
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = challengeParams
+                this.challengeName = ChallengeNameType.EmailOtp
+            }
+        }
+
+        val expectedEvent = SignInEvent(
+            SignInEvent.EventType.ReceivedChallenge(
+                AuthChallenge(
+                    challengeName = ChallengeNameType.EmailOtp.value,
+                    username = username,
+                    session = dummySession,
+                    availableChallenges = null,
+                    parameters = challengeParams
+                )
+            )
+        )
+
+        UserAuthSignInCognitoActions.initiateUserAuthSignIn(
+            SignInEvent.EventType.InitiateUserAuth(
+                username = username,
+                preferredChallenge = AuthFactorType.EMAIL_OTP,
+                callingActivity = WeakReference(callingActivity),
+                metadata = emptyMap()
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+        assertEquals(
+            dummySession,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.session
+        )
+        assertEquals(
+            ChallengeNameType.EmailOtp.value,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.challengeName
+        )
+        assertEquals(
+            username,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.username
+        )
+        assertEquals(
+            challengeParams,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.parameters
+        )
+        assertNull(
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.availableChallenges
+        )
+    }
+
+    @Test
+    fun `Test preferred preference of SMS_OTP and receive RECEIVED_CHALLENGE`() = runTest {
+        val challengeParams = mapOf(
+            "CODE_DELIVERY_DELIVERY_MEDIUM" to "SMS",
+            "CODE_DELIVERY_DESTINATION" to "a***@a***"
+        )
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = challengeParams
+                this.challengeName = ChallengeNameType.SmsOtp
+            }
+        }
+
+        val expectedEvent = SignInEvent(
+            SignInEvent.EventType.ReceivedChallenge(
+                AuthChallenge(
+                    challengeName = ChallengeNameType.SmsOtp.value,
+                    username = username,
+                    session = dummySession,
+                    availableChallenges = null,
+                    parameters = challengeParams
+                )
+            )
+        )
+
+        UserAuthSignInCognitoActions.initiateUserAuthSignIn(
+            SignInEvent.EventType.InitiateUserAuth(
+                username = username,
+                preferredChallenge = AuthFactorType.SMS_OTP,
+                callingActivity = WeakReference(callingActivity),
+                metadata = emptyMap()
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+        assertEquals(
+            dummySession,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.session
+        )
+        assertEquals(
+            ChallengeNameType.SmsOtp.value,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.challengeName
+        )
+        assertEquals(
+            username,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.username
+        )
+        assertEquals(
+            challengeParams,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.parameters
+        )
+        assertNull(
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.ReceivedChallenge)
+                .challenge.availableChallenges
+        )
+    }
+
+    @Test
+    fun `Test preferred preference of WEB_AUTHN and receive RECEIVED_CHALLENGE`() = runTest {
+        val capturedRequest = slot<InitiateAuthRequest>()
+        coEvery {
+            cognitoIdentityProviderClientMock.initiateAuth(capture(capturedRequest))
+        }.answers {
+            InitiateAuthResponse.invoke {
+                this.session = dummySession
+                this.challengeParameters = mapOf(
+                    "CREDENTIAL_REQUEST_OPTIONS" to "json"
+                )
+                this.challengeName = ChallengeNameType.WebAuthn
+            }
+        }
+
+        val callingActivityReference = WeakReference(callingActivity)
+
+        val expectedEvent = SignInEvent(
+            SignInEvent.EventType.InitiateWebAuthnSignIn(
+                WebAuthnSignInContext(
+                    username = username,
+                    callingActivity = callingActivityReference,
+                    session = dummySession,
+                    requestJson = "json"
+                )
+            )
+        )
+
+        UserAuthSignInCognitoActions.initiateUserAuthSignIn(
+            SignInEvent.EventType.InitiateUserAuth(
+                username = username,
+                preferredChallenge = AuthFactorType.WEB_AUTHN,
+                callingActivity = callingActivityReference,
+                metadata = emptyMap()
+            )
+        ).execute(dispatcher, authEnvironment)
+
+        assertEquals(
+            expectedEvent.type,
+            capturedEvent.captured.type
+        )
+        assertEquals(
+            dummySession,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.InitiateWebAuthnSignIn)
+                .signInContext.session
+        )
+        assertEquals(
+            username,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.InitiateWebAuthnSignIn)
+                .signInContext.username
+        )
+        assertEquals(
+            "json",
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.InitiateWebAuthnSignIn)
+                .signInContext.requestJson
+        )
+        assertEquals(
+            callingActivityReference,
+            ((capturedEvent.captured as SignInEvent).eventType as SignInEvent.EventType.InitiateWebAuthnSignIn)
+                .signInContext.callingActivity
+        )
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/WebAuthnSignInCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/WebAuthnSignInCognitoActionsTest.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.actions
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthenticationResultType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.RespondToAuthChallengeResponse
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.helpers.WebAuthnHelper
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.statemachine.EventDispatcher
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.ChallengeParameter
+import com.amplifyframework.statemachine.codegen.data.WebAuthnSignInContext
+import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
+import com.amplifyframework.statemachine.codegen.events.SignInEvent
+import com.amplifyframework.statemachine.codegen.events.WebAuthnEvent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.MockKAssertScope
+import io.mockk.MockKVerificationScope
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.verify
+import java.lang.ref.WeakReference
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class WebAuthnSignInCognitoActionsTest {
+
+    private val signInContext = WebAuthnSignInContext(
+        username = "username",
+        callingActivity = WeakReference(null),
+        session = "session",
+        requestJson = null,
+        responseJson = null
+    )
+
+    private val identityProviderClient = mockk<CognitoIdentityProviderClient>()
+
+    private val dispatcher = mockk<EventDispatcher>(relaxed = true)
+    private val authEnvironment = mockk<AuthEnvironment> {
+        every { context } returns mockk()
+        every { cognitoAuthService.cognitoIdentityProviderClient } returns identityProviderClient
+        coEvery { getUserContextData(any()) } returns null
+        every { getPinpointEndpointId() } returns null
+        every { configuration.userPool?.appClient } returns "app-client"
+    }
+
+    @Test
+    fun `fetchCredentialOptions dispatches assert credentials event`() = runTest {
+        val expectedSignInContext = WebAuthnSignInContext(
+            username = signInContext.username,
+            callingActivity = signInContext.callingActivity,
+            session = "new-session",
+            requestJson = "request-json",
+            responseJson = null
+        )
+
+        coEvery { identityProviderClient.respondToAuthChallenge(any()) } returns RespondToAuthChallengeResponse {
+            session = "new-session"
+            challengeName = ChallengeNameType.WebAuthn
+            challengeParameters = mapOf(
+                ChallengeParameter.CredentialRequestOptions.key to "request-json"
+            )
+        }
+
+        val event = WebAuthnEvent.EventType.FetchCredentialOptions(signInContext)
+        val action = WebAuthnSignInCognitoActions.fetchCredentialOptions(event)
+        action.execute(dispatcher, authEnvironment)
+
+        verify {
+            dispatcher.send(
+                withSignInEvent<SignInEvent.EventType.InitiateWebAuthnSignIn> {
+                    it.signInContext shouldBe expectedSignInContext
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `fetchCredentialsOptions results in InvalidStateException if there is no identity provider client`() = runTest {
+        every { authEnvironment.cognitoAuthService.cognitoIdentityProviderClient } returns null
+
+        val event = WebAuthnEvent.EventType.FetchCredentialOptions(signInContext)
+        val action = WebAuthnSignInCognitoActions.fetchCredentialOptions(event)
+        action.execute(dispatcher, authEnvironment)
+
+        verify {
+            dispatcher.send(
+                withWebAuthnEvent<WebAuthnEvent.EventType.ThrowError> {
+                    it.exception.shouldBeInstanceOf<InvalidStateException>()
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `assertCredentials dispatches verify credentials event`() = runTest {
+        val requestContext = signInContext.copy(requestJson = "request-json")
+        val expectedSignInContext = requestContext.copy(responseJson = "response-json")
+
+        val event = WebAuthnEvent.EventType.AssertCredentialOptions(requestContext)
+        val action = WebAuthnSignInCognitoActions.assertCredentials(event)
+
+        mockkConstructor(WebAuthnHelper::class) {
+            coEvery { anyConstructed<WebAuthnHelper>().getCredential("request-json", any()) } returns "response-json"
+            action.execute(dispatcher, authEnvironment)
+        }
+
+        verify {
+            dispatcher.send(
+                withWebAuthnEvent<WebAuthnEvent.EventType.VerifyCredentialsAndSignIn> {
+                    it.signInContext shouldBe expectedSignInContext
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `assertCredentials results in InvalidStateException if request JSON is missing`() = runTest {
+        val requestContext = signInContext.copy(requestJson = null)
+        val event = WebAuthnEvent.EventType.AssertCredentialOptions(requestContext)
+        val action = WebAuthnSignInCognitoActions.assertCredentials(event)
+
+        mockkConstructor(WebAuthnHelper::class) {
+            coEvery { anyConstructed<WebAuthnHelper>().getCredential("request-json", any()) } returns "response-json"
+            action.execute(dispatcher, authEnvironment)
+        }
+
+        verify {
+            dispatcher.send(
+                withWebAuthnEvent<WebAuthnEvent.EventType.ThrowError> {
+                    it.exception.shouldBeInstanceOf<InvalidStateException>()
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `verifyCredentials dispatches signedInCompleted event`() = runTest {
+        val requestContext = signInContext.copy(responseJson = "response-json")
+
+        coEvery { identityProviderClient.respondToAuthChallenge(any()) } returns RespondToAuthChallengeResponse {
+            authenticationResult = AuthenticationResultType {
+            }
+        }
+
+        val event = WebAuthnEvent.EventType.VerifyCredentialsAndSignIn(requestContext)
+        val action = WebAuthnSignInCognitoActions.verifyCredentialAndSignIn(event)
+        action.execute(dispatcher, authEnvironment)
+
+        verify {
+            dispatcher.send(withAuthEvent<AuthenticationEvent.EventType.SignInCompleted>())
+        }
+    }
+
+    @Test
+    fun `verifyCredentials results in InvalidStateException if missing response json`() = runTest {
+        val requestContext = signInContext.copy(responseJson = null)
+
+        coEvery { identityProviderClient.respondToAuthChallenge(any()) } returns RespondToAuthChallengeResponse {
+            authenticationResult = AuthenticationResultType {
+            }
+        }
+
+        val event = WebAuthnEvent.EventType.VerifyCredentialsAndSignIn(requestContext)
+        val action = WebAuthnSignInCognitoActions.verifyCredentialAndSignIn(event)
+        action.execute(dispatcher, authEnvironment)
+
+        verify {
+            dispatcher.send(
+                withWebAuthnEvent<WebAuthnEvent.EventType.ThrowError> {
+                    it.exception.shouldBeInstanceOf<InvalidStateException>()
+                }
+            )
+        }
+    }
+
+    private inline fun <reified T : WebAuthnEvent.EventType> MockKVerificationScope.withWebAuthnEvent(
+        noinline assertions: MockKAssertScope.(T) -> Unit = { }
+    ) = withArg<StateMachineEvent> {
+        val event = it.shouldBeInstanceOf<WebAuthnEvent>()
+        val type = event.eventType.shouldBeInstanceOf<T>()
+        assertions(type)
+    }
+
+    private inline fun <reified T : SignInEvent.EventType> MockKVerificationScope.withSignInEvent(
+        noinline assertions: MockKAssertScope.(T) -> Unit = { }
+    ) = withArg<StateMachineEvent> {
+        val event = it.shouldBeInstanceOf<SignInEvent>()
+        val type = event.eventType.shouldBeInstanceOf<T>()
+        assertions(type)
+    }
+
+    private inline fun <reified T : AuthenticationEvent.EventType> MockKVerificationScope.withAuthEvent(
+        noinline assertions: MockKAssertScope.(T) -> Unit = { }
+    ) = withArg<StateMachineEvent> {
+        val event = it.shouldBeInstanceOf<AuthenticationEvent>()
+        val type = event.eventType.shouldBeInstanceOf<T>()
+        assertions(type)
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/AuthAPI.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/AuthAPI.kt
@@ -43,6 +43,7 @@ enum class AuthAPI {
     resendUserAttributeConfirmationCode,
     resetPassword,
     signIn,
+    autoSignIn,
     signInWithSocialWebUI,
     signInWithWebUI,
     signOut,

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/SerializationTools.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/SerializationTools.kt
@@ -16,6 +16,7 @@
 package com.amplifyframework.auth.cognito.featuretest.generators
 
 import aws.sdk.kotlin.services.cognitoidentity.model.CognitoIdentityException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.CognitoIdentityProviderException
 import aws.smithy.kotlin.runtime.time.Instant
 import com.amplifyframework.auth.AuthException
@@ -27,6 +28,7 @@ import com.amplifyframework.auth.cognito.featuretest.serializers.serialize
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
 import com.amplifyframework.auth.result.AuthSessionResult
 import com.amplifyframework.statemachine.codegen.states.AuthState
+import com.amplifyframework.statemachine.codegen.states.SignUpState
 import com.google.gson.Gson
 import java.io.BufferedWriter
 import java.io.File
@@ -81,7 +83,13 @@ internal fun AuthState.exportJson() {
     val reverse = result.deserializeToAuthState()
 
     val dirName = "states"
-    val fileName = "${authNState?.javaClass?.simpleName}_${authZState?.javaClass?.simpleName}.json"
+    val signUpState = authSignUpState?.let { signUpState ->
+        if (signUpState !is SignUpState.NotStarted) {
+            "_${signUpState.javaClass.simpleName}"
+        }
+    }
+    val fileName = "${authNState?.javaClass?.simpleName}_${authZState?.javaClass?.simpleName}$signUpState.json"
+
     writeFile(result, dirName, fileName)
     println("Json exported:\n $result")
     println("Serialized can be reversed = ${reverse.serialize() == result}")
@@ -179,6 +187,7 @@ fun Any?.toJsonElement(): JsonElement {
             CognitoIdentityProviderExceptionSerializer,
             this
         )
+        is AuthFlowType -> this.value.toJsonElement()
         is AuthSessionResult<*> -> toJsonElement()
         is CognitoIdentityException -> Json.encodeToJsonElement(CognitoIdentityExceptionSerializer, this)
         else -> gsonBasedSerializer(this)

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/authstategenerators/AuthStateJsonGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/authstategenerators/AuthStateJsonGenerator.kt
@@ -15,13 +15,18 @@
 
 package com.amplifyframework.auth.cognito.featuretest.generators.authstategenerators
 
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.cognito.featuretest.generators.SerializableProvider
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.auth.result.step.AuthNextSignUpStep
+import com.amplifyframework.auth.result.step.AuthSignUpStep
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
+import com.amplifyframework.statemachine.codegen.data.SignUpData
 import com.amplifyframework.statemachine.codegen.data.SignedInData
 import com.amplifyframework.statemachine.codegen.data.SignedOutData
 import com.amplifyframework.statemachine.codegen.states.AuthState
@@ -29,6 +34,7 @@ import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.AuthorizationState
 import com.amplifyframework.statemachine.codegen.states.SignInChallengeState
 import com.amplifyframework.statemachine.codegen.states.SignInState
+import com.amplifyframework.statemachine.codegen.states.SignUpState
 import java.util.Date
 
 /**
@@ -48,7 +54,9 @@ object AuthStateJsonGenerator : SerializableProvider {
     const val expiration: Long = 2342134
     const val userId = "userId"
 
-    private const val username = "username"
+    const val username = "username"
+    const val session = "session-id"
+    val emptySession = null
 
     private val signedInData = SignedInData(
         userId = userId,
@@ -76,12 +84,14 @@ object AuthStateJsonGenerator : SerializableProvider {
 
     private val signedInState = AuthState.Configured(
         AuthenticationState.SignedIn(signedInData, DeviceMetadata.Empty),
-        AuthorizationState.SessionEstablished(signedInAmplifyCredential)
+        AuthorizationState.SessionEstablished(signedInAmplifyCredential),
+        SignUpState.NotStarted()
     )
 
     private val signedOutState = AuthState.Configured(
         AuthenticationState.SignedOut(SignedOutData(username)),
-        AuthorizationState.Configured()
+        AuthorizationState.Configured(),
+        SignUpState.NotStarted()
     )
 
     private val receivedChallengeState = AuthState.Configured(
@@ -100,7 +110,85 @@ object AuthStateJsonGenerator : SerializableProvider {
                 )
             )
         ),
-        AuthorizationState.SigningIn()
+        AuthorizationState.SigningIn(),
+        SignUpState.NotStarted()
+    )
+
+    private val passwordlessSignUpAwaitingUserConfirmationState = AuthState.Configured(
+        AuthenticationState.SignedOut(SignedOutData(username)),
+        AuthorizationState.Configured(),
+        SignUpState.AwaitingUserConfirmation(
+            SignUpData(
+                username,
+                null,
+                null,
+                session,
+                ""
+            ),
+            AuthSignUpResult(
+                false,
+                AuthNextSignUpStep(
+                    AuthSignUpStep.CONFIRM_SIGN_UP_STEP,
+                    emptyMap(),
+                    AuthCodeDeliveryDetails(
+                        "user@domain.com",
+                        AuthCodeDeliveryDetails.DeliveryMedium.EMAIL,
+                        "attributeName"
+                    )
+                ),
+                "" // aligned with mock in CognitoMockFactory
+            )
+        )
+    )
+
+    private val nonPasswordlessSignUpAwaitingUserConfirmationState = AuthState.Configured(
+        AuthenticationState.SignedOut(SignedOutData(username)),
+        AuthorizationState.SessionEstablished(signedInAmplifyCredential),
+        SignUpState.AwaitingUserConfirmation(
+            SignUpData(
+                username,
+                null,
+                null,
+                emptySession,
+                ""
+            ),
+            AuthSignUpResult(
+                false,
+                AuthNextSignUpStep(
+                    AuthSignUpStep.CONFIRM_SIGN_UP_STEP,
+                    emptyMap(),
+                    AuthCodeDeliveryDetails(
+                        "user@domain.com",
+                        AuthCodeDeliveryDetails.DeliveryMedium.EMAIL,
+                        "attributeName"
+                    )
+                ),
+                "" // aligned with mock in CognitoMockFactory
+            )
+        )
+    )
+
+    private val passwordlessSignedUpState = AuthState.Configured(
+        AuthenticationState.SignedOut(SignedOutData(username)),
+        AuthorizationState.SessionEstablished(signedInAmplifyCredential),
+        SignUpState.SignedUp(
+            SignUpData(
+                username,
+                null,
+                null,
+                session,
+                ""
+            ),
+            AuthSignUpResult(
+                true,
+                AuthNextSignUpStep(
+                    AuthSignUpStep.COMPLETE_AUTO_SIGN_IN,
+                    emptyMap(),
+                    null
+                ),
+                "" // aligned with mock in CognitoMockFactory
+            )
+        )
     )
 
     private val receivedCustomChallengeState = AuthState.Configured(
@@ -121,8 +209,16 @@ object AuthStateJsonGenerator : SerializableProvider {
                 )
             )
         ),
-        AuthorizationState.SigningIn()
+        AuthorizationState.SigningIn(),
+        SignUpState.NotStarted()
     )
 
-    override val serializables: List<Any> = listOf(signedInState, signedOutState, receivedChallengeState)
+    override val serializables: List<Any> = listOf(
+        signedInState,
+        signedOutState,
+        receivedChallengeState,
+        passwordlessSignUpAwaitingUserConfirmationState,
+        nonPasswordlessSignUpAwaitingUserConfirmationState,
+        passwordlessSignedUpState
+    )
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/ConfirmSignUpTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/ConfirmSignUpTestCaseGenerator.kt
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.featuretest.generators.testcasegenerators
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.CodeMismatchException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InvalidParameterException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserNotFoundException
+import com.amplifyframework.auth.cognito.featuretest.API
+import com.amplifyframework.auth.cognito.featuretest.AuthAPI
+import com.amplifyframework.auth.cognito.featuretest.CognitoType
+import com.amplifyframework.auth.cognito.featuretest.ExpectationShapes
+import com.amplifyframework.auth.cognito.featuretest.FeatureTestCase
+import com.amplifyframework.auth.cognito.featuretest.MockResponse
+import com.amplifyframework.auth.cognito.featuretest.PreConditions
+import com.amplifyframework.auth.cognito.featuretest.ResponseType
+import com.amplifyframework.auth.cognito.featuretest.generators.SerializableProvider
+import com.amplifyframework.auth.cognito.featuretest.generators.authstategenerators.AuthStateJsonGenerator
+import com.amplifyframework.auth.cognito.featuretest.generators.toJsonElement
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.auth.result.step.AuthNextSignUpStep
+import com.amplifyframework.auth.result.step.AuthSignUpStep
+import kotlinx.serialization.json.JsonObject
+
+object ConfirmSignUpTestCaseGenerator : SerializableProvider {
+    private val username = AuthStateJsonGenerator.username
+    private val session = AuthStateJsonGenerator.session
+    private val confirmationCode = "123"
+
+    private val unregisteredUserException = UserNotFoundException.invoke {}
+    private val invalidUsernameException = InvalidParameterException.invoke {}
+    private val invalidConfirmationCodeException = CodeMismatchException.invoke {}
+
+    private val expectedPasswordlessCognitoConfirmSignUpRequest = ExpectationShapes.Cognito.CognitoIdentityProvider(
+        apiName = "confirmSignUp",
+        request = mapOf(
+            "clientId" to "testAppClientId", // This should be pulled from configuration
+            "username" to username,
+            "confirmationCode" to confirmationCode,
+            "session" to session // non-null value in passwordless (is set to session stored in previous state)
+        ).toJsonElement()
+    )
+
+    private val expectedNonPasswordlessCognitoConfirmSignUpRequest = ExpectationShapes.Cognito.CognitoIdentityProvider(
+        apiName = "confirmSignUp",
+        request = mapOf(
+            "clientId" to "testAppClientId", // This should be pulled from configuration
+            "username" to username,
+            "confirmationCode" to confirmationCode
+            // the retrieved session from the previous state is null in non-passwordless
+        ).toJsonElement()
+    )
+
+    private val passwordlessConfirmSignUpReturnsCompleteAutoSignIn = FeatureTestCase(
+        description = "Test that passwordless confirmSignUp returns CompleteAutoSignIn",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured_AwaitingUserConfirmation.json",
+            mockedResponses = listOf(
+                MockResponse(
+                    CognitoType.CognitoIdentityProvider,
+                    "confirmSignUp",
+                    ResponseType.Success,
+                    mapOf(
+                        "session" to session
+                    ).toJsonElement()
+                )
+            )
+        ),
+        api = API(
+            AuthAPI.confirmSignUp,
+            params = mapOf(
+                "username" to username,
+                "confirmationCode" to confirmationCode
+            ).toJsonElement(),
+            options = JsonObject(emptyMap())
+        ),
+        validations = listOf(
+            expectedPasswordlessCognitoConfirmSignUpRequest,
+            ExpectationShapes.Amplify(
+                apiName = AuthAPI.confirmSignUp,
+                responseType = ResponseType.Success,
+                response = AuthSignUpResult(
+                    true,
+                    AuthNextSignUpStep(
+                        AuthSignUpStep.COMPLETE_AUTO_SIGN_IN,
+                        emptyMap(),
+                        null
+                    ),
+                    "" // set to userId stored in previous state
+                ).toJsonElement()
+            )
+        )
+    )
+
+    private val passwordlessConfirmSignUpWithUnregisteredUserReturnsException = FeatureTestCase(
+        description = "Test that passwordless confirmSignUp with Unregistered User returns Exception",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured_AwaitingUserConfirmation.json",
+            mockedResponses = listOf(
+                MockResponse(
+                    CognitoType.CognitoIdentityProvider,
+                    "confirmSignUp",
+                    ResponseType.Failure,
+                    unregisteredUserException.toJsonElement()
+                )
+            )
+        ),
+        api = API(
+            AuthAPI.confirmSignUp,
+            params = mapOf(
+                "username" to username,
+                "confirmationCode" to confirmationCode
+            ).toJsonElement(),
+            options = JsonObject(emptyMap())
+        ),
+        validations = listOf(
+            expectedPasswordlessCognitoConfirmSignUpRequest,
+            ExpectationShapes.Amplify(
+                apiName = AuthAPI.confirmSignUp,
+                responseType = ResponseType.Failure,
+                com.amplifyframework.auth.cognito.exceptions.service.UserNotFoundException(
+                    unregisteredUserException
+                ).toJsonElement()
+            )
+        )
+    )
+
+    private val passwordlessConfirmSignUpWithInvalidUsernameReturnsException = FeatureTestCase(
+        description = "Test that passwordless confirmSignUp with Invalid Username returns Exception",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured_AwaitingUserConfirmation.json",
+            mockedResponses = listOf(
+                MockResponse(
+                    CognitoType.CognitoIdentityProvider,
+                    "confirmSignUp",
+                    ResponseType.Failure,
+                    invalidUsernameException.toJsonElement()
+                )
+            )
+        ),
+        api = API(
+            AuthAPI.confirmSignUp,
+            params = mapOf(
+                "username" to username,
+                "confirmationCode" to confirmationCode
+            ).toJsonElement(),
+            options = JsonObject(emptyMap())
+        ),
+        validations = listOf(
+            expectedPasswordlessCognitoConfirmSignUpRequest,
+            ExpectationShapes.Amplify(
+                apiName = AuthAPI.confirmSignUp,
+                responseType = ResponseType.Failure,
+                com.amplifyframework.auth.cognito.exceptions.service.InvalidParameterException(
+                    cause = invalidUsernameException
+                ).toJsonElement()
+            )
+        )
+    )
+
+    private val passwordlessConfirmSignUpWithInvalidConfirmationCodeReturnsException = FeatureTestCase(
+        description = "Test that passwordless confirmSignUp with Invalid Confirmation Code returns Exception",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured_AwaitingUserConfirmation.json",
+            mockedResponses = listOf(
+                MockResponse(
+                    CognitoType.CognitoIdentityProvider,
+                    "confirmSignUp",
+                    ResponseType.Failure,
+                    invalidConfirmationCodeException.toJsonElement()
+                )
+            )
+        ),
+        api = API(
+            AuthAPI.confirmSignUp,
+            params = mapOf(
+                "username" to username,
+                "confirmationCode" to confirmationCode
+            ).toJsonElement(),
+            options = JsonObject(emptyMap())
+        ),
+        validations = listOf(
+            expectedPasswordlessCognitoConfirmSignUpRequest,
+            ExpectationShapes.Amplify(
+                apiName = AuthAPI.confirmSignUp,
+                responseType = ResponseType.Failure,
+                com.amplifyframework.auth.cognito.exceptions.service.CodeMismatchException(
+                    cause = invalidConfirmationCodeException
+                ).toJsonElement()
+            )
+        )
+    )
+
+    private val nonpasswordlessConfirmSignUpReturnsDone = FeatureTestCase(
+        description = "Test that non passwordless confirmSignUp returns Done",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_SessionEstablished_AwaitingUserConfirmation.json",
+            mockedResponses = listOf(
+                MockResponse(
+                    CognitoType.CognitoIdentityProvider,
+                    "confirmSignUp",
+                    ResponseType.Success,
+                    emptyMap<Any, Any>().toJsonElement()
+                )
+            )
+        ),
+        api = API(
+            AuthAPI.confirmSignUp,
+            params = mapOf(
+                "username" to username,
+                "confirmationCode" to confirmationCode
+            ).toJsonElement(),
+            options = JsonObject(emptyMap())
+        ),
+        validations = listOf(
+            expectedNonPasswordlessCognitoConfirmSignUpRequest,
+            ExpectationShapes.Amplify(
+                apiName = AuthAPI.confirmSignUp,
+                responseType = ResponseType.Success,
+                response = AuthSignUpResult(
+                    true,
+                    AuthNextSignUpStep(
+                        AuthSignUpStep.DONE,
+                        emptyMap(),
+                        null
+                    ),
+                    "" // set to userId stored in previous state
+                ).toJsonElement()
+            )
+        )
+    )
+
+    override val serializables: List<Any> = listOf(
+        passwordlessConfirmSignUpReturnsCompleteAutoSignIn,
+        passwordlessConfirmSignUpWithUnregisteredUserReturnsException,
+        passwordlessConfirmSignUpWithInvalidUsernameReturnsException,
+        passwordlessConfirmSignUpWithInvalidConfirmationCodeReturnsException,
+        nonpasswordlessConfirmSignUpReturnsDone
+    )
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignInTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignInTestCaseGenerator.kt
@@ -16,7 +16,9 @@
 package com.amplifyframework.auth.cognito.featuretest.generators.testcasegenerators
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChallengeNameType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ResourceNotFoundException
+import com.amplifyframework.auth.AuthFactorType
 import com.amplifyframework.auth.cognito.featuretest.API
 import com.amplifyframework.auth.cognito.featuretest.AuthAPI
 import com.amplifyframework.auth.cognito.featuretest.CognitoType
@@ -29,6 +31,7 @@ import com.amplifyframework.auth.cognito.featuretest.generators.SerializableProv
 import com.amplifyframework.auth.cognito.featuretest.generators.authstategenerators.AuthStateJsonGenerator
 import com.amplifyframework.auth.cognito.featuretest.generators.toJsonElement
 import com.amplifyframework.auth.cognito.options.AuthFlowType
+import com.amplifyframework.auth.exceptions.InvalidStateException
 import kotlinx.serialization.json.JsonObject
 
 object SignInTestCaseGenerator : SerializableProvider {
@@ -36,13 +39,15 @@ object SignInTestCaseGenerator : SerializableProvider {
     private const val username = "username"
     private const val password = "password"
     private const val phone = "+12345678900"
+    private const val email = "test@****.com"
+    private const val session = "someSession"
 
     private val mockedInitiateAuthResponse = MockResponse(
         CognitoType.CognitoIdentityProvider,
         "initiateAuth",
         ResponseType.Success,
         mapOf(
-            "challengeName" to ChallengeNameType.PasswordVerifier.toString(),
+            "challengeName" to ChallengeNameType.PasswordVerifier.value,
             "challengeParameters" to mapOf(
                 "SALT" to "abc",
                 "SECRET_BLOCK" to "secretBlock",
@@ -53,17 +58,70 @@ object SignInTestCaseGenerator : SerializableProvider {
         ).toJsonElement()
     )
 
+    private val mockedInitiateAuthPasswordResponse = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "initiateAuth",
+        ResponseType.Success,
+        mapOf(
+            "authenticationResult" to mapOf(
+                "idToken" to AuthStateJsonGenerator.dummyToken,
+                "accessToken" to AuthStateJsonGenerator.dummyToken,
+                "refreshToken" to AuthStateJsonGenerator.dummyToken,
+                "expiresIn" to 300
+            )
+        ).toJsonElement()
+    )
+
+    private val mockedInitiateAuthSelectChallengeResponse = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "initiateAuth",
+        ResponseType.Success,
+        mapOf(
+            "challengeName" to ChallengeNameType.SelectChallenge.value,
+            "session" to session,
+            "parameters" to JsonObject(emptyMap()),
+            "availableChallenges" to listOf(
+                ChallengeNameType.Password.value,
+                ChallengeNameType.WebAuthn.value,
+                ChallengeNameType.EmailOtp.value
+            )
+        ).toJsonElement()
+    )
+
+    private fun mockedInitiateAuthEmailOrSmsResponse(challengeNameType: ChallengeNameType): MockResponse {
+        val (medium, destination) = if (challengeNameType == ChallengeNameType.EmailOtp) {
+            Pair("EMAIL", email)
+        } else {
+            Pair("SMS", phone)
+        }
+
+        return MockResponse(
+            CognitoType.CognitoIdentityProvider,
+            "initiateAuth",
+            ResponseType.Success,
+            mapOf(
+                "challengeName" to challengeNameType.value,
+                "session" to session,
+                "parameters" to JsonObject(emptyMap()),
+                "challengeParameters" to mapOf(
+                    "CODE_DELIVERY_DELIVERY_MEDIUM" to medium,
+                    "CODE_DELIVERY_DESTINATION" to destination
+                )
+            ).toJsonElement()
+        )
+    }
+
     private val mockedInitiateAuthForCustomAuthWithoutSRPResponse = MockResponse(
         CognitoType.CognitoIdentityProvider,
         "initiateAuth",
         ResponseType.Success,
         mapOf(
-            "challengeName" to ChallengeNameType.CustomChallenge.toString(),
+            "challengeName" to ChallengeNameType.CustomChallenge.value,
             "challengeParameters" to mapOf(
                 "SALT" to "abc",
                 "SECRET_BLOCK" to "secretBlock",
                 "SRP_B" to "def",
-                "USERNAME" to username,
+                "USERNAME" to username
             )
         ).toJsonElement()
     )
@@ -87,6 +145,31 @@ object SignInTestCaseGenerator : SerializableProvider {
         "respondToAuthChallenge",
         ResponseType.Failure,
         ResourceNotFoundException.invoke {}.toJsonElement()
+    )
+
+    private val mockedInitAuthNotAuthorizedException = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "initiateAuth",
+        ResponseType.Failure,
+        NotAuthorizedException.invoke {
+            message = "Incorrect username or password."
+        }.toJsonElement()
+    )
+
+    private val notAuthorizedExceptionExpectation = ExpectationShapes.Amplify(
+        AuthAPI.signIn,
+        ResponseType.Failure,
+        com.amplifyframework.auth.exceptions.NotAuthorizedException(
+            cause = NotAuthorizedException.invoke {
+                message = "Incorrect username or password."
+            }
+        ).toJsonElement()
+    )
+
+    private val mockedInvalidStateException = ExpectationShapes.Amplify(
+        AuthAPI.autoSignIn,
+        ResponseType.Failure,
+        InvalidStateException().toJsonElement()
     )
 
     private val mockedRespondToAuthChallengeWithDeviceMetadataResponse = MockResponse(
@@ -181,7 +264,7 @@ object SignInTestCaseGenerator : SerializableProvider {
             "isSignedIn" to true,
             "nextStep" to mapOf(
                 "signInStep" to "DONE",
-                "additionalInfo" to JsonObject(emptyMap()),
+                "additionalInfo" to JsonObject(emptyMap())
             )
         ).toJsonElement()
     )
@@ -196,11 +279,51 @@ object SignInTestCaseGenerator : SerializableProvider {
                 "additionalInfo" to JsonObject(emptyMap()),
                 "codeDeliveryDetails" to mapOf(
                     "destination" to phone,
-                    "deliveryMedium" to "SMS",
+                    "deliveryMedium" to "SMS"
                 )
             )
         ).toJsonElement()
     )
+
+    private val mockedSignInSelectChallengeExpectation = ExpectationShapes.Amplify(
+        apiName = AuthAPI.signIn,
+        responseType = ResponseType.Success,
+        response = mapOf(
+            "isSignedIn" to false,
+            "nextStep" to mapOf(
+                "signInStep" to "CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION",
+                "additionalInfo" to JsonObject(emptyMap()),
+                "availableFactors" to listOf(
+                    AuthFactorType.PASSWORD.challengeResponse,
+                    AuthFactorType.WEB_AUTHN.challengeResponse,
+                    AuthFactorType.EMAIL_OTP.challengeResponse
+                )
+            )
+        ).toJsonElement()
+    )
+
+    private fun mockedConfirmSignInWithOtpExpectation(challengeNameType: ChallengeNameType): ExpectationShapes.Amplify {
+        val (medium, destination) = if (challengeNameType == ChallengeNameType.EmailOtp) {
+            Pair("EMAIL", email)
+        } else {
+            Pair("SMS", phone)
+        }
+        return ExpectationShapes.Amplify(
+            apiName = AuthAPI.signIn,
+            responseType = ResponseType.Success,
+            response = mapOf(
+                "isSignedIn" to false,
+                "nextStep" to mapOf(
+                    "signInStep" to "CONFIRM_SIGN_IN_WITH_OTP",
+                    "additionalInfo" to JsonObject(emptyMap()),
+                    "codeDeliveryDetails" to mapOf(
+                        "destination" to destination,
+                        "deliveryMedium" to medium
+                    )
+                )
+            ).toJsonElement()
+        )
+    }
 
     private val mockedSignInCustomAuthChallengeExpectation = ExpectationShapes.Amplify(
         apiName = AuthAPI.signIn,
@@ -236,6 +359,20 @@ object SignInTestCaseGenerator : SerializableProvider {
         ).toJsonElement()
     )
 
+    private val expectedCognitoAutoSignInRequest = ExpectationShapes.Cognito.CognitoIdentityProvider(
+        apiName = "initiateAuth",
+        request = mapOf(
+            "authFlow" to aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType.UserAuth,
+            "clientId" to "testAppClientId", // This should be pulled from configuration
+            "authParameters" to mapOf(
+                "USERNAME" to AuthStateJsonGenerator.username, // pulled from loaded SignedUp state
+                "SECRET_HASH" to "a hash"
+            ),
+            "clientMetadata" to emptyMap<String, String>(),
+            "session" to AuthStateJsonGenerator.session // pulled from loaded SignedUp state
+        ).toJsonElement()
+    )
+
     private val mockConfirmDeviceResponse = MockResponse(
         CognitoType.CognitoIdentityProvider,
         "confirmDevice",
@@ -252,7 +389,7 @@ object SignInTestCaseGenerator : SerializableProvider {
                 mockedInitiateAuthResponse,
                 mockedRespondToAuthChallengeResponse,
                 mockedIdentityIdResponse,
-                mockedAWSCredentialsResponse,
+                mockedAWSCredentialsResponse
             )
         ),
         api = API(
@@ -269,6 +406,292 @@ object SignInTestCaseGenerator : SerializableProvider {
         )
     )
 
+    // Init USER_AUTH with no preference
+    private val signInWithUserAuthWithNoPreferenceReturnsSelectChallenge = FeatureTestCase(
+        description = "Test that USER_AUTH signIn with no preference returns Select Challenge",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitiateAuthSelectChallengeResponse
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to ""
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to
+                    mapOf(
+                        "authFlow" to AuthFlowType.USER_AUTH.toString(),
+                        "preferredFirstFactor" to null
+                    )
+            ).toJsonElement()
+
+        ),
+        validations = listOf(
+            mockedSignInSelectChallengeExpectation,
+            ExpectationShapes.State("SigningIn_SelectChallenge.json")
+        )
+    )
+
+    // Init USER_AUTH with a preference not supported for the user
+    private val signInWithUserAuthWithUnsupportedPreferenceReturnsSelectChallenge = FeatureTestCase(
+        description = "Test that USER_AUTH signIn with an unsupported preference returns Select Challenge",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitiateAuthSelectChallengeResponse
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to ""
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to
+                    mapOf(
+                        "authFlow" to AuthFlowType.USER_AUTH.toString(),
+                        "preferredFirstFactor" to AuthFactorType.SMS_OTP.challengeResponse
+                    )
+            ).toJsonElement()
+
+        ),
+        validations = listOf(
+            mockedSignInSelectChallengeExpectation,
+            ExpectationShapes.State("SigningIn_SelectChallenge.json")
+        )
+    )
+
+    // Init USER_AUTH with EMAIL_OTP preference
+    private val signInWithUserAuthWithEmailOtpPreferenceReturnsVerifyChallenge = FeatureTestCase(
+        description = "Test that USER_AUTH signIn with EMAIL preference returns Confirm Sign In With OTP",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitiateAuthEmailOrSmsResponse(ChallengeNameType.EmailOtp)
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to ""
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to
+                    mapOf(
+                        "authFlow" to AuthFlowType.USER_AUTH.toString(),
+                        "preferredFirstFactor" to AuthFactorType.EMAIL_OTP.challengeResponse
+                    )
+            ).toJsonElement()
+
+        ),
+        validations = listOf(
+            mockedConfirmSignInWithOtpExpectation(ChallengeNameType.EmailOtp),
+            ExpectationShapes.State("SigningIn_EmailOtp.json")
+        )
+    )
+
+    // Init USER_AUTH with SMS_OTP preference
+    private val signInWithUserAuthWithSmsOtpPreferenceReturnsVerifyChallenge = FeatureTestCase(
+        description = "Test that USER_AUTH signIn with SMS preference returns Confirm Sign In With OTP",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitiateAuthEmailOrSmsResponse(ChallengeNameType.SmsOtp)
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to ""
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to
+                    mapOf(
+                        "authFlow" to AuthFlowType.USER_AUTH.toString(),
+                        "preferredFirstFactor" to AuthFactorType.SMS_OTP.challengeResponse
+                    )
+            ).toJsonElement()
+
+        ),
+        validations = listOf(
+            mockedConfirmSignInWithOtpExpectation(ChallengeNameType.SmsOtp),
+            ExpectationShapes.State("SigningIn_SmsOtp.json")
+        )
+    )
+
+    // Init USER_AUTH with PASSWORD_SRP preference with correct password
+    private val signInWithUserAuthWithPasswordSrpPreferenceSucceeds = FeatureTestCase(
+        description = "Test that USER_AUTH signIn with PASSWORD_SRP preference succeeds",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitiateAuthResponse,
+                mockedRespondToAuthChallengeResponse,
+                mockedIdentityIdResponse,
+                mockedAWSCredentialsResponse
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to password
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to
+                    mapOf(
+                        "authFlow" to AuthFlowType.USER_AUTH.toString(),
+                        "preferredFirstFactor" to AuthFactorType.PASSWORD_SRP.challengeResponse
+                    )
+            ).toJsonElement()
+
+        ),
+        validations = listOf(
+            mockedSignInSuccessExpectation,
+            ExpectationShapes.State("SignedIn_SessionEstablished.json")
+        )
+    )
+
+    // Init USER_AUTH with PASSWORD_SRP preference with incorrect password
+    private val signInWithUserAuthWithPasswordSrpPreferenceFails = FeatureTestCase(
+        description = "Test that USER_AUTH signIn with PASSWORD_SRP preference fails",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitAuthNotAuthorizedException
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to password
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to
+                    mapOf(
+                        "authFlow" to AuthFlowType.USER_AUTH.toString(),
+                        "preferredFirstFactor" to AuthFactorType.PASSWORD_SRP.challengeResponse
+                    )
+            ).toJsonElement()
+
+        ),
+        validations = listOf(
+            notAuthorizedExceptionExpectation
+        )
+    )
+
+    // Init USER_AUTH with PASSWORD preference with correct password
+    private val signInWithUserAuthWithPasswordPreferenceSucceeds = FeatureTestCase(
+        description = "Test that USER_AUTH signIn with PASSWORD preference succeeds",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitiateAuthPasswordResponse
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to password
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to
+                    mapOf(
+                        "authFlow" to AuthFlowType.USER_AUTH.toString(),
+                        "preferredFirstFactor" to ChallengeNameType.Password.value
+                    )
+            ).toJsonElement()
+
+        ),
+        validations = listOf(
+            mockedSignInSuccessExpectation,
+            ExpectationShapes.State("SignedIn_SessionEstablished.json")
+        )
+    )
+
+    // Init USER_AUTH with PASSWORD preference with incorrect password
+    private val signInWithUserAuthWithPasswordPreferenceFails = FeatureTestCase(
+        description = "Test that USER_AUTH signIn with PASSWORD preference fails",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedInitAuthNotAuthorizedException
+            )
+        ),
+        api = API(
+            AuthAPI.signIn,
+            params = mapOf(
+                "username" to username,
+                "password" to password
+            ).toJsonElement(),
+            options = mapOf(
+                "signInOptions" to
+                    mapOf(
+                        "authFlow" to AuthFlowType.USER_AUTH.toString(),
+                        "preferredFirstFactor" to ChallengeNameType.Password.value
+                    )
+            ).toJsonElement()
+
+        ),
+        validations = listOf(
+            notAuthorizedExceptionExpectation
+        )
+    )
+
+    private val autoSignInSucceeds = FeatureTestCase(
+        description = "Test that autoSignIn invokes proper cognito request and returns DONE",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_SessionEstablished_SignedUp.json",
+            mockedResponses = listOf(
+                mockedInitiateAuthPasswordResponse
+            )
+        ),
+        api = API(
+            AuthAPI.autoSignIn,
+            params = emptyMap<Any, Any>().toJsonElement(),
+            options = JsonObject(emptyMap())
+        ),
+        validations = listOf(
+            expectedCognitoAutoSignInRequest,
+            mockedSignInSuccessExpectation
+        )
+    )
+
+    private val autoSignInWithoutConfirmSignUpFails = FeatureTestCase(
+        description = "Test that autoSignIn without ConfirmSignUp fails",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_SessionEstablished_AwaitingUserConfirmation.json",
+            mockedResponses = listOf()
+        ),
+        api = API(
+            AuthAPI.autoSignIn,
+            params = emptyMap<Any, Any>().toJsonElement(),
+            options = JsonObject(emptyMap())
+        ),
+        validations = listOf(
+            mockedInvalidStateException
+        )
+    )
+
     private val signInWhenResourceNotFoundExceptionCase = FeatureTestCase(
         description = "Test that SRP signIn invokes proper cognito request and returns " +
             "ResourceNotFoundException but still signs in successfully",
@@ -280,7 +703,7 @@ object SignInTestCaseGenerator : SerializableProvider {
                 mockedRespondToAuthChallengeResponseWhenResourceNotFoundException,
                 mockedRespondToAuthChallengeResponse,
                 mockedIdentityIdResponse,
-                mockedAWSCredentialsResponse,
+                mockedAWSCredentialsResponse
             )
         ),
         api = API(
@@ -307,7 +730,7 @@ object SignInTestCaseGenerator : SerializableProvider {
                 mockedRespondToAuthChallengeWithDeviceMetadataResponse,
                 mockConfirmDeviceResponse,
                 mockedIdentityIdResponse,
-                mockedAWSCredentialsResponse,
+                mockedAWSCredentialsResponse
             )
         ),
         api = API(
@@ -331,7 +754,7 @@ object SignInTestCaseGenerator : SerializableProvider {
             "SignedOut_Configured.json",
             mockedResponses = listOf(
                 mockedInitiateAuthResponse,
-                mockedSMSChallengeResponse,
+                mockedSMSChallengeResponse
             )
         ),
         validations = listOf(
@@ -347,7 +770,7 @@ object SignInTestCaseGenerator : SerializableProvider {
             "SigningIn_SigningIn.json",
             mockedResponses = listOf(
                 mockedInitiateAuthResponse,
-                mockedSMSChallengeResponse,
+                mockedSMSChallengeResponse
             )
         ),
         api = API(
@@ -378,7 +801,7 @@ object SignInTestCaseGenerator : SerializableProvider {
             AuthAPI.signIn,
             params = mapOf(
                 "username" to username,
-                "password" to "",
+                "password" to ""
             ).toJsonElement(),
             options = mapOf(
                 "signInOptions" to
@@ -407,7 +830,7 @@ object SignInTestCaseGenerator : SerializableProvider {
             AuthAPI.signIn,
             params = mapOf(
                 "username" to username,
-                "password" to "",
+                "password" to ""
             ).toJsonElement(),
             options = mapOf(
                 "signInOptions" to
@@ -434,7 +857,7 @@ object SignInTestCaseGenerator : SerializableProvider {
             AuthAPI.signIn,
             params = mapOf(
                 "username" to username,
-                "password" to "",
+                "password" to ""
             ).toJsonElement(),
             options = mapOf(
                 "signInOptions" to mapOf("authFlow" to AuthFlowType.CUSTOM_AUTH_WITH_SRP.toString())
@@ -461,7 +884,7 @@ object SignInTestCaseGenerator : SerializableProvider {
             AuthAPI.signIn,
             params = mapOf(
                 "username" to username,
-                "password" to "",
+                "password" to ""
             ).toJsonElement(),
             options = mapOf(
                 "signInOptions" to mapOf("authFlow" to AuthFlowType.CUSTOM_AUTH_WITH_SRP.toString())
@@ -489,7 +912,7 @@ object SignInTestCaseGenerator : SerializableProvider {
             AuthAPI.signIn,
             params = mapOf(
                 "username" to username,
-                "password" to "",
+                "password" to ""
             ).toJsonElement(),
             options = mapOf(
                 "signInOptions" to mapOf("authFlow" to AuthFlowType.CUSTOM_AUTH_WITH_SRP.toString())
@@ -511,6 +934,16 @@ object SignInTestCaseGenerator : SerializableProvider {
         customAuthWithSRPWhenResourceNotFoundExceptionCase,
         customAuthCaseWhenResourceNotFoundExceptionCase,
         signInWhenResourceNotFoundExceptionCase,
-        customAuthWithSRPCaseWhenAliasIsUsedToSignIn
+        customAuthWithSRPCaseWhenAliasIsUsedToSignIn,
+        signInWithUserAuthWithNoPreferenceReturnsSelectChallenge,
+        signInWithUserAuthWithUnsupportedPreferenceReturnsSelectChallenge,
+        signInWithUserAuthWithEmailOtpPreferenceReturnsVerifyChallenge,
+        signInWithUserAuthWithSmsOtpPreferenceReturnsVerifyChallenge,
+        signInWithUserAuthWithPasswordSrpPreferenceSucceeds,
+        signInWithUserAuthWithPasswordSrpPreferenceFails,
+        signInWithUserAuthWithPasswordPreferenceSucceeds,
+        signInWithUserAuthWithPasswordPreferenceFails,
+        autoSignInSucceeds,
+        autoSignInWithoutConfirmSignUpFails
     )
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignUpTestCaseGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/testcasegenerators/SignUpTestCaseGenerator.kt
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.auth.cognito.featuretest.generators.testcasegenerators
 
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InvalidParameterException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UsernameExistsException
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.cognito.featuretest.API
@@ -33,8 +35,11 @@ import com.amplifyframework.auth.result.step.AuthSignUpStep
 
 object SignUpTestCaseGenerator : SerializableProvider {
     private val username = "user"
+    private val existingUsername = "anExistingUsername"
+    private val invalidUsername = "anInvalidUsername"
     private val password = "password"
     private val email = "user@domain.com"
+    private val session = "session-id"
 
     private val codeDeliveryDetails = mapOf(
         "destination" to email,
@@ -48,18 +53,90 @@ object SignUpTestCaseGenerator : SerializableProvider {
         "attributeName" to ""
     )
 
+// mock responses for non-passwordless flow region starts
+    private val mockedUnconfirmedSignUpResponse = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "signUp",
+        ResponseType.Success,
+        mapOf(
+            "codeDeliveryDetails" to codeDeliveryDetails
+        ).toJsonElement()
+    )
+
+    private val mockedConfirmedSignUpResponse = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "signUp",
+        ResponseType.Success,
+        mapOf(
+            "codeDeliveryDetails" to emptyCodeDeliveryDetails,
+            "userConfirmed" to true
+        ).toJsonElement()
+    )
+// mock responses for non-passwordless flow region starts
+
+// mock responses for passwordless flow region starts
+    private val mockedPasswordlessUnconfirmedSignUpResponse = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "signUp",
+        ResponseType.Success,
+        mapOf(
+            "codeDeliveryDetails" to codeDeliveryDetails,
+            "session" to session
+        ).toJsonElement()
+    )
+
+    private val mockedPasswordlessConfirmedSignUpResponse = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "signUp",
+        ResponseType.Success,
+        mapOf(
+            "codeDeliveryDetails" to emptyCodeDeliveryDetails,
+            "session" to session,
+            "userConfirmed" to true
+        ).toJsonElement()
+    )
+// mock responses for passwordless flow region starts
+
+// mock error responses flow region starts
+    private val usernameExistsException = UsernameExistsException.invoke {}
+    private val usernameInvalidException = InvalidParameterException.invoke {}
+
+    private val mockedSignUpWithExistingUsernameResponse = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "signUp",
+        ResponseType.Failure,
+        usernameExistsException.toJsonElement()
+    )
+
+    private val mockedSignUpWithInvalidUsernameResponse = MockResponse(
+        CognitoType.CognitoIdentityProvider,
+        "signUp",
+        ResponseType.Failure,
+        usernameInvalidException.toJsonElement()
+    )
+// mock error responses flow region starts
+
+    private fun expectedCognitoSignUpRequest(
+        username: String,
+        password: String?
+    ) = ExpectationShapes.Cognito.CognitoIdentityProvider(
+        apiName = "signUp",
+        // see [https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignUp.html]
+        request = mapOf(
+            "clientId" to "testAppClientId", // This should be pulled from configuration
+            "username" to username,
+            "password" to password,
+            "userAttributes" to listOf(mapOf("name" to "email", "value" to email))
+        ).toJsonElement()
+    )
+
     val baseCase = FeatureTestCase(
         description = "Test that signup invokes proper cognito request and returns success",
         preConditions = PreConditions(
             "authconfiguration.json",
             "SignedOut_Configured.json",
             mockedResponses = listOf(
-                MockResponse(
-                    CognitoType.CognitoIdentityProvider,
-                    "signUp",
-                    ResponseType.Success,
-                    mapOf("codeDeliveryDetails" to codeDeliveryDetails).toJsonElement()
-                )
+                mockedUnconfirmedSignUpResponse
             )
         ),
         api = API(
@@ -73,16 +150,7 @@ object SignUpTestCaseGenerator : SerializableProvider {
             ).toJsonElement()
         ),
         validations = listOf(
-            ExpectationShapes.Cognito.CognitoIdentityProvider(
-                apiName = "signUp",
-                // see [https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignUp.html]
-                request = mapOf(
-                    "clientId" to "testAppClientId", // This should be pulled from configuration
-                    "username" to username,
-                    "password" to password,
-                    "userAttributes" to listOf(mapOf("name" to "email", "value" to email))
-                ).toJsonElement()
-            ),
+            expectedCognitoSignUpRequest(username, password),
             ExpectationShapes.Amplify(
                 apiName = AuthAPI.signUp,
                 responseType = ResponseType.Success,
@@ -97,7 +165,7 @@ object SignUpTestCaseGenerator : SerializableProvider {
                             "attributeName"
                         )
                     ),
-                    null
+                    "" // aligned with mock in CognitoMockFactory
                 ).toJsonElement()
             )
         )
@@ -107,25 +175,11 @@ object SignUpTestCaseGenerator : SerializableProvider {
         description = "Sign up finishes if user is confirmed in the first step",
         preConditions = baseCase.preConditions.copy(
             mockedResponses = listOf(
-                MockResponse(
-                    CognitoType.CognitoIdentityProvider,
-                    "signUp",
-                    ResponseType.Success,
-                    mapOf("codeDeliveryDetails" to emptyCodeDeliveryDetails, "userConfirmed" to true).toJsonElement()
-                )
+                mockedConfirmedSignUpResponse
             )
         ),
         validations = listOf(
-            ExpectationShapes.Cognito.CognitoIdentityProvider(
-                apiName = "signUp",
-                // see [https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignUp.html]
-                request = mapOf(
-                    "clientId" to "testAppClientId", // This should be pulled from configuration
-                    "username" to username,
-                    "password" to password,
-                    "userAttributes" to listOf(mapOf("name" to "email", "value" to email))
-                ).toJsonElement()
-            ),
+            expectedCognitoSignUpRequest(username, password),
             ExpectationShapes.Amplify(
                 apiName = AuthAPI.signUp,
                 responseType = ResponseType.Success,
@@ -135,13 +189,168 @@ object SignUpTestCaseGenerator : SerializableProvider {
                     AuthNextSignUpStep(
                         AuthSignUpStep.DONE,
                         emptyMap(),
-                        null
+                        AuthCodeDeliveryDetails(
+                            "",
+                            AuthCodeDeliveryDetails.DeliveryMedium.UNKNOWN,
+                            ""
+                        )
                     ),
-                    null
+                    "" // aligned with mock in CognitoMockFactory
                 ).toJsonElement()
             )
         )
     )
 
-    override val serializables: List<Any> = listOf(baseCase, signupSuccessCase)
+    private val passwordlessUnconfirmedSignUpWithValidUsernameReturnsConfirmSignUpStep = FeatureTestCase(
+        description = "Test that passwordless uncofirmed signUp with valid username returns ConfirmSignUpStep",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedPasswordlessUnconfirmedSignUpResponse
+            )
+        ),
+        api = API(
+            AuthAPI.signUp,
+            params = mapOf(
+                "username" to username,
+                "password" to ""
+            ).toJsonElement(),
+            options = mapOf(
+                "userAttributes" to mapOf(AuthUserAttributeKey.email().keyString to email)
+            ).toJsonElement()
+        ),
+        validations = listOf(
+            expectedCognitoSignUpRequest(username, ""),
+            ExpectationShapes.Amplify(
+                apiName = AuthAPI.signUp,
+                responseType = ResponseType.Success,
+                response = AuthSignUpResult(
+                    false,
+                    AuthNextSignUpStep(
+                        AuthSignUpStep.CONFIRM_SIGN_UP_STEP,
+                        emptyMap(),
+                        AuthCodeDeliveryDetails(
+                            email,
+                            AuthCodeDeliveryDetails.DeliveryMedium.EMAIL,
+                            "attributeName"
+                        )
+                    ),
+                    "" // aligned with mock in CognitoMockFactory
+                ).toJsonElement()
+            )
+        )
+    )
+
+    private val passwordlessConfirmedSignUpWithValidUsernameReturnsCompleteAutoSignIn = FeatureTestCase(
+        description = "Test that passwordless confirmed signUp with valid username returns CompleteAutoSignIn",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedPasswordlessConfirmedSignUpResponse
+            )
+        ),
+        api = API(
+            AuthAPI.signUp,
+            params = mapOf(
+                "username" to username,
+                "password" to ""
+            ).toJsonElement(),
+            options = mapOf(
+                "userAttributes" to mapOf(AuthUserAttributeKey.email().keyString to email)
+            ).toJsonElement()
+        ),
+        validations = listOf(
+            expectedCognitoSignUpRequest(username, ""),
+            ExpectationShapes.Amplify(
+                apiName = AuthAPI.signUp,
+                responseType = ResponseType.Success,
+                response = AuthSignUpResult(
+                    true,
+                    AuthNextSignUpStep(
+                        AuthSignUpStep.COMPLETE_AUTO_SIGN_IN,
+                        emptyMap(),
+                        AuthCodeDeliveryDetails(
+                            "",
+                            AuthCodeDeliveryDetails.DeliveryMedium.UNKNOWN,
+                            ""
+                        )
+                    ),
+                    "" // aligned with mock in CognitoMockFactory
+                ).toJsonElement()
+            )
+        )
+    )
+
+    private val passwordlessSignUpWithExistingUsernameFails = FeatureTestCase(
+        description = "Test that passwordless signUp with an existing username fails",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedSignUpWithExistingUsernameResponse
+            )
+        ),
+        api = API(
+            AuthAPI.signUp,
+            params = mapOf(
+                "username" to existingUsername,
+                "password" to ""
+            ).toJsonElement(),
+            options = mapOf(
+                "userAttributes" to mapOf(AuthUserAttributeKey.email().keyString to email)
+            ).toJsonElement()
+        ),
+        validations = listOf(
+            expectedCognitoSignUpRequest(existingUsername, ""),
+            ExpectationShapes.Amplify(
+                AuthAPI.signUp,
+                ResponseType.Failure,
+                com.amplifyframework.auth.cognito.exceptions.service.UsernameExistsException(
+                    usernameExistsException
+                ).toJsonElement()
+            )
+        )
+    )
+
+    private val passwordlessSignUpWithInvalidUsernameFails = FeatureTestCase(
+        description = "Test that passwordless signUp with an invalid username fails",
+        preConditions = PreConditions(
+            "authconfiguration_userauth.json",
+            "SignedOut_Configured.json",
+            mockedResponses = listOf(
+                mockedSignUpWithInvalidUsernameResponse
+            )
+        ),
+        api = API(
+            AuthAPI.signUp,
+            params = mapOf(
+                "username" to invalidUsername,
+                "password" to ""
+            ).toJsonElement(),
+            options = mapOf(
+                "userAttributes" to mapOf(AuthUserAttributeKey.email().keyString to email)
+            ).toJsonElement()
+        ),
+        validations = listOf(
+            expectedCognitoSignUpRequest(invalidUsername, ""),
+            ExpectationShapes.Amplify(
+                AuthAPI.signUp,
+                ResponseType.Failure,
+                com.amplifyframework.auth.cognito.exceptions.service.InvalidParameterException(
+                    cause = usernameInvalidException
+                ).toJsonElement()
+            )
+        )
+    )
+
+    override val serializables: List<Any> = listOf(
+        baseCase,
+        signupSuccessCase,
+        passwordlessUnconfirmedSignUpWithValidUsernameReturnsConfirmSignUpStep,
+        passwordlessConfirmedSignUpWithValidUsernameReturnsCompleteAutoSignIn,
+        passwordlessSignUpWithExistingUsernameFails,
+        passwordlessSignUpWithInvalidUsernameFails
+    )
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/serializers/AuthSignUpResultSerializer.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/serializers/AuthSignUpResultSerializer.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.featuretest.serializers
+
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.google.gson.Gson
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * gson based AuthSignUpResult Serializer as part of AuthStatesSerializer.
+ * This is needed for java class serialization with kotlinx.serialization library
+ */
+object AuthSignUpResultSerializer : KSerializer<AuthSignUpResult> {
+    private val gson = Gson()
+
+    override val descriptor: SerialDescriptor
+        get() = buildClassSerialDescriptor("AuthSignUpResult")
+
+    override fun deserialize(decoder: Decoder): AuthSignUpResult {
+        val jsonString = decoder.decodeString()
+        return gson.fromJson(jsonString, AuthSignUpResult::class.java)
+    }
+
+    override fun serialize(encoder: Encoder, value: AuthSignUpResult) {
+        val jsonString = gson.toJson(value)
+        encoder.encodeString(jsonString)
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/serializers/AuthStatesSerializer.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/serializers/AuthStatesSerializer.kt
@@ -18,9 +18,11 @@
 package com.amplifyframework.auth.cognito.featuretest.serializers
 
 import com.amplifyframework.auth.cognito.featuretest.serializers.AuthStatesProxy.Companion.format
+import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.AuthChallenge
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
+import com.amplifyframework.statemachine.codegen.data.SignUpData
 import com.amplifyframework.statemachine.codegen.data.SignedInData
 import com.amplifyframework.statemachine.codegen.data.SignedOutData
 import com.amplifyframework.statemachine.codegen.states.AuthState
@@ -28,11 +30,11 @@ import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.AuthorizationState
 import com.amplifyframework.statemachine.codegen.states.SignInChallengeState
 import com.amplifyframework.statemachine.codegen.states.SignInState
+import com.amplifyframework.statemachine.codegen.states.SignUpState
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.encoding.Decoder
@@ -51,6 +53,9 @@ internal data class AuthStatesProxy(
     @SerialName("AuthorizationState")
     val authZState: AuthorizationState? = null,
     @Contextual
+    @SerialName("SignUpState")
+    val signUpState: SignUpState? = null,
+    @Contextual
     @SerialName("SignInState")
     val signInState: SignInState = SignInState.NotStarted(),
     @Contextual
@@ -61,6 +66,10 @@ internal data class AuthStatesProxy(
     @Contextual
     val signedOutData: SignedOutData? = null,
     @Contextual
+    val signUpData: SignUpData? = null,
+    @Serializable(with = AuthSignUpResultSerializer::class)
+    val signUpResult: AuthSignUpResult? = null,
+    @Contextual
     val authChallenge: AuthChallenge? = null,
     @Contextual
     val amplifyCredential: AmplifyCredential? = null
@@ -68,7 +77,7 @@ internal data class AuthStatesProxy(
 
     internal fun <T> toRealAuthState(): T {
         return when (type) {
-            "AuthState.Configured" -> AuthState.Configured(authNState, authZState) as T
+            "AuthState.Configured" -> AuthState.Configured(authNState, authZState, signUpState) as T
             "AuthenticationState.SignedOut" -> signedOutData?.let { AuthenticationState.SignedOut(it) } as T
             "AuthenticationState.SignedIn" -> signedInData?.let {
                 AuthenticationState.SignedIn(it, DeviceMetadata.Empty)
@@ -78,6 +87,23 @@ internal data class AuthStatesProxy(
             "AuthorizationState.SessionEstablished" -> amplifyCredential?.let {
                 AuthorizationState.SessionEstablished(it)
             } as T
+            "SignUpState.NotStarted" -> SignUpState.NotStarted("") as T
+            "SignUpState.InitiatingSignUp" -> signUpData?.let { SignUpState.InitiatingSignUp(it) } as T
+            "SignUpState.ConfirmingSignUp" -> signUpData?.let { SignUpState.ConfirmingSignUp(it) } as T
+            "SignUpState.AwaitingUserConfirmation" -> {
+                signUpData?.let { data ->
+                    signUpResult?.let { result ->
+                        SignUpState.AwaitingUserConfirmation(data, result)
+                    }
+                } as T
+            }
+            "SignUpState.SignedUp" -> {
+                signUpData?.let { data ->
+                    signUpResult?.let { result ->
+                        SignUpState.SignedUp(data, result)
+                    }
+                } as T
+            }
             "AuthorizationState.SigningIn" -> AuthorizationState.SigningIn() as T
             "SignInState.ResolvingChallenge" -> SignInState.ResolvingChallenge(signInChallengeState) as T
             "SignInChallengeState.WaitingForAnswer" -> authChallenge?.let {
@@ -97,7 +123,8 @@ internal data class AuthStatesProxy(
                         is AuthState.Configured -> AuthStatesProxy(
                             type = "AuthState.Configured",
                             authNState = authState.authNState,
-                            authZState = authState.authZState
+                            authZState = authState.authZState,
+                            signUpState = authState.authSignUpState,
                         )
                         is AuthState.ConfiguringAuth -> TODO()
                         is AuthState.ConfiguringAuthentication -> TODO()
@@ -171,6 +198,9 @@ internal data class AuthStatesProxy(
                         is SignInState.SigningInWithSRP -> TODO()
                         is SignInState.SigningInWithSRPCustom -> TODO()
                         is SignInState.ResolvingTOTPSetup -> TODO()
+                        is SignInState.SigningInWithUserAuth -> TODO()
+                        is SignInState.SigningInWithWebAuthn -> TODO()
+                        is SignInState.AutoSigningIn -> TODO()
                     }
                 }
                 is SignInChallengeState -> {
@@ -183,6 +213,32 @@ internal data class AuthStatesProxy(
                             authChallenge = authState.challenge
                         )
                         is SignInChallengeState.Error -> TODO()
+                    }
+                }
+                is SignUpState -> {
+                    when (authState) {
+                        is SignUpState.NotStarted -> AuthStatesProxy(
+                            type = "SignUpState.NotStarted"
+                        )
+                        is SignUpState.AwaitingUserConfirmation -> AuthStatesProxy(
+                            type = "SignUpState.AwaitingUserConfirmation",
+                            signUpData = authState.signUpData,
+                            signUpResult = authState.signUpResult
+                        )
+                        is SignUpState.ConfirmingSignUp -> AuthStatesProxy(
+                            type = "SignUpState.ConfirmingSignUp",
+                            signUpData = authState.signUpData
+                        )
+                        is SignUpState.Error -> TODO()
+                        is SignUpState.InitiatingSignUp -> AuthStatesProxy(
+                            type = "SignUpState.InitiatingSignUp",
+                            signUpData = authState.signUpData
+                        )
+                        is SignUpState.SignedUp -> AuthStatesProxy(
+                            type = "SignUpState.SignedUp",
+                            signUpData = authState.signUpData,
+                            signUpResult = authState.signUpResult
+                        )
                     }
                 }
                 else -> {
@@ -202,6 +258,11 @@ internal data class AuthStatesProxy(
                 contextual(object : KSerializer<AuthorizationState> by AuthStatesSerializer() {})
                 contextual(object : KSerializer<AuthorizationState.SessionEstablished> by AuthStatesSerializer() {})
                 contextual(object : KSerializer<AuthenticationState.SignedOut> by AuthStatesSerializer() {})
+                contextual(object : KSerializer<SignUpState> by AuthStatesSerializer() {})
+                contextual(object : KSerializer<SignUpState.InitiatingSignUp> by AuthStatesSerializer() {})
+                contextual(object : KSerializer<SignUpState.ConfirmingSignUp> by AuthStatesSerializer() {})
+                contextual(object : KSerializer<SignUpState.AwaitingUserConfirmation> by AuthStatesSerializer() {})
+                contextual(object : KSerializer<SignUpState.SignedUp> by AuthStatesSerializer() {})
             }
             prettyPrint = true
         }
@@ -214,9 +275,7 @@ internal fun String.deserializeToAuthState(): AuthState = format.decodeFromStrin
 private class AuthStatesSerializer<T> : KSerializer<T> {
     val serializer = AuthStatesProxy.serializer()
 
-    override fun deserialize(decoder: Decoder): T {
-        return decoder.decodeSerializableValue(serializer).toRealAuthState()
-    }
+    override fun deserialize(decoder: Decoder): T = decoder.decodeSerializableValue(serializer).toRealAuthState()
 
     override val descriptor: SerialDescriptor = serializer.descriptor
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/serializers/CognitoExceptionSerializers.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/serializers/CognitoExceptionSerializers.kt
@@ -21,8 +21,11 @@ import aws.sdk.kotlin.services.cognitoidentity.model.CognitoIdentityException
 import aws.sdk.kotlin.services.cognitoidentity.model.TooManyRequestsException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.CodeMismatchException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.CognitoIdentityProviderException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InvalidParameterException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ResourceNotFoundException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserNotFoundException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UsernameExistsException
 import com.amplifyframework.auth.exceptions.UnknownException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -44,6 +47,15 @@ private data class CognitoExceptionSurrogate(
                 message = errorMessage
             } as T
             TooManyRequestsException::class.java.simpleName -> TooManyRequestsException.invoke {
+                message = errorMessage
+            } as T
+            UsernameExistsException::class.java.simpleName -> UsernameExistsException.invoke {
+                message = errorMessage
+            } as T
+            InvalidParameterException::class.java.simpleName -> InvalidParameterException.invoke {
+                message = errorMessage
+            } as T
+            UserNotFoundException::class.java.simpleName -> UserNotFoundException.invoke {
                 message = errorMessage
             } as T
             UnknownException::class.java.simpleName -> UnknownException(message = errorMessage ?: "") as T

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelperTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelperTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.helpers
+
+import android.app.Activity
+import android.content.Context
+import androidx.credentials.CreatePublicKeyCredentialResponse
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.PublicKeyCredential
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.lang.ref.WeakReference
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WebAuthnHelperTest {
+
+    private val requestJson = """{"user":{"name":"test"}}"""
+    private val responseJson = """{"response":"json"}"""
+
+    private val context = mockk<Context>()
+    private val credentialManager = mockk<CredentialManager> {
+        coEvery { getCredential(any(), any<GetCredentialRequest>()) } returns
+            GetCredentialResponse(PublicKeyCredential(responseJson))
+        coEvery { createCredential(any(), any()) } returns CreatePublicKeyCredentialResponse(responseJson)
+    }
+    private val helper = WebAuthnHelper(
+        context = context,
+        credentialManager = credentialManager
+    )
+
+    @Test
+    fun `gets credential`() = runTest {
+        val result = helper.getCredential(requestJson, WeakReference(mockk()))
+        result shouldBe responseJson
+    }
+
+    @Test
+    fun `uses activity context if provided`() = runTest {
+        val activity = mockk<Activity>()
+        helper.getCredential(requestJson, WeakReference(activity))
+        coVerify {
+            credentialManager.getCredential(activity, any<GetCredentialRequest>())
+        }
+    }
+
+    @Test
+    fun `uses application context if activity is not provided`() = runTest {
+        helper.getCredential(requestJson, WeakReference(null))
+        coVerify {
+            credentialManager.getCredential(context, any<GetCredentialRequest>())
+        }
+    }
+
+    @Test
+    fun `creates credential`() = runTest {
+        val result = helper.createCredential(requestJson, mockk())
+        result shouldBe responseJson
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/AssociateWebAuthnCredentialUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/AssociateWebAuthnCredentialUseCaseTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.CompleteWebAuthnRegistrationResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.StartWebAuthnRegistrationResponse
+import aws.smithy.kotlin.runtime.content.Document
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.helpers.WebAuthnHelper
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AssociateWebAuthnCredentialUseCaseTest {
+    private val identityProviderClient: CognitoIdentityProviderClient = mockk {
+        coEvery { startWebAuthnRegistration(any()) } returns StartWebAuthnRegistrationResponse {
+            this.credentialCreationOptions = Document(mapOf("a" to Document("b")))
+        }
+        coEvery { completeWebAuthnRegistration(any()) } returns CompleteWebAuthnRegistrationResponse {}
+    }
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(mockk(), mockk())
+    }
+    private val webAuthnHelper: WebAuthnHelper = mockk {
+        coEvery { createCredential(any(), any()) } returns """{"created":"credential"}"""
+    }
+
+    private val useCase = AssociateWebAuthnCredentialUseCase(
+        identityProviderClient,
+        fetchAuthSession,
+        stateMachine,
+        webAuthnHelper
+    )
+
+    @Test
+    fun `fails if not in SignedIn state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute(mockk(), AuthAssociateWebAuthnCredentialsOptions.defaults())
+        }
+    }
+
+    @Test
+    fun `invokes startWebAuthnRegistration`() = runTest {
+        useCase.execute(mockk(), AuthAssociateWebAuthnCredentialsOptions.defaults())
+        coVerify {
+            identityProviderClient.startWebAuthnRegistration(
+                withArg { it.accessToken shouldBe "access token" }
+            )
+        }
+    }
+
+    @Test
+    fun `invokes webAuthnHelper with expected JSON`() = runTest {
+        useCase.execute(mockk(), AuthAssociateWebAuthnCredentialsOptions.defaults())
+        coVerify {
+            webAuthnHelper.createCredential("{\"a\":\"b\"}", any())
+        }
+    }
+
+    @Test
+    fun `invokes completeWebAuthnRegistration with created credential`() = runTest {
+        useCase.execute(mockk(), AuthAssociateWebAuthnCredentialsOptions.defaults())
+        coVerify {
+            identityProviderClient.completeWebAuthnRegistration(
+                withArg {
+                    it.credential shouldBe Document(mapOf("created" to Document("credential")))
+                    it.accessToken shouldBe "access token"
+                }
+            )
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/DeleteWebAuthnCredentialsUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/DeleteWebAuthnCredentialsUseCaseTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeleteWebAuthnCredentialResponse
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DeleteWebAuthnCredentialsUseCaseTest {
+    private val identityProviderClient: CognitoIdentityProviderClient = mockk {
+        coEvery { deleteWebAuthnCredential(any()) } returns DeleteWebAuthnCredentialResponse { }
+    }
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(mockk(), mockk())
+    }
+    private val useCase = DeleteWebAuthnCredentialUseCase(
+        identityProviderClient,
+        fetchAuthSession,
+        stateMachine
+    )
+
+    @Test
+    fun `fails if not in SignedIn state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute("credentialId", AuthDeleteWebAuthnCredentialOptions.defaults())
+        }
+    }
+
+    @Test
+    fun `invokes Kotlin SDK`() = runTest {
+        useCase.execute("credentialId", AuthDeleteWebAuthnCredentialOptions.defaults())
+
+        coVerify {
+            identityProviderClient.deleteWebAuthnCredential(
+                withArg {
+                    it.credentialId shouldBe "credentialId"
+                    it.accessToken shouldBe "access token"
+                }
+            )
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ListWebAuthnCredentialsUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ListWebAuthnCredentialsUseCaseTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ListWebAuthnCredentialsResponse
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.mockWebAuthnCredentialDescription
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthListWebAuthnCredentialsOptions
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldMatchEach
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ListWebAuthnCredentialsUseCaseTest {
+
+    private val identityProviderClient: CognitoIdentityProviderClient = mockk {
+        coEvery { listWebAuthnCredentials(any()) } returns ListWebAuthnCredentialsResponse { credentials = emptyList() }
+    }
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(mockk(), mockk())
+    }
+    private val useCase = ListWebAuthnCredentialsUseCase(identityProviderClient, fetchAuthSession, stateMachine)
+
+    @Test
+    fun `invokes identity provider service and maps result`() = runTest {
+        val credentials = listOf(
+            mockWebAuthnCredentialDescription(friendlyName = "a"),
+            mockWebAuthnCredentialDescription(friendlyName = "b")
+        )
+
+        coEvery { identityProviderClient.listWebAuthnCredentials(any()) } returns ListWebAuthnCredentialsResponse {
+            this.credentials = credentials
+            nextToken = "next"
+        }
+
+        val result = useCase.execute(AuthListWebAuthnCredentialsOptions.defaults())
+
+        result.nextToken shouldBe "next"
+        result.credentials shouldMatchEach listOf(
+            { it.friendlyName shouldBe "a" },
+            { it.friendlyName shouldBe "b" }
+        )
+    }
+
+    @Test
+    fun `sets options in request`() = runTest {
+        val options = AWSCognitoAuthListWebAuthnCredentialsOptions {
+            nextToken = "testNext"
+            maxResults = 34
+        }
+        useCase.execute(options)
+
+        coVerify {
+            identityProviderClient.listWebAuthnCredentials(
+                withArg {
+                    it.nextToken shouldBe "testNext"
+                    it.maxResults shouldBe 34
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `passes null for missing options`() = runTest {
+        useCase.execute(AuthListWebAuthnCredentialsOptions.defaults())
+
+        coVerify {
+            identityProviderClient.listWebAuthnCredentials(
+                withArg {
+                    it.nextToken.shouldBeNull()
+                    it.maxResults.shouldBeNull()
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `fails if not in SignedIn state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute(AuthListWebAuthnCredentialsOptions.defaults())
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/util/MaskUtilTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/util/MaskUtilTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.util
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class MaskUtilTest {
+
+    @Test
+    fun `masks string`() {
+        val string = "hello world"
+        string.mask() shouldBe "hell***"
+    }
+
+    @Test
+    fun `string of length four is just stars`() {
+        val string = "1234"
+        string.mask() shouldBe "***"
+    }
+
+    @Test
+    fun `string of length one is just stars`() {
+        val string = "1"
+        string.mask() shouldBe "***"
+    }
+
+    @Test
+    fun `null string is just stars`() {
+        val string: String? = null
+        string.mask() shouldBe "***"
+    }
+
+    @Test
+    fun `masks values in map`() {
+        val map = mapOf("test" to "something", "other" to "otherthing", "short" to "123")
+        map.mask("test", "short").toString() shouldBe "{test=some***, other=otherthing, short=***}"
+    }
+}

--- a/aws-auth-cognito/src/test/java/featureTest/utilities/AuthOptionsFactory.kt
+++ b/aws-auth-cognito/src/test/java/featureTest/utilities/AuthOptionsFactory.kt
@@ -21,6 +21,7 @@ import com.amplifyframework.auth.cognito.featuretest.AuthAPI
 import com.amplifyframework.auth.cognito.featuretest.AuthAPI.resetPassword
 import com.amplifyframework.auth.cognito.featuretest.AuthAPI.signIn
 import com.amplifyframework.auth.cognito.featuretest.AuthAPI.signUp
+import com.amplifyframework.auth.cognito.helpers.toAuthFactorTypeOrNull
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
 import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions
@@ -62,6 +63,7 @@ object AuthOptionsFactory {
         AuthAPI.resendSignUpCode -> AuthResendSignUpCodeOptions.defaults()
         AuthAPI.resendUserAttributeConfirmationCode -> AuthResendUserAttributeConfirmationCodeOptions.defaults()
         signIn -> getSignInOptions(optionsData)
+        AuthAPI.autoSignIn -> null
         AuthAPI.signInWithSocialWebUI -> AuthWebUISignInOptions.builder().build()
         AuthAPI.signInWithWebUI -> AuthWebUISignInOptions.builder().build()
         AuthAPI.signOut -> getSignOutOptions(optionsData)
@@ -76,16 +78,20 @@ object AuthOptionsFactory {
         AuthAPI.getVersion -> TODO()
     } as T
 
-    private fun getSignInOptions(optionsData: JsonObject): AuthSignInOptions {
-        return if (optionsData.containsKey("signInOptions")) {
+    private fun getSignInOptions(optionsData: JsonObject): AuthSignInOptions =
+        if (optionsData.containsKey("signInOptions")) {
             val authFlowType = AuthFlowType.valueOf(
                 ((optionsData["signInOptions"] as Map<String, String>)["authFlow"] as JsonPrimitive).content
             )
-            AWSCognitoAuthSignInOptions.builder().authFlowType(authFlowType).build()
+            val preferredFirstFactor =
+                ((optionsData["signInOptions"] as Map<String, String>)["preferredFirstFactor"] as? JsonPrimitive)
+                    ?.content?.toAuthFactorTypeOrNull()
+            AWSCognitoAuthSignInOptions.builder().authFlowType(
+                authFlowType
+            ).preferredFirstFactor(preferredFirstFactor).build()
         } else {
             AuthSignInOptions.defaults()
         }
-    }
 
     private fun getSignUpOptions(optionsData: JsonObject): AuthSignUpOptions =
         AuthSignUpOptions.builder().userAttributes(

--- a/aws-auth-cognito/src/test/java/featureTest/utilities/CognitoRequestFactory.kt
+++ b/aws-auth-cognito/src/test/java/featureTest/utilities/CognitoRequestFactory.kt
@@ -16,7 +16,10 @@
 package featureTest.utilities
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AuthFlowType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ConfirmSignUpRequest
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ForgotPasswordRequest
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.InitiateAuthRequest
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.SignUpRequest
 import com.amplifyframework.auth.cognito.featuretest.ExpectationShapes
 import com.amplifyframework.auth.cognito.helpers.AuthHelper
@@ -42,6 +45,33 @@ object CognitoRequestFactory {
             }
 
             ForgotPasswordRequest.invoke(expectedRequestBuilder)
+        }
+
+        "confirmSignUp" -> {
+            val params = targetApi.request as JsonObject
+            val expectedRequest: ConfirmSignUpRequest.Builder.() -> Unit = {
+                clientId = (params["clientId"] as JsonPrimitive).content
+                username = (params["username"] as JsonPrimitive).content
+                confirmationCode = (params["confirmationCode"] as JsonPrimitive).content
+                session = (params["session"] as? JsonPrimitive)?.content
+
+                secretHash = AuthHelper.getSecretHash("", "", "")
+            }
+            ConfirmSignUpRequest.invoke(expectedRequest)
+        }
+
+        "initiateAuth" -> {
+            val params = targetApi.request as JsonObject
+            val expectedRequestBuilder: InitiateAuthRequest.Builder.() -> Unit = {
+                authFlow = AuthFlowType.fromValue((params["authFlow"] as JsonPrimitive).content)
+                clientId = (params["clientId"] as JsonPrimitive).content
+                authParameters =
+                    Json.decodeFromJsonElement<Map<String, String>>(params["authParameters"] as JsonObject)
+                session = (params["session"] as JsonPrimitive).content
+                clientMetadata =
+                    Json.decodeFromJsonElement<Map<String, String>>(params["clientMetadata"] as JsonObject)
+            }
+            InitiateAuthRequest.invoke(expectedRequestBuilder)
         }
 
         "signUp" -> {

--- a/aws-auth-cognito/src/test/resources/feature-test/configuration/authconfiguration_userauth.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/configuration/authconfiguration_userauth.json
@@ -1,0 +1,36 @@
+{
+  "UserAgent": "aws-amplify-cli/2.0",
+  "Version": "1.0",
+  "auth": {
+    "plugins": {
+      "awsCognitoAuthPlugin": {
+        "UserAgent": "aws-amplify/cli",
+        "Version": "0.1.0",
+        "IdentityManager": {
+          "Default": {}
+        },
+        "CredentialsProvider": {
+          "CognitoIdentity": {
+            "Default": {
+              "PoolId": "us-east-1_testIdentityPoolId",
+              "Region": "us-east-1"
+            }
+          }
+        },
+        "CognitoUserPool": {
+          "Default": {
+            "PoolId": "us-east-1_testUserPoolId",
+            "AppClientId": "testAppClientId",
+            "AppClientSecret": "testAppClientSecret",
+            "Region": "us-east-1"
+          }
+        },
+        "Auth": {
+          "Default": {
+            "authenticationFlowType": "USER_AUTH"
+          }
+        }
+      }
+    }
+  }
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SignedIn_SessionEstablished.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SignedIn_SessionEstablished.json
@@ -45,5 +45,8 @@
                 "expiration": 2342134
             }
         }
+    },
+    "SignUpState": {
+        "type": "SignUpState.NotStarted"
     }
 }

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SignedOut_Configured.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SignedOut_Configured.json
@@ -8,5 +8,8 @@
     },
     "AuthorizationState": {
         "type": "AuthorizationState.Configured"
+    },
+    "SignUpState": {
+        "type": "SignUpState.NotStarted"
     }
 }

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SignedOut_Configured_AwaitingUserConfirmation.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SignedOut_Configured_AwaitingUserConfirmation.json
@@ -1,0 +1,21 @@
+{
+    "type": "AuthState.Configured",
+    "AuthenticationState": {
+        "type": "AuthenticationState.SignedOut",
+        "signedOutData": {
+            "lastKnownUsername": "username"
+        }
+    },
+    "AuthorizationState": {
+        "type": "AuthorizationState.Configured"
+    },
+    "SignUpState": {
+        "type": "SignUpState.AwaitingUserConfirmation",
+        "signUpData": {
+            "username": "username",
+            "session": "session-id",
+            "userId": ""
+        },
+        "signUpResult": "{\"isSignUpComplete\":false,\"nextStep\":{\"signUpStep\":\"CONFIRM_SIGN_UP_STEP\",\"additionalInfo\":{},\"codeDeliveryDetails\":{\"destination\":\"user@domain.com\",\"deliveryMedium\":\"EMAIL\",\"attributeName\":\"attributeName\"}},\"userId\":\"\"}"
+    }
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SignedOut_SessionEstablished_AwaitingUserConfirmation.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SignedOut_SessionEstablished_AwaitingUserConfirmation.json
@@ -1,0 +1,45 @@
+{
+    "type": "AuthState.Configured",
+    "AuthenticationState": {
+        "type": "AuthenticationState.SignedOut",
+        "signedOutData": {
+            "lastKnownUsername": "username"
+        }
+    },
+    "AuthorizationState": {
+        "type": "AuthorizationState.SessionEstablished",
+        "amplifyCredential": {
+            "type": "userAndIdentityPool",
+            "signedInData": {
+                "userId": "userId",
+                "username": "username",
+                "signedInDate": 1707022800000,
+                "signInMethod": {
+                    "type": "SignInMethod.ApiBased",
+                    "authType": "USER_SRP_AUTH"
+                },
+                "cognitoUserPoolTokens": {
+                    "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "expiration": 300
+                }
+            },
+            "identityId": "someIdentityId",
+            "credentials": {
+                "accessKeyId": "someAccessKey",
+                "secretAccessKey": "someSecretKey",
+                "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                "expiration": 2342134
+            }
+        }
+    },
+    "SignUpState": {
+        "type": "SignUpState.AwaitingUserConfirmation",
+        "signUpData": {
+            "username": "username",
+            "userId": ""
+        },
+        "signUpResult": "{\"isSignUpComplete\":false,\"nextStep\":{\"signUpStep\":\"CONFIRM_SIGN_UP_STEP\",\"additionalInfo\":{},\"codeDeliveryDetails\":{\"destination\":\"user@domain.com\",\"deliveryMedium\":\"EMAIL\",\"attributeName\":\"attributeName\"}},\"userId\":\"\"}"
+    }
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SignedOut_SessionEstablished_SignedUp.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SignedOut_SessionEstablished_SignedUp.json
@@ -1,0 +1,46 @@
+{
+    "type": "AuthState.Configured",
+    "AuthenticationState": {
+        "type": "AuthenticationState.SignedOut",
+        "signedOutData": {
+            "lastKnownUsername": "username"
+        }
+    },
+    "AuthorizationState": {
+        "type": "AuthorizationState.SessionEstablished",
+        "amplifyCredential": {
+            "type": "userAndIdentityPool",
+            "signedInData": {
+                "userId": "userId",
+                "username": "username",
+                "signedInDate": 1707022800000,
+                "signInMethod": {
+                    "type": "SignInMethod.ApiBased",
+                    "authType": "USER_SRP_AUTH"
+                },
+                "cognitoUserPoolTokens": {
+                    "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                    "expiration": 300
+                }
+            },
+            "identityId": "someIdentityId",
+            "credentials": {
+                "accessKeyId": "someAccessKey",
+                "secretAccessKey": "someSecretKey",
+                "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                "expiration": 2342134
+            }
+        }
+    },
+    "SignUpState": {
+        "type": "SignUpState.SignedUp",
+        "signUpData": {
+            "username": "username",
+            "session": "session-id",
+            "userId": ""
+        },
+        "signUpResult": "{\"isSignUpComplete\":true,\"nextStep\":{\"signUpStep\":\"COMPLETE_AUTO_SIGN_IN\",\"additionalInfo\":{}},\"userId\":\"\"}"
+    }
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_EmailOtp.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_EmailOtp.json
@@ -1,0 +1,24 @@
+{
+    "type": "AuthState.Configured",
+    "AuthenticationState": {
+        "type": "AuthenticationState.SigningIn",
+        "SignInState": {
+            "type": "SignInState.ResolvingChallenge",
+            "SignInChallengeState": {
+                "type": "SignInChallengeState.WaitingForAnswer",
+                "authChallenge": {
+                    "challengeName": "EMAIL_OTP",
+                    "username": "username",
+                    "session": "someSession",
+                    "parameters": {
+                        "CODE_DELIVERY_DELIVERY_MEDIUM": "EMAIL",
+                        "CODE_DELIVERY_DESTINATION": "test@****.com"
+                    }
+                }
+            }
+        }
+    },
+    "AuthorizationState": {
+        "type": "AuthorizationState.SigningIn"
+    }
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SelectChallenge.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SelectChallenge.json
@@ -1,0 +1,22 @@
+{
+    "type": "AuthState.Configured",
+    "AuthenticationState": {
+        "type": "AuthenticationState.SigningIn",
+        "SignInState": {
+            "type": "SignInState.ResolvingChallenge",
+            "SignInChallengeState": {
+                "type": "SignInChallengeState.WaitingForAnswer",
+                "authChallenge": {
+                    "challengeName": "SELECT_CHALLENGE",
+                    "username": "username",
+                    "session": "someSession",
+                    "parameters" : {},
+                    "availableChallenges": [ "PASSWORD", "WEB_AUTHN", "EMAIL_OTP" ]
+                }
+            }
+        }
+    },
+    "AuthorizationState": {
+        "type": "AuthorizationState.SigningIn"
+    }
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SigningIn.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SigningIn.json
@@ -20,5 +20,8 @@
     },
     "AuthorizationState": {
         "type": "AuthorizationState.SigningIn"
+    },
+    "SignUpState": {
+        "type": "SignUpState.NotStarted"
     }
 }

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SmsOtp.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SmsOtp.json
@@ -1,0 +1,24 @@
+{
+    "type": "AuthState.Configured",
+    "AuthenticationState": {
+        "type": "AuthenticationState.SigningIn",
+        "SignInState": {
+            "type": "SignInState.ResolvingChallenge",
+            "SignInChallengeState": {
+                "type": "SignInChallengeState.WaitingForAnswer",
+                "authChallenge": {
+                    "challengeName": "SMS_OTP",
+                    "username": "username",
+                    "session": "someSession",
+                    "parameters": {
+                        "CODE_DELIVERY_DELIVERY_MEDIUM": "SMS",
+                        "CODE_DELIVERY_DESTINATION": "+12345678900"
+                    }
+                }
+            }
+        }
+    },
+    "AuthorizationState": {
+        "type": "AuthorizationState.SigningIn"
+    }
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/autoSignIn/Test_that_autoSignIn_invokes_proper_cognito_request_and_returns_DONE.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/autoSignIn/Test_that_autoSignIn_invokes_proper_cognito_request_and_returns_DONE.json
@@ -1,0 +1,55 @@
+{
+    "description": "Test that autoSignIn invokes proper cognito request and returns DONE",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_SessionEstablished_SignedUp.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "authenticationResult": {
+                        "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiresIn": 300
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "autoSignIn",
+        "params": {},
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "initiateAuth",
+            "request": {
+                "authFlow": "USER_AUTH",
+                "clientId": "testAppClientId",
+                "authParameters": {
+                    "USERNAME": "username",
+                    "SECRET_HASH": "a hash"
+                },
+                "clientMetadata": {},
+                "session": "session-id"
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": true,
+                "nextStep": {
+                    "signInStep": "DONE",
+                    "additionalInfo": {}
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/autoSignIn/Test_that_autoSignIn_without_ConfirmSignUp_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/autoSignIn/Test_that_autoSignIn_without_ConfirmSignUp_fails.json
@@ -1,0 +1,26 @@
+{
+    "description": "Test that autoSignIn without ConfirmSignUp fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_SessionEstablished_AwaitingUserConfirmation.json",
+        "mockedResponses": []
+    },
+    "api": {
+        "name": "autoSignIn",
+        "params": {},
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "autoSignIn",
+            "responseType": "failure",
+            "response": {
+                "errorType": "InvalidStateException",
+                "errorMessage": "Auth state is an invalid state, cannot process the request.",
+                "recoverySuggestion": "Operation performed is not a valid operation for the current auth state.",
+                "cause": null
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_entering_the_correct_SMS_OTP_code_signs_the_user_in.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_entering_the_correct_SMS_OTP_code_signs_the_user_in.json
@@ -1,0 +1,68 @@
+{
+    "description": "Test that entering the correct SMS OTP code signs the user in",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_SmsOtp.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "authenticationResult": {
+                        "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiresIn": 300
+                    }
+                }
+            },
+            {
+                "type": "cognitoIdentity",
+                "apiName": "getId",
+                "responseType": "success",
+                "response": {
+                    "identityId": "someIdentityId"
+                }
+            },
+            {
+                "type": "cognitoIdentity",
+                "apiName": "getCredentialsForIdentity",
+                "responseType": "success",
+                "response": {
+                    "credentials": {
+                        "accessKeyId": "someAccessKey",
+                        "secretKey": "someSecretKey",
+                        "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiration": 2342134
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "000000"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "confirmSignIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": true,
+                "nextStep": {
+                    "signInStep": "DONE",
+                    "additionalInfo": {}
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SignedIn_SessionEstablished.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_entering_the_correct_email_OTP_code_signs_the_user_in.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_entering_the_correct_email_OTP_code_signs_the_user_in.json
@@ -1,0 +1,68 @@
+{
+    "description": "Test that entering the correct email OTP code signs the user in",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_EmailOtp.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "authenticationResult": {
+                        "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiresIn": 300
+                    }
+                }
+            },
+            {
+                "type": "cognitoIdentity",
+                "apiName": "getId",
+                "responseType": "success",
+                "response": {
+                    "identityId": "someIdentityId"
+                }
+            },
+            {
+                "type": "cognitoIdentity",
+                "apiName": "getCredentialsForIdentity",
+                "responseType": "success",
+                "response": {
+                    "credentials": {
+                        "accessKeyId": "someAccessKey",
+                        "secretKey": "someSecretKey",
+                        "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiration": 2342134
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "000000"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "confirmSignIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": true,
+                "nextStep": {
+                    "signInStep": "DONE",
+                    "additionalInfo": {}
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SignedIn_SessionEstablished.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_entering_the_incorrect_SMS_OTP_code_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_entering_the_incorrect_SMS_OTP_code_fails.json
@@ -1,0 +1,41 @@
+{
+    "description": "Test that entering the incorrect SMS OTP code fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_SmsOtp.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "CodeMismatchException",
+                    "errorMessage": "Confirmation code entered is not correct."
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "000000"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "confirmSignIn",
+            "responseType": "failure",
+            "response": {
+                "errorType": "CodeMismatchException",
+                "errorMessage": "Confirmation code entered is not correct.",
+                "recoverySuggestion": "Enter correct confirmation code.",
+                "cause": {
+                    "errorType": "CodeMismatchException",
+                    "errorMessage": "Confirmation code entered is not correct."
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_entering_the_incorrect_email_OTP_code_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_entering_the_incorrect_email_OTP_code_fails.json
@@ -1,0 +1,41 @@
+{
+    "description": "Test that entering the incorrect email OTP code fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_EmailOtp.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "CodeMismatchException",
+                    "errorMessage": "Confirmation code entered is not correct."
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "000000"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "confirmSignIn",
+            "responseType": "failure",
+            "response": {
+                "errorType": "CodeMismatchException",
+                "errorMessage": "Confirmation code entered is not correct.",
+                "recoverySuggestion": "Enter correct confirmation code.",
+                "cause": {
+                    "errorType": "CodeMismatchException",
+                    "errorMessage": "Confirmation code entered is not correct."
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_PASSWORD_SRP_challenge_with_the_correct_password_succeeds.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_PASSWORD_SRP_challenge_with_the_correct_password_succeeds.json
@@ -1,0 +1,83 @@
+{
+    "description": "Test that selecting the PASSWORD_SRP challenge with the correct password succeeds",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_SelectChallenge.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "PASSWORD_VERIFIER",
+                    "challengeParameters": {
+                        "SALT": "abc",
+                        "SECRET_BLOCK": "secretBlock",
+                        "SRP_B": "def",
+                        "USERNAME": "username",
+                        "USER_ID_FOR_SRP": "userId"
+                    }
+                }
+            },
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "authenticationResult": {
+                        "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiresIn": 300
+                    }
+                }
+            },
+            {
+                "type": "cognitoIdentity",
+                "apiName": "getId",
+                "responseType": "success",
+                "response": {
+                    "identityId": "someIdentityId"
+                }
+            },
+            {
+                "type": "cognitoIdentity",
+                "apiName": "getCredentialsForIdentity",
+                "responseType": "success",
+                "response": {
+                    "credentials": {
+                        "accessKeyId": "someAccessKey",
+                        "secretKey": "someSecretKey",
+                        "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiration": 2342134
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "password"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "confirmSignIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": true,
+                "nextStep": {
+                    "signInStep": "DONE",
+                    "additionalInfo": {}
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SignedIn_SessionEstablished.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_PASSWORD_SRP_challenge_with_the_incorrect_password_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_PASSWORD_SRP_challenge_with_the_incorrect_password_fails.json
@@ -1,0 +1,41 @@
+{
+    "description": "Test that selecting the PASSWORD_SRP challenge with the incorrect password fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_SelectChallenge.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "NotAuthorizedException",
+                    "errorMessage": "Incorrect username or password."
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "password"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "confirmSignIn",
+            "responseType": "failure",
+            "response": {
+                "errorType": "NotAuthorizedException",
+                "errorMessage": "Failed since user is not authorized.",
+                "recoverySuggestion": "Check whether the given values are correct and the user is authorized to perform the operation.",
+                "cause": {
+                    "errorType": "NotAuthorizedException",
+                    "errorMessage": "Incorrect username or password."
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_PASSWORD_challenge_with_the_correct_password_succeeds.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_PASSWORD_challenge_with_the_correct_password_succeeds.json
@@ -1,0 +1,47 @@
+{
+    "description": "Test that selecting the PASSWORD challenge with the correct password succeeds",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_SelectChallenge.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "authenticationResult": {
+                        "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiresIn": 300
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "password"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "confirmSignIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": true,
+                "nextStep": {
+                    "signInStep": "DONE",
+                    "additionalInfo": {}
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SignedIn_SessionEstablished.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_PASSWORD_challenge_with_the_incorrect_password_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_PASSWORD_challenge_with_the_incorrect_password_fails.json
@@ -1,0 +1,41 @@
+{
+    "description": "Test that selecting the PASSWORD challenge with the incorrect password fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_SelectChallenge.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "NotAuthorizedException",
+                    "errorMessage": "Incorrect username or password."
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "password"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "confirmSignIn",
+            "responseType": "failure",
+            "response": {
+                "errorType": "NotAuthorizedException",
+                "errorMessage": "Failed since user is not authorized.",
+                "recoverySuggestion": "Check whether the given values are correct and the user is authorized to perform the operation.",
+                "cause": {
+                    "errorType": "NotAuthorizedException",
+                    "errorMessage": "Incorrect username or password."
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_SMS_OTP_challenge_returns_the_proper_state.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_SMS_OTP_challenge_returns_the_proper_state.json
@@ -1,0 +1,52 @@
+{
+    "description": "Test that selecting the SMS OTP challenge returns the proper state",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_SelectChallenge.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "SMS_OTP",
+                    "session": "someSession",
+                    "parameters": {},
+                    "challengeParameters": {
+                        "CODE_DELIVERY_DELIVERY_MEDIUM": "SMS",
+                        "CODE_DELIVERY_DESTINATION": "+12345678900"
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "SMS_OTP"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": false,
+                "nextStep": {
+                    "signInStep": "CONFIRM_SIGN_IN_WITH_OTP",
+                    "additionalInfo": {},
+                    "codeDeliveryDetails": {
+                        "destination": "+12345678900",
+                        "deliveryMedium": "SMS"
+                    }
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SigningIn_SmsOtp.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_email_OTP_challenge_returns_the_proper_state.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignIn/Test_that_selecting_the_email_OTP_challenge_returns_the_proper_state.json
@@ -1,0 +1,52 @@
+{
+    "description": "Test that selecting the email OTP challenge returns the proper state",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SigningIn_SelectChallenge.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "EMAIL_OTP",
+                    "session": "someSession",
+                    "parameters": {},
+                    "challengeParameters": {
+                        "CODE_DELIVERY_DELIVERY_MEDIUM": "EMAIL",
+                        "CODE_DELIVERY_DESTINATION": "test@****.com"
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignIn",
+        "params": {
+            "challengeResponse": "EMAIL_OTP"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": false,
+                "nextStep": {
+                    "signInStep": "CONFIRM_SIGN_IN_WITH_OTP",
+                    "additionalInfo": {},
+                    "codeDeliveryDetails": {
+                        "destination": "test@****.com",
+                        "deliveryMedium": "EMAIL"
+                    }
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SigningIn_EmailOtp.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_non_passwordless_confirmSignUp_returns_Done.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_non_passwordless_confirmSignUp_returns_Done.json
@@ -1,0 +1,47 @@
+{
+    "description": "Test that non passwordless confirmSignUp returns Done",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_SessionEstablished_AwaitingUserConfirmation.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "confirmSignUp",
+                "responseType": "success",
+                "response": {}
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignUp",
+        "params": {
+            "username": "username",
+            "confirmationCode": "123"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "confirmSignUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "username",
+                "confirmationCode": "123"
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "confirmSignUp",
+            "responseType": "success",
+            "response": {
+                "isSignUpComplete": true,
+                "nextStep": {
+                    "signUpStep": "DONE",
+                    "additionalInfo": {}
+                },
+                "userId": ""
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_passwordless_confirmSignUp_returns_CompleteAutoSignIn.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_passwordless_confirmSignUp_returns_CompleteAutoSignIn.json
@@ -1,0 +1,50 @@
+{
+    "description": "Test that passwordless confirmSignUp returns CompleteAutoSignIn",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured_AwaitingUserConfirmation.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "confirmSignUp",
+                "responseType": "success",
+                "response": {
+                    "session": "session-id"
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignUp",
+        "params": {
+            "username": "username",
+            "confirmationCode": "123"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "confirmSignUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "username",
+                "confirmationCode": "123",
+                "session": "session-id"
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "confirmSignUp",
+            "responseType": "success",
+            "response": {
+                "isSignUpComplete": true,
+                "nextStep": {
+                    "signUpStep": "COMPLETE_AUTO_SIGN_IN",
+                    "additionalInfo": {}
+                },
+                "userId": ""
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_passwordless_confirmSignUp_with_Invalid_Confirmation_Code_returns_Exception.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_passwordless_confirmSignUp_with_Invalid_Confirmation_Code_returns_Exception.json
@@ -1,0 +1,52 @@
+{
+    "description": "Test that passwordless confirmSignUp with Invalid Confirmation Code returns Exception",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured_AwaitingUserConfirmation.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "confirmSignUp",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "CodeMismatchException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignUp",
+        "params": {
+            "username": "username",
+            "confirmationCode": "123"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "confirmSignUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "username",
+                "confirmationCode": "123",
+                "session": "session-id"
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "confirmSignUp",
+            "responseType": "failure",
+            "response": {
+                "errorType": "CodeMismatchException",
+                "errorMessage": "Confirmation code entered is not correct.",
+                "recoverySuggestion": "Enter correct confirmation code.",
+                "cause": {
+                    "errorType": "CodeMismatchException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_passwordless_confirmSignUp_with_Invalid_Username_returns_Exception.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_passwordless_confirmSignUp_with_Invalid_Username_returns_Exception.json
@@ -1,0 +1,52 @@
+{
+    "description": "Test that passwordless confirmSignUp with Invalid Username returns Exception",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured_AwaitingUserConfirmation.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "confirmSignUp",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "InvalidParameterException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignUp",
+        "params": {
+            "username": "username",
+            "confirmationCode": "123"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "confirmSignUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "username",
+                "confirmationCode": "123",
+                "session": "session-id"
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "confirmSignUp",
+            "responseType": "failure",
+            "response": {
+                "errorType": "InvalidParameterException",
+                "errorMessage": "One or more parameters are incorrect.",
+                "recoverySuggestion": "Enter correct parameters.",
+                "cause": {
+                    "errorType": "InvalidParameterException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_passwordless_confirmSignUp_with_Unregistered_User_returns_Exception.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/confirmSignUp/Test_that_passwordless_confirmSignUp_with_Unregistered_User_returns_Exception.json
@@ -1,0 +1,52 @@
+{
+    "description": "Test that passwordless confirmSignUp with Unregistered User returns Exception",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured_AwaitingUserConfirmation.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "confirmSignUp",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "UserNotFoundException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "confirmSignUp",
+        "params": {
+            "username": "username",
+            "confirmationCode": "123"
+        },
+        "options": {}
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "confirmSignUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "username",
+                "confirmationCode": "123",
+                "session": "session-id"
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "confirmSignUp",
+            "responseType": "failure",
+            "response": {
+                "errorType": "UserNotFoundException",
+                "errorMessage": "User not found in the system.",
+                "recoverySuggestion": "Please enter correct username.",
+                "cause": {
+                    "errorType": "UserNotFoundException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_invokes_proper_cognito_request_and_returns_success.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_invokes_proper_cognito_request_and_returns_success.json
@@ -1,0 +1,60 @@
+{
+    "description": "Test that USER_AUTH signIn invokes proper cognito request and returns success",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "SELECT_CHALLENGE",
+                    "session": "session-id",
+                    "parameters": {},
+                    "availableChallenges": [
+                        "PASSWORD",
+                        "WEB_AUTHN",
+                        "EMAIL_OTP"
+                    ]
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": ""
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": null
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": false,
+                "nextStep": {
+                    "signInStep": "CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION",
+                    "additionalInfo": {},
+                    "availableFactors": [
+                        "PASSWORD",
+                        "WEB_AUTHN",
+                        "EMAIL_OTP"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SigningIn_SelectChallenge.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_EMAIL_preference_returns_Confirm_Sign_In_With_OTP.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_EMAIL_preference_returns_Confirm_Sign_In_With_OTP.json
@@ -1,0 +1,58 @@
+{
+    "description": "Test that USER_AUTH signIn with EMAIL preference returns Confirm Sign In With OTP",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "EMAIL_OTP",
+                    "session": "someSession",
+                    "parameters": {},
+                    "challengeParameters": {
+                        "CODE_DELIVERY_DELIVERY_MEDIUM": "EMAIL",
+                        "CODE_DELIVERY_DESTINATION": "test@****.com"
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": ""
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": "EMAIL_OTP"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": false,
+                "nextStep": {
+                    "signInStep": "CONFIRM_SIGN_IN_WITH_OTP",
+                    "additionalInfo": {},
+                    "codeDeliveryDetails": {
+                        "destination": "test@****.com",
+                        "deliveryMedium": "EMAIL"
+                    }
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SigningIn_EmailOtp.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_PASSWORD_SRP_preference_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_PASSWORD_SRP_preference_fails.json
@@ -1,0 +1,47 @@
+{
+    "description": "Test that USER_AUTH signIn with PASSWORD_SRP preference fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "NotAuthorizedException",
+                    "errorMessage": "Incorrect username or password."
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": "password"
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": "PASSWORD_SRP"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "errorType": "NotAuthorizedException",
+                "errorMessage": "Failed since user is not authorized.",
+                "recoverySuggestion": "Check whether the given values are correct and the user is authorized to perform the operation.",
+                "cause": {
+                    "errorType": "NotAuthorizedException",
+                    "errorMessage": "Incorrect username or password."
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_PASSWORD_SRP_preference_succeeds.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_PASSWORD_SRP_preference_succeeds.json
@@ -1,0 +1,89 @@
+{
+    "description": "Test that USER_AUTH signIn with PASSWORD_SRP preference succeeds",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "PASSWORD_VERIFIER",
+                    "challengeParameters": {
+                        "SALT": "abc",
+                        "SECRET_BLOCK": "secretBlock",
+                        "SRP_B": "def",
+                        "USERNAME": "username",
+                        "USER_ID_FOR_SRP": "userId"
+                    }
+                }
+            },
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "respondToAuthChallenge",
+                "responseType": "success",
+                "response": {
+                    "authenticationResult": {
+                        "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiresIn": 300
+                    }
+                }
+            },
+            {
+                "type": "cognitoIdentity",
+                "apiName": "getId",
+                "responseType": "success",
+                "response": {
+                    "identityId": "someIdentityId"
+                }
+            },
+            {
+                "type": "cognitoIdentity",
+                "apiName": "getCredentialsForIdentity",
+                "responseType": "success",
+                "response": {
+                    "credentials": {
+                        "accessKeyId": "someAccessKey",
+                        "secretKey": "someSecretKey",
+                        "sessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiration": 2342134
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": "password"
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": "PASSWORD_SRP"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": true,
+                "nextStep": {
+                    "signInStep": "DONE",
+                    "additionalInfo": {}
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SignedIn_SessionEstablished.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_PASSWORD_preference_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_PASSWORD_preference_fails.json
@@ -1,0 +1,47 @@
+{
+    "description": "Test that USER_AUTH signIn with PASSWORD preference fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "NotAuthorizedException",
+                    "errorMessage": "Incorrect username or password."
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": "password"
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": "PASSWORD"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "errorType": "NotAuthorizedException",
+                "errorMessage": "Failed since user is not authorized.",
+                "recoverySuggestion": "Check whether the given values are correct and the user is authorized to perform the operation.",
+                "cause": {
+                    "errorType": "NotAuthorizedException",
+                    "errorMessage": "Incorrect username or password."
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_PASSWORD_preference_succeeds.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_PASSWORD_preference_succeeds.json
@@ -1,0 +1,53 @@
+{
+    "description": "Test that USER_AUTH signIn with PASSWORD preference succeeds",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "authenticationResult": {
+                        "idToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyLCJvcmlnaW5fanRpIjoib3JpZ2luX2p0aSJ9.Xqa-vjJe5wwwsqeRAdHf8kTBn_rYSkDn2lB7xj9Z1xU",
+                        "expiresIn": 300
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": "password"
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": "PASSWORD"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": true,
+                "nextStep": {
+                    "signInStep": "DONE",
+                    "additionalInfo": {}
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SignedIn_SessionEstablished.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_SMS_preference_returns_Confirm_Sign_In_With_OTP.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_SMS_preference_returns_Confirm_Sign_In_With_OTP.json
@@ -1,0 +1,58 @@
+{
+    "description": "Test that USER_AUTH signIn with SMS preference returns Confirm Sign In With OTP",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "SMS_OTP",
+                    "session": "someSession",
+                    "parameters": {},
+                    "challengeParameters": {
+                        "CODE_DELIVERY_DELIVERY_MEDIUM": "SMS",
+                        "CODE_DELIVERY_DESTINATION": "+12345678900"
+                    }
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": ""
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": "SMS_OTP"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": false,
+                "nextStep": {
+                    "signInStep": "CONFIRM_SIGN_IN_WITH_OTP",
+                    "additionalInfo": {},
+                    "codeDeliveryDetails": {
+                        "destination": "+12345678900",
+                        "deliveryMedium": "SMS"
+                    }
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SigningIn_SmsOtp.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_an_unsupported_preference_returns_Select_Challenge.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_an_unsupported_preference_returns_Select_Challenge.json
@@ -1,0 +1,60 @@
+{
+    "description": "Test that USER_AUTH signIn with an unsupported preference returns Select Challenge",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "SELECT_CHALLENGE",
+                    "session": "someSession",
+                    "parameters": {},
+                    "availableChallenges": [
+                        "PASSWORD",
+                        "WEB_AUTHN",
+                        "EMAIL_OTP"
+                    ]
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": ""
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": "SMS_OTP"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": false,
+                "nextStep": {
+                    "signInStep": "CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION",
+                    "additionalInfo": {},
+                    "availableFactors": [
+                        "PASSWORD",
+                        "WEB_AUTHN",
+                        "EMAIL_OTP"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SigningIn_SelectChallenge.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_no_preference_returns_Select_Challenge.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signIn/Test_that_USER_AUTH_signIn_with_no_preference_returns_Select_Challenge.json
@@ -1,0 +1,60 @@
+{
+    "description": "Test that USER_AUTH signIn with no preference returns Select Challenge",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "initiateAuth",
+                "responseType": "success",
+                "response": {
+                    "challengeName": "SELECT_CHALLENGE",
+                    "session": "someSession",
+                    "parameters": {},
+                    "availableChallenges": [
+                        "PASSWORD",
+                        "WEB_AUTHN",
+                        "EMAIL_OTP"
+                    ]
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signIn",
+        "params": {
+            "username": "username",
+            "password": ""
+        },
+        "options": {
+            "signInOptions": {
+                "authFlow": "USER_AUTH",
+                "preferredFirstFactor": null
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "amplify",
+            "apiName": "signIn",
+            "responseType": "success",
+            "response": {
+                "isSignedIn": false,
+                "nextStep": {
+                    "signInStep": "CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION",
+                    "additionalInfo": {},
+                    "availableFactors": [
+                        "PASSWORD",
+                        "WEB_AUTHN",
+                        "EMAIL_OTP"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "state",
+            "expectedState": "SigningIn_SelectChallenge.json"
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Sign_up_finishes_if_user_is_confirmed_in_the_first_step.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Sign_up_finishes_if_user_is_confirmed_in_the_first_step.json
@@ -55,7 +55,11 @@
                 "isSignUpComplete": true,
                 "nextStep": {
                     "signUpStep": "DONE",
-                    "additionalInfo": {
+                    "additionalInfo": {},
+                    "codeDeliveryDetails": {
+                        "destination": "",
+                        "deliveryMedium": "UNKNOWN",
+                        "attributeName": ""
                     }
                 },
                 "userId": ""

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_passwordless_confirmed_signUp_with_valid_username_returns_CompleteAutoSignIn.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_passwordless_confirmed_signUp_with_valid_username_returns_CompleteAutoSignIn.json
@@ -1,0 +1,70 @@
+{
+    "description": "Test that passwordless confirmed signUp with valid username returns CompleteAutoSignIn",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "signUp",
+                "responseType": "success",
+                "response": {
+                    "codeDeliveryDetails": {
+                        "destination": "",
+                        "deliveryMedium": "",
+                        "attributeName": ""
+                    },
+                    "session": "session-id",
+                    "userConfirmed": true
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signUp",
+        "params": {
+            "username": "user",
+            "password": ""
+        },
+        "options": {
+            "userAttributes": {
+                "email": "user@domain.com"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "signUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "user",
+                "password": "",
+                "userAttributes": [
+                    {
+                        "name": "email",
+                        "value": "user@domain.com"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "signUp",
+            "responseType": "success",
+            "response": {
+                "isSignUpComplete": true,
+                "nextStep": {
+                    "signUpStep": "COMPLETE_AUTO_SIGN_IN",
+                    "additionalInfo": {},
+                    "codeDeliveryDetails": {
+                        "destination": "",
+                        "deliveryMedium": "UNKNOWN",
+                        "attributeName": ""
+                    }
+                },
+                "userId": ""
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_passwordless_signUp_with_an_existing_username_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_passwordless_signUp_with_an_existing_username_fails.json
@@ -1,0 +1,61 @@
+{
+    "description": "Test that passwordless signUp with an existing username fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "signUp",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "UsernameExistsException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signUp",
+        "params": {
+            "username": "anExistingUsername",
+            "password": ""
+        },
+        "options": {
+            "userAttributes": {
+                "email": "user@domain.com"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "signUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "anExistingUsername",
+                "password": "",
+                "userAttributes": [
+                    {
+                        "name": "email",
+                        "value": "user@domain.com"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "signUp",
+            "responseType": "failure",
+            "response": {
+                "errorType": "UsernameExistsException",
+                "errorMessage": "Username already exists in the system.",
+                "recoverySuggestion": "Retry operation and enter another username.",
+                "cause": {
+                    "errorType": "UsernameExistsException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_passwordless_signUp_with_an_invalid_username_fails.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_passwordless_signUp_with_an_invalid_username_fails.json
@@ -1,0 +1,61 @@
+{
+    "description": "Test that passwordless signUp with an invalid username fails",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "signUp",
+                "responseType": "failure",
+                "response": {
+                    "errorType": "InvalidParameterException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signUp",
+        "params": {
+            "username": "anInvalidUsername",
+            "password": ""
+        },
+        "options": {
+            "userAttributes": {
+                "email": "user@domain.com"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "signUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "anInvalidUsername",
+                "password": "",
+                "userAttributes": [
+                    {
+                        "name": "email",
+                        "value": "user@domain.com"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "signUp",
+            "responseType": "failure",
+            "response": {
+                "errorType": "InvalidParameterException",
+                "errorMessage": "One or more parameters are incorrect.",
+                "recoverySuggestion": "Enter correct parameters.",
+                "cause": {
+                    "errorType": "InvalidParameterException",
+                    "errorMessage": "Error type: Client, Protocol response: (empty response)"
+                }
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_passwordless_uncofirmed_signUp_with_valid_username_returns_ConfirmSignUpStep.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_passwordless_uncofirmed_signUp_with_valid_username_returns_ConfirmSignUpStep.json
@@ -1,0 +1,69 @@
+{
+    "description": "Test that passwordless uncofirmed signUp with valid username returns ConfirmSignUpStep",
+    "preConditions": {
+        "amplify-configuration": "authconfiguration_userauth.json",
+        "state": "SignedOut_Configured.json",
+        "mockedResponses": [
+            {
+                "type": "cognitoIdentityProvider",
+                "apiName": "signUp",
+                "responseType": "success",
+                "response": {
+                    "codeDeliveryDetails": {
+                        "destination": "user@domain.com",
+                        "deliveryMedium": "EMAIL",
+                        "attributeName": "attributeName"
+                    },
+                    "session": "session-id"
+                }
+            }
+        ]
+    },
+    "api": {
+        "name": "signUp",
+        "params": {
+            "username": "user",
+            "password": ""
+        },
+        "options": {
+            "userAttributes": {
+                "email": "user@domain.com"
+            }
+        }
+    },
+    "validations": [
+        {
+            "type": "cognitoIdentityProvider",
+            "apiName": "signUp",
+            "request": {
+                "clientId": "testAppClientId",
+                "username": "user",
+                "password": "",
+                "userAttributes": [
+                    {
+                        "name": "email",
+                        "value": "user@domain.com"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "amplify",
+            "apiName": "signUp",
+            "responseType": "success",
+            "response": {
+                "isSignUpComplete": false,
+                "nextStep": {
+                    "signUpStep": "CONFIRM_SIGN_UP_STEP",
+                    "additionalInfo": {},
+                    "codeDeliveryDetails": {
+                        "destination": "user@domain.com",
+                        "deliveryMedium": "EMAIL",
+                        "attributeName": "attributeName"
+                    }
+                },
+                "userId": ""
+            }
+        }
+    ]
+}

--- a/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_signup_invokes_proper_cognito_request_and_returns_success.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/testsuites/signUp/Test_that_signup_invokes_proper_cognito_request_and_returns_success.json
@@ -54,8 +54,7 @@
                 "isSignUpComplete": false,
                 "nextStep": {
                     "signUpStep": "CONFIRM_SIGN_UP_STEP",
-                    "additionalInfo": {
-                    },
+                    "additionalInfo": {},
                     "codeDeliveryDetails": {
                         "destination": "user@domain.com",
                         "deliveryMedium": "EMAIL",

--- a/aws-core/build.gradle.kts
+++ b/aws-core/build.gradle.kts
@@ -38,6 +38,10 @@ dependencies {
     implementation(libs.aws.credentials)
     // slf4j dependency is added to fix https://github.com/awslabs/aws-sdk-kotlin/issues/993#issuecomment-1678885524
     implementation(libs.slf4j)
+
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.kotest.assertions)
+    testImplementation(libs.test.robolectric)
 }
 
 afterEvaluate {

--- a/aws-core/src/main/java/com/amplifyframework/util/DocumentExtensions.kt
+++ b/aws-core/src/main/java/com/amplifyframework/util/DocumentExtensions.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.util
+
+import aws.smithy.kotlin.runtime.content.Document
+import com.amplifyframework.annotations.InternalAmplifyApi
+import java.lang.StringBuilder
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Converts a Smithy document to a JSON string
+ */
+@InternalAmplifyApi
+fun Document.toJsonString(): String = buildString { appendTo(this) }
+
+/**
+ * Converts a JSON string to a Smithy document.
+ * NOTE: This assumes the string represents a JSON object!
+ */
+@Suppress("FunctionName")
+@InternalAmplifyApi
+fun JsonDocument(content: String): Document = DocumentBuilder().process(JSONObject(content))
+
+private fun Document?.appendTo(builder: StringBuilder) {
+    when (val doc = this) {
+        is Document.String -> {
+            builder.append('"')
+            builder.append(doc.asString())
+            builder.append('"')
+        }
+        is Document.Boolean -> builder.append(doc.asBoolean())
+        is Document.List -> {
+            builder.append('[')
+            doc.forEachIndexed { index, document ->
+                document.appendTo(builder)
+                if (index < doc.size - 1) builder.append(',')
+            }
+            builder.append(']')
+        }
+        is Document.Map -> {
+            builder.append('{')
+            doc.entries.forEachIndexed { index, (key, value) ->
+                builder.append('"')
+                builder.append(key)
+                builder.append("\":")
+                value.appendTo(builder)
+                if (index < doc.size - 1) builder.append(',')
+            }
+            builder.append('}')
+        }
+        is Document.Number -> builder.append(doc.value)
+        null -> builder.append("null")
+    }
+}
+
+internal class DocumentBuilder {
+    fun process(obj: JSONObject): Document.Map {
+        val map = mutableMapOf<String, Document?>()
+        obj.keys().forEach { key ->
+            val document = process(obj.get(key))
+            map[key] = document
+        }
+        return Document.Map(map)
+    }
+
+    fun process(array: JSONArray): Document.List {
+        val list = mutableListOf<Document?>()
+        for (i in 0 until array.length()) {
+            val document = process(array.opt(i))
+            list.add(document)
+        }
+        return Document.List(list)
+    }
+
+    fun process(value: Any?): Document? = when (value) {
+        is JSONArray -> process(value)
+        is JSONObject -> process(value)
+        is Number -> Document(value)
+        is String -> Document(value)
+        is Boolean -> Document(value)
+        JSONObject.NULL -> null
+        null -> null
+        else -> throw IllegalArgumentException("Unknown value type")
+    }
+}

--- a/aws-core/src/test/java/com/amplifyframework/util/DocumentExtensionsTest.kt
+++ b/aws-core/src/test/java/com/amplifyframework/util/DocumentExtensionsTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.util
+
+import aws.smithy.kotlin.runtime.content.Document
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DocumentExtensionsTest {
+    @Test
+    fun `converts number`() {
+        val doc = Document(42.0)
+        doc.toJsonString() shouldBe "42.0"
+    }
+
+    @Test
+    fun `converts int`() {
+        val doc = Document(42)
+        doc.toJsonString() shouldBe "42"
+    }
+
+    @Test
+    fun `converts boolean`() {
+        val falseDoc = Document(false)
+        val trueDoc = Document(true)
+        falseDoc.toJsonString() shouldBe "false"
+        trueDoc.toJsonString() shouldBe "true"
+    }
+
+    @Test
+    fun `converts string`() {
+        val doc = Document("hello world")
+        doc.toJsonString() shouldBe "\"hello world\""
+    }
+
+    @Test
+    fun `converts list`() {
+        val list = listOf(
+            Document("a"),
+            Document(2),
+            null,
+            Document(true)
+        )
+        val doc = Document(list)
+        doc.toJsonString() shouldBe """
+            ["a",2,null,true]
+        """.trimIndent()
+    }
+
+    @Test
+    fun `converts map`() {
+        val map = mapOf(
+            "a" to Document(1),
+            "b" to Document("b"),
+            "c" to null,
+            "d" to Document(true)
+        )
+        val doc = Document(map)
+        doc.toJsonString() shouldBe """
+            {"a":1,"b":"b","c":null,"d":true}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `converts complex document`() {
+        val doc = Document(
+            mapOf(
+                "a" to Document(1),
+                "b" to Document("b"),
+                "c" to null,
+                "d" to Document(listOf(Document("d1"), Document("d2"))),
+                "e" to Document(
+                    mapOf(
+                        "e1" to Document(true),
+                        "e2" to Document(listOf(Document("e2.1"), null)),
+                        "e3" to Document(mapOf()),
+                        "e4" to null
+                    )
+                )
+            )
+        )
+
+        doc.toJsonString() shouldBe """
+            {"a":1,"b":"b","c":null,"d":["d1","d2"],"e":{"e1":true,"e2":["e2.1",null],"e3":{},"e4":null}}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `converts complex json into document and back again`() {
+        val json = """
+            {"a":1,"b":"b","c":null,"d":["d1","d2"],"e":{"e1":true,"e2":["e2.1",null],"e3":{},"e4":null}}
+        """.trimIndent()
+
+        val doc = JsonDocument(json)
+        val result = doc.toJsonString()
+
+        result shouldBe json
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,12 +43,6 @@ plugins {
 }
 
 allprojects {
-    repositories {
-        maven(url = "https://aws.oss.sonatype.org/content/repositories/snapshots/")
-        google()
-        mavenCentral()
-    }
-
     gradle.projectsEvaluated {
         tasks.withType<JavaCompile>().configureEach {
             options.compilerArgs.apply {

--- a/core-kotlin/api/core-kotlin.api
+++ b/core-kotlin/api/core-kotlin.api
@@ -55,17 +55,21 @@ public final class com/amplifyframework/kotlin/api/Rest$DefaultImpls {
 }
 
 public abstract interface class com/amplifyframework/kotlin/auth/Auth {
+	public abstract fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun autoSignIn (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmResetPasswordOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun confirmSignIn (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignInOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun confirmSignUp (Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignUpOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun confirmUserAttribute (Lcom/amplifyframework/auth/AuthUserAttributeKey;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchAuthSession (Lcom/amplifyframework/auth/options/AuthFetchSessionOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchDevices (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchUserAttributes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun forgetDevice (Lcom/amplifyframework/auth/AuthDevice;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getCurrentUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun handleWebUISignInResponse (Landroid/content/Intent;)V
+	public abstract fun listWebAuthnCredentials (Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun rememberDevice (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthResendSignUpCodeOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun resendUserAttributeConfirmationCode (Lcom/amplifyframework/auth/AuthUserAttributeKey;Lcom/amplifyframework/auth/options/AuthResendUserAttributeConfirmationCodeOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -83,11 +87,14 @@ public abstract interface class com/amplifyframework/kotlin/auth/Auth {
 }
 
 public final class com/amplifyframework/kotlin/auth/Auth$DefaultImpls {
+	public static synthetic fun associateWebAuthnCredential$default (Lcom/amplifyframework/kotlin/auth/Auth;Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun confirmResetPassword$default (Lcom/amplifyframework/kotlin/auth/Auth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmResetPasswordOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun confirmSignIn$default (Lcom/amplifyframework/kotlin/auth/Auth;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignInOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun confirmSignUp$default (Lcom/amplifyframework/kotlin/auth/Auth;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignUpOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteWebAuthnCredential$default (Lcom/amplifyframework/kotlin/auth/Auth;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun fetchAuthSession$default (Lcom/amplifyframework/kotlin/auth/Auth;Lcom/amplifyframework/auth/options/AuthFetchSessionOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun forgetDevice$default (Lcom/amplifyframework/kotlin/auth/Auth;Lcom/amplifyframework/auth/AuthDevice;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun listWebAuthnCredentials$default (Lcom/amplifyframework/kotlin/auth/Auth;Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun resendSignUpCode$default (Lcom/amplifyframework/kotlin/auth/Auth;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthResendSignUpCodeOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun resendUserAttributeConfirmationCode$default (Lcom/amplifyframework/kotlin/auth/Auth;Lcom/amplifyframework/auth/AuthUserAttributeKey;Lcom/amplifyframework/auth/options/AuthResendUserAttributeConfirmationCodeOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun resetPassword$default (Lcom/amplifyframework/kotlin/auth/Auth;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthResetPasswordOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -105,17 +112,21 @@ public final class com/amplifyframework/kotlin/auth/KotlinAuthFacade : com/ampli
 	public fun <init> ()V
 	public fun <init> (Lcom/amplifyframework/auth/AuthCategoryBehavior;)V
 	public synthetic fun <init> (Lcom/amplifyframework/auth/AuthCategoryBehavior;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun autoSignIn (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmResetPasswordOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun confirmSignIn (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignInOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun confirmSignUp (Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignUpOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun confirmUserAttribute (Lcom/amplifyframework/auth/AuthUserAttributeKey;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchAuthSession (Lcom/amplifyframework/auth/options/AuthFetchSessionOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchDevices (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchUserAttributes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun forgetDevice (Lcom/amplifyframework/auth/AuthDevice;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCurrentUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handleWebUISignInResponse (Landroid/content/Intent;)V
+	public fun listWebAuthnCredentials (Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun rememberDevice (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthResendSignUpCodeOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun resendUserAttributeConfirmationCode (Lcom/amplifyframework/auth/AuthUserAttributeKey;Lcom/amplifyframework/auth/options/AuthResendUserAttributeConfirmationCodeOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/Auth.kt
@@ -26,10 +26,13 @@ import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.TOTPSetupDetails
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions
 import com.amplifyframework.auth.options.AuthFetchSessionOptions
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions
 import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions
 import com.amplifyframework.auth.options.AuthResetPasswordOptions
@@ -40,6 +43,7 @@ import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions
 import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions
 import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions
 import com.amplifyframework.auth.options.AuthWebUISignInOptions
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult
 import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.AuthSignOutResult
@@ -68,10 +72,9 @@ interface Auth {
     @Throws(AuthException::class)
     suspend fun signUp(
         username: String,
-        password: String,
+        password: String?,
         options: AuthSignUpOptions = AuthSignUpOptions.builder().build()
-    ):
-        AuthSignUpResult
+    ): AuthSignUpResult
 
     /**
      * If you have attribute confirmation enabled, this will allow the user
@@ -125,8 +128,7 @@ interface Auth {
         username: String? = null,
         password: String? = null,
         options: AuthSignInOptions = AuthSignInOptions.defaults()
-    ):
-        AuthSignInResult
+    ): AuthSignInResult
 
     /**
      * Submit the confirmation code received as part of multi-factor Authentication during sign in.
@@ -139,8 +141,14 @@ interface Auth {
     suspend fun confirmSignIn(
         challengeResponse: String,
         options: AuthConfirmSignInOptions = AuthConfirmSignInOptions.defaults()
-    ):
-        AuthSignInResult
+    ): AuthSignInResult
+
+    /**
+     * Sign in the user after signed up confirmation.
+     * @return A sign-in result; check the nextStep field for cues on additional sign-in challenges
+     */
+    @Throws(AuthException::class)
+    suspend fun autoSignIn(): AuthSignInResult
 
     /**
      * Launch the specified auth provider's web UI sign in experience. You should also put the
@@ -157,8 +165,7 @@ interface Auth {
         provider: AuthProvider,
         callingActivity: Activity,
         options: AuthWebUISignInOptions = AuthWebUISignInOptions.builder().build()
-    ):
-        AuthSignInResult
+    ): AuthSignInResult
 
     /**
      * Launch a hosted web sign in UI flow. You should also put the {@link #handleWebUISignInResponse(Intent)}
@@ -172,8 +179,7 @@ interface Auth {
     suspend fun signInWithWebUI(
         callingActivity: Activity,
         options: AuthWebUISignInOptions = AuthWebUISignInOptions.builder().build()
-    ):
-        AuthSignInResult
+    ): AuthSignInResult
 
     /**
      * Handles the response which comes back from {@link #signInWithWebUI(Activity, Consumer, Consumer)}.
@@ -346,5 +352,39 @@ interface Auth {
     suspend fun verifyTOTPSetup(
         code: String,
         options: AuthVerifyTOTPSetupOptions = AuthVerifyTOTPSetupOptions.defaults()
+    )
+
+    /**
+     * Create and register a passkey on this device, enabling passwordless sign in using passkeys.
+     * The user must be signed in to call this API.
+     * @param callingActivity The current Activity instance, used for launching the CredentialManager UI
+     * @param options Advanced options for associating credentials
+     */
+    @Throws(AuthException::class)
+    suspend fun associateWebAuthnCredential(
+        callingActivity: Activity,
+        options: AuthAssociateWebAuthnCredentialsOptions = AuthAssociateWebAuthnCredentialsOptions.defaults()
+    )
+
+    /**
+     * Retrieve a list of WebAuthn credentials that are associated with the user's account.
+     * The user must be signed in to call this API.
+     * @param options Advanced options for listing credentials
+     * @return The list of associated WebAuthn credentials
+     */
+    @Throws(AuthException::class)
+    suspend fun listWebAuthnCredentials(
+        options: AuthListWebAuthnCredentialsOptions = AuthListWebAuthnCredentialsOptions.defaults()
+    ): AuthListWebAuthnCredentialsResult
+
+    /**
+     * Delete the credential matching the given identifier.
+     * @param credentialId The identifier for the credential to delete
+     * @param options Advanced options for deleting credentials
+     */
+    @Throws(AuthException::class)
+    suspend fun deleteWebAuthnCredential(
+        credentialId: String,
+        options: AuthDeleteWebAuthnCredentialOptions = AuthDeleteWebAuthnCredentialOptions.defaults()
     )
 }

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -32,6 +32,7 @@ import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.auth.options.AuthFetchSessionOptions
 import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult
 import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.AuthSignOutResult
@@ -39,10 +40,15 @@ import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.Answer
+import io.mockk.Call
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -1036,5 +1042,61 @@ class KotlinAuthFacadeTest {
             onError.accept(error)
         }
         auth.verifyTOTPSetup(code)
+    }
+
+    @Test
+    fun `associateWebAuthnCredential succeeds`() = runTest {
+        every { delegate.associateWebAuthnCredential(any(), any(), any(), any()) } answers CallAction(2)
+        auth.associateWebAuthnCredential(mockk())
+    }
+
+    @Test
+    fun `associateWebAuthnCredential fails`() = runTest {
+        val error = AuthException("oops", "bad")
+        every { delegate.associateWebAuthnCredential(any(), any(), any(), any()) } answers Accept(3, error)
+        shouldThrow<AuthException> { auth.associateWebAuthnCredential(mockk()) } shouldBe error
+    }
+
+    @Test
+    fun `listWebAuthnCredentials succeeds`() = runTest {
+        val result = mockk<AuthListWebAuthnCredentialsResult>()
+        every { delegate.listWebAuthnCredentials(any(), any(), any()) } answers Accept(1, result)
+        auth.listWebAuthnCredentials() shouldBe result
+    }
+
+    @Test
+    fun `listWebAuthnCredentials fails`() = runTest {
+        val error = AuthException("oh", "no")
+        every { delegate.listWebAuthnCredentials(any(), any(), any()) } answers Accept(2, error)
+        shouldThrow<AuthException> { auth.listWebAuthnCredentials() } shouldBe error
+    }
+
+    @Test
+    fun `deleteWebAuthnCredential succeeds`() = runTest {
+        val credentialId = "cred"
+        every { delegate.deleteWebAuthnCredential(credentialId, any(), any(), any()) } answers CallAction(2)
+        auth.deleteWebAuthnCredential(credentialId)
+    }
+
+    @Test
+    fun `deleteWebAuthnCredential fails`() = runTest {
+        val credentialId = "cred"
+        val error = AuthException("oh", "no")
+        every { delegate.deleteWebAuthnCredential(credentialId, any(), any(), any()) } answers Accept(3, error)
+        shouldThrow<AuthException> { auth.deleteWebAuthnCredential(credentialId) } shouldBe error
+    }
+
+    private class CallAction(val index: Int) : Answer<Unit> {
+        override fun answer(call: Call) {
+            val action = call.invocation.args[index] as Action
+            action.call()
+        }
+    }
+
+    private class Accept<T : Any>(val index: Int, val answer: T) : Answer<Unit> {
+        override fun answer(call: Call) {
+            val onSuccess = call.invocation.args[index] as Consumer<T>
+            onSuccess.accept(answer)
+        }
     }
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -478,6 +478,9 @@ public final class com/amplifyframework/api/rest/RestResponse$Data {
 
 public final class com/amplifyframework/auth/AuthCategory : com/amplifyframework/core/category/Category, com/amplifyframework/auth/AuthCategoryBehavior {
 	public fun <init> ()V
+	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public fun autoSignIn (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmResetPasswordOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun confirmSignIn (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignInOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
@@ -486,6 +489,8 @@ public final class com/amplifyframework/auth/AuthCategory : com/amplifyframework
 	public fun confirmSignUp (Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun confirmUserAttribute (Lcom/amplifyframework/auth/AuthUserAttributeKey;Ljava/lang/String;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun deleteUser (Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun fetchAuthSession (Lcom/amplifyframework/auth/options/AuthFetchSessionOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun fetchAuthSession (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun fetchDevices (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
@@ -495,6 +500,8 @@ public final class com/amplifyframework/auth/AuthCategory : com/amplifyframework
 	public fun getCategoryType ()Lcom/amplifyframework/core/category/CategoryType;
 	public fun getCurrentUser (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun handleWebUISignInResponse (Landroid/content/Intent;)V
+	public fun listWebAuthnCredentials (Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
+	public fun listWebAuthnCredentials (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun rememberDevice (Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthResendSignUpCodeOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
@@ -522,6 +529,9 @@ public final class com/amplifyframework/auth/AuthCategory : com/amplifyframework
 }
 
 public abstract interface class com/amplifyframework/auth/AuthCategoryBehavior {
+	public abstract fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public abstract fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public abstract fun autoSignIn (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmResetPasswordOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun confirmSignIn (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignInOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
@@ -530,6 +540,8 @@ public abstract interface class com/amplifyframework/auth/AuthCategoryBehavior {
 	public abstract fun confirmSignUp (Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun confirmUserAttribute (Lcom/amplifyframework/auth/AuthUserAttributeKey;Ljava/lang/String;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun deleteUser (Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public abstract fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
+	public abstract fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun fetchAuthSession (Lcom/amplifyframework/auth/options/AuthFetchSessionOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun fetchAuthSession (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun fetchDevices (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
@@ -538,6 +550,8 @@ public abstract interface class com/amplifyframework/auth/AuthCategoryBehavior {
 	public abstract fun forgetDevice (Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun getCurrentUser (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun handleWebUISignInResponse (Landroid/content/Intent;)V
+	public abstract fun listWebAuthnCredentials (Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
+	public abstract fun listWebAuthnCredentials (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun rememberDevice (Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthResendSignUpCodeOptions;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
 	public abstract fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V
@@ -613,6 +627,18 @@ public final class com/amplifyframework/auth/AuthDevice {
 public class com/amplifyframework/auth/AuthException : com/amplifyframework/AmplifyException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amplifyframework/auth/AuthFactorType : java/lang/Enum {
+	public static final field EMAIL_OTP Lcom/amplifyframework/auth/AuthFactorType;
+	public static final field PASSWORD Lcom/amplifyframework/auth/AuthFactorType;
+	public static final field PASSWORD_SRP Lcom/amplifyframework/auth/AuthFactorType;
+	public static final field SMS_OTP Lcom/amplifyframework/auth/AuthFactorType;
+	public static final field WEB_AUTHN Lcom/amplifyframework/auth/AuthFactorType;
+	public final fun getChallengeResponse ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/amplifyframework/auth/AuthFactorType;
+	public static fun values ()[Lcom/amplifyframework/auth/AuthFactorType;
 }
 
 public abstract class com/amplifyframework/auth/AuthPlugin : com/amplifyframework/auth/AuthCategoryBehavior, com/amplifyframework/core/plugin/Plugin {
@@ -772,6 +798,22 @@ public class com/amplifyframework/auth/exceptions/ValidationException : com/ampl
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public abstract class com/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions {
+	public static final field Companion Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions$Companion;
+	protected fun <init> ()V
+	public static final fun defaults ()Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;
+}
+
+public abstract class com/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions$Builder {
+	public fun <init> ()V
+	public abstract fun build ()Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;
+	public abstract fun getThis ()Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions$Builder;
+}
+
+public final class com/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions$Companion {
+	public final fun defaults ()Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;
+}
+
 public abstract class com/amplifyframework/auth/options/AuthConfirmResetPasswordOptions {
 	public fun <init> ()V
 	public static fun defaults ()Lcom/amplifyframework/auth/options/AuthConfirmResetPasswordOptions$DefaultAuthConfirmResetPasswordOptions;
@@ -823,6 +865,22 @@ public final class com/amplifyframework/auth/options/AuthConfirmSignUpOptions$De
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class com/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions {
+	public static final field Companion Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions$Companion;
+	protected fun <init> ()V
+	public static final fun defaults ()Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;
+}
+
+public abstract class com/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions$Builder {
+	public fun <init> ()V
+	public abstract fun build ()Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;
+	public abstract fun getThis ()Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions$Builder;
+}
+
+public final class com/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions$Companion {
+	public final fun defaults ()Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;
+}
+
 public class com/amplifyframework/auth/options/AuthFetchSessionOptions {
 	public static final field Companion Lcom/amplifyframework/auth/options/AuthFetchSessionOptions$Companion;
 	protected fun <init> (Z)V
@@ -851,6 +909,22 @@ public final class com/amplifyframework/auth/options/AuthFetchSessionOptions$Cor
 	public fun <init> ()V
 	public synthetic fun getThis ()Lcom/amplifyframework/auth/options/AuthFetchSessionOptions$Builder;
 	public fun getThis ()Lcom/amplifyframework/auth/options/AuthFetchSessionOptions$CoreBuilder;
+}
+
+public abstract class com/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions {
+	public static final field Companion Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions$Companion;
+	protected fun <init> ()V
+	public static final fun defaults ()Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;
+}
+
+public abstract class com/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions$Builder {
+	public fun <init> ()V
+	public abstract fun build ()Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;
+	public abstract fun getThis ()Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions$Builder;
+}
+
+public final class com/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions$Companion {
+	public final fun defaults ()Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;
 }
 
 public abstract class com/amplifyframework/auth/options/AuthResendSignUpCodeOptions {
@@ -1042,6 +1116,10 @@ public final class com/amplifyframework/auth/options/AuthWebUISignInOptions$Core
 	public fun getThis ()Lcom/amplifyframework/auth/options/AuthWebUISignInOptions$CoreBuilder;
 }
 
+public abstract interface class com/amplifyframework/auth/result/AuthListWebAuthnCredentialsResult {
+	public abstract fun getCredentials ()Ljava/util/List;
+}
+
 public final class com/amplifyframework/auth/result/AuthResetPasswordResult {
 	public fun <init> (ZLcom/amplifyframework/auth/result/step/AuthNextResetPasswordStep;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -1101,6 +1179,13 @@ public final class com/amplifyframework/auth/result/AuthUpdateAttributeResult {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/amplifyframework/auth/result/AuthWebAuthnCredential {
+	public abstract fun getCreatedAt ()Ljava/time/Instant;
+	public abstract fun getCredentialId ()Ljava/lang/String;
+	public abstract fun getFriendlyName ()Ljava/lang/String;
+	public abstract fun getRelyingPartyId ()Ljava/lang/String;
+}
+
 public final class com/amplifyframework/auth/result/step/AuthNextResetPasswordStep {
 	public fun <init> (Lcom/amplifyframework/auth/result/step/AuthResetPasswordStep;Ljava/util/Map;Lcom/amplifyframework/auth/AuthCodeDeliveryDetails;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -1112,10 +1197,11 @@ public final class com/amplifyframework/auth/result/step/AuthNextResetPasswordSt
 }
 
 public final class com/amplifyframework/auth/result/step/AuthNextSignInStep {
-	public fun <init> (Lcom/amplifyframework/auth/result/step/AuthSignInStep;Ljava/util/Map;Lcom/amplifyframework/auth/AuthCodeDeliveryDetails;Lcom/amplifyframework/auth/TOTPSetupDetails;Ljava/util/Set;)V
+	public fun <init> (Lcom/amplifyframework/auth/result/step/AuthSignInStep;Ljava/util/Map;Lcom/amplifyframework/auth/AuthCodeDeliveryDetails;Lcom/amplifyframework/auth/TOTPSetupDetails;Ljava/util/Set;Ljava/util/Set;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAdditionalInfo ()Ljava/util/Map;
 	public fun getAllowedMFATypes ()Ljava/util/Set;
+	public fun getAvailableFactors ()Ljava/util/Set;
 	public fun getCodeDeliveryDetails ()Lcom/amplifyframework/auth/AuthCodeDeliveryDetails;
 	public fun getSignInStep ()Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public fun getTotpSetupDetails ()Lcom/amplifyframework/auth/TOTPSetupDetails;
@@ -1154,10 +1240,12 @@ public final class com/amplifyframework/auth/result/step/AuthSignInStep : java/l
 	public static final field CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONFIRM_SIGN_IN_WITH_NEW_PASSWORD Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONFIRM_SIGN_IN_WITH_OTP Lcom/amplifyframework/auth/result/step/AuthSignInStep;
+	public static final field CONFIRM_SIGN_IN_WITH_PASSWORD Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONFIRM_SIGN_IN_WITH_TOTP_CODE Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONFIRM_SIGN_UP Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONTINUE_SIGN_IN_WITH_EMAIL_MFA_SETUP Lcom/amplifyframework/auth/result/step/AuthSignInStep;
+	public static final field CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONTINUE_SIGN_IN_WITH_MFA_SELECTION Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION Lcom/amplifyframework/auth/result/step/AuthSignInStep;
 	public static final field CONTINUE_SIGN_IN_WITH_TOTP_SETUP Lcom/amplifyframework/auth/result/step/AuthSignInStep;
@@ -1168,6 +1256,7 @@ public final class com/amplifyframework/auth/result/step/AuthSignInStep : java/l
 }
 
 public final class com/amplifyframework/auth/result/step/AuthSignUpStep : java/lang/Enum {
+	public static final field COMPLETE_AUTO_SIGN_IN Lcom/amplifyframework/auth/result/step/AuthSignUpStep;
 	public static final field CONFIRM_SIGN_UP_STEP Lcom/amplifyframework/auth/result/step/AuthSignUpStep;
 	public static final field DONE Lcom/amplifyframework/auth/result/step/AuthSignUpStep;
 	public static fun valueOf (Ljava/lang/String;)Lcom/amplifyframework/auth/result/step/AuthSignUpStep;

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -20,10 +20,13 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions;
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions;
 import com.amplifyframework.auth.options.AuthFetchSessionOptions;
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions;
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions;
 import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthResetPasswordOptions;
@@ -34,6 +37,7 @@ import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
 import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
 import com.amplifyframework.auth.result.AuthSignOutResult;
@@ -63,7 +67,7 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     @Override
     public void signUp(
             @NonNull String username,
-            @NonNull String password,
+            @Nullable String password,
             @NonNull AuthSignUpOptions options,
             @NonNull Consumer<AuthSignUpResult> onSuccess,
             @NonNull Consumer<AuthException> onError
@@ -411,6 +415,69 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     public void verifyTOTPSetup(@NonNull String code, @NonNull AuthVerifyTOTPSetupOptions options,
                                 @NonNull Action onSuccess, @NonNull Consumer<AuthException> onError) {
         getSelectedPlugin().verifyTOTPSetup(code, options, onSuccess, onError);
+    }
+
+    @Override
+    public void associateWebAuthnCredential(
+            @NonNull Activity callingActivity,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().associateWebAuthnCredential(callingActivity, onSuccess, onError);
+    }
+
+    @Override
+    public void associateWebAuthnCredential(
+            @NonNull Activity callingActivity,
+            @NonNull AuthAssociateWebAuthnCredentialsOptions options,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().associateWebAuthnCredential(callingActivity, options, onSuccess, onError);
+    }
+
+    @Override
+    public void listWebAuthnCredentials(
+            @NonNull Consumer<AuthListWebAuthnCredentialsResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().listWebAuthnCredentials(onSuccess, onError);
+    }
+
+    @Override
+    public void listWebAuthnCredentials(
+            @NonNull AuthListWebAuthnCredentialsOptions options,
+            @NonNull Consumer<AuthListWebAuthnCredentialsResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().listWebAuthnCredentials(options, onSuccess, onError);
+    }
+
+    @Override
+    public void deleteWebAuthnCredential(
+            @NonNull String credentialId,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().deleteWebAuthnCredential(credentialId, onSuccess, onError);
+    }
+
+    @Override
+    public void deleteWebAuthnCredential(
+            @NonNull String credentialId,
+            @NonNull AuthDeleteWebAuthnCredentialOptions options,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().deleteWebAuthnCredential(credentialId, options, onSuccess, onError);
+    }
+
+    @Override
+    public void autoSignIn(
+            @NonNull Consumer<AuthSignInResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().autoSignIn(onSuccess, onError);
     }
 }
 

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -20,10 +20,13 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions;
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions;
 import com.amplifyframework.auth.options.AuthFetchSessionOptions;
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions;
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions;
 import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthResetPasswordOptions;
@@ -34,6 +37,7 @@ import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
 import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
 import com.amplifyframework.auth.result.AuthSignOutResult;
@@ -61,7 +65,7 @@ public interface AuthCategoryBehavior {
      */
     void signUp(
             @NonNull String username,
-            @NonNull String password,
+            @Nullable String password,
             @NonNull AuthSignUpOptions options,
             @NonNull Consumer<AuthSignUpResult> onSuccess,
             @NonNull Consumer<AuthException> onError);
@@ -547,5 +551,93 @@ public interface AuthCategoryBehavior {
         @NonNull AuthVerifyTOTPSetupOptions options,
         @NonNull Action onSuccess,
         @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Create and register a passkey on this device, enabling passwordless sign in using passkeys.
+     * The user must be signed in to call this API.
+     * @param callingActivity The current Activity instance, used for launching the CredentialManager UI
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void associateWebAuthnCredential(
+        @NonNull Activity callingActivity,
+        @NonNull Action onSuccess,
+        @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Create and register a passkey on this device, enabling passwordless sign in using passkeys.
+     * The user must be signed in to call this API.
+     * @param callingActivity The current Activity instance, used for launching the CredentialManager UI
+     * @param options Advanced options for associating credentials
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void associateWebAuthnCredential(
+            @NonNull Activity callingActivity,
+            @NonNull AuthAssociateWebAuthnCredentialsOptions options,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Retrieve a list of WebAuthn credentials that are associated with the user's account.
+     * The user must be signed in to call this API.
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void listWebAuthnCredentials(
+        @NonNull Consumer<AuthListWebAuthnCredentialsResult> onSuccess,
+        @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Retrieve a list of WebAuthn credentials that are associated with the user's account.
+     * The user must be signed in to call this API.
+     * @param options Advanced options for listing credentials
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void listWebAuthnCredentials(
+            @NonNull AuthListWebAuthnCredentialsOptions options,
+            @NonNull Consumer<AuthListWebAuthnCredentialsResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Delete the credential matching the given identifier.
+     * @param credentialId The identifier for the credential to delete
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void deleteWebAuthnCredential(
+        @NonNull String credentialId,
+        @NonNull Action onSuccess,
+        @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Delete the credential matching the given identifier.
+     * @param credentialId The identifier for the credential to delete
+     * @param options Advanced options for deleting credentials
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void deleteWebAuthnCredential(
+            @NonNull String credentialId,
+            @NonNull AuthDeleteWebAuthnCredentialOptions options,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
+    );
+
+    /**
+     * Automatically sign in the user.
+     * @param onSuccess Success callback
+     * @param onError Error callback
+     */
+    void autoSignIn(
+            @NonNull Consumer<AuthSignInResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
     );
 }

--- a/core/src/main/java/com/amplifyframework/auth/AuthFactorType.kt
+++ b/core/src/main/java/com/amplifyframework/auth/AuthFactorType.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.auth
+
+/**
+ * Enumeration of the possible mechanisms that can be used to authenticate a user when signing in with USER_AUTH.
+ * @param challengeResponse The response that should be sent to select a factor during the
+ *                          CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION step.
+ */
+enum class AuthFactorType(val challengeResponse: String) {
+    /**
+     * Sign in using the user's password
+     */
+    PASSWORD("PASSWORD"),
+
+    /**
+     * Sign in using the user's password via a Secure Remote Password flow
+     */
+    PASSWORD_SRP("PASSWORD_SRP"),
+
+    /**
+     * Sign in using a One Time Password sent to the user's email address
+     */
+    EMAIL_OTP("EMAIL_OTP"),
+
+    /**
+     * Sign in using a One Time Password sent to the user's SMS number
+     */
+    SMS_OTP("SMS_OTP"),
+
+    /**
+     * Sign in with WebAuthn (i.e. PassKey)
+     */
+    WEB_AUTHN("WEB_AUTHN")
+}

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions.kt
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options
+
+/**
+ * The shared options among all Auth plugins.
+ */
+abstract class AuthAssociateWebAuthnCredentialsOptions protected constructor() {
+    companion object {
+        /**
+         * Use the default associateWebAuthnCredential options.
+         * @return Default associateWebAuthnCredential options.
+         */
+        @JvmStatic
+        fun defaults(): AuthAssociateWebAuthnCredentialsOptions = DefaultAuthAssociateWebAuthnCredentialOptions()
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    abstract class Builder<T : Builder<T>> {
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        abstract fun getThis(): T
+
+        /**
+         * Build an instance of AuthAssociateWebAuthnCredentialsOptions (or one of its subclasses).
+         * @return an instance of AuthAssociateWebAuthnCredentialsOptions (or one of its subclasses)
+         */
+        abstract fun build(): AuthAssociateWebAuthnCredentialsOptions
+    }
+
+    private class DefaultAuthAssociateWebAuthnCredentialOptions : AuthAssociateWebAuthnCredentialsOptions() {
+        override fun hashCode() = javaClass.hashCode()
+        override fun toString() = javaClass.simpleName
+        override fun equals(other: Any?) = other is DefaultAuthAssociateWebAuthnCredentialOptions
+    }
+}

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions.kt
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options
+
+/**
+ * The shared options among all Auth plugins.
+ */
+abstract class AuthDeleteWebAuthnCredentialOptions protected constructor() {
+    companion object {
+        /**
+         * Use the default deleteWebAuthnCredential options.
+         * @return Default deleteWebAuthnCredential options.
+         */
+        @JvmStatic
+        fun defaults(): AuthDeleteWebAuthnCredentialOptions = DefaultAuthDeleteWebAuthnCredentialOptions()
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    abstract class Builder<T : Builder<T>> {
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        abstract fun getThis(): T
+
+        /**
+         * Build an instance of AuthDeleteWebAuthnCredentialOptions (or one of its subclasses).
+         * @return an instance of AuthDeleteWebAuthnCredentialOptions (or one of its subclasses)
+         */
+        abstract fun build(): AuthDeleteWebAuthnCredentialOptions
+    }
+
+    private class DefaultAuthDeleteWebAuthnCredentialOptions : AuthDeleteWebAuthnCredentialOptions() {
+        override fun hashCode() = javaClass.hashCode()
+        override fun toString() = javaClass.simpleName
+        override fun equals(other: Any?) = other is DefaultAuthDeleteWebAuthnCredentialOptions
+    }
+}

--- a/core/src/main/java/com/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions.kt
+++ b/core/src/main/java/com/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.options
+
+/**
+ * The shared options among all Auth plugins.
+ */
+abstract class AuthListWebAuthnCredentialsOptions protected constructor() {
+    companion object {
+        /**
+         * Use the default listWebAuthnCredentials options.
+         * @return Default listWebAuthnCredentials options.
+         */
+        @JvmStatic
+        fun defaults(): AuthListWebAuthnCredentialsOptions = DefaultAuthListWebAuthnCredentialsOptions()
+    }
+
+    /**
+     * The builder for this class.
+     * @param <T> The type of builder - used to support plugin extensions of this.
+     */
+    abstract class Builder<T : Builder<T>> {
+        /**
+         * Return the type of builder this is so that chaining can work correctly without implicit casting.
+         * @return the type of builder this is
+         */
+        abstract fun getThis(): T
+        /**
+         * Build an instance of AuthListWebAuthnCredentialsOptions (or one of its subclasses).
+         * @return an instance of AuthListWebAuthnCredentialsOptions (or one of its subclasses)
+         */
+        abstract fun build(): AuthListWebAuthnCredentialsOptions
+    }
+
+    private class DefaultAuthListWebAuthnCredentialsOptions : AuthListWebAuthnCredentialsOptions() {
+        override fun hashCode() = javaClass.hashCode()
+        override fun toString() = javaClass.simpleName
+        override fun equals(other: Any?) = other is DefaultAuthListWebAuthnCredentialsOptions
+    }
+}

--- a/core/src/main/java/com/amplifyframework/auth/result/AuthListWebAuthnCredentialsResult.kt
+++ b/core/src/main/java/com/amplifyframework/auth/result/AuthListWebAuthnCredentialsResult.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.result
+
+import java.time.Instant
+
+/**
+ * A WebAuthn credential associated with the user's account
+ */
+interface AuthWebAuthnCredential {
+    /**
+     * The identifier for the credential
+     */
+    val credentialId: String
+
+    /**
+     * The user-readable credential name
+     */
+    val friendlyName: String?
+
+    /**
+     * The ID of the Relying Party used when registering the passkey
+     */
+    val relyingPartyId: String
+
+    /**
+     * When the credential was registered
+     */
+    val createdAt: Instant
+}
+
+/**
+ * The result returned from the listWebAuthnCredentials API
+ */
+interface AuthListWebAuthnCredentialsResult {
+    /**
+     * The returned credentials
+     */
+    val credentials: List<AuthWebAuthnCredential>
+}

--- a/core/src/main/java/com/amplifyframework/auth/result/step/AuthNextSignInStep.java
+++ b/core/src/main/java/com/amplifyframework/auth/result/step/AuthNextSignInStep.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.auth.AuthCodeDeliveryDetails;
+import com.amplifyframework.auth.AuthFactorType;
 import com.amplifyframework.auth.MFAType;
 import com.amplifyframework.auth.TOTPSetupDetails;
 
@@ -40,6 +41,7 @@ public final class AuthNextSignInStep {
 
     private final TOTPSetupDetails totpSetupDetails;
     private final Set<MFAType> allowedMFATypes;
+    private final Set<AuthFactorType> availableFactors;
 
     /**
      * Gives details on the next step, if there is one, in the sign in flow.
@@ -48,19 +50,23 @@ public final class AuthNextSignInStep {
      * @param codeDeliveryDetails Details about how a code was sent, if relevant to the current step
      * @param totpSetupDetails Details to setup TOTP, if relevant to the current step
      * @param allowedMFATypes Set of allowed MFA type, if relevant to the current step
+     * @param availableFactors Set of available AuthFactorType to choose from, if relevant to the
+     *                         current step
      */
     public AuthNextSignInStep(
             @NonNull AuthSignInStep signInStep,
             @NonNull Map<String, String> additionalInfo,
             @Nullable AuthCodeDeliveryDetails codeDeliveryDetails,
             @Nullable TOTPSetupDetails totpSetupDetails,
-            @Nullable Set<MFAType> allowedMFATypes) {
+            @Nullable Set<MFAType> allowedMFATypes,
+            @Nullable Set<AuthFactorType> availableFactors) {
         this.signInStep = Objects.requireNonNull(signInStep);
         this.additionalInfo = new HashMap<>();
         this.additionalInfo.putAll(Objects.requireNonNull(additionalInfo));
         this.codeDeliveryDetails = codeDeliveryDetails;
         this.totpSetupDetails = totpSetupDetails;
         this.allowedMFATypes = allowedMFATypes;
+        this.availableFactors = availableFactors;
     }
 
     /**
@@ -109,6 +115,15 @@ public final class AuthNextSignInStep {
     }
 
     /**
+     * Set of available auth factors.
+     * @return Set of available auth factors, if relevant to the current step - null otherwise
+     */
+    @Nullable
+    public Set<AuthFactorType> getAvailableFactors() {
+        return availableFactors;
+    }
+
+    /**
      * When overriding, be sure to include signInStep, additionalInfo, and codeDeliveryDetails in the hash.
      * @return Hash code of this object
      */
@@ -119,7 +134,8 @@ public final class AuthNextSignInStep {
                 getAdditionalInfo(),
                 getCodeDeliveryDetails(),
                 getTotpSetupDetails(),
-                getAllowedMFATypes()
+                getAllowedMFATypes(),
+                getAvailableFactors()
         );
     }
 
@@ -139,7 +155,8 @@ public final class AuthNextSignInStep {
                     ObjectsCompat.equals(getAdditionalInfo(), authSignUpResult.getAdditionalInfo()) &&
                     ObjectsCompat.equals(getCodeDeliveryDetails(), authSignUpResult.getCodeDeliveryDetails()) &&
                     ObjectsCompat.equals(getTotpSetupDetails(), authSignUpResult.getTotpSetupDetails()) &&
-                    ObjectsCompat.equals(getAllowedMFATypes(), authSignUpResult.getAllowedMFATypes());
+                    ObjectsCompat.equals(getAllowedMFATypes(), authSignUpResult.getAllowedMFATypes()) &&
+                    ObjectsCompat.equals(getAvailableFactors(), authSignUpResult.getAvailableFactors());
         }
     }
 
@@ -155,6 +172,7 @@ public final class AuthNextSignInStep {
                 ", codeDeliveryDetails=" + getCodeDeliveryDetails() +
                 ", totpSetupDetails=" + getTotpSetupDetails() +
                 ", allowedMFATypes=" + getAllowedMFATypes() +
+                ", availableFactors=" + getAvailableFactors() +
                 '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/auth/result/step/AuthSignInStep.java
+++ b/core/src/main/java/com/amplifyframework/auth/result/step/AuthSignInStep.java
@@ -94,12 +94,26 @@ public enum AuthSignInStep {
     CONFIRM_SIGN_IN_WITH_TOTP_CODE,
 
     /**
+     * The user is required to select which form of first factor authentication to use
+     * Call {@link com.amplifyframework.auth.AuthCategoryBehavior#confirmSignIn(String, Consumer, Consumer)}
+     * with the preferred {@link com.amplifyframework.auth.AuthFactorType}.challengeResponse.
+     */
+    CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION,
+
+    /**
      * MFA is enabled on this account and requires the user to confirm with the code received by
      * email, sms, etc.
      * Call {@link com.amplifyframework.auth.AuthCategoryBehavior#confirmSignIn(String, Consumer, Consumer)}
      * with the OTP code.
      */
     CONFIRM_SIGN_IN_WITH_OTP,
+
+    /**
+     * The user is required to provide a password for authentication
+     * Call {@link com.amplifyframework.auth.AuthCategoryBehavior#confirmSignIn(String, Consumer, Consumer)}
+     * with the password.
+     */
+    CONFIRM_SIGN_IN_WITH_PASSWORD,
 
     /**
      * No further steps are needed in the sign in flow.

--- a/core/src/main/java/com/amplifyframework/auth/result/step/AuthSignUpStep.java
+++ b/core/src/main/java/com/amplifyframework/auth/result/step/AuthSignUpStep.java
@@ -28,5 +28,10 @@ public enum AuthSignUpStep {
     /**
      * The flow is completed and no further steps are needed.
      */
-    DONE;
+    DONE,
+
+    /**
+     * Auto sign in needs to be called to complete sign up workflow.
+     */
+    COMPLETE_AUTO_SIGN_IN
 }

--- a/core/src/test/java/com/amplifyframework/auth/AuthPluginTest.kt
+++ b/core/src/test/java/com/amplifyframework/auth/AuthPluginTest.kt
@@ -18,10 +18,13 @@ package com.amplifyframework.auth
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions
 import com.amplifyframework.auth.options.AuthFetchSessionOptions
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions
 import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions
 import com.amplifyframework.auth.options.AuthResetPasswordOptions
@@ -31,6 +34,7 @@ import com.amplifyframework.auth.options.AuthSignUpOptions
 import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions
 import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions
 import com.amplifyframework.auth.options.AuthWebUISignInOptions
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult
 import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.AuthSignOutResult
@@ -62,7 +66,7 @@ class AuthPluginTest {
     private class TestPlugin : AuthPlugin<Unit>() {
         override fun signUp(
             username: String,
-            password: String,
+            password: String?,
             options: AuthSignUpOptions,
             onSuccess: Consumer<AuthSignUpResult>,
             onError: Consumer<AuthException>
@@ -229,6 +233,41 @@ class AuthPluginTest {
         override fun signOut(onComplete: Consumer<AuthSignOutResult>) {}
         override fun signOut(options: AuthSignOutOptions, onComplete: Consumer<AuthSignOutResult>) {}
         override fun deleteUser(onSuccess: Action, onError: Consumer<AuthException>) {}
+        override fun listWebAuthnCredentials(
+            onSuccess: Consumer<AuthListWebAuthnCredentialsResult>,
+            onError: Consumer<AuthException>
+        ) {}
+        override fun listWebAuthnCredentials(
+            options: AuthListWebAuthnCredentialsOptions,
+            onSuccess: Consumer<AuthListWebAuthnCredentialsResult>,
+            onError: Consumer<AuthException>
+        ) { }
+        override fun autoSignIn(onSuccess: Consumer<AuthSignInResult>, onError: Consumer<AuthException>) {}
+        override fun associateWebAuthnCredential(
+            callingActivity: Activity,
+            onSuccess: Action,
+            onError: Consumer<AuthException>
+        ) {}
+
+        override fun associateWebAuthnCredential(
+            callingActivity: Activity,
+            options: AuthAssociateWebAuthnCredentialsOptions,
+            onSuccess: Action,
+            onError: Consumer<AuthException>
+        ) {}
+
+        override fun deleteWebAuthnCredential(
+            credentialId: String,
+            onSuccess: Action,
+            onError: Consumer<AuthException>
+        ) {}
+
+        override fun deleteWebAuthnCredential(
+            credentialId: String,
+            options: AuthDeleteWebAuthnCredentialOptions,
+            onSuccess: Action,
+            onError: Consumer<AuthException>
+        ) {}
         override fun getPluginKey() = ""
         override fun configure(pluginConfiguration: JSONObject?, context: Context) {}
         override fun getEscapeHatch() = Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-appcompat = "1.2.0"
 androidx-browser = "1.4.0"
 androidx-concurrent = "1.1.0"
 androidx-core = "1.5.0"
+androidx-credentials = "1.3.0"
 androidx-fragment = "1.3.1"
 androidx-legacy = "1.0.0"
 androidx-lifecycle = "2.4.1"
@@ -60,6 +61,7 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref="and
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-credentials = { module = "androidx.credentials:credentials", version.ref="androidx-credentials" }
 androidx-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junit-ktx" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidx-lifecycle" }
 androidx-nav-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "navigation" }

--- a/rxbindings/api/rxbindings.api
+++ b/rxbindings/api/rxbindings.api
@@ -28,6 +28,9 @@ public abstract interface class com/amplifyframework/rx/RxApiCategoryBehavior : 
 }
 
 public abstract interface class com/amplifyframework/rx/RxAuthCategoryBehavior {
+	public abstract fun associateWebAuthnCredential (Landroid/app/Activity;)Lio/reactivex/rxjava3/core/Completable;
+	public abstract fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;)Lio/reactivex/rxjava3/core/Completable;
+	public abstract fun autoSignIn ()Lio/reactivex/rxjava3/core/Single;
 	public abstract fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/rxjava3/core/Completable;
 	public abstract fun confirmResetPassword (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmResetPasswordOptions;)Lio/reactivex/rxjava3/core/Completable;
 	public abstract fun confirmSignIn (Ljava/lang/String;)Lio/reactivex/rxjava3/core/Single;
@@ -36,6 +39,8 @@ public abstract interface class com/amplifyframework/rx/RxAuthCategoryBehavior {
 	public abstract fun confirmSignUp (Ljava/lang/String;Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthConfirmSignUpOptions;)Lio/reactivex/rxjava3/core/Single;
 	public abstract fun confirmUserAttribute (Lcom/amplifyframework/auth/AuthUserAttributeKey;Ljava/lang/String;)Lio/reactivex/rxjava3/core/Completable;
 	public abstract fun deleteUser ()Lio/reactivex/rxjava3/core/Completable;
+	public abstract fun deleteWebAuthnCredential (Ljava/lang/String;)Lio/reactivex/rxjava3/core/Completable;
+	public abstract fun deleteWebAuthnCredential (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthDeleteWebAuthnCredentialOptions;)Lio/reactivex/rxjava3/core/Completable;
 	public abstract fun fetchAuthSession ()Lio/reactivex/rxjava3/core/Single;
 	public abstract fun fetchAuthSession (Lcom/amplifyframework/auth/options/AuthFetchSessionOptions;)Lio/reactivex/rxjava3/core/Single;
 	public abstract fun fetchDevices ()Lio/reactivex/rxjava3/core/Single;
@@ -44,6 +49,8 @@ public abstract interface class com/amplifyframework/rx/RxAuthCategoryBehavior {
 	public abstract fun forgetDevice (Lcom/amplifyframework/auth/AuthDevice;)Lio/reactivex/rxjava3/core/Completable;
 	public abstract fun getCurrentUser ()Lio/reactivex/rxjava3/core/Single;
 	public abstract fun handleWebUISignInResponse (Landroid/content/Intent;)V
+	public abstract fun listWebAuthnCredentials ()Lio/reactivex/rxjava3/core/Single;
+	public abstract fun listWebAuthnCredentials (Lcom/amplifyframework/auth/options/AuthListWebAuthnCredentialsOptions;)Lio/reactivex/rxjava3/core/Single;
 	public abstract fun rememberDevice ()Lio/reactivex/rxjava3/core/Completable;
 	public abstract fun resendSignUpCode (Ljava/lang/String;)Lio/reactivex/rxjava3/core/Single;
 	public abstract fun resendSignUpCode (Ljava/lang/String;Lcom/amplifyframework/auth/options/AuthResendSignUpCodeOptions;)Lio/reactivex/rxjava3/core/Single;

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -31,10 +31,13 @@ import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.TOTPSetupDetails;
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions;
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions;
 import com.amplifyframework.auth.options.AuthFetchSessionOptions;
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions;
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions;
 import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthResetPasswordOptions;
@@ -45,6 +48,7 @@ import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
 import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
 import com.amplifyframework.auth.result.AuthSignOutResult;
@@ -117,7 +121,7 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
 
     @Override
     public Single<AuthSignInResult> confirmSignIn(
-            @Nullable String challengeResponse, @NonNull AuthConfirmSignInOptions options) {
+            @NonNull String challengeResponse, @NonNull AuthConfirmSignInOptions options) {
         return toSingle((onResult, onError) ->
                 delegate.confirmSignIn(challengeResponse, options, onResult, onError));
     }
@@ -125,6 +129,11 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
     @Override
     public Single<AuthSignInResult> confirmSignIn(@NonNull String challengeResponse) {
         return toSingle((onResult, onError) -> delegate.confirmSignIn(challengeResponse, onResult, onError));
+    }
+
+    @Override
+    public Single<AuthSignInResult> autoSignIn() {
+        return toSingle(delegate::autoSignIn);
     }
 
     @Override
@@ -329,6 +338,48 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
     @Override
     public Completable verifyTOTPSetup(@NonNull String code, @NonNull AuthVerifyTOTPSetupOptions options) {
         return toCompletable((onComplete, onError) -> delegate.verifyTOTPSetup(code, options, onComplete, onError));
+    }
+
+    @Override
+    public Completable associateWebAuthnCredential(@NonNull Activity callingActivity) {
+        return toCompletable((onComplete, onError) ->
+                delegate.associateWebAuthnCredential(callingActivity, onComplete, onError));
+    }
+
+    @Override
+    public Completable associateWebAuthnCredential(
+            @NonNull Activity callingActivity,
+            @NonNull AuthAssociateWebAuthnCredentialsOptions options
+    ) {
+        return toCompletable((onComplete, onError) ->
+                delegate.associateWebAuthnCredential(callingActivity, options, onComplete, onError));
+    }
+
+    @Override
+    public Single<AuthListWebAuthnCredentialsResult> listWebAuthnCredentials() {
+        return toSingle(delegate::listWebAuthnCredentials);
+    }
+
+    @Override
+    public Single<AuthListWebAuthnCredentialsResult> listWebAuthnCredentials(
+            @NonNull AuthListWebAuthnCredentialsOptions options
+    ) {
+        return toSingle(delegate::listWebAuthnCredentials);
+    }
+
+    @Override
+    public Completable deleteWebAuthnCredential(@NonNull String credentialId) {
+        return toCompletable((onComplete, onError) ->
+                delegate.deleteWebAuthnCredential(credentialId, onComplete, onError));
+    }
+
+    @Override
+    public Completable deleteWebAuthnCredential(
+            @NonNull String credentialId,
+            @NonNull AuthDeleteWebAuthnCredentialOptions options
+    ) {
+        return toCompletable(((onComplete, onError) ->
+                delegate.deleteWebAuthnCredential(credentialId, options, onComplete, onError)));
     }
 
     private <T> Single<T> toSingle(VoidBehaviors.ResultEmitter<T, AuthException> behavior) {

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -30,10 +30,13 @@ import com.amplifyframework.auth.AuthUser;
 import com.amplifyframework.auth.AuthUserAttribute;
 import com.amplifyframework.auth.AuthUserAttributeKey;
 import com.amplifyframework.auth.TOTPSetupDetails;
+import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions;
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions;
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions;
+import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions;
 import com.amplifyframework.auth.options.AuthFetchSessionOptions;
+import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions;
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions;
 import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions;
 import com.amplifyframework.auth.options.AuthResetPasswordOptions;
@@ -44,11 +47,13 @@ import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions;
 import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions;
 import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions;
 import com.amplifyframework.auth.options.AuthWebUISignInOptions;
+import com.amplifyframework.auth.result.AuthListWebAuthnCredentialsResult;
 import com.amplifyframework.auth.result.AuthResetPasswordResult;
 import com.amplifyframework.auth.result.AuthSignInResult;
 import com.amplifyframework.auth.result.AuthSignOutResult;
 import com.amplifyframework.auth.result.AuthSignUpResult;
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult;
+import com.amplifyframework.auth.result.AuthWebAuthnCredential;
 
 import java.util.List;
 import java.util.Map;
@@ -156,7 +161,7 @@ public interface RxAuthCategoryBehavior {
      *         {@link AuthException} on failure
      */
     Single<AuthSignInResult> confirmSignIn(
-            @Nullable String challengeResponse,
+            @NonNull String challengeResponse,
             @NonNull AuthConfirmSignInOptions options
     );
 
@@ -167,6 +172,13 @@ public interface RxAuthCategoryBehavior {
      *         {@link AuthException} on failure
      */
     Single<AuthSignInResult> confirmSignIn(@NonNull String challengeResponse);
+
+    /**
+     * Sign in the user after signed up confirmation.
+     * @return An Rx {@link Single} which emits {@link AuthSignInResult} on success,
+     *         {@link AuthException} on failure
+     */
+    Single<AuthSignInResult> autoSignIn();
 
     /**
      * Launch the specified auth provider's web UI sign in experience. You should also put the
@@ -462,4 +474,62 @@ public interface RxAuthCategoryBehavior {
      */
     Completable verifyTOTPSetup(@NonNull String code, @NonNull AuthVerifyTOTPSetupOptions options);
 
+    /**
+     * Create and register a passkey on this device, enabling passwordless sign in using passkeys.
+     * The user must be signed in to call this API.
+     * @param callingActivity The current Activity instance, used for launching the CredentialManager UI
+     * @return An Rx {@link Completable} which completes upon successfully associating a new credential;
+     *         emits an {@link AuthException} otherwise
+     */
+    Completable associateWebAuthnCredential(@NonNull Activity callingActivity);
+
+    /**
+     * Create and register a passkey on this device, enabling passwordless sign in using passkeys.
+     * The user must be signed in to call this API.
+     * @param callingActivity The current Activity instance, used for launching the CredentialManager UI
+     * @param options Advanced options for associating credentials
+     * @return An Rx {@link Completable} which completes upon successfully associating a new credential;
+     *         emits an {@link AuthException} otherwise
+     */
+    Completable associateWebAuthnCredential(
+            @NonNull Activity callingActivity,
+            @NonNull AuthAssociateWebAuthnCredentialsOptions options
+    );
+
+    /**
+     * Retrieve a list of WebAuthn credentials that are associated with the user's account.
+     * The user must be signed in to call this API.
+     * @return An Rx {@link Single} which emits a list of {@link AuthWebAuthnCredential} on completion
+     */
+    Single<AuthListWebAuthnCredentialsResult> listWebAuthnCredentials();
+
+    /**
+     * Retrieve a list of WebAuthn credentials that are associated with the user's account.
+     * The user must be signed in to call this API.
+     * @param options Advanced options for listing credentials
+     * @return An Rx {@link Single} which emits a list of {@link AuthWebAuthnCredential} on completion
+     */
+    Single<AuthListWebAuthnCredentialsResult> listWebAuthnCredentials(
+            @NonNull AuthListWebAuthnCredentialsOptions options
+    );
+
+    /**
+     * Delete the credential matching the given identifier.
+     * @param credentialId The identifier for the credential to delete
+     * @return An Rx {@link Completable} which completes upon successfully deleting the credential;
+     *         emits an {@link AuthException} otherwise
+     */
+    Completable deleteWebAuthnCredential(@NonNull String credentialId);
+
+    /**
+     * Delete the credential matching the given identifier.
+     * @param credentialId The identifier for the credential to delete
+     * @param options Advanced options for deleting credentials
+     * @return An Rx {@link Completable} which completes upon successfully deleting the credential;
+     *         emits an {@link AuthException} otherwise
+     */
+    Completable deleteWebAuthnCredential(
+            @NonNull String credentialId,
+            @NonNull AuthDeleteWebAuthnCredentialOptions options
+    );
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         maven {
             url = uri("https://aws.oss.sonatype.org/content/repositories/snapshots/")

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -129,7 +129,7 @@ public final class SynchronousAuth {
     @NonNull
     public AuthSignUpResult signUp(
             @NonNull String username,
-            @NonNull String password,
+            @Nullable String password,
             @NonNull AuthSignUpOptions options
     ) throws AuthException {
         return Await.<AuthSignUpResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
@@ -271,6 +271,16 @@ public final class SynchronousAuth {
         return Await.<AuthSignInResult, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
                 asyncDelegate.confirmSignIn(challengeResponse, onResult, onError)
         );
+    }
+
+    /**
+     * Automatically sign in synchronously.
+     * @return result object
+     * @throws AuthException exception
+     */
+    @NonNull
+    public AuthSignInResult autoSignIn() throws AuthException {
+        return Await.result(AUTH_OPERATION_TIMEOUT_MS, asyncDelegate::autoSignIn);
     }
 
     /**


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
This PR adds support for Cognito's new [Passwordless Sign In Flows](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow-methods.html#amazon-cognito-user-pools-authentication-flow-methods-passwordless).

This includes the following new functionality for the Auth category:
- Passwordless Sign-Up using a One Time Passcode (OTP) sent to a user's email address or SMS number
- Auto-Sign In feature to sign in directly after signing up, without needing to re-enter the user's information
- New USER_AUTH flow that can be used to sign in with any of the following mechanisms
  - Password & Password SRP
  - Email OTP
  - SMS OTP
  - WebAuthn
- WebAuthn credential management APIs
  - Register device as a WebAuthn credential, allowing user to sign in with biometrics
  - List the registered WebAuthn credentials for the current user
  - Remove a registered WebAuthn credential

Please see the associated docs PR for a more comprehensive overview of these new features.

*How did you test these changes?*
- Integration tests
- Unit tests
- Manual verification

*Documentation update required?*
- [ ] No
- [x] Yes: https://github.com/aws-amplify/docs/pull/8122

*General Checklist*
- [x] Added Unit Tests
- [x] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
