### PR TITLE
fix(auth): Return cached user id and username instead of refetching them in getCurrentUser

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -397,7 +397,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     ) = enqueue(onSuccess, onError) { queueFacade.confirmUserAttribute(attributeKey, confirmationCode) }
 
     override fun getCurrentUser(onSuccess: Consumer<AuthUser>, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.getCurrentUser() }
+        enqueue(onSuccess, onError) { useCaseFactory.getCurrentUser().execute() }
 
     override fun signOut(onComplete: Consumer<AuthSignOutResult>) = enqueue(
         onComplete,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -20,7 +20,6 @@ import android.content.Intent
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthProvider
 import com.amplifyframework.auth.AuthSession
-import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.TOTPSetupDetails
@@ -51,12 +50,8 @@ import kotlin.coroutines.suspendCoroutine
 
 internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuthPlugin) {
 
-    suspend fun signUp(
-        username: String,
-        password: String?,
-        options: AuthSignUpOptions
-    ): AuthSignUpResult {
-        return suspendCoroutine { continuation ->
+    suspend fun signUp(username: String, password: String?, options: AuthSignUpOptions): AuthSignUpResult =
+        suspendCoroutine { continuation ->
             delegate.signUp(
                 username,
                 password,
@@ -65,13 +60,9 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
-    suspend fun confirmSignUp(
-        username: String,
-        confirmationCode: String
-    ): AuthSignUpResult {
-        return suspendCoroutine { continuation ->
+    suspend fun confirmSignUp(username: String, confirmationCode: String): AuthSignUpResult =
+        suspendCoroutine { continuation ->
             delegate.confirmSignUp(
                 username,
                 confirmationCode,
@@ -79,41 +70,31 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
     suspend fun confirmSignUp(
         username: String,
         confirmationCode: String,
         options: AuthConfirmSignUpOptions
-    ): AuthSignUpResult {
-        return suspendCoroutine { continuation ->
-            delegate.confirmSignUp(
-                username,
-                confirmationCode,
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    ): AuthSignUpResult = suspendCoroutine { continuation ->
+        delegate.confirmSignUp(
+            username,
+            confirmationCode,
+            options,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun resendSignUpCode(
-        username: String
-    ): AuthCodeDeliveryDetails {
-        return suspendCoroutine { continuation ->
-            delegate.resendSignUpCode(
-                username,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun resendSignUpCode(username: String): AuthCodeDeliveryDetails = suspendCoroutine { continuation ->
+        delegate.resendSignUpCode(
+            username,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun resendSignUpCode(
-        username: String,
-        options: AuthResendSignUpCodeOptions
-    ): AuthCodeDeliveryDetails {
-        return suspendCoroutine { continuation ->
+    suspend fun resendSignUpCode(username: String, options: AuthResendSignUpCodeOptions): AuthCodeDeliveryDetails =
+        suspendCoroutine { continuation ->
             delegate.resendSignUpCode(
                 username,
                 options,
@@ -121,28 +102,18 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
+
+    suspend fun signIn(username: String?, password: String?): AuthSignInResult = suspendCoroutine { continuation ->
+        delegate.signIn(
+            username,
+            password,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun signIn(
-        username: String?,
-        password: String?
-    ): AuthSignInResult {
-        return suspendCoroutine { continuation ->
-            delegate.signIn(
-                username,
-                password,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-    }
-
-    suspend fun signIn(
-        username: String?,
-        password: String?,
-        options: AuthSignInOptions
-    ): AuthSignInResult {
-        return suspendCoroutine { continuation ->
+    suspend fun signIn(username: String?, password: String?, options: AuthSignInOptions): AuthSignInResult =
+        suspendCoroutine { continuation ->
             delegate.signIn(
                 username,
                 password,
@@ -151,25 +122,17 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
+
+    suspend fun confirmSignIn(challengeResponse: String): AuthSignInResult = suspendCoroutine { continuation ->
+        delegate.confirmSignIn(
+            challengeResponse,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun confirmSignIn(
-        challengeResponse: String
-    ): AuthSignInResult {
-        return suspendCoroutine { continuation ->
-            delegate.confirmSignIn(
-                challengeResponse,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-    }
-
-    suspend fun confirmSignIn(
-        challengeResponse: String,
-        options: AuthConfirmSignInOptions
-    ): AuthSignInResult {
-        return suspendCoroutine { continuation ->
+    suspend fun confirmSignIn(challengeResponse: String, options: AuthConfirmSignInOptions): AuthSignInResult =
+        suspendCoroutine { continuation ->
             delegate.confirmSignIn(
                 challengeResponse,
                 options,
@@ -177,13 +140,9 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
-    suspend fun signInWithSocialWebUI(
-        provider: AuthProvider,
-        callingActivity: Activity
-    ): AuthSignInResult {
-        return suspendCoroutine { continuation ->
+    suspend fun signInWithSocialWebUI(provider: AuthProvider, callingActivity: Activity): AuthSignInResult =
+        suspendCoroutine { continuation ->
             delegate.signInWithSocialWebUI(
                 provider,
                 callingActivity,
@@ -191,41 +150,31 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
     suspend fun signInWithSocialWebUI(
         provider: AuthProvider,
         callingActivity: Activity,
         options: AuthWebUISignInOptions
-    ): AuthSignInResult {
-        return suspendCoroutine { continuation ->
-            delegate.signInWithSocialWebUI(
-                provider,
-                callingActivity,
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    ): AuthSignInResult = suspendCoroutine { continuation ->
+        delegate.signInWithSocialWebUI(
+            provider,
+            callingActivity,
+            options,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun signInWithWebUI(
-        callingActivity: Activity
-    ): AuthSignInResult {
-        return suspendCoroutine { continuation ->
-            delegate.signInWithWebUI(
-                callingActivity,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun signInWithWebUI(callingActivity: Activity): AuthSignInResult = suspendCoroutine { continuation ->
+        delegate.signInWithWebUI(
+            callingActivity,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun signInWithWebUI(
-        callingActivity: Activity,
-        options: AuthWebUISignInOptions
-    ): AuthSignInResult {
-        return suspendCoroutine { continuation ->
+    suspend fun signInWithWebUI(callingActivity: Activity, options: AuthWebUISignInOptions): AuthSignInResult =
+        suspendCoroutine { continuation ->
             delegate.signInWithWebUI(
                 callingActivity,
                 options,
@@ -233,48 +182,36 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
     fun handleWebUISignInResponse(intent: Intent?) {
         delegate.handleWebUISignInResponse(intent)
     }
 
-    suspend fun fetchAuthSession(): AuthSession {
-        return suspendCoroutine { continuation ->
-            delegate.fetchAuthSession(
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun fetchAuthSession(): AuthSession = suspendCoroutine { continuation ->
+        delegate.fetchAuthSession(
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun fetchAuthSession(options: AuthFetchSessionOptions): AuthSession {
-        return suspendCoroutine { continuation ->
-            delegate.fetchAuthSession(
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun fetchAuthSession(options: AuthFetchSessionOptions): AuthSession = suspendCoroutine { continuation ->
+        delegate.fetchAuthSession(
+            options,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun resetPassword(
-        username: String
-    ): AuthResetPasswordResult {
-        return suspendCoroutine { continuation ->
-            delegate.resetPassword(
-                username,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun resetPassword(username: String): AuthResetPasswordResult = suspendCoroutine { continuation ->
+        delegate.resetPassword(
+            username,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun resetPassword(
-        username: String,
-        options: AuthResetPasswordOptions
-    ): AuthResetPasswordResult {
-        return suspendCoroutine { continuation ->
+    suspend fun resetPassword(username: String, options: AuthResetPasswordOptions): AuthResetPasswordResult =
+        suspendCoroutine { continuation ->
             delegate.resetPassword(
                 username,
                 options,
@@ -282,14 +219,9 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
-    suspend fun confirmResetPassword(
-        username: String,
-        newPassword: String,
-        confirmationCode: String
-    ) {
-        return suspendCoroutine { continuation ->
+    suspend fun confirmResetPassword(username: String, newPassword: String, confirmationCode: String) =
+        suspendCoroutine { continuation ->
             delegate.confirmResetPassword(
                 username,
                 newPassword,
@@ -298,129 +230,105 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
     suspend fun confirmResetPassword(
         username: String,
         newPassword: String,
         confirmationCode: String,
         options: AuthConfirmResetPasswordOptions
-    ) {
-        return suspendCoroutine { continuation ->
-            delegate.confirmResetPassword(
-                username,
-                newPassword,
-                confirmationCode,
-                options,
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    ) = suspendCoroutine { continuation ->
+        delegate.confirmResetPassword(
+            username,
+            newPassword,
+            confirmationCode,
+            options,
+            { continuation.resume(Unit) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun updatePassword(oldPassword: String, newPassword: String) {
-        return suspendCoroutine { continuation ->
-            delegate.updatePassword(
-                oldPassword,
-                newPassword,
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun updatePassword(oldPassword: String, newPassword: String) = suspendCoroutine { continuation ->
+        delegate.updatePassword(
+            oldPassword,
+            newPassword,
+            { continuation.resume(Unit) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun fetchUserAttributes(): List<AuthUserAttribute> {
-        return suspendCoroutine { continuation ->
-            delegate.fetchUserAttributes(
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun fetchUserAttributes(): List<AuthUserAttribute> = suspendCoroutine { continuation ->
+        delegate.fetchUserAttributes(
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun updateUserAttribute(
-        attribute: AuthUserAttribute
-    ): AuthUpdateAttributeResult {
-        return suspendCoroutine { continuation ->
+    suspend fun updateUserAttribute(attribute: AuthUserAttribute): AuthUpdateAttributeResult =
+        suspendCoroutine { continuation ->
             delegate.updateUserAttribute(
                 attribute,
                 { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
     suspend fun updateUserAttribute(
         attribute: AuthUserAttribute,
         options: AuthUpdateUserAttributeOptions
-    ): AuthUpdateAttributeResult {
-        return suspendCoroutine { continuation ->
-            delegate.updateUserAttribute(
-                attribute,
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    ): AuthUpdateAttributeResult = suspendCoroutine { continuation ->
+        delegate.updateUserAttribute(
+            attribute,
+            options,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
     suspend fun updateUserAttributes(
         attributes: List<AuthUserAttribute>
-    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> {
-        return suspendCoroutine { continuation ->
-            delegate.updateUserAttributes(
-                attributes,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> = suspendCoroutine { continuation ->
+        delegate.updateUserAttributes(
+            attributes,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
     suspend fun updateUserAttributes(
         attributes: List<AuthUserAttribute>,
         options: AuthUpdateUserAttributesOptions
-    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> {
-        return suspendCoroutine { continuation ->
-            delegate.updateUserAttributes(
-                attributes,
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    ): Map<AuthUserAttributeKey, AuthUpdateAttributeResult> = suspendCoroutine { continuation ->
+        delegate.updateUserAttributes(
+            attributes,
+            options,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun resendUserAttributeConfirmationCode(
-        attributeKey: AuthUserAttributeKey
-    ): AuthCodeDeliveryDetails {
-        return suspendCoroutine { continuation ->
+    suspend fun resendUserAttributeConfirmationCode(attributeKey: AuthUserAttributeKey): AuthCodeDeliveryDetails =
+        suspendCoroutine { continuation ->
             delegate.resendUserAttributeConfirmationCode(
                 attributeKey,
                 { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
     suspend fun resendUserAttributeConfirmationCode(
         attributeKey: AuthUserAttributeKey,
         options: AuthResendUserAttributeConfirmationCodeOptions
-    ): AuthCodeDeliveryDetails {
-        return suspendCoroutine { continuation ->
-            delegate.resendUserAttributeConfirmationCode(
-                attributeKey,
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    ): AuthCodeDeliveryDetails = suspendCoroutine { continuation ->
+        delegate.resendUserAttributeConfirmationCode(
+            attributeKey,
+            options,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun confirmUserAttribute(
-        attributeKey: AuthUserAttributeKey,
-        confirmationCode: String
-    ) {
-        return suspendCoroutine { continuation ->
+    suspend fun confirmUserAttribute(attributeKey: AuthUserAttributeKey, confirmationCode: String) =
+        suspendCoroutine { continuation ->
             delegate.confirmUserAttribute(
                 attributeKey,
                 confirmationCode,
@@ -428,97 +336,67 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
+
+    suspend fun signOut(): AuthSignOutResult = suspendCoroutine { continuation ->
+        delegate.signOut { continuation.resume(it) }
     }
 
-    suspend fun getCurrentUser(): AuthUser {
-        return suspendCoroutine { continuation ->
-            delegate.getCurrentUser(
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun signOut(options: AuthSignOutOptions): AuthSignOutResult = suspendCoroutine { continuation ->
+        delegate.signOut(options) { continuation.resume(it) }
     }
 
-    suspend fun signOut(): AuthSignOutResult {
-        return suspendCoroutine { continuation ->
-            delegate.signOut { continuation.resume(it) }
-        }
-    }
-
-    suspend fun signOut(options: AuthSignOutOptions): AuthSignOutResult {
-        return suspendCoroutine { continuation ->
-            delegate.signOut(options) { continuation.resume(it) }
-        }
-    }
-
-    suspend fun deleteUser() {
-        return suspendCoroutine { continuation ->
-            delegate.deleteUser(
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun deleteUser() = suspendCoroutine { continuation ->
+        delegate.deleteUser(
+            { continuation.resume(Unit) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
     suspend fun federateToIdentityPool(
         providerToken: String,
         authProvider: AuthProvider,
         options: FederateToIdentityPoolOptions?
-    ): FederateToIdentityPoolResult {
-        return suspendCoroutine { continuation ->
-            delegate.federateToIdentityPool(
-                providerToken,
-                authProvider,
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    ): FederateToIdentityPoolResult = suspendCoroutine { continuation ->
+        delegate.federateToIdentityPool(
+            providerToken,
+            authProvider,
+            options,
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun clearFederationToIdentityPool() {
-        return suspendCoroutine { continuation ->
-            delegate.clearFederationToIdentityPool(
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun clearFederationToIdentityPool() = suspendCoroutine { continuation ->
+        delegate.clearFederationToIdentityPool(
+            { continuation.resume(Unit) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun setUpTOTP(): TOTPSetupDetails {
-        return suspendCoroutine { continuation ->
-            delegate.setUpTOTP(
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun setUpTOTP(): TOTPSetupDetails = suspendCoroutine { continuation ->
+        delegate.setUpTOTP(
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
-    suspend fun verifyTOTPSetup(code: String, options: AuthVerifyTOTPSetupOptions) {
-        return suspendCoroutine { continuation ->
-            delegate.verifyTOTPSetup(
-                code,
-                options,
-                { continuation.resume(Unit) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun verifyTOTPSetup(code: String, options: AuthVerifyTOTPSetupOptions) = suspendCoroutine { continuation ->
+        delegate.verifyTOTPSetup(
+            code,
+            options,
+            { continuation.resume(Unit) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun fetchMFAPreference(): UserMFAPreference {
-        return suspendCoroutine { continuation ->
-            delegate.fetchMFAPreference(
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun fetchMFAPreference(): UserMFAPreference = suspendCoroutine { continuation ->
+        delegate.fetchMFAPreference(
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 
-    suspend fun updateMFAPreference(
-        sms: MFAPreference?,
-        totp: MFAPreference?,
-        email: MFAPreference?
-    ) {
-        return suspendCoroutine { continuation ->
+    suspend fun updateMFAPreference(sms: MFAPreference?, totp: MFAPreference?, email: MFAPreference?) =
+        suspendCoroutine { continuation ->
             delegate.updateMFAPreference(
                 sms,
                 totp,
@@ -527,14 +405,11 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
                 { continuation.resumeWithException(it) }
             )
         }
-    }
 
-    suspend fun autoSignIn(): AuthSignInResult {
-        return suspendCoroutine { continuation ->
-            delegate.autoSignIn(
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
+    suspend fun autoSignIn(): AuthSignInResult = suspendCoroutine { continuation ->
+        delegate.autoSignIn(
+            { continuation.resume(it) },
+            { continuation.resumeWithException(it) }
+        )
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -48,7 +48,6 @@ import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.AuthFactorType
 import com.amplifyframework.auth.AuthProvider
 import com.amplifyframework.auth.AuthSession
-import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.MFAType
@@ -1920,23 +1919,6 @@ internal class RealAWSCognitoAuthPlugin(
                 }
                 is AuthenticationState.SignedOut -> onError.accept(SignedOutException())
                 else -> onError.accept(InvalidStateException())
-            }
-        }
-    }
-
-    fun getCurrentUser(onSuccess: Consumer<AuthUser>, onError: Consumer<AuthException>) {
-        authStateMachine.getCurrentState { authState ->
-            when (val authNState = authState.authNState) {
-                is AuthenticationState.SignedIn -> {
-                    val data = authNState.signedInData
-                    onSuccess.accept(AuthUser(data.userId, data.username))
-                }
-                is AuthenticationState.SignedOut -> {
-                    onError.accept(SignedOutException())
-                }
-                else -> {
-                    onError.accept(InvalidStateException())
-                }
             }
         }
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -69,6 +69,7 @@ internal class AuthUseCaseFactory(
     )
 
     fun getCurrentUser() = GetCurrentUserUseCase(
+        fetchAuthSession = fetchAuthSession(),
         stateMachine = stateMachine
     )
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -67,4 +67,8 @@ internal class AuthUseCaseFactory(
         fetchAuthSession = fetchAuthSession(),
         stateMachine = stateMachine
     )
+
+    fun getCurrentUser() = GetCurrentUserUseCase(
+        stateMachine = stateMachine
+    )
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCase.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import com.amplifyframework.auth.AuthUser
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.requireSignedInState
+
+internal class GetCurrentUserUseCase(private val stateMachine: AuthStateMachine) {
+    suspend fun execute(): AuthUser {
+        val state = stateMachine.requireSignedInState()
+        val data = state.signedInData
+        return AuthUser(data.userId, data.username)
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCase.kt
@@ -18,11 +18,23 @@ package com.amplifyframework.auth.cognito.usecases
 import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.requireSignedInState
+import com.amplifyframework.auth.exceptions.SessionExpiredException
+import com.amplifyframework.util.throwIf
 
-internal class GetCurrentUserUseCase(private val stateMachine: AuthStateMachine) {
+internal class GetCurrentUserUseCase(
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val stateMachine: AuthStateMachine
+) {
     suspend fun execute(): AuthUser {
         val state = stateMachine.requireSignedInState()
-        val data = state.signedInData
-        return AuthUser(data.userId, data.username)
+
+        // Throw exception if session is expired
+        val result = fetchAuthSession.execute().userPoolTokensResult
+        result.error.throwIf<SessionExpiredException>()
+
+        return AuthUser(
+            state.signedInData.userId,
+            state.signedInData.username
+        )
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -608,9 +608,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthUser> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.getCurrentUser()
+
         authPlugin.getCurrentUser(expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.getCurrentUser(any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute() }
     }
 
     @Test

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/MockData.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/MockData.kt
@@ -23,6 +23,10 @@ import com.amplifyframework.auth.MFAType
 import com.amplifyframework.auth.TOTPSetupDetails
 import com.amplifyframework.auth.result.step.AuthNextSignInStep
 import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
+import com.amplifyframework.statemachine.codegen.data.SignInMethod
+import com.amplifyframework.statemachine.codegen.data.SignedInData
+import java.util.Date
 
 fun mockWebAuthnCredentialDescription(
     credentialId: String = "id",
@@ -51,4 +55,19 @@ fun mockAuthNextSignInStep(
     totpSetupDetails,
     allowedMFATypes,
     availableFactors
+)
+
+internal fun mockSignedInData(
+    userId: String = "userid",
+    username: String = "username",
+    signedInDate: Date = Date(),
+    signInMethod: SignInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_SRP_AUTH),
+    cognitoUserPoolTokens: CognitoUserPoolTokens =
+        CognitoUserPoolTokens(idToken = null, accessToken = null, refreshToken = null, expiration = null)
+) = SignedInData(
+    userId = userId,
+    username = username,
+    signedInDate = signedInDate,
+    signInMethod = signInMethod,
+    cognitoUserPoolTokens = cognitoUserPoolTokens
 )

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
@@ -53,7 +53,6 @@ import com.amplifyframework.auth.TOTPSetupDetails
 import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
 import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.cognito.helpers.SRPHelper
-import com.amplifyframework.auth.cognito.helpers.SessionHelper
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthResendUserAttributeConfirmationCodeOptions
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthUpdateUserAttributeOptions
@@ -62,7 +61,6 @@ import com.amplifyframework.auth.cognito.options.AWSCognitoAuthVerifyTOTPSetupOp
 import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.auth.cognito.usecases.ResetPasswordUseCase
 import com.amplifyframework.auth.exceptions.InvalidStateException
-import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
@@ -84,7 +82,6 @@ import com.amplifyframework.statemachine.codegen.data.CognitoUserPoolTokens
 import com.amplifyframework.statemachine.codegen.data.SignInMethod
 import com.amplifyframework.statemachine.codegen.data.SignedInData
 import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
-import com.amplifyframework.statemachine.codegen.errors.SessionError
 import com.amplifyframework.statemachine.codegen.states.AuthState
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.AuthorizationState
@@ -245,9 +242,12 @@ class RealAWSCognitoAuthPluginTest {
         // GIVEN
         val onSuccess = ConsumerWithLatch<AuthUser>()
         val onError = mockk<Consumer<AuthException>>()
-        mockkObject(SessionHelper)
-        every { SessionHelper.getUsername(any()) } returns "username"
-        every { SessionHelper.getUserSub(any()) } returns "sub"
+
+        val data = mockSignedInData(userId = "sub", username = "username")
+        setupCurrentAuthState(
+            authNState = AuthenticationState.SignedIn(signedInData = data, deviceMetadata = mockk())
+        )
+
         // WHEN
         plugin.getCurrentUser(onSuccess, onError)
 
@@ -288,43 +288,6 @@ class RealAWSCognitoAuthPluginTest {
         // THEN
         onError.shouldBeCalled()
         verify(exactly = 0) { onSuccess.accept(any()) }
-    }
-
-    @Test
-    fun testGetCurrentUserFailsWithExpiredSessionException() {
-        // GIVEN
-        val onGetCurrentUserSuccess = mockk<Consumer<AuthUser>>()
-        val onGetCurrentUserError = ConsumerWithLatch<AuthException>(expect = SessionExpiredException())
-        val sessionExpiredException = SessionExpiredException()
-        val sessionError = SessionError(sessionExpiredException, credentials)
-        val authNState = AuthenticationState.SignedIn(mockk { every { username } returns "username" }, mockk())
-        val authZState = AuthorizationState.Error(sessionError)
-
-        setupCurrentAuthState(
-            authNState = authNState,
-            authZState = authZState
-        )
-
-        val sessionErrorState = mockk<AuthState> {
-            every { this@mockk.authNState } returns AuthenticationState.SignedIn(
-                mockk { every { username } returns "username" },
-                mockk()
-            )
-            every { this@mockk.authZState } returns AuthorizationState.Error(sessionError)
-        }
-
-        every {
-            authStateMachine.listen(any(), captureLambda(), null)
-        } answers {
-            lambda<(AuthState) -> Unit>().invoke(sessionErrorState)
-        }
-
-        // WHEN
-        plugin.getCurrentUser(onGetCurrentUserSuccess, onGetCurrentUserError)
-
-        // THEN
-        onGetCurrentUserError.shouldBeCalled()
-        verify(exactly = 0) { onGetCurrentUserSuccess.accept(any()) }
     }
 
     @Test

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
@@ -45,7 +45,6 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifyUserAttribute
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.AuthSession
-import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.AuthUserAttribute
 import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.MFAType
@@ -61,7 +60,6 @@ import com.amplifyframework.auth.cognito.options.AWSCognitoAuthVerifyTOTPSetupOp
 import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.auth.cognito.usecases.ResetPasswordUseCase
 import com.amplifyframework.auth.exceptions.InvalidStateException
-import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
 import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions
@@ -234,59 +232,6 @@ class RealAWSCognitoAuthPluginTest {
         plugin.fetchAuthSession(onSuccess, onError)
 
         // THEN
-        verify(exactly = 0) { onSuccess.accept(any()) }
-    }
-
-    @Test
-    fun testGetCurrentUserSucceedsIfSignedIn() {
-        // GIVEN
-        val onSuccess = ConsumerWithLatch<AuthUser>()
-        val onError = mockk<Consumer<AuthException>>()
-
-        val data = mockSignedInData(userId = "sub", username = "username")
-        setupCurrentAuthState(
-            authNState = AuthenticationState.SignedIn(signedInData = data, deviceMetadata = mockk())
-        )
-
-        // WHEN
-        plugin.getCurrentUser(onSuccess, onError)
-
-        // THEN
-        onSuccess.shouldBeCalled()
-        verify(exactly = 0) { onError.accept(any()) }
-    }
-
-    @Test
-    fun testGetCurrentUserFailsWithInvalidStateException() {
-        // GIVEN
-        val onSuccess = mockk<Consumer<AuthUser>>()
-        val onError = ConsumerWithLatch<AuthException>(expect = InvalidStateException())
-
-        setupCurrentAuthState(authNState = AuthenticationState.NotConfigured())
-
-        // WHEN
-        plugin.getCurrentUser(onSuccess, onError)
-
-        // THEN
-        onError.shouldBeCalled()
-        verify(exactly = 0) { onSuccess.accept(any()) }
-    }
-
-    @Test
-    fun testGetCurrentUserFailsWithSignedOutException() {
-        // GIVEN
-        val onSuccess = mockk<Consumer<AuthUser>>()
-        val onError = ConsumerWithLatch<AuthException>(expect = SignedOutException())
-
-        setupCurrentAuthState(
-            authNState = AuthenticationState.SignedOut(mockk()),
-            authZState = AuthorizationState.Configured()
-        )
-        // WHEN
-        plugin.getCurrentUser(onSuccess, onError)
-
-        // THEN
-        onError.shouldBeCalled()
         verify(exactly = 0) { onSuccess.accept(any()) }
     }
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCaseTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.mockSignedInData
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.exceptions.SignedOutException
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class GetCurrentUserUseCaseTest {
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockSignedInData(username = "username", userId = "sub"),
+            deviceMetadata = mockk()
+        )
+    }
+
+    private val useCase = GetCurrentUserUseCase(stateMachine = stateMachine)
+
+    @Test
+    fun `gets auth user`() = runTest {
+        val user = useCase.execute()
+
+        user.username shouldBe "username"
+        user.userId shouldBe "sub"
+    }
+
+    @Test
+    fun `throws exception if not in signed in state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+        shouldThrow<InvalidStateException> {
+            useCase.execute()
+        }
+    }
+
+    @Test
+    fun `throws exception if signed out`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+        shouldThrow<SignedOutException> {
+            useCase.execute()
+        }
+    }
+}

--- a/core/src/main/java/com/amplifyframework/util/ExceptionExtensions.kt
+++ b/core/src/main/java/com/amplifyframework/util/ExceptionExtensions.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.util
+
+import com.amplifyframework.annotations.InternalAmplifyApi
+
+// Throws exception if it is the specified type or a subtype
+@InternalAmplifyApi
+inline fun <reified T : Throwable> Exception?.throwIf() {
+    if (this is T) {
+        throw this
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

Use the cached user id (this is the "sub" from cognito) and username when invoking `getCurrentUser` instead of trying to fetch and parse a new access token.

This fixes a bug where `getCurrentUser` returns an error if the device is offline and the access token is expired. The user is still considered "signed in" in this scenario, however, so failing to return the current user is incongruent behaviour.

*How did you test these changes?*
- Reproduced bug before fix, verified it does not occur after fix
- Unit tests

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
