### PR TITLE
chore(auth): Move Attribute management into usecase classes

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -348,53 +348,53 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     ) = enqueue(onSuccess, onError) { queueFacade.updatePassword(oldPassword, newPassword) }
 
     override fun fetchUserAttributes(onSuccess: Consumer<List<AuthUserAttribute>>, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.fetchUserAttributes() }
+        enqueue(onSuccess, onError) { useCaseFactory.fetchUserAttributes().execute() }
 
     override fun updateUserAttribute(
         attribute: AuthUserAttribute,
         options: AuthUpdateUserAttributeOptions,
         onSuccess: Consumer<AuthUpdateAttributeResult>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.updateUserAttribute(attribute, options) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.updateUserAttributes().execute(attribute, options) }
 
     override fun updateUserAttribute(
         attribute: AuthUserAttribute,
         onSuccess: Consumer<AuthUpdateAttributeResult>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.updateUserAttribute(attribute) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.updateUserAttributes().execute(attribute) }
 
     override fun updateUserAttributes(
         attributes: List<AuthUserAttribute>,
         options: AuthUpdateUserAttributesOptions,
         onSuccess: Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.updateUserAttributes(attributes, options) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.updateUserAttributes().execute(attributes, options) }
 
     override fun updateUserAttributes(
         attributes: List<AuthUserAttribute>,
         onSuccess: Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.updateUserAttributes(attributes) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.updateUserAttributes().execute(attributes) }
 
     override fun resendUserAttributeConfirmationCode(
         attributeKey: AuthUserAttributeKey,
         options: AuthResendUserAttributeConfirmationCodeOptions,
         onSuccess: Consumer<AuthCodeDeliveryDetails>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.resendUserAttributeConfirmationCode(attributeKey, options) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.resendUserAttributeConfirmation().execute(attributeKey, options) }
 
     override fun resendUserAttributeConfirmationCode(
         attributeKey: AuthUserAttributeKey,
         onSuccess: Consumer<AuthCodeDeliveryDetails>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.resendUserAttributeConfirmationCode(attributeKey) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.resendUserAttributeConfirmation().execute(attributeKey) }
 
     override fun confirmUserAttribute(
         attributeKey: AuthUserAttributeKey,
         confirmationCode: String,
         onSuccess: Action,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.confirmUserAttribute(attributeKey, confirmationCode) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.confirmUserAttribute().execute(attributeKey, confirmationCode) }
 
     override fun getCurrentUser(onSuccess: Consumer<AuthUser>, onError: Consumer<AuthException>) =
         enqueue(onSuccess, onError) { useCaseFactory.getCurrentUser().execute() }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -20,8 +20,6 @@ import android.content.Intent
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthProvider
 import com.amplifyframework.auth.AuthSession
-import com.amplifyframework.auth.AuthUserAttribute
-import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.TOTPSetupDetails
 import com.amplifyframework.auth.cognito.options.FederateToIdentityPoolOptions
 import com.amplifyframework.auth.cognito.result.FederateToIdentityPoolResult
@@ -30,20 +28,16 @@ import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
 import com.amplifyframework.auth.options.AuthFetchSessionOptions
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions
-import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions
 import com.amplifyframework.auth.options.AuthResetPasswordOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
-import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions
-import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions
 import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions
 import com.amplifyframework.auth.options.AuthWebUISignInOptions
 import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.AuthSignOutResult
 import com.amplifyframework.auth.result.AuthSignUpResult
-import com.amplifyframework.auth.result.AuthUpdateAttributeResult
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -255,87 +249,6 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
             { continuation.resumeWithException(it) }
         )
     }
-
-    suspend fun fetchUserAttributes(): List<AuthUserAttribute> = suspendCoroutine { continuation ->
-        delegate.fetchUserAttributes(
-            { continuation.resume(it) },
-            { continuation.resumeWithException(it) }
-        )
-    }
-
-    suspend fun updateUserAttribute(attribute: AuthUserAttribute): AuthUpdateAttributeResult =
-        suspendCoroutine { continuation ->
-            delegate.updateUserAttribute(
-                attribute,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-
-    suspend fun updateUserAttribute(
-        attribute: AuthUserAttribute,
-        options: AuthUpdateUserAttributeOptions
-    ): AuthUpdateAttributeResult = suspendCoroutine { continuation ->
-        delegate.updateUserAttribute(
-            attribute,
-            options,
-            { continuation.resume(it) },
-            { continuation.resumeWithException(it) }
-        )
-    }
-
-    suspend fun updateUserAttributes(
-        attributes: List<AuthUserAttribute>
-    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> = suspendCoroutine { continuation ->
-        delegate.updateUserAttributes(
-            attributes,
-            { continuation.resume(it) },
-            { continuation.resumeWithException(it) }
-        )
-    }
-
-    suspend fun updateUserAttributes(
-        attributes: List<AuthUserAttribute>,
-        options: AuthUpdateUserAttributesOptions
-    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> = suspendCoroutine { continuation ->
-        delegate.updateUserAttributes(
-            attributes,
-            options,
-            { continuation.resume(it) },
-            { continuation.resumeWithException(it) }
-        )
-    }
-
-    suspend fun resendUserAttributeConfirmationCode(attributeKey: AuthUserAttributeKey): AuthCodeDeliveryDetails =
-        suspendCoroutine { continuation ->
-            delegate.resendUserAttributeConfirmationCode(
-                attributeKey,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-
-    suspend fun resendUserAttributeConfirmationCode(
-        attributeKey: AuthUserAttributeKey,
-        options: AuthResendUserAttributeConfirmationCodeOptions
-    ): AuthCodeDeliveryDetails = suspendCoroutine { continuation ->
-        delegate.resendUserAttributeConfirmationCode(
-            attributeKey,
-            options,
-            { continuation.resume(it) },
-            { continuation.resumeWithException(it) }
-        )
-    }
-
-    suspend fun confirmUserAttribute(attributeKey: AuthUserAttributeKey, confirmationCode: String) =
-        suspendCoroutine { continuation ->
-            delegate.confirmUserAttribute(
-                attributeKey,
-                confirmationCode,
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
 
     suspend fun signOut(): AuthSignOutResult = suspendCoroutine { continuation ->
         delegate.signOut { continuation.resume(it) }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -68,6 +68,30 @@ internal class AuthUseCaseFactory(
         stateMachine = stateMachine
     )
 
+    fun fetchUserAttributes() = FetchUserAttributesUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
+
+    fun updateUserAttributes() = UpdateUserAttributesUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
+
+    fun confirmUserAttribute() = ConfirmUserAttributeUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
+
+    fun resendUserAttributeConfirmation() = ResendUserAttributeConfirmationUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
+
     fun getCurrentUser() = GetCurrentUserUseCase(
         fetchAuthSession = fetchAuthSession(),
         stateMachine = stateMachine

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ConfirmUserAttributeUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ConfirmUserAttributeUseCase.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.verifyUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.requireAccessToken
+import com.amplifyframework.auth.cognito.requireSignedInState
+
+internal class ConfirmUserAttributeUseCase(
+    private val client: CognitoIdentityProviderClient,
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val stateMachine: AuthStateMachine
+) {
+    suspend fun execute(attributeKey: AuthUserAttributeKey, confirmationCode: String) {
+        stateMachine.requireSignedInState()
+
+        val token = fetchAuthSession.execute().requireAccessToken()
+
+        client.verifyUserAttribute {
+            accessToken = token
+            attributeName = attributeKey.keyString
+            code = confirmationCode
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/FetchUserAttributesUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/FetchUserAttributesUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.getUser
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.requireSignedInState
+
+internal class FetchUserAttributesUseCase(
+    private val client: CognitoIdentityProviderClient,
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val stateMachine: AuthStateMachine
+) {
+    suspend fun execute(): List<AuthUserAttribute> {
+        stateMachine.requireSignedInState()
+        val token = fetchAuthSession.execute().accessToken
+        val user = client.getUser { accessToken = token }
+        return user.userAttributes.map { AuthUserAttribute(AuthUserAttributeKey.custom(it.name), it.value) }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ResendUserAttributeConfirmationUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ResendUserAttributeConfirmationUseCase.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.getUserAttributeVerificationCode
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.exceptions.service.CodeDeliveryFailureException
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthResendUserAttributeConfirmationCodeOptions
+import com.amplifyframework.auth.cognito.requireAccessToken
+import com.amplifyframework.auth.cognito.requireSignedInState
+import com.amplifyframework.auth.options.AuthResendUserAttributeConfirmationCodeOptions
+
+internal class ResendUserAttributeConfirmationUseCase(
+    private val client: CognitoIdentityProviderClient,
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val stateMachine: AuthStateMachine
+) {
+    suspend fun execute(
+        attributeKey: AuthUserAttributeKey,
+        options: AuthResendUserAttributeConfirmationCodeOptions =
+            AuthResendUserAttributeConfirmationCodeOptions.defaults()
+    ): AuthCodeDeliveryDetails {
+        stateMachine.requireSignedInState()
+
+        val token = fetchAuthSession.execute().requireAccessToken()
+        val metadata = (options as? AWSCognitoAuthResendUserAttributeConfirmationCodeOptions)?.metadata
+
+        val response = client.getUserAttributeVerificationCode {
+            accessToken = token
+            attributeName = attributeKey.keyString
+            clientMetadata = metadata
+        }
+
+        return response.codeDeliveryDetails?.toAuthCodeDeliveryDetails() ?: throw CodeDeliveryFailureException()
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/UpdateUserAttributesUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/UpdateUserAttributesUseCase.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UpdateUserAttributesResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.updateUserAttributes
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributeOptions
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributesOptions
+import com.amplifyframework.auth.cognito.requireAccessToken
+import com.amplifyframework.auth.cognito.requireSignedInState
+import com.amplifyframework.auth.options.AuthUpdateUserAttributeOptions
+import com.amplifyframework.auth.options.AuthUpdateUserAttributesOptions
+import com.amplifyframework.auth.result.AuthUpdateAttributeResult
+import com.amplifyframework.auth.result.step.AuthNextUpdateAttributeStep
+import com.amplifyframework.auth.result.step.AuthUpdateAttributeStep
+
+internal class UpdateUserAttributesUseCase(
+    private val client: CognitoIdentityProviderClient,
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val stateMachine: AuthStateMachine
+) {
+    // Update multiple attributes at once
+    suspend fun execute(
+        attributes: List<AuthUserAttribute>,
+        options: AuthUpdateUserAttributesOptions = AuthUpdateUserAttributesOptions.defaults()
+    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> {
+        val metadata = (options as? AWSCognitoAuthUpdateUserAttributesOptions)?.metadata
+        return updateAttributes(attributes, metadata)
+    }
+
+    // Update a single attribute
+    suspend fun execute(
+        attribute: AuthUserAttribute,
+        options: AuthUpdateUserAttributeOptions = AuthUpdateUserAttributeOptions.defaults()
+    ): AuthUpdateAttributeResult {
+        val metadata = (options as? AWSCognitoAuthUpdateUserAttributeOptions)?.metadata
+        val result = updateAttributes(listOf(attribute), metadata)
+        return result.values.first()
+    }
+
+    private suspend fun updateAttributes(
+        attributes: List<AuthUserAttribute>,
+        metadata: Map<String, String>?
+    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> {
+        stateMachine.requireSignedInState()
+
+        val token = fetchAuthSession.execute().requireAccessToken()
+
+        val response = client.updateUserAttributes {
+            accessToken = token
+            clientMetadata = metadata
+            userAttributes = attributes.map {
+                AttributeType {
+                    name = it.key.keyString
+                    value = it.value
+                }
+            }
+        }
+
+        return response.mapResults(attributes)
+    }
+
+    private fun UpdateUserAttributesResponse.mapResults(
+        attributes: List<AuthUserAttribute>
+    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> = buildMap {
+        // Place the specific values returned in the result
+        codeDeliveryDetailsList?.forEach { item ->
+            item.attributeName?.let {
+                val key = AuthUserAttributeKey.custom(it)
+                val nextStep = AuthNextUpdateAttributeStep(
+                    AuthUpdateAttributeStep.CONFIRM_ATTRIBUTE_WITH_CODE,
+                    HashMap(),
+                    item.toAuthCodeDeliveryDetails()
+                )
+                val result = AuthUpdateAttributeResult(false, nextStep)
+                put(key, result)
+            }
+        }
+
+        // Set any missing attributes to "DONE"
+        val doneStep = AuthNextUpdateAttributeStep(
+            AuthUpdateAttributeStep.DONE,
+            HashMap(),
+            null
+        )
+        val doneResult = AuthUpdateAttributeResult(true, doneStep)
+        attributes.forEach { attribute ->
+            if (!contains(attribute.key)) {
+                put(attribute.key, doneResult)
+            }
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -470,9 +470,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<List<AuthUserAttribute>> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.fetchUserAttributes()
+
         authPlugin.fetchUserAttributes(expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.fetchUserAttributes(any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute() }
     }
 
     @Test
@@ -481,9 +483,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthUpdateAttributeResult> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.updateUserAttributes()
+
         authPlugin.updateUserAttribute(expectedAttribute, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.updateUserAttribute(expectedAttribute, any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(expectedAttribute) }
     }
 
     @Test
@@ -493,10 +497,12 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthUpdateAttributeResult> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.updateUserAttributes()
+
         authPlugin.updateUserAttribute(expectedAttribute, expectedOptions, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.updateUserAttribute(expectedAttribute, expectedOptions, any(), any())
+        coVerify(timeout = CHANNEL_TIMEOUT) {
+            useCase.execute(expectedAttribute, expectedOptions)
         }
     }
 
@@ -506,9 +512,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.updateUserAttributes()
+
         authPlugin.updateUserAttributes(expectedAttributes, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.updateUserAttributes(expectedAttributes, any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(expectedAttributes) }
     }
 
     @Test
@@ -518,16 +526,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<Map<AuthUserAttributeKey, AuthUpdateAttributeResult>> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.updateUserAttributes()
+
         authPlugin.updateUserAttributes(expectedAttributes, expectedOptions, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.updateUserAttributes(
-                expectedAttributes,
-                expectedOptions,
-                any(),
-                any()
-            )
-        }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(expectedAttributes, expectedOptions) }
     }
 
     @Test
@@ -544,15 +547,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthCodeDeliveryDetails> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.resendUserAttributeConfirmation()
+
         authPlugin.resendUserAttributeConfirmationCode(expectedAttributeKey, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.resendUserAttributeConfirmationCode(
-                expectedAttributeKey,
-                any(),
-                any()
-            )
-        }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(expectedAttributeKey) }
     }
 
     @Test
@@ -562,6 +561,8 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthCodeDeliveryDetails> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.resendUserAttributeConfirmation()
+
         authPlugin.resendUserAttributeConfirmationCode(
             expectedAttributeKey,
             expectedOptions,
@@ -569,14 +570,7 @@ class AWSCognitoAuthPluginTest {
             expectedOnError
         )
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.resendUserAttributeConfirmationCode(
-                expectedAttributeKey,
-                expectedOptions,
-                any(),
-                any()
-            )
-        }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(expectedAttributeKey, expectedOptions) }
     }
 
     @Test
@@ -586,6 +580,8 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.confirmUserAttribute()
+
         authPlugin.confirmUserAttribute(
             expectedAttributeKey,
             expectedConfirmationCode,
@@ -593,14 +589,7 @@ class AWSCognitoAuthPluginTest {
             expectedOnError
         )
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.confirmUserAttribute(
-                expectedAttributeKey,
-                expectedConfirmationCode,
-                any(),
-                any()
-            )
-        }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(expectedAttributeKey, expectedConfirmationCode) }
     }
 
     @Test

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/CustomMatchers.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/CustomMatchers.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito
+
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
+import com.amplifyframework.auth.AuthCodeDeliveryDetails.DeliveryMedium
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+
+fun haveAttributeName(name: String) = Matcher<AuthCodeDeliveryDetails> { value ->
+    MatcherResult(
+        value.attributeName == name,
+        { "attribute name should be $name but was ${value.attributeName}" },
+        { "attribute name should not be $name but it was" }
+    )
+}
+
+fun haveDestination(destination: String) = Matcher<AuthCodeDeliveryDetails> { value ->
+    MatcherResult(
+        value.destination == destination,
+        { "destination should be $destination but was ${value.destination}" },
+        { "destination should not be $destination but it was" }
+    )
+}
+
+fun haveDeliveryMedium(medium: DeliveryMedium) = Matcher<AuthCodeDeliveryDetails> { value ->
+    MatcherResult(
+        value.deliveryMedium == medium,
+        { "delivery medium should be $medium but was ${value.deliveryMedium}" },
+        { "delivery medium should not be $medium but it was" }
+    )
+}
+
+infix fun AuthCodeDeliveryDetails.shouldHaveAttributeName(name: String) = apply { this should haveAttributeName(name) }
+infix fun AuthCodeDeliveryDetails.shouldHaveDestination(destination: String) = apply {
+    this should haveDestination(destination)
+}
+infix fun AuthCodeDeliveryDetails.shouldHaveDeliveryMedium(medium: DeliveryMedium) = apply {
+    this should haveDeliveryMedium(medium)
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ConfirmUserAttributeUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ConfirmUserAttributeUseCaseTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.CognitoIdentityProviderException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifyUserAttributeResponse
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ConfirmUserAttributeUseCaseTest {
+
+    private val client = mockk<CognitoIdentityProviderClient>(relaxed = true)
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockk { every { username } returns "user" },
+            deviceMetadata = mockk()
+        )
+    }
+
+    private val useCase = ConfirmUserAttributeUseCase(
+        client = client,
+        fetchAuthSession = fetchAuthSession,
+        stateMachine = stateMachine
+    )
+
+    @Test
+    fun `confirm user attribute fails when not in SignedIn state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute(AuthUserAttributeKey.email(), "000000")
+        }
+    }
+
+    @Test
+    fun `confirm user attribute fails when access token is invalid`() = runTest {
+        coEvery { fetchAuthSession.execute().accessToken } returns null
+
+        shouldThrow<InvalidUserPoolConfigurationException> {
+            useCase.execute(AuthUserAttributeKey.email(), "000000")
+        }
+    }
+
+    @Test
+    fun `confirm user attributes with cognito api call error`() = runTest {
+        val expectedException = CognitoIdentityProviderException("Some Cognito Message")
+        coEvery { client.verifyUserAttribute(any()) } throws expectedException
+
+        val exception = shouldThrow<CognitoIdentityProviderException> {
+            useCase.execute(AuthUserAttributeKey.email(), "000000")
+        }
+
+        exception shouldBe expectedException
+    }
+
+    @Test
+    fun `confirm user attributes with success`() = runTest {
+        coEvery { client.verifyUserAttribute(any()) } returns VerifyUserAttributeResponse {}
+
+        useCase.execute(AuthUserAttributeKey.email(), "000000")
+
+        coVerify {
+            client.verifyUserAttribute(
+                withArg {
+                    it.attributeName shouldBe "email"
+                    it.code shouldBe "000000"
+                }
+            )
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/FetchUserAttributesUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/FetchUserAttributesUseCaseTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.GetUserResponse
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.exceptions.SignedOutException
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class FetchUserAttributesUseCaseTest {
+
+    private val client = mockk<CognitoIdentityProviderClient>(relaxed = true)
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(mockk(), mockk())
+    }
+
+    private val useCase = FetchUserAttributesUseCase(
+        client = client,
+        fetchAuthSession = fetchAuthSession,
+        stateMachine = stateMachine
+    )
+
+    @Test
+    fun `fetch user attributes with success`() = runTest {
+        val attributes = listOf(
+            AttributeType {
+                name = "email"
+                value = "email"
+            },
+            AttributeType {
+                name = "nickname"
+                value = "nickname"
+            }
+        )
+
+        val expectedResult = attributes.map { AuthUserAttribute(AuthUserAttributeKey.custom(it.name), it.value) }
+
+        coEvery {
+            client.getUser(any())
+        } returns GetUserResponse {
+            userAttributes = attributes
+            username = ""
+        }
+
+        val result = useCase.execute()
+
+        result shouldBe expectedResult
+    }
+
+    @Test
+    fun `fetch user attributes fails when not in SignedIn state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+
+        shouldThrow<SignedOutException> {
+            useCase.execute()
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ResendUserAttributeConfirmationUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ResendUserAttributeConfirmationUseCaseTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.CodeDeliveryDetailsType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.CognitoIdentityProviderException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeliveryMediumType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.GetUserAttributeVerificationCodeResponse
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthResendUserAttributeConfirmationCodeOptions
+import com.amplifyframework.auth.cognito.shouldHaveAttributeName
+import com.amplifyframework.auth.cognito.shouldHaveDeliveryMedium
+import com.amplifyframework.auth.cognito.shouldHaveDestination
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ResendUserAttributeConfirmationUseCaseTest {
+
+    private val client = mockk<CognitoIdentityProviderClient>(relaxed = true)
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockk { every { username } returns "user" },
+            deviceMetadata = mockk()
+        )
+    }
+
+    private val useCase = ResendUserAttributeConfirmationUseCase(
+        client = client,
+        fetchAuthSession = fetchAuthSession,
+        stateMachine = stateMachine
+    )
+
+    @Test
+    fun `resend user attribute confirmation code fails when not in SignedIn state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute(AuthUserAttributeKey.email())
+        }
+    }
+
+    @Test
+    fun `resend user attribute confirmation code fails when access token is invalid`() = runTest {
+        coEvery { fetchAuthSession.execute().accessToken } returns null
+
+        shouldThrow<InvalidUserPoolConfigurationException> {
+            useCase.execute(AuthUserAttributeKey.email())
+        }
+    }
+
+    @Test
+    fun `resend user attribute confirmation code with cognito api call error`() = runTest {
+        val expectedException = CognitoIdentityProviderException("Some Cognito Message")
+        coEvery { client.getUserAttributeVerificationCode(any()) } throws expectedException
+
+        val exception = shouldThrow<CognitoIdentityProviderException> {
+            useCase.execute(AuthUserAttributeKey.email())
+        }
+
+        exception shouldBe expectedException
+    }
+
+    @Test
+    fun `resend user attribute confirmation code with delivery code success`() = runTest {
+        coEvery { client.getUserAttributeVerificationCode(any()) } returns GetUserAttributeVerificationCodeResponse {
+            codeDeliveryDetails = CodeDeliveryDetailsType {
+                attributeName = "email"
+                deliveryMedium = DeliveryMediumType.Email
+                destination = "test"
+            }
+        }
+
+        val options = AWSCognitoAuthResendUserAttributeConfirmationCodeOptions.builder().metadata(
+            mapOf("x" to "x", "y" to "y", "z" to "z")
+        ).build()
+
+        val result = useCase.execute(AuthUserAttributeKey.email(), options)
+
+        result.shouldHaveAttributeName("email")
+            .shouldHaveDestination("test")
+            .shouldHaveDeliveryMedium(AuthCodeDeliveryDetails.DeliveryMedium.EMAIL)
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/UpdateUserAttributesUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/UpdateUserAttributesUseCaseTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.CodeDeliveryDetailsType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeliveryMediumType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UpdateUserAttributesResponse
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributeOptions
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributesOptions
+import com.amplifyframework.auth.cognito.shouldHaveAttributeName
+import com.amplifyframework.auth.cognito.shouldHaveDeliveryMedium
+import com.amplifyframework.auth.cognito.shouldHaveDestination
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.result.step.AuthUpdateAttributeStep
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.maps.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class UpdateUserAttributesUseCaseTest {
+    private val client = mockk<CognitoIdentityProviderClient>(relaxed = true)
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockk { every { username } returns "user" },
+            deviceMetadata = mockk()
+        )
+    }
+
+    private val useCase = UpdateUserAttributesUseCase(
+        client = client,
+        fetchAuthSession = fetchAuthSession,
+        stateMachine = stateMachine
+    )
+
+    private val attributes = listOf(
+        AuthUserAttribute(AuthUserAttributeKey.email(), "test@test.com"),
+        AuthUserAttribute(AuthUserAttributeKey.nickname(), "test")
+    )
+
+    @Test
+    fun `update user attribute fails when not in SignedIn state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute(attributes.first())
+        }
+    }
+
+    @Test
+    fun `update user attributes fails when not in SignedIn state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrow<InvalidStateException> {
+            useCase.execute(attributes)
+        }
+    }
+
+    @Test
+    fun `update single user attribute with no attribute options and delivery code success`() = runTest {
+        coEvery { client.updateUserAttributes(any()) } returns UpdateUserAttributesResponse { }
+
+        val result = useCase.execute(attributes.first())
+
+        result.isUpdated.shouldBeTrue()
+        result.nextStep.codeDeliveryDetails.shouldBeNull()
+        result.nextStep.updateAttributeStep shouldBe AuthUpdateAttributeStep.DONE
+    }
+
+    @Test
+    fun `update single user attribute with attribute options and no delivery code success`() = runTest {
+        coEvery { client.updateUserAttributes(any()) } returns UpdateUserAttributesResponse { }
+
+        val options = AWSCognitoAuthUpdateUserAttributeOptions.builder().metadata(
+            mapOf("x" to "x", "y" to "y", "z" to "z")
+        ).build()
+
+        val result = useCase.execute(attributes.first(), options)
+
+        result.isUpdated.shouldBeTrue()
+        result.nextStep.codeDeliveryDetails.shouldBeNull()
+        result.nextStep.updateAttributeStep shouldBe AuthUpdateAttributeStep.DONE
+    }
+
+    @Test
+    fun `update user attributes with delivery code success`() = runTest {
+        coEvery { client.updateUserAttributes(any()) } returns UpdateUserAttributesResponse {
+            codeDeliveryDetailsList = listOf(
+                CodeDeliveryDetailsType {
+                    attributeName = "email"
+                    deliveryMedium = DeliveryMediumType.Email
+                    destination = "test"
+                }
+            )
+        }
+
+        val options = AWSCognitoAuthUpdateUserAttributesOptions.builder().metadata(
+            mapOf("x" to "x", "y" to "y", "z" to "z")
+        ).build()
+
+        val result = useCase.execute(attributes, options)
+
+        result.shouldHaveSize(2)
+
+        val nicknameResult = result[AuthUserAttributeKey.nickname()]!!
+        val emailResult = result[AuthUserAttributeKey.email()]!!
+
+        nicknameResult.isUpdated.shouldBeTrue()
+        nicknameResult.nextStep.codeDeliveryDetails.shouldBeNull()
+        nicknameResult.nextStep.updateAttributeStep shouldBe AuthUpdateAttributeStep.DONE
+
+        emailResult.isUpdated.shouldBeFalse()
+        emailResult.nextStep.codeDeliveryDetails.shouldNotBeNull()
+            .shouldHaveAttributeName("email")
+            .shouldHaveDestination("test")
+            .shouldHaveDeliveryMedium(AuthCodeDeliveryDetails.DeliveryMedium.EMAIL)
+        emailResult.nextStep.updateAttributeStep shouldBe AuthUpdateAttributeStep.CONFIRM_ATTRIBUTE_WITH_CODE
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Continues refactoring `RealAWSCognitoAuthPlugin` class into smaller, coroutine based usecases. This PR covers the `fetchUserAttributes`, `confirmUserAttribute`, `resendUserAttributeConfirmationCode`, `updateUserAttribute` and `updateUserAttributes` APIs.

*How did you test these changes?*
Unit test
Test App

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
