### PR TITLE
fix(storage): Fix SocketTimeoutException when executing a long multi-part upload

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/AbortMultiPartUploadWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/AbortMultiPartUploadWorker.kt
@@ -33,7 +33,7 @@ internal class AbortMultiPartUploadWorker(
     private val transferStatusUpdater: TransferStatusUpdater,
     context: Context,
     workerParameters: WorkerParameters
-) : BaseTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
+) : SuspendingTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
 
     override suspend fun performWork(): Result {
         val s3: S3Client = clientProvider.getStorageTransferClient(transferRecord.region, transferRecord.bucketName)

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/BaseTransferWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/BaseTransferWorker.kt
@@ -15,20 +15,10 @@
 
 package com.amplifyframework.storage.s3.transfer.worker
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
-import android.util.Log
-import androidx.annotation.RequiresApi
-import androidx.core.app.NotificationCompat
-import androidx.work.CoroutineWorker
-import androidx.work.Data
-import androidx.work.ForegroundInfo
-import androidx.work.WorkerParameters
-import androidx.work.workDataOf
 import aws.sdk.kotlin.services.s3.model.ObjectCannedAcl
 import aws.sdk.kotlin.services.s3.model.PutObjectRequest
 import aws.sdk.kotlin.services.s3.model.RequestPayer
@@ -37,40 +27,15 @@ import aws.sdk.kotlin.services.s3.model.StorageClass
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.content.fromFile
 import aws.smithy.kotlin.runtime.time.Instant
-import com.amplifyframework.core.Amplify
-import com.amplifyframework.core.category.CategoryType
 import com.amplifyframework.storage.ObjectMetadata
-import com.amplifyframework.storage.TransferState
-import com.amplifyframework.storage.s3.AWSS3StoragePlugin
-import com.amplifyframework.storage.s3.R
 import com.amplifyframework.storage.s3.transfer.ProgressListener
-import com.amplifyframework.storage.s3.transfer.TransferDB
 import com.amplifyframework.storage.s3.transfer.TransferRecord
-import com.amplifyframework.storage.s3.transfer.TransferStatusUpdater
 import java.io.File
-import java.lang.Exception
-import java.net.SocketException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.isActive
 
 /**
  * Base worker to perform transfer file task.
  */
-internal abstract class BaseTransferWorker(
-    private val transferStatusUpdater: TransferStatusUpdater,
-    private val transferDB: TransferDB,
-    context: Context,
-    workerParameters: WorkerParameters
-) : CoroutineWorker(context, workerParameters) {
-
-    internal lateinit var transferRecord: TransferRecord
-    internal lateinit var outputData: Data
-    private val logger =
-        Amplify.Logging.logger(
-            CategoryType.STORAGE,
-            AWSS3StoragePlugin.AWS_S3_STORAGE_LOG_NAMESPACE.format(this::class.java.simpleName)
-        )
+internal interface BaseTransferWorker {
 
     companion object {
         internal const val PART_RECORD_ID = "PART_RECORD_ID"
@@ -86,91 +51,7 @@ internal abstract class BaseTransferWorker(
         internal const val MULTIPART_UPLOAD: String = "MULTIPART_UPLOAD"
     }
 
-    override suspend fun doWork(): Result {
-        // Foreground task is disabled until the foreground notification behavior and the recent customer feedback,
-        // it will be enabled in future based on the customer request.
-        val isForegroundTask: Boolean = (inputData.keyValueMap[RUN_AS_FOREGROUND_TASK] ?: false) as Boolean
-        if (isForegroundTask) {
-            setForegroundAsync(getForegroundInfo())
-        }
-        val result = runCatching {
-            val transferRecordId =
-                inputData.keyValueMap[PART_RECORD_ID] as? Int ?: inputData.keyValueMap[TRANSFER_RECORD_ID] as Int
-            outputData = workDataOf(OUTPUT_TRANSFER_RECORD_ID to inputData.keyValueMap[TRANSFER_RECORD_ID] as Int)
-            transferDB.getTransferRecordById(transferRecordId)?.let { tr ->
-                transferRecord = tr
-                performWork()
-            } ?: return run {
-                Result.failure(outputData)
-            }
-        }
-
-        return when {
-            result.isSuccess -> {
-                result.getOrThrow()
-            }
-            else -> {
-                val ex = result.exceptionOrNull()
-                if (currentCoroutineContext().isActive) {
-                    logger.error("${this.javaClass.simpleName} failed with exception: ${Log.getStackTraceString(ex)}")
-                }
-                if (!currentCoroutineContext().isActive && isRetryableError(ex)) {
-                    Result.retry()
-                } else {
-                    transferStatusUpdater.updateOnError(transferRecord.id, Exception(ex))
-                    transferStatusUpdater.updateTransferState(
-                        transferRecord.id,
-                        TransferState.FAILED
-                    )
-                    Result.failure(outputData)
-                }
-            }
-        }
-    }
-
-    abstract suspend fun performWork(): Result
-
-    internal open var maxRetryCount = 0
-
-    override suspend fun getForegroundInfo(): ForegroundInfo {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            createChannel()
-        }
-        val appIcon = R.drawable.amplify_storage_transfer_notification_icon
-        return ForegroundInfo(
-            1,
-            NotificationCompat.Builder(
-                applicationContext,
-                applicationContext.getString(R.string.amplify_storage_notification_channel_id)
-            )
-                .setSmallIcon(appIcon)
-                .setContentTitle(applicationContext.getString(R.string.amplify_storage_notification_title))
-                .build()
-        )
-    }
-
-    private fun isRetryableError(e: Throwable?): Boolean {
-        return !isNetworkAvailable(applicationContext) ||
-            runAttemptCount < maxRetryCount ||
-            e is CancellationException ||
-            // SocketException is thrown when download is terminated due to network disconnection.
-            e is SocketException
-    }
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    private fun createChannel() {
-        val notificationManager =
-            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.createNotificationChannel(
-            NotificationChannel(
-                applicationContext.getString(R.string.amplify_storage_notification_channel_id),
-                applicationContext.getString(R.string.amplify_storage_notification_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT
-            )
-        )
-    }
-
-    private fun isNetworkAvailable(context: Context): Boolean {
+    fun isNetworkAvailable(context: Context): Boolean {
         val connectivityManager =
             context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -198,7 +79,7 @@ internal abstract class BaseTransferWorker(
         return false
     }
 
-    internal fun createPutObjectRequest(
+    fun createPutObjectRequest(
         transferRecord: TransferRecord,
         progressListener: ProgressListener?
     ): PutObjectRequest {

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/BlockingTransferWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/BlockingTransferWorker.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.transfer.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Data
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.category.CategoryType
+import com.amplifyframework.storage.TransferState
+import com.amplifyframework.storage.s3.AWSS3StoragePlugin
+import com.amplifyframework.storage.s3.transfer.TransferDB
+import com.amplifyframework.storage.s3.transfer.TransferRecord
+import com.amplifyframework.storage.s3.transfer.TransferStatusUpdater
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.OUTPUT_TRANSFER_RECORD_ID
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.PART_RECORD_ID
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.TRANSFER_RECORD_ID
+import java.lang.Exception
+import java.net.SocketException
+
+/**
+ * Base worker to perform transfer file task.
+ */
+internal abstract class BlockingTransferWorker(
+    private val transferStatusUpdater: TransferStatusUpdater,
+    private val transferDB: TransferDB,
+    context: Context,
+    workerParameters: WorkerParameters
+) : Worker(context, workerParameters), BaseTransferWorker {
+
+    internal lateinit var transferRecord: TransferRecord
+    internal lateinit var outputData: Data
+
+    private val logger =
+        Amplify.Logging.logger(
+            CategoryType.STORAGE,
+            AWSS3StoragePlugin.AWS_S3_STORAGE_LOG_NAMESPACE.format(this::class.java.simpleName)
+        )
+
+    override fun doWork(): Result {
+        val result = runCatching {
+            val transferRecordId =
+                inputData.keyValueMap[PART_RECORD_ID] as? Int ?: inputData.keyValueMap[TRANSFER_RECORD_ID] as Int
+            outputData = workDataOf(OUTPUT_TRANSFER_RECORD_ID to inputData.keyValueMap[TRANSFER_RECORD_ID] as Int)
+            transferDB.getTransferRecordById(transferRecordId)?.let { tr ->
+                transferRecord = tr
+                performWork()
+            } ?: return run {
+                Result.failure(outputData)
+            }
+        }
+
+        return when {
+            result.isSuccess -> {
+                result.getOrThrow()
+            }
+            else -> {
+                val ex = result.exceptionOrNull()
+                logger.error("${this.javaClass.simpleName} failed with exception: ${Log.getStackTraceString(ex)}")
+                if (isRetryableError(ex)) {
+                    Result.retry()
+                } else {
+                    transferStatusUpdater.updateOnError(transferRecord.id, Exception(ex))
+                    transferStatusUpdater.updateTransferState(
+                        transferRecord.id,
+                        TransferState.FAILED
+                    )
+                    Result.failure(outputData)
+                }
+            }
+        }
+    }
+
+    abstract fun performWork(): Result
+
+    internal open var maxRetryCount = 0
+
+    private fun isRetryableError(e: Throwable?): Boolean {
+        return !isNetworkAvailable(applicationContext) ||
+            runAttemptCount < maxRetryCount ||
+            // SocketException is thrown when download is terminated due to network disconnection.
+            e is SocketException
+    }
+}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/CompleteMultiPartUploadWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/CompleteMultiPartUploadWorker.kt
@@ -33,7 +33,7 @@ internal class CompleteMultiPartUploadWorker(
     private val transferStatusUpdater: TransferStatusUpdater,
     context: Context,
     workerParameters: WorkerParameters
-) : BaseTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
+) : SuspendingTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
 
     override suspend fun performWork(): Result {
         val completedParts = transferDB.queryPartETagsOfUpload(transferRecord.id)

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/DownloadWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/DownloadWorker.kt
@@ -46,7 +46,7 @@ internal class DownloadWorker(
     private val transferStatusUpdater: TransferStatusUpdater,
     context: Context,
     workerParameters: WorkerParameters
-) : BaseTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
+) : SuspendingTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
 
     private lateinit var downloadProgressListener: DownloadProgressListener
     private val defaultBufferSize = 8192L

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/InitiateMultiPartUploadTransferWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/InitiateMultiPartUploadTransferWorker.kt
@@ -24,6 +24,8 @@ import com.amplifyframework.storage.TransferState
 import com.amplifyframework.storage.s3.transfer.StorageTransferClientProvider
 import com.amplifyframework.storage.s3.transfer.TransferDB
 import com.amplifyframework.storage.s3.transfer.TransferStatusUpdater
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.MULTI_PART_UPLOAD_ID
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.TRANSFER_RECORD_ID
 
 /**
  * Worker to initiate multipart upload
@@ -34,7 +36,7 @@ internal class InitiateMultiPartUploadTransferWorker(
     private val transferStatusUpdater: TransferStatusUpdater,
     context: Context,
     workerParameters: WorkerParameters
-) : BaseTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
+) : SuspendingTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
 
     override suspend fun performWork(): Result {
         val s3: S3Client = clientProvider.getStorageTransferClient(transferRecord.region, transferRecord.bucketName)

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/RouterWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/RouterWorker.kt
@@ -43,7 +43,7 @@ internal class RouterWorker(
             ?: throw IllegalArgumentException("Worker class name is missing")
     private val workerId = parameter.inputData.getString(BaseTransferWorker.WORKER_ID)
 
-    private var delegateWorker: BaseTransferWorker? = null
+    private var delegateWorker: ListenableWorker? = null
 
     companion object {
         internal const val WORKER_CLASS_NAME = "WORKER_CLASS_NAME"

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/SinglePartUploadWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/SinglePartUploadWorker.kt
@@ -34,7 +34,7 @@ internal class SinglePartUploadWorker(
     private val transferStatusUpdater: TransferStatusUpdater,
     context: Context,
     workerParameters: WorkerParameters
-) : BaseTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
+) : SuspendingTransferWorker(transferStatusUpdater, transferDB, context, workerParameters) {
 
     private lateinit var uploadProgressListener: UploadProgressListener
 

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/SuspendingTransferWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/SuspendingTransferWorker.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.storage.s3.transfer.worker
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.category.CategoryType
+import com.amplifyframework.storage.TransferState
+import com.amplifyframework.storage.s3.AWSS3StoragePlugin
+import com.amplifyframework.storage.s3.R
+import com.amplifyframework.storage.s3.transfer.TransferDB
+import com.amplifyframework.storage.s3.transfer.TransferRecord
+import com.amplifyframework.storage.s3.transfer.TransferStatusUpdater
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.OUTPUT_TRANSFER_RECORD_ID
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.PART_RECORD_ID
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.RUN_AS_FOREGROUND_TASK
+import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker.Companion.TRANSFER_RECORD_ID
+import java.lang.Exception
+import java.net.SocketException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+
+/**
+ * Base worker to perform transfer file task.
+ */
+internal abstract class SuspendingTransferWorker(
+    private val transferStatusUpdater: TransferStatusUpdater,
+    private val transferDB: TransferDB,
+    context: Context,
+    workerParameters: WorkerParameters
+) : CoroutineWorker(context, workerParameters), BaseTransferWorker {
+
+    internal lateinit var transferRecord: TransferRecord
+    internal lateinit var outputData: Data
+
+    private val logger =
+        Amplify.Logging.logger(
+            CategoryType.STORAGE,
+            AWSS3StoragePlugin.AWS_S3_STORAGE_LOG_NAMESPACE.format(this::class.java.simpleName)
+        )
+
+    override suspend fun doWork(): Result {
+        // Foreground task is disabled until the foreground notification behavior and the recent customer feedback,
+        // it will be enabled in future based on the customer request.
+        val isForegroundTask: Boolean = (inputData.keyValueMap[RUN_AS_FOREGROUND_TASK] ?: false) as Boolean
+        if (isForegroundTask) {
+            setForegroundAsync(getForegroundInfo())
+        }
+        val result = runCatching {
+            val transferRecordId =
+                inputData.keyValueMap[PART_RECORD_ID] as? Int ?: inputData.keyValueMap[TRANSFER_RECORD_ID] as Int
+            outputData = workDataOf(OUTPUT_TRANSFER_RECORD_ID to inputData.keyValueMap[TRANSFER_RECORD_ID] as Int)
+            transferDB.getTransferRecordById(transferRecordId)?.let { tr ->
+                transferRecord = tr
+                performWork()
+            } ?: return run {
+                Result.failure(outputData)
+            }
+        }
+
+        return when {
+            result.isSuccess -> {
+                result.getOrThrow()
+            }
+            else -> {
+                val ex = result.exceptionOrNull()
+                if (currentCoroutineContext().isActive) {
+                    logger.error("${this.javaClass.simpleName} failed with exception: ${Log.getStackTraceString(ex)}")
+                }
+                if (!currentCoroutineContext().isActive && isRetryableError(ex)) {
+                    Result.retry()
+                } else {
+                    transferStatusUpdater.updateOnError(transferRecord.id, Exception(ex))
+                    transferStatusUpdater.updateTransferState(
+                        transferRecord.id,
+                        TransferState.FAILED
+                    )
+                    Result.failure(outputData)
+                }
+            }
+        }
+    }
+
+    abstract suspend fun performWork(): Result
+
+    internal open var maxRetryCount = 0
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createChannel()
+        }
+        val appIcon = R.drawable.amplify_storage_transfer_notification_icon
+        return ForegroundInfo(
+            1,
+            NotificationCompat.Builder(
+                applicationContext,
+                applicationContext.getString(R.string.amplify_storage_notification_channel_id)
+            )
+                .setSmallIcon(appIcon)
+                .setContentTitle(applicationContext.getString(R.string.amplify_storage_notification_title))
+                .build()
+        )
+    }
+
+    private fun isRetryableError(e: Throwable?): Boolean {
+        return !isNetworkAvailable(applicationContext) ||
+            runAttemptCount < maxRetryCount ||
+            e is CancellationException ||
+            // SocketException is thrown when download is terminated due to network disconnection.
+            e is SocketException
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createChannel() {
+        val notificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                applicationContext.getString(R.string.amplify_storage_notification_channel_id),
+                applicationContext.getString(R.string.amplify_storage_notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+        )
+    }
+}

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/TransferWorkerFactory.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/TransferWorkerFactory.kt
@@ -15,6 +15,7 @@
 package com.amplifyframework.storage.s3.transfer.worker
 
 import android.content.Context
+import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import com.amplifyframework.storage.s3.transfer.StorageTransferClientProvider
@@ -33,7 +34,7 @@ internal class TransferWorkerFactory(
         appContext: Context,
         workerClassName: String,
         workerParameters: WorkerParameters
-    ): BaseTransferWorker {
+    ): ListenableWorker {
         when (workerClassName) {
             DownloadWorker::class.java.name ->
                 return DownloadWorker(


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Problem:* We found that with multi-part uploads that took a long time (e.g. a large file being uploaded or a slow network connection) would eventually cause `SocketTimeoutException`s. After a long investigation, we found that the issue is with creating a lot of `CoroutineWorkers` and queuing them up at the same time. Since all of the pending part uploads were being queued at the same time, `WorkManager` would actually queue them ALL of them at the same time because the S3 uploadPart call is a suspending function. So a part upload may "start" at T:0, get suspended because 20 other parts are trying to upload at the same time, and then not actually continue until 5 minutes later. And since the socket connection was already open, it would timeout because nothing got sent.

*Description of change:*
The fix to this was to change the underlying `Worker` for the PartUploader from a `CoroutineWorker` (suspending) to a plain `Worker` (blocking).

This fixes the issue and I was able to upload a 400MB file over a simulated 4G connection (so like a half hour lol). Looking at the logs and network, only 3-4 Workers were active at a time. 

Had to get creative with abstraction because of the `RouterWorker` that's being used to route a work item into the appropriate subclassed *Worker. `BaseTransferWorker` got converted from an `abstract class` to an `interface` and then logic got moved to abstract classes `SuspendingTransferWorker` and `BlockingTransferWorker` as appropriate.

*How did you test these changes?*
Besides testing multi-part, I regression tested all of the child Workers that got touched. Test cases:

1. Aborting an upload
2. Uploading a single part upload (i.e. less than 5MB file)
3. Downloading a file
4. Closing the app and reopening the app for all of the above cases to make sure `WorkManager` could continue pending Work.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
