### PR TITLE
fix(auth): Fix Device Metadata migration if alised userId was used

### DIFF
--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoLegacyCredentialStoreInstrumentationTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoLegacyCredentialStoreInstrumentationTest.kt
@@ -56,18 +56,18 @@ class AWSCognitoLegacyCredentialStoreInstrumentationTest {
 
     @Test
     fun test_legacy_store_implementation_can_retrieve_device_metadata_using_aws_sdk() {
-        val user1DeviceMetadata = store.retrieveDeviceMetadata(credentialStoreUtil.user1UserId)
-        val user2DeviceMetadata = store.retrieveDeviceMetadata(credentialStoreUtil.user2UserId)
+        val user1DeviceMetadata = store.retrieveDeviceMetadata(credentialStoreUtil.user1Username)
+        val user2DeviceMetadata = store.retrieveDeviceMetadata(credentialStoreUtil.user2Username)
 
         assertEquals(credentialStoreUtil.getUser1DeviceMetadata(), user1DeviceMetadata)
         assertEquals(credentialStoreUtil.getUser2DeviceMetadata(), user2DeviceMetadata)
     }
 
     @Test
-    fun test_legacy_store_implementation_can_retrieve_userIds_for_device_metadata() {
-        val expectedUserIds = listOf(credentialStoreUtil.user1UserId, credentialStoreUtil.user2UserId)
-        val deviceMetadataUserIds = store.retrieveDeviceMetadataUserIdList()
+    fun test_legacy_store_implementation_can_retrieve_usernames_for_device_metadata() {
+        val expectedUsernames = listOf(credentialStoreUtil.user1Username, credentialStoreUtil.user2Username)
+        val deviceMetadataUsernames = store.retrieveDeviceMetadataUsernameList()
 
-        assertEquals(expectedUserIds, deviceMetadataUserIds)
+        assertEquals(expectedUsernames, deviceMetadataUsernames)
     }
 }

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/CredentialStoreStateMachineInstrumentationTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/CredentialStoreStateMachineInstrumentationTest.kt
@@ -20,9 +20,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.amplifyframework.auth.cognito.data.AWSCognitoAuthCredentialStore
 import com.amplifyframework.auth.cognito.testutils.AuthConfigurationProvider
 import com.amplifyframework.auth.cognito.testutils.CredentialStoreUtil
+import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.google.gson.Gson
 import junit.framework.TestCase.assertEquals
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,17 +32,21 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CredentialStoreStateMachineInstrumentationTest {
     private val context = InstrumentationRegistry.getInstrumentation().context
+    private val credentialStoreUtil = CredentialStoreUtil()
 
     private val configuration = AuthConfigurationProvider.getAuthConfigurationObject()
     private val userPoolId = configuration.userPool.userPool.PoolId
     private val identityPoolId = configuration.credentials.cognitoIdentity.identityData.PoolId
     private val userPoolAppClientId = configuration.userPool.userPool.AppClientId
 
-    private val credential = CredentialStoreUtil.getDefaultCredential()
-
     @Before
     fun setup() {
-        CredentialStoreUtil.setupLegacyStore(context, userPoolAppClientId, userPoolId, identityPoolId)
+        credentialStoreUtil.setupLegacyStore(context, userPoolAppClientId, userPoolId, identityPoolId)
+    }
+
+    @After
+    fun tearDown() {
+        credentialStoreUtil.clearSharedPreferences(context)
     }
 
     private val authConfigJson = JSONObject(Gson().toJson(configuration))
@@ -51,11 +57,83 @@ class CredentialStoreStateMachineInstrumentationTest {
         plugin.configure(authConfigJson, context)
         plugin.initialize(context)
 
-        val receivedCredentials = AWSCognitoAuthCredentialStore(
+        val credentialStore = AWSCognitoAuthCredentialStore(
             context,
             AuthConfiguration.fromJson(authConfigJson)
-        ).retrieveCredential()
+        )
 
-        assertEquals(credential, receivedCredentials)
+        assertEquals(credentialStoreUtil.getDefaultCredential(), credentialStore.retrieveCredential())
+        assertEquals(
+            credentialStoreUtil.getUser1DeviceMetadata(),
+            credentialStore.retrieveDeviceMetadata(credentialStoreUtil.user1UserId)
+        )
+        assertEquals(
+            credentialStoreUtil.getUser2DeviceMetadata(),
+            credentialStore.retrieveDeviceMetadata(credentialStoreUtil.user2UserId)
+        )
+    }
+
+    @Test
+    fun test_CredentialStore_Missing_DeviceMetadata_Migration_Succeeds_On_Plugin_Configuration() {
+        // GIVEN
+        val userAUsername = "userA"
+        val expectedUserADeviceMetadata = DeviceMetadata.Metadata("A", "B", "C")
+        val userBUsername = "userB"
+        val expectedUserBDeviceMetadata = DeviceMetadata.Metadata("1", "2", "3")
+
+        AWSCognitoAuthPlugin().apply {
+            configure(authConfigJson, context)
+            initialize(context)
+        }
+
+        AWSCognitoAuthCredentialStore(
+            context,
+            AuthConfiguration.fromJson(authConfigJson)
+        ).apply {
+            saveDeviceMetadata("userA", expectedUserADeviceMetadata)
+        }
+
+        // WHEN
+        // Simulating missed device metadata migration from issue 2929
+        // We expect this to not migrate as it will conflict with existing metadata already saved
+        credentialStoreUtil.saveLegacyDeviceMetadata(
+            context,
+            userPoolId,
+            userAUsername,
+            DeviceMetadata.Metadata("X", "Y", "Z")
+        )
+
+        // We expect this to migrate as it does not conflict with any existing saved metadata
+        credentialStoreUtil.saveLegacyDeviceMetadata(
+            context,
+            userPoolId,
+            userBUsername,
+            expectedUserBDeviceMetadata
+        )
+
+        // THEN
+
+        // Initialize plugin again to complete migration of missing device metadata
+        AWSCognitoAuthPlugin().apply {
+            configure(authConfigJson, context)
+            initialize(context)
+        }
+
+        // WHEN
+        val credentialStore = AWSCognitoAuthCredentialStore(
+            context,
+            AuthConfiguration.fromJson(authConfigJson)
+        )
+
+        // Expect the device metadata for user A to have not changed from data that was already saved in v2 store
+        assertEquals(
+            expectedUserADeviceMetadata,
+            credentialStore.retrieveDeviceMetadata(userAUsername)
+        )
+        // Expect the device metadata for user A to have not changed from data that was already saved in v2 store
+        assertEquals(
+            expectedUserBDeviceMetadata,
+            credentialStore.retrieveDeviceMetadata(userBUsername)
+        )
     }
 }

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/CredentialStoreStateMachineInstrumentationTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/CredentialStoreStateMachineInstrumentationTest.kt
@@ -65,11 +65,11 @@ class CredentialStoreStateMachineInstrumentationTest {
         assertEquals(credentialStoreUtil.getDefaultCredential(), credentialStore.retrieveCredential())
         assertEquals(
             credentialStoreUtil.getUser1DeviceMetadata(),
-            credentialStore.retrieveDeviceMetadata(credentialStoreUtil.user1UserId)
+            credentialStore.retrieveDeviceMetadata(credentialStoreUtil.user1Username)
         )
         assertEquals(
             credentialStoreUtil.getUser2DeviceMetadata(),
-            credentialStore.retrieveDeviceMetadata(credentialStoreUtil.user2UserId)
+            credentialStore.retrieveDeviceMetadata(credentialStoreUtil.user2Username)
         )
     }
 

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/testutils/CredentialStoreUtil.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/testutils/CredentialStoreUtil.kt
@@ -20,13 +20,15 @@ import com.amazonaws.internal.keyvaluestore.AWSKeyValueStore
 import com.amplifyframework.statemachine.codegen.data.AWSCredentials
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
 import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
+import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
 import com.amplifyframework.statemachine.codegen.data.SignedInData
+import java.io.File
 import java.util.Date
 
-internal object CredentialStoreUtil {
+ internal class CredentialStoreUtil {
 
-    private const val accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiO" +
+    private val accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiO" +
         "iJhbXBsaWZ5X3VzZXIiLCJpYXQiOjE1MTYyMzkwMjJ9.zBiQ0guLRX34pUEYLPyDxQAyDDlXmL0JY7kgPWAHZos"
 
     private val credential = AmplifyCredential.UserAndIdentityPool(
@@ -50,7 +52,28 @@ internal object CredentialStoreUtil {
         return credential
     }
 
+    val user1UserId = "2924030b-54c0-48bc-8bff-948418fba949"
+    val user2UserId = "7e001127-5f11-41fb-9d10-ab9d6cf41dba"
+
+    fun getUser1DeviceMetadata(): DeviceMetadata.Metadata {
+        return DeviceMetadata.Metadata(
+            "DeviceKey1",
+            "DeviceGroupKey1",
+            "DeviceSecret1"
+        )
+    }
+
+    fun getUser2DeviceMetadata(): DeviceMetadata.Metadata {
+        return DeviceMetadata.Metadata(
+            "DeviceKey2",
+            "DeviceGroupKey2",
+            "DeviceSecret2"
+        )
+    }
+
     fun setupLegacyStore(context: Context, appClientId: String, userPoolId: String, identityPoolId: String) {
+
+        clearSharedPreferences(context)
 
         AWSKeyValueStore(context, "CognitoIdentityProviderCache", true).apply {
             put("CognitoIdentityProvider.$appClientId.testuser.idToken", "idToken")
@@ -60,10 +83,16 @@ internal object CredentialStoreUtil {
             put("CognitoIdentityProvider.$appClientId.LastAuthUser", "testuser")
         }
 
-        AWSKeyValueStore(context, "CognitoIdentityProviderDeviceCache.$userPoolId.testuser", true).apply {
-            put("DeviceKey", "someDeviceKey")
-            put("DeviceGroupKey", "someDeviceGroupKey")
-            put("DeviceSecret", "someSecret")
+        AWSKeyValueStore(context, "CognitoIdentityProviderDeviceCache.$userPoolId.$user1UserId", true).apply {
+            put("DeviceKey", "DeviceKey1")
+            put("DeviceGroupKey", "DeviceGroupKey1")
+            put("DeviceSecret", "DeviceSecret1")
+        }
+
+        AWSKeyValueStore(context, "CognitoIdentityProviderDeviceCache.$userPoolId.$user2UserId", true).apply {
+            put("DeviceKey", "DeviceKey2")
+            put("DeviceGroupKey", "DeviceGroupKey2")
+            put("DeviceSecret", "DeviceSecret2")
         }
 
         AWSKeyValueStore(context, "com.amazonaws.android.auth", true).apply {
@@ -73,5 +102,45 @@ internal object CredentialStoreUtil {
             put("$identityPoolId.expirationDate", "1212")
             put("$identityPoolId.identityId", "identityId")
         }
+
+        // we need to wait for shared prefs to actually hit filesystem as we always use apply instead of commit
+        val beginWait = System.currentTimeMillis()
+        while(System.currentTimeMillis() - beginWait < 3000) {
+            if ((File(context.dataDir, "shared_prefs").listFiles()?.size ?: 0) >= 4) {
+                break
+            } else {
+                Thread.sleep(50)
+            }
+        }
     }
+
+     fun saveLegacyDeviceMetadata(
+         context: Context,
+         userPoolId: String,
+         userId: String,
+         deviceMetadata: DeviceMetadata.Metadata
+     ) {
+         val prefsName = "CognitoIdentityProviderDeviceCache.$userPoolId.$userId"
+         AWSKeyValueStore(
+             context,
+             "CognitoIdentityProviderDeviceCache.$userPoolId.$userId", true).apply {
+             put("DeviceKey", deviceMetadata.deviceKey)
+             put("DeviceGroupKey", deviceMetadata.deviceGroupKey)
+             put("DeviceSecret", deviceMetadata.deviceSecret)
+         }
+
+         // we need to wait for shared prefs to actually hit filesystem as we always use apply instead of commit
+         val beginWait = System.currentTimeMillis()
+         while(System.currentTimeMillis() - beginWait < 3000) {
+             if (File(context.dataDir, "shared_prefs/$prefsName.xml").exists()) {
+                 break
+             } else {
+                 Thread.sleep(50)
+             }
+         }
+     }
+
+     fun clearSharedPreferences(context: Context) {
+         File(context.dataDir, "shared_prefs").listFiles()?.forEach { it.delete() }
+     }
 }

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/testutils/CredentialStoreUtil.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/testutils/CredentialStoreUtil.kt
@@ -52,8 +52,8 @@ import java.util.Date
         return credential
     }
 
-    val user1UserId = "2924030b-54c0-48bc-8bff-948418fba949"
-    val user2UserId = "7e001127-5f11-41fb-9d10-ab9d6cf41dba"
+    val user1Username = "2924030b-54c0-48bc-8bff-948418fba949"
+    val user2Username = "7e001127-5f11-41fb-9d10-ab9d6cf41dba"
 
     fun getUser1DeviceMetadata(): DeviceMetadata.Metadata {
         return DeviceMetadata.Metadata(
@@ -83,13 +83,13 @@ import java.util.Date
             put("CognitoIdentityProvider.$appClientId.LastAuthUser", "testuser")
         }
 
-        AWSKeyValueStore(context, "CognitoIdentityProviderDeviceCache.$userPoolId.$user1UserId", true).apply {
+        AWSKeyValueStore(context, "CognitoIdentityProviderDeviceCache.$userPoolId.$user1Username", true).apply {
             put("DeviceKey", "DeviceKey1")
             put("DeviceGroupKey", "DeviceGroupKey1")
             put("DeviceSecret", "DeviceSecret1")
         }
 
-        AWSKeyValueStore(context, "CognitoIdentityProviderDeviceCache.$userPoolId.$user2UserId", true).apply {
+        AWSKeyValueStore(context, "CognitoIdentityProviderDeviceCache.$userPoolId.$user2Username", true).apply {
             put("DeviceKey", "DeviceKey2")
             put("DeviceGroupKey", "DeviceGroupKey2")
             put("DeviceSecret", "DeviceSecret2")
@@ -117,13 +117,13 @@ import java.util.Date
      fun saveLegacyDeviceMetadata(
          context: Context,
          userPoolId: String,
-         userId: String,
+         username: String,
          deviceMetadata: DeviceMetadata.Metadata
      ) {
-         val prefsName = "CognitoIdentityProviderDeviceCache.$userPoolId.$userId"
+         val prefsName = "CognitoIdentityProviderDeviceCache.$userPoolId.$username"
          AWSKeyValueStore(
              context,
-             "CognitoIdentityProviderDeviceCache.$userPoolId.$userId", true).apply {
+             "CognitoIdentityProviderDeviceCache.$userPoolId.$username", true).apply {
              put("DeviceKey", deviceMetadata.deviceKey)
              put("DeviceGroupKey", deviceMetadata.deviceGroupKey)
              put("DeviceSecret", deviceMetadata.deviceSecret)

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/testutils/CredentialStoreUtil.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/testutils/CredentialStoreUtil.kt
@@ -26,8 +26,7 @@ import com.amplifyframework.statemachine.codegen.data.SignedInData
 import java.io.File
 import java.util.Date
 
- internal class CredentialStoreUtil {
-
+internal class CredentialStoreUtil {
     private val accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiO" +
         "iJhbXBsaWZ5X3VzZXIiLCJpYXQiOjE1MTYyMzkwMjJ9.zBiQ0guLRX34pUEYLPyDxQAyDDlXmL0JY7kgPWAHZos"
 
@@ -105,7 +104,7 @@ import java.util.Date
 
         // we need to wait for shared prefs to actually hit filesystem as we always use apply instead of commit
         val beginWait = System.currentTimeMillis()
-        while(System.currentTimeMillis() - beginWait < 3000) {
+        while (System.currentTimeMillis() - beginWait < 3000) {
             if ((File(context.dataDir, "shared_prefs").listFiles()?.size ?: 0) >= 4) {
                 break
             } else {
@@ -114,33 +113,34 @@ import java.util.Date
         }
     }
 
-     fun saveLegacyDeviceMetadata(
-         context: Context,
-         userPoolId: String,
-         username: String,
-         deviceMetadata: DeviceMetadata.Metadata
-     ) {
-         val prefsName = "CognitoIdentityProviderDeviceCache.$userPoolId.$username"
-         AWSKeyValueStore(
-             context,
-             "CognitoIdentityProviderDeviceCache.$userPoolId.$username", true).apply {
-             put("DeviceKey", deviceMetadata.deviceKey)
-             put("DeviceGroupKey", deviceMetadata.deviceGroupKey)
-             put("DeviceSecret", deviceMetadata.deviceSecret)
-         }
+    fun saveLegacyDeviceMetadata(
+        context: Context,
+        userPoolId: String,
+        username: String,
+        deviceMetadata: DeviceMetadata.Metadata
+    ) {
+        val prefsName = "CognitoIdentityProviderDeviceCache.$userPoolId.$username"
+        AWSKeyValueStore(
+            context,
+            "CognitoIdentityProviderDeviceCache.$userPoolId.$username", true
+        ).apply {
+            put("DeviceKey", deviceMetadata.deviceKey)
+            put("DeviceGroupKey", deviceMetadata.deviceGroupKey)
+            put("DeviceSecret", deviceMetadata.deviceSecret)
+        }
 
-         // we need to wait for shared prefs to actually hit filesystem as we always use apply instead of commit
-         val beginWait = System.currentTimeMillis()
-         while(System.currentTimeMillis() - beginWait < 3000) {
-             if (File(context.dataDir, "shared_prefs/$prefsName.xml").exists()) {
-                 break
-             } else {
-                 Thread.sleep(50)
-             }
-         }
-     }
+        // we need to wait for shared prefs to actually hit filesystem as we always use apply instead of commit
+        val beginWait = System.currentTimeMillis()
+        while (System.currentTimeMillis() - beginWait < 3000) {
+            if (File(context.dataDir, "shared_prefs/$prefsName.xml").exists()) {
+                break
+            } else {
+                Thread.sleep(50)
+            }
+        }
+    }
 
-     fun clearSharedPreferences(context: Context) {
-         File(context.dataDir, "shared_prefs").listFiles()?.forEach { it.delete() }
-     }
+    fun clearSharedPreferences(context: Context) {
+        File(context.dataDir, "shared_prefs").listFiles()?.forEach { it.delete() }
+    }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/CredentialStoreCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/CredentialStoreCognitoActions.kt
@@ -38,24 +38,25 @@ internal object CredentialStoreCognitoActions : CredentialStoreActions {
 
                 /*
                 Migrate Device Metadata
-                1. We first need to get the list of userIds that contain device metadata on the device.
-                2. For each userId, we check to see if the current credential store has device metadata for that user.
+                1. We first need to get the list of usernames that contain device metadata on the device.
+                2. For each username, we check to see if the current credential store has device metadata for that user.
                 3. If the current user does not have device metadata in the current store, migrate from legacy.
                 This is a possibility because of a bug where we were previously attempting to migrate using an aliased
-                userId lookup. This situation would happen if a user migrated, signed out, then signed back in. Upon
-                signing back in, they would be granted new device metadata. Since that new metadata is what is
-                associated with the refresh token, we do not want to overwrite it.
+                username lookup.
                 4. If the current user has device metadata in the current credential store, do not migrate from legacy.
-                5. Upon migration completion, we delete the legacy device metadata.
+                This situation would happen if a user updated from legacy, signed out, then signed back in. Upon
+                signing back in, they would be granted new device metadata. Since that new metadata is what is
+                associated with the refresh token, we do not want to overwrite it with legacy metadata.
+                5. Upon completed migration, we delete the legacy device metadata.
                  */
-                legacyCredentialStore.retrieveDeviceMetadataUserIdList().forEach { userId ->
-                    val deviceMetaData = legacyCredentialStore.retrieveDeviceMetadata(userId)
+                legacyCredentialStore.retrieveDeviceMetadataUsernameList().forEach { username ->
+                    val deviceMetaData = legacyCredentialStore.retrieveDeviceMetadata(username)
                     if (deviceMetaData != DeviceMetadata.Empty) {
-                        credentialStore.retrieveDeviceMetadata(userId)
-                        if (credentialStore.retrieveDeviceMetadata(userId) == DeviceMetadata.Empty) {
-                            credentialStore.saveDeviceMetadata(userId, deviceMetaData)
+                        credentialStore.retrieveDeviceMetadata(username)
+                        if (credentialStore.retrieveDeviceMetadata(username) == DeviceMetadata.Empty) {
+                            credentialStore.saveDeviceMetadata(username, deviceMetaData)
                         }
-                        legacyCredentialStore.deleteDeviceKeyCredential(userId)
+                        legacyCredentialStore.deleteDeviceKeyCredential(username)
                     }
                 }
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
@@ -233,9 +233,9 @@ internal class AWSCognitoLegacyCredentialStore(
 
     /*
     During migration away from the legacy credential store, we need to find all shared preference files that store
-    device metadata. These filenames contain the real userId (not aliased) for the tracked device metadata.
+    device metadata. These filenames contain the real username (not aliased) for the tracked device metadata.
      */
-    fun retrieveDeviceMetadataUserIdList(): List<String> {
+    fun retrieveDeviceMetadataUsernameList(): List<String> {
         return try {
             val sharedPrefsSuffix = ".xml"
             File(context.dataDir, "shared_prefs").listFiles { _, filename ->

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
@@ -29,6 +29,7 @@ import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.FederatedToken
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
 import com.amplifyframework.statemachine.codegen.data.SignedInData
+import java.io.File
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
@@ -74,6 +75,7 @@ internal class AWSCognitoLegacyCredentialStore(
         const val TOKEN_KEY = "token"
     }
 
+    private val userDeviceDetailsCacheKeyPrefix = "$APP_DEVICE_INFO_CACHE.${authConfiguration.userPool?.poolId}."
     private val userDeviceDetailsCacheKey = "$APP_DEVICE_INFO_CACHE.${authConfiguration.userPool?.poolId}.%s"
 
     private val idAndCredentialsKeyValue: KeyValueRepository by lazy {
@@ -227,6 +229,22 @@ internal class AWSCognitoLegacyCredentialStore(
             signInMethod,
             cognitoUserPoolTokens
         )
+    }
+
+    /*
+    During migration away from the legacy credential store, we need to find all shared preference files that store
+    device metadata. These filenames contain the real userId (not aliased) for the tracked device metadata.
+     */
+    fun retrieveDeviceMetadataUserIdList(): List<String> {
+        return try {
+            val sharedPrefsSuffix = ".xml"
+            File(context.dataDir, "shared_prefs").listFiles { _, filename ->
+                filename.startsWith(userDeviceDetailsCacheKeyPrefix) && filename.endsWith(sharedPrefsSuffix)
+            }?.map { it.name.substringAfter(userDeviceDetailsCacheKeyPrefix).substringBefore(sharedPrefsSuffix) }
+                ?.filter { it.isNotBlank() } ?: emptyList()
+        } catch (e: Exception) {
+            return emptyList()
+        }
     }
 
     @Synchronized


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

Amplify v1 (or standalone AWS Android SDK) migrations to Amplify v2 do not migrate all required data in some cases. This results in token refresh failures.

Requirements for Issue:

1. Device Tracking Enabled
2. Sign in is completed with an alias that does not match the real Cognito assigned userId (ex: sign in with email)
3. Amplify v1 Sign In completed with sign in method that supports device tracking (ex: SRP, not HostedUI)

Cause of Bug

Amplify v2 pulls "LastAuthUserId" from the legacy (v1) credential store. This value is the alias (ex: email address), not necessarily the actual userId. This results in a failed lookup for device metadata. Device metadata will not be migrated to the new credential store format, and the existing file remains untouched on the device.

Additional Bug Discovered

We are only migrating device metadata for the "LastAuthUserId". We shouldn't have this restriction.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/2929

*Description of changes:*

We can pull a list of userIds (not aliased) with device metadata stored on the device, by scanning shared preference files.
We then iterate through each of those userIds, and lookup the legacy device metadata. If we do not currently have device metadata for the given userId in the Amplify v2 credential store, we will now properly migrate the device metadata from the legacy keystore.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
