### PR TITLE
fix(storage): Prevent duplicate observer registration in TransferWorkerObserver to mitigate OOM issues

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferWorkerObserver.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferWorkerObserver.kt
@@ -50,8 +50,7 @@ internal class TransferWorkerObserver private constructor(
             AWSS3StoragePlugin.AWS_S3_STORAGE_LOG_NAMESPACE.format(this::class.java.simpleName)
         )
 
-    private val observedTags =
-        ConcurrentHashMap.newKeySet<String>()
+    private val observedTags = ConcurrentHashMap.newKeySet<String>()
 
     init {
         attachObserverForPendingTransfer()

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferWorkerObserver.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferWorkerObserver.kt
@@ -25,13 +25,13 @@ import com.amplifyframework.storage.TransferState
 import com.amplifyframework.storage.s3.AWSS3StoragePlugin
 import com.amplifyframework.storage.s3.TransferOperations
 import com.amplifyframework.storage.s3.transfer.worker.BaseTransferWorker
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.concurrent.ConcurrentHashMap
 
 internal class TransferWorkerObserver private constructor(
     context: Context,

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferWorkerObserver.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/TransferWorkerObserver.kt
@@ -199,7 +199,7 @@ internal class TransferWorkerObserver private constructor(
 
     private suspend fun attachObserver(tag: String) {
         withContext(Dispatchers.Main) {
-            if (observedTags.contains(tag)) return@withContext
+            if (!observedTags.add(tag)) return@withContext
             val liveData = workManager.getWorkInfosByTagLiveData(tag)
             liveData.observeForever(this@TransferWorkerObserver)
         }
@@ -207,10 +207,9 @@ internal class TransferWorkerObserver private constructor(
 
     private suspend fun removeObserver(tag: String) {
         withContext(Dispatchers.Main) {
-            if (!observedTags.contains(tag)) return@withContext
+            if (!observedTags.remove(tag)) return@withContext
             workManager.getWorkInfosByTagLiveData(tag)
                 .removeObserver(this@TransferWorkerObserver)
-            observedTags.remove(tag)
         }
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
Issue #2840

*Description of changes:*
The error appears on devices with limited heap (for example, some tablets or set-top boxes running Android 7.1.2/OS 14) when many pending transfers trigger multiple LiveData observer registrations in the TransferWorkerObserver. These duplicate observer registrations may lead to excessive internal allocations (via Room’s InvalidationTracker, MapBuilder, and SetBuilder), eventually causing OOM.

To address this, the PR introduces a thread-safe set (observedTags) that tracks which transfer tags have already been observed. In the attachObserver() method, we now check if the tag is already present in observedTags and return early if so; otherwise, the observer is registered and the tag is added to the set. Similarly, in removeObserver(), we first verify that the tag exists in observedTags before unregistering the observer and then remove the tag. This change prevents the same transfer from being observed multiple times, reducing memory pressure and mitigating OOM issues without impacting the core functionality of transfer monitoring.

*How did you test these changes?*
Due to the internal and private visibility of several classes and methods in this module, direct testing of these functions is challenging.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
