### PR TITLE
chore: Resolve warnings in Gradle scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ allprojects {
 }
 
 tasks.register<Delete>("clean").configure {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }
 
 val internalApiAnnotations = listOf(
@@ -132,7 +132,6 @@ fun Project.configureAndroid() {
         val sdkVersionName = findProperty("VERSION_NAME") ?: rootProject.findProperty("VERSION_NAME")
 
         configure<LibraryExtension> {
-            buildToolsVersion = "30.0.3"
             compileSdk = 34
 
             buildFeatures {
@@ -142,7 +141,6 @@ fun Project.configureAndroid() {
 
             defaultConfig {
                 minSdk = 24
-                targetSdk = 30
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
                 testInstrumentationRunnerArguments += "clearPackageData" to "true"
                 consumerProguardFiles += rootProject.file("configuration/consumer-rules.pro")
@@ -170,7 +168,7 @@ fun Project.configureAndroid() {
             // Needed when running integration tests. The oauth2 library uses relies on two
             // dependencies (Apache's httpcore and httpclient), both of which include
             // META-INF/DEPENDENCIES. Tried a couple other options to no avail.
-            packagingOptions {
+            packaging {
                 resources.excludes.addAll(
                     listOf(
                         "META-INF/DEPENDENCIES",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.4.0"
 androidx-activity = "1.2.0"
-androidx-annotation = "1.1.0"
+androidx-annotation = "1.9.1"
 androidx-appcompat = "1.2.0"
 androidx-browser = "1.4.0"
 androidx-concurrent = "1.1.0"


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Resolved a few warnings in our Gradle builds
- Using deprecated `project.buildDir` (should be `project.layout.buildDirectory`)
- Using unsupported build tools (build tools version is now set automatically by AGP)
- Specifying useless `targetSdk` in a library project (only app projects should set targetSdk)
- Using deprecated `packagingOptions` (renamed to `packaging`)
- Unable to resolve `androidx.annotation:annotation:1.1.0` - I'm not sure why this happens since that artifact [does exist](https://mvnrepository.com/artifact/androidx.annotation/annotation/1.1.0), but upgrading to 1.9.1 appears to resolve 🤷‍♂️

This PR does not resolve compilation warnings, only warnings from the Gradle build itself.

*How did you test these changes?*
- Ran clean build, observed no more warnings

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
