### PR TITLE
fix(core): Fix random failures in RxStorageBindingTest

### DIFF
--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxStorageBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxStorageBindingTest.java
@@ -242,7 +242,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
             Consumer<StorageDownloadFileResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
 
-            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
+            Observable.interval(250, 100, TimeUnit.MILLISECONDS)
                       .take(5)
                       .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                       .doOnComplete(() -> resultConsumer.accept(result))
@@ -282,7 +282,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
             Consumer<StorageDownloadFileResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
 
-            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
+            Observable.interval(250, 100, TimeUnit.MILLISECONDS)
                     .take(5)
                     .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                     .doOnComplete(() -> resultConsumer.accept(result))
@@ -409,7 +409,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageUploadFileResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
 
-            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
+            Observable.interval(250, 100, TimeUnit.MILLISECONDS)
                       .take(5)
                       .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                       .doOnComplete(() -> resultConsumer.accept(result))
@@ -448,7 +448,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageUploadFileResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
 
-            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
+            Observable.interval(250, 100, TimeUnit.MILLISECONDS)
                     .take(5)
                     .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                     .doOnComplete(() -> resultConsumer.accept(result))
@@ -520,7 +520,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageUploadInputStreamResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
 
-            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
+            Observable.interval(250, 100, TimeUnit.MILLISECONDS)
                     .take(5)
                     .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                     .doOnComplete(() -> resultConsumer.accept(result))
@@ -563,7 +563,7 @@ public final class RxStorageBindingTest {
             Consumer<StorageUploadInputStreamResult> resultConsumer = invocation.getArgument(indexOfResultConsumer);
             Consumer<StorageTransferProgress> progressConsumer = invocation.getArgument(indexOfProgressConsumer);
 
-            Observable.interval(100, 100, TimeUnit.MILLISECONDS)
+            Observable.interval(250, 100, TimeUnit.MILLISECONDS)
                     .take(5)
                     .doOnNext(aLong -> progressConsumer.accept(new StorageTransferProgress(aLong, 500)))
                     .doOnComplete(() -> resultConsumer.accept(result))


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
These tests are frequently failing on CI. This appears to happen because the initial delay is too small, so the first update often gets missed by the observer. This is easy to reproduce locally by setting a small initial delay (like 10) which will cause the tests to often fail locally. On CI the delay needs to be much higher.

*How did you test these changes?*

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
