### PR TITLE
chore: Fix transient legacy credential store integ test failure

### DIFF
--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoLegacyCredentialStoreInstrumentationTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoLegacyCredentialStoreInstrumentationTest.kt
@@ -65,8 +65,8 @@ class AWSCognitoLegacyCredentialStoreInstrumentationTest {
 
     @Test
     fun test_legacy_store_implementation_can_retrieve_usernames_for_device_metadata() {
-        val expectedUsernames = listOf(credentialStoreUtil.user1Username, credentialStoreUtil.user2Username)
-        val deviceMetadataUsernames = store.retrieveDeviceMetadataUsernameList()
+        val expectedUsernames = setOf(credentialStoreUtil.user1Username, credentialStoreUtil.user2Username)
+        val deviceMetadataUsernames = store.retrieveDeviceMetadataUsernameList().toSet()
 
         assertEquals(expectedUsernames, deviceMetadataUsernames)
     }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:* From the [Android documentation for File.listFiles()](https://developer.android.com/reference/java/io/File#listFiles()):
```
There is no guarantee that the name strings in the resulting array will appear in any specific order; 
they are not, in particular, guaranteed to appear in alphabetical order.
```

This is important because the test is doing a list comparison where order matters and the test failure shows that:
`java.lang.AssertionError: expected:<[2924030b-54c0-48bc-8bff-948418fba949, 7e001127-5f11-41fb-9d10-ab9d6cf41dba]> but was:<[7e001127-5f11-41fb-9d10-ab9d6cf41dba, 2924030b-54c0-48bc-8bff-948418fba949]>`

*How did you test these changes?*
Validated no regression

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [x] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
