### PR TITLE
feat(Apollo): Add constructor to ApolloAmplifyConnector for directly specifying connection information

### DIFF
--- a/apollo/README.md
+++ b/apollo/README.md
@@ -38,6 +38,12 @@ For applications using `apollo-appsync-amplify`, you can connect directly to you
 
 ```kotlin
 val connector = ApolloAmplifyConnector(context, AmplifyOutputs(R.raw.amplify_outputs))
+// or
+val connector = ApolloAmplifyConnector(
+    endpointUrl = "https://example1234567890123456789.appsync-api.us-east-1.amazonaws.com/graphql",
+    region = "us-east-1",
+    apiKey = "[YOUR_API_KEY]"
+)
 
 val apolloClient = ApolloClient.Builder()
     .appSync(connector.endpoint, connector.apiKeyAuthorizer())
@@ -75,7 +81,6 @@ val authorizer = ApiKeyAuthorizer { fetchApiKey() }
 ```
 ```kotlin
 // Using ApolloAmplifyConnector to read API key from amplify_outputs.json
-val connector = ApolloAmplifyConnector(context, AmplifyOutputs(R.raw.amplify_outputs))
 val authorizer = connector.apiKeyAuthorizer()
 ```
 
@@ -95,10 +100,7 @@ val authorizer = AuthTokenAuthorizer { fetchUserToken() }
 ```
 ```kotlin
 // Use ApolloAmplifyConnector to get Cognito tokens from Amplify for the signed-in user
-val connector = ApolloAmplifyConnector(context, AmplifyOutputs(R.raw.amplify_outputs))
 val authorizer = connector.authTokenAuthorizer()
-// or
-val authorizer = AuthTokenAuthorizer { ApolloAmplifyConnector.fetchLatestCognitoAuthToken() }
 ```
 
 ### IamAuthorizer
@@ -114,10 +116,7 @@ val authorizer = IamAuthorizer { signRequestAndReturnHeaders(it) }
 ```
 ```kotlin
 // Use ApolloAmplifyConnector to sign the request
-val connector = ApolloAmplifyConnector(context, AmplifyOutputs(R.raw.amplify_outputs))
 val authorizer = connector.iamAuthorizer()
-// or supply a region to sign via the companion function
-val authorizer = IamAuthorizer { ApolloAmplifyConnector.signAppSyncRequest(it, "us-east-1") }
 ```
 
 ## Contributing

--- a/apollo/apollo-appsync-amplify/api/apollo-appsync-amplify.api
+++ b/apollo/apollo-appsync-amplify/api/apollo-appsync-amplify.api
@@ -1,6 +1,8 @@
 public final class com/amplifyframework/apollo/appsync/ApolloAmplifyConnector {
 	public static final field Companion Lcom/amplifyframework/apollo/appsync/ApolloAmplifyConnector$Companion;
 	public fun <init> (Landroid/content/Context;Lcom/amplifyframework/core/configuration/AmplifyOutputs;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun apiKeyAuthorizer ()Lcom/amplifyframework/apollo/appsync/authorizers/ApiKeyAuthorizer;
 	public final fun cognitoUserPoolAuthorizer ()Lcom/amplifyframework/apollo/appsync/authorizers/AuthTokenAuthorizer;
 	public static final fun fetchLatestCognitoAuthToken (Ljava/util/function/Consumer;Ljava/util/function/Consumer;)V

--- a/apollo/apollo-appsync-amplify/src/test/java/com/amplifyframework/apollo/appsync/ApolloAmplifyConnectorTest.kt
+++ b/apollo/apollo-appsync-amplify/src/test/java/com/amplifyframework/apollo/appsync/ApolloAmplifyConnectorTest.kt
@@ -30,29 +30,35 @@ import org.junit.Test
 
 class ApolloAmplifyConnectorTest {
     private val serverUrl = "https://example1234567890123456789.appsync-api.us-east-1.amazonaws.com/graphql"
+    private val region = "us-east-1"
+    private val key = "test-key"
 
     private val outputs = mockk<AmplifyOutputsData.Data> {
         every { url } returns serverUrl
-        every { awsRegion } returns "us-east-1"
-        every { apiKey } returns "test-key"
+        every { awsRegion } returns region
+        every { apiKey } returns key
     }
 
     @Test
-    fun `reads endpoint from AmplifyOutputs`() {
+    fun `reads data from AmplifyOutputs`() {
         val connector = ApolloAmplifyConnector(outputs)
+
         connector.endpoint.serverUrl.toString() shouldBe serverUrl
+        connector.region shouldBe region
+        connector.apiKey shouldBe key
     }
 
     @Test
-    fun `reads region from AmplifyOutputs`() {
-        val connector = ApolloAmplifyConnector(outputs)
-        connector.region shouldBe "us-east-1"
-    }
+    fun `returns data passed to constructor`() {
+        val connector = ApolloAmplifyConnector(
+            endpointUrl = serverUrl,
+            region = region,
+            apiKey = key
+        )
 
-    @Test
-    fun `reads api key from AmplifyOutputs`() {
-        val connector = ApolloAmplifyConnector(outputs)
-        connector.apiKey shouldBe "test-key"
+        connector.endpoint.serverUrl.toString() shouldBe serverUrl
+        connector.region shouldBe region
+        connector.apiKey shouldBe key
     }
 
     @Test


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
ApolloAmplifyConnector was created to read AppSync connection information from `amplify_outputs.json`, but some customers who do use Amplify but do not have a Gen2 configuration file (e.g. existing Gen1 customers) may also want to use this class. They already could use the companion functions, but this new constructor makes it possible for them to use the convenience authorizer factories instead.

So now a Gen1 customer can do the following:

```kotlin
val connector = ApolloAmplifyConnector(
    endpointUrl = "https://example1234567890123456789.appsync-api.us-east-1.amazonaws.com/graphql",
    region = "us-east-1",
    apiKey = "[YOUR_API_KEY]"
)

val apolloClient = ApolloClient.Builder()
    .appSync(connector.endpoint, connector.apiKeyAuthorizer())
    .build()
```

*How did you test these changes?*
Unit test

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
