### PR TITLE
chore(auth): Create use cases for device management APIs

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -297,16 +297,16 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         enqueue(onSuccess, onError) { queueFacade.fetchAuthSession() }
 
     override fun rememberDevice(onSuccess: Action, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.rememberDevice() }
+        enqueue(onSuccess, onError) { useCaseFactory.rememberDevice().execute() }
 
     override fun forgetDevice(onSuccess: Action, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.forgetDevice() }
+        enqueue(onSuccess, onError) { useCaseFactory.forgetDevice().execute() }
 
     override fun forgetDevice(device: AuthDevice, onSuccess: Action, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.forgetDevice(device) }
+        enqueue(onSuccess, onError) { useCaseFactory.forgetDevice().execute(device) }
 
     override fun fetchDevices(onSuccess: Consumer<List<AuthDevice>>, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.fetchDevices() }
+        enqueue(onSuccess, onError) { useCaseFactory.fetchDevices().execute() }
 
     override fun resetPassword(
         username: String,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthStateMachine.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthStateMachine.kt
@@ -33,6 +33,7 @@ import com.amplifyframework.auth.cognito.actions.SignUpCognitoActions
 import com.amplifyframework.auth.cognito.actions.UserAuthSignInCognitoActions
 import com.amplifyframework.auth.cognito.actions.WebAuthnSignInCognitoActions
 import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.statemachine.Environment
 import com.amplifyframework.statemachine.StateMachine
 import com.amplifyframework.statemachine.StateMachineResolver
@@ -135,5 +136,14 @@ internal suspend inline fun <reified T : AuthenticationState> AuthStateMachine.r
         throw InvalidStateException(
             "Auth State Machine is not in the required authentication state: ${T::class.simpleName}"
         )
+    }
+}
+
+// Returns the SignedInState or throws SignedOutException or InvalidStateException
+internal suspend fun AuthStateMachine.requireSignedInState(): AuthenticationState.SignedIn {
+    return when (val state = getCurrentState().authNState) {
+        is AuthenticationState.SignedIn -> state
+        is AuthenticationState.SignedOut -> throw SignedOutException()
+        else -> throw InvalidStateException()
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -18,7 +18,6 @@ package com.amplifyframework.auth.cognito
 import android.app.Activity
 import android.content.Intent
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
-import com.amplifyframework.auth.AuthDevice
 import com.amplifyframework.auth.AuthProvider
 import com.amplifyframework.auth.AuthSession
 import com.amplifyframework.auth.AuthUser
@@ -253,43 +252,6 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         return suspendCoroutine { continuation ->
             delegate.fetchAuthSession(
                 options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-    }
-
-    suspend fun rememberDevice() {
-        return suspendCoroutine { continuation ->
-            delegate.rememberDevice(
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-    }
-
-    suspend fun forgetDevice() {
-        return suspendCoroutine { continuation ->
-            delegate.forgetDevice(
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-    }
-
-    suspend fun forgetDevice(device: AuthDevice) {
-        return suspendCoroutine { continuation ->
-            delegate.forgetDevice(
-                device,
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-    }
-
-    suspend fun fetchDevices(): List<AuthDevice> {
-        return suspendCoroutine { continuation ->
-            delegate.fetchDevices(
                 { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
             )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AssociateWebAuthnCredentialUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AssociateWebAuthnCredentialUseCase.kt
@@ -22,9 +22,8 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.startWebAuthnRegistration
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.helpers.WebAuthnHelper
 import com.amplifyframework.auth.cognito.helpers.authLogger
-import com.amplifyframework.auth.cognito.requireAuthenticationState
+import com.amplifyframework.auth.cognito.requireSignedInState
 import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions
-import com.amplifyframework.statemachine.codegen.states.AuthenticationState.SignedIn
 import com.amplifyframework.statemachine.util.mask
 import com.amplifyframework.util.JsonDocument
 import com.amplifyframework.util.toJsonString
@@ -40,7 +39,7 @@ internal class AssociateWebAuthnCredentialUseCase(
     @Suppress("UNUSED_PARAMETER")
     suspend fun execute(callingActivity: Activity, options: AuthAssociateWebAuthnCredentialsOptions) {
         // User must be signed in to call this API
-        stateMachine.requireAuthenticationState<SignedIn>()
+        stateMachine.requireSignedInState()
 
         val accessToken = fetchAuthSession.execute().accessToken
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -47,4 +47,24 @@ internal class AuthUseCaseFactory(
         fetchAuthSession = fetchAuthSession(),
         stateMachine = stateMachine
     )
+
+    fun rememberDevice() = RememberDeviceUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine,
+        environment = authEnvironment
+    )
+
+    fun forgetDevice() = ForgetDeviceUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine,
+        environment = authEnvironment
+    )
+
+    fun fetchDevices() = FetchDevicesUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ListWebAuthnCredentialsUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ListWebAuthnCredentialsUseCase.kt
@@ -21,11 +21,10 @@ import aws.smithy.kotlin.runtime.time.toJvmInstant
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthListWebAuthnCredentialsOptions.Companion.maxResults
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthListWebAuthnCredentialsOptions.Companion.nextToken
-import com.amplifyframework.auth.cognito.requireAuthenticationState
+import com.amplifyframework.auth.cognito.requireSignedInState
 import com.amplifyframework.auth.cognito.result.AWSCognitoAuthListWebAuthnCredentialsResult
 import com.amplifyframework.auth.cognito.result.CognitoWebAuthnCredential
 import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions
-import com.amplifyframework.statemachine.codegen.states.AuthenticationState.SignedIn
 
 internal class ListWebAuthnCredentialsUseCase(
     private val client: CognitoIdentityProviderClient,
@@ -34,7 +33,7 @@ internal class ListWebAuthnCredentialsUseCase(
 ) {
     suspend fun execute(options: AuthListWebAuthnCredentialsOptions): AWSCognitoAuthListWebAuthnCredentialsResult {
         // User must be SignedIn to call this API
-        stateMachine.requireAuthenticationState<SignedIn>()
+        stateMachine.requireSignedInState()
 
         val token = fetchAuthSession.execute().accessToken
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/RememberDeviceUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/RememberDeviceUseCase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,25 +16,27 @@
 package com.amplifyframework.auth.cognito.usecases
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
-import aws.sdk.kotlin.services.cognitoidentityprovider.deleteWebAuthnCredential
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeviceRememberedStatusType
+import aws.sdk.kotlin.services.cognitoidentityprovider.updateDeviceStatus
+import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.requireSignedInState
-import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions
 
-internal class DeleteWebAuthnCredentialUseCase(
+internal class RememberDeviceUseCase(
     private val client: CognitoIdentityProviderClient,
     private val fetchAuthSession: FetchAuthSessionUseCase,
-    private val stateMachine: AuthStateMachine
+    private val stateMachine: AuthStateMachine,
+    private val environment: AuthEnvironment
 ) {
-    @Suppress("UNUSED_PARAMETER")
-    suspend fun execute(credentialId: String, options: AuthDeleteWebAuthnCredentialOptions) {
-        // User must be signed in to call this API
-        stateMachine.requireSignedInState()
+    suspend fun execute() {
+        val username = stateMachine.requireSignedInState().signedInData.username
+        val deviceId = environment.getDeviceMetadata(username)?.deviceKey
+        val token = fetchAuthSession.execute().accessToken
 
-        val accessToken = fetchAuthSession.execute().accessToken
-        client.deleteWebAuthnCredential {
-            this.accessToken = accessToken
-            this.credentialId = credentialId
+        client.updateDeviceStatus {
+            accessToken = token
+            deviceKey = deviceId
+            deviceRememberedStatus = DeviceRememberedStatusType.Remembered
         }
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -327,9 +327,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.rememberDevice()
+
         authPlugin.rememberDevice(expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.rememberDevice(any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute() }
     }
 
     @Test
@@ -337,9 +339,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.forgetDevice()
+
         authPlugin.forgetDevice(expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.forgetDevice(any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute() }
     }
 
     @Test
@@ -348,9 +352,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.forgetDevice()
+
         authPlugin.forgetDevice(expectedDevice, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.forgetDevice(expectedDevice, any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(expectedDevice) }
     }
 
     @Test
@@ -358,9 +364,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<List<AuthDevice>> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.fetchDevices()
+
         authPlugin.fetchDevices(expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.fetchDevices(any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute() }
     }
 
     @Test

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/AssociateWebAuthnCredentialUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/AssociateWebAuthnCredentialUseCaseTest.kt
@@ -21,7 +21,7 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.StartWebAuthnRegist
 import aws.smithy.kotlin.runtime.content.Document
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.helpers.WebAuthnHelper
-import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.auth.options.AuthAssociateWebAuthnCredentialsOptions
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import io.kotest.assertions.throwables.shouldThrow
@@ -60,7 +60,7 @@ class AssociateWebAuthnCredentialUseCaseTest {
     fun `fails if not in SignedIn state`() = runTest {
         coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
 
-        shouldThrow<InvalidStateException> {
+        shouldThrow<SignedOutException> {
             useCase.execute(mockk(), AuthAssociateWebAuthnCredentialsOptions.defaults())
         }
     }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/DeleteWebAuthnCredentialsUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/DeleteWebAuthnCredentialsUseCaseTest.kt
@@ -18,7 +18,7 @@ package com.amplifyframework.auth.cognito.usecases
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeleteWebAuthnCredentialResponse
 import com.amplifyframework.auth.cognito.AuthStateMachine
-import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.auth.options.AuthDeleteWebAuthnCredentialOptions
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import io.kotest.assertions.throwables.shouldThrow
@@ -49,7 +49,7 @@ class DeleteWebAuthnCredentialsUseCaseTest {
     fun `fails if not in SignedIn state`() = runTest {
         coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
 
-        shouldThrow<InvalidStateException> {
+        shouldThrow<SignedOutException> {
             useCase.execute("credentialId", AuthDeleteWebAuthnCredentialOptions.defaults())
         }
     }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/FetchDevicesUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/FetchDevicesUseCaseTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeviceType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ListDevicesResponse
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.SignedOutException
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class FetchDevicesUseCaseTest {
+    private val client = mockk<CognitoIdentityProviderClient>()
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(mockk(), mockk())
+    }
+
+    private val useCase = FetchDevicesUseCase(
+        client = client,
+        fetchAuthSession = fetchAuthSession,
+        stateMachine = stateMachine
+    )
+
+    @Test
+    fun `fetch devices returns device id and name`() = runTest {
+        coEvery { client.listDevices(any()) } returns ListDevicesResponse {
+            devices = listOf(
+                DeviceType {
+                    deviceKey = "id1"
+                    deviceAttributes = listOf(
+                        AttributeType {
+                            name = "device_name"
+                            value = "name1"
+                        }
+                    )
+                }
+            )
+        }
+
+        val result = useCase.execute()
+        result.first().id shouldBe "id1"
+        result.first().name shouldBe "name1"
+    }
+
+    @Test
+    fun `fetch devices returns error if listDevices fails`() = runTest {
+        coEvery { client.listDevices(any()) } throws Exception("bad")
+
+        shouldThrowWithMessage<Exception>("bad") {
+            useCase.execute()
+        }
+    }
+
+    @Test
+    fun `fetch devices returns error if signed out`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+
+        shouldThrow<SignedOutException> {
+            useCase.execute()
+        }
+    }
+
+    @Test
+    fun `fetch devices returns error if not signed in`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute()
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ForgetDeviceUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ForgetDeviceUseCaseTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import com.amplifyframework.auth.AuthDevice
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.SignedOutException
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ForgetDeviceUseCaseTest {
+    private val client = mockk<CognitoIdentityProviderClient>(relaxed = true)
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockk { every { username } returns "user" },
+            deviceMetadata = mockk()
+        )
+    }
+    private val authEnvironment = mockk<AuthEnvironment> {
+        coEvery { getDeviceMetadata("user")?.deviceKey } returns "test deviceKey"
+    }
+
+    private val useCase = ForgetDeviceUseCase(
+        client = client,
+        fetchAuthSession = fetchAuthSession,
+        stateMachine = stateMachine,
+        environment = authEnvironment
+    )
+
+    @Test
+    fun `forget device invokes API`() = runTest {
+        useCase.execute()
+
+        coVerify {
+            client.forgetDevice(
+                withArg { request ->
+                    request.accessToken shouldBe "access token"
+                    request.deviceKey shouldBe "test deviceKey"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `forget device invokes API with device ID`() = runTest {
+        val device = AuthDevice.fromId("specified id")
+
+        useCase.execute(device)
+
+        coVerify {
+            client.forgetDevice(
+                withArg { request ->
+                    request.accessToken shouldBe "access token"
+                    request.deviceKey shouldBe "specified id"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `forget device returns error if forgetDevice fails`() = runTest {
+        coEvery { client.forgetDevice(any()) } throws Exception("bad")
+
+        shouldThrowWithMessage<Exception>("bad") {
+            useCase.execute()
+        }
+    }
+
+    @Test
+    fun `forget device returns error if signed out`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+
+        shouldThrow<SignedOutException> {
+            useCase.execute()
+        }
+    }
+
+    @Test
+    fun `forget device returns error if not signed in`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute()
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ListWebAuthnCredentialsUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ListWebAuthnCredentialsUseCaseTest.kt
@@ -20,7 +20,7 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.ListWebAuthnCredent
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.mockWebAuthnCredentialDescription
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthListWebAuthnCredentialsOptions
-import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.auth.options.AuthListWebAuthnCredentialsOptions
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import io.kotest.assertions.throwables.shouldThrow
@@ -103,7 +103,7 @@ class ListWebAuthnCredentialsUseCaseTest {
     fun `fails if not in SignedIn state`() = runTest {
         coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
 
-        shouldThrow<InvalidStateException> {
+        shouldThrow<SignedOutException> {
             useCase.execute(AuthListWebAuthnCredentialsOptions.defaults())
         }
     }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/RememberDeviceUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/RememberDeviceUseCaseTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeviceRememberedStatusType
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.SignedOutException
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RememberDeviceUseCaseTest {
+    private val client = mockk<CognitoIdentityProviderClient>(relaxed = true)
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockk { every { username } returns "user" },
+            deviceMetadata = mockk()
+        )
+    }
+    private val authEnvironment = mockk<AuthEnvironment> {
+        coEvery { getDeviceMetadata("user")?.deviceKey } returns "test deviceKey"
+    }
+
+    private val useCase = RememberDeviceUseCase(
+        client = client,
+        fetchAuthSession = fetchAuthSession,
+        stateMachine = stateMachine,
+        environment = authEnvironment
+    )
+
+    @Test
+    fun `remember device invokes API`() = runTest {
+        useCase.execute()
+        coVerify {
+            client.updateDeviceStatus(
+                withArg { request ->
+                    request.accessToken shouldBe "access token"
+                    request.deviceKey shouldBe "test deviceKey"
+                    request.deviceRememberedStatus shouldBe DeviceRememberedStatusType.Remembered
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `remember device returns error if updateDeviceStatus fails`() = runTest {
+        coEvery { client.updateDeviceStatus(any()) } throws Exception("bad")
+
+        shouldThrowWithMessage<Exception>("bad") {
+            useCase.execute()
+        }
+    }
+
+    @Test
+    fun `remember device returns error if signed out`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+
+        shouldThrow<SignedOutException> {
+            useCase.execute()
+        }
+    }
+
+    @Test
+    fun `remember device returns error if not signed in`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute()
+        }
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Moves logic for device management APIs (remember device, forget device, fetch devices) out of `RealAWSAuthCognitoPlugin` and into use case classes.

*How did you test these changes?*
Unit tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
