### PR TITLE
chore(auth): Migrate TOTP setup to use case classes

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -414,7 +414,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     }
 
     override fun setUpTOTP(onSuccess: Consumer<TOTPSetupDetails>, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.setUpTOTP() }
+        enqueue(onSuccess, onError) { useCaseFactory.setupTotp().execute() }
 
     override fun verifyTOTPSetup(code: String, onSuccess: Action, onError: Consumer<AuthException>) {
         verifyTOTPSetup(code, AWSCognitoAuthVerifyTOTPSetupOptions.CognitoBuilder().build(), onSuccess, onError)
@@ -425,7 +425,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         options: AuthVerifyTOTPSetupOptions,
         onSuccess: Action,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.verifyTOTPSetup(code, options) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.verifyTotpSetup().execute(code, options) }
 
     override fun associateWebAuthnCredential(
         callingActivity: Activity,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -20,7 +20,6 @@ import android.content.Intent
 import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthProvider
 import com.amplifyframework.auth.AuthSession
-import com.amplifyframework.auth.TOTPSetupDetails
 import com.amplifyframework.auth.cognito.options.FederateToIdentityPoolOptions
 import com.amplifyframework.auth.cognito.result.FederateToIdentityPoolResult
 import com.amplifyframework.auth.options.AuthConfirmResetPasswordOptions
@@ -32,7 +31,6 @@ import com.amplifyframework.auth.options.AuthResetPasswordOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
-import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions
 import com.amplifyframework.auth.options.AuthWebUISignInOptions
 import com.amplifyframework.auth.result.AuthResetPasswordResult
 import com.amplifyframework.auth.result.AuthSignInResult
@@ -281,21 +279,6 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
 
     suspend fun clearFederationToIdentityPool() = suspendCoroutine { continuation ->
         delegate.clearFederationToIdentityPool(
-            { continuation.resume(Unit) },
-            { continuation.resumeWithException(it) }
-        )
-    }
-
-    suspend fun setUpTOTP(): TOTPSetupDetails = suspendCoroutine { continuation ->
-        delegate.setUpTOTP(
-            { continuation.resume(it) },
-            { continuation.resumeWithException(it) }
-        )
-    }
-    suspend fun verifyTOTPSetup(code: String, options: AuthVerifyTOTPSetupOptions) = suspendCoroutine { continuation ->
-        delegate.verifyTOTPSetup(
-            code,
-            options,
             { continuation.resume(Unit) },
             { continuation.resumeWithException(it) }
         )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -96,4 +96,16 @@ internal class AuthUseCaseFactory(
         fetchAuthSession = fetchAuthSession(),
         stateMachine = stateMachine
     )
+
+    fun setupTotp() = SetupTotpUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
+
+    fun verifyTotpSetup() = VerifyTotpSetupUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        fetchAuthSession = fetchAuthSession(),
+        stateMachine = stateMachine
+    )
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/SetupTotpUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/SetupTotpUseCase.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.associateSoftwareToken
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.TOTPSetupDetails
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.requireAccessToken
+import com.amplifyframework.auth.cognito.requireSignedInState
+
+internal class SetupTotpUseCase(
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val client: CognitoIdentityProviderClient,
+    private val stateMachine: AuthStateMachine
+) {
+
+    suspend fun execute(): TOTPSetupDetails {
+        val state = stateMachine.requireSignedInState()
+
+        val token = fetchAuthSession.execute().requireAccessToken()
+
+        val response = client.associateSoftwareToken {
+            accessToken = token
+        }
+
+        val sharedSecret = response.secretCode ?: throw AuthException(
+            "Shared secret missing from response",
+            AmplifyException.REPORT_BUG_TO_AWS_SUGGESTION
+        )
+
+        return TOTPSetupDetails(
+            sharedSecret = sharedSecret,
+            username = state.signedInData.username
+        )
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/VerifyTotpSetupUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/VerifyTotpSetupUseCase.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifySoftwareTokenResponseType
+import aws.sdk.kotlin.services.cognitoidentityprovider.verifySoftwareToken
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthVerifyTOTPSetupOptions
+import com.amplifyframework.auth.cognito.requireAccessToken
+import com.amplifyframework.auth.cognito.requireSignedInState
+import com.amplifyframework.auth.exceptions.ServiceException
+import com.amplifyframework.auth.options.AuthVerifyTOTPSetupOptions
+
+internal class VerifyTotpSetupUseCase(
+    private val fetchAuthSession: FetchAuthSessionUseCase,
+    private val client: CognitoIdentityProviderClient,
+    private val stateMachine: AuthStateMachine
+) {
+
+    suspend fun execute(code: String, options: AuthVerifyTOTPSetupOptions) {
+        val cognitoOptions = options as? AWSCognitoAuthVerifyTOTPSetupOptions
+        val deviceName = cognitoOptions?.friendlyDeviceName
+
+        stateMachine.requireSignedInState()
+
+        val token = fetchAuthSession.execute().requireAccessToken()
+
+        val response = client.verifySoftwareToken {
+            userCode = code
+            friendlyDeviceName = deviceName
+            accessToken = token
+        }
+
+        if (response.status != VerifySoftwareTokenResponseType.Success) {
+            throw ServiceException(
+                message = "An unknown service error has occurred",
+                recoverySuggestion = AmplifyException.TODO_RECOVERY_SUGGESTION
+            )
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -692,8 +692,11 @@ class AWSCognitoAuthPluginTest {
     fun setUpTOTP() {
         val expectedOnSuccess = Consumer<TOTPSetupDetails> { }
         val expectedOnError = Consumer<AuthException> { }
+
+        val useCase = authPlugin.useCaseFactory.setupTotp()
+
         authPlugin.setUpTOTP(expectedOnSuccess, expectedOnError)
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.setUpTOTP(any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute() }
     }
 
     @Test
@@ -701,8 +704,11 @@ class AWSCognitoAuthPluginTest {
         val code = "123456"
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
+
+        val useCase = authPlugin.useCaseFactory.verifyTotpSetup()
+
         authPlugin.verifyTOTPSetup(code, expectedOnSuccess, expectedOnError)
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.verifyTOTPSetup(code, any(), any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(code, any()) }
     }
 
     @Test
@@ -711,8 +717,11 @@ class AWSCognitoAuthPluginTest {
         val options = AWSCognitoAuthVerifyTOTPSetupOptions.CognitoBuilder().friendlyDeviceName("DEVICE_NAME").build()
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
+
+        val useCase = authPlugin.useCaseFactory.verifyTotpSetup()
+
         authPlugin.verifyTOTPSetup(code, options, expectedOnSuccess, expectedOnError)
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.verifyTOTPSetup(code, options, any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(code, options) }
     }
 
     @Test

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/SetupTotpUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/SetupTotpUseCaseTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AssociateSoftwareTokenResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeleteWebAuthnCredentialResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.SoftwareTokenMfaNotFoundException
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.mockSignedInData
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SetupTotpUseCaseTest {
+    private val client: CognitoIdentityProviderClient = mockk {
+        coEvery { deleteWebAuthnCredential(any()) } returns DeleteWebAuthnCredentialResponse { }
+    }
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockSignedInData(username = "user"),
+            deviceMetadata = mockk()
+        )
+    }
+
+    private val useCase = SetupTotpUseCase(
+        fetchAuthSession = fetchAuthSession,
+        client = client,
+        stateMachine = stateMachine
+    )
+
+    @Test
+    fun `setupTOTP on success`() = runTest {
+        val session = "SESSION"
+        val secretCode = "SECRET_CODE"
+
+        coEvery { client.associateSoftwareToken(any()) } returns AssociateSoftwareTokenResponse {
+            this.session = session
+            this.secretCode = secretCode
+        }
+
+        val result = useCase.execute()
+
+        result.username shouldBe "user"
+        result.sharedSecret shouldBe secretCode
+    }
+
+    @Test
+    fun `setupTOTP on error`() = runTest {
+        val expectedErrorMessage = "Software token MFA not enabled"
+        coEvery { client.associateSoftwareToken(any()) } throws SoftwareTokenMfaNotFoundException {
+            message = expectedErrorMessage
+        }
+
+        shouldThrowWithMessage<SoftwareTokenMfaNotFoundException>(expectedErrorMessage) {
+            useCase.execute()
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/VerifyTotpSetupUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/VerifyTotpSetupUseCaseTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.CodeMismatchException
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.DeleteWebAuthnCredentialResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifySoftwareTokenRequest
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifySoftwareTokenResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.VerifySoftwareTokenResponseType
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.mockSignedInData
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthVerifyTOTPSetupOptions
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class VerifyTotpSetupUseCaseTest {
+    private val client: CognitoIdentityProviderClient = mockk {
+        coEvery { deleteWebAuthnCredential(any()) } returns DeleteWebAuthnCredentialResponse { }
+    }
+    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
+        coEvery { execute().accessToken } returns "access token"
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockSignedInData(),
+            deviceMetadata = mockk()
+        )
+    }
+
+    private val useCase = VerifyTotpSetupUseCase(
+        fetchAuthSession = fetchAuthSession,
+        client = client,
+        stateMachine = stateMachine
+    )
+
+    @Test
+    fun `verifyTOTP on success`() = runTest {
+        val code = "123456"
+        val deviceName = "DEVICE_NAME"
+        val options = AWSCognitoAuthVerifyTOTPSetupOptions.builder().friendlyDeviceName(deviceName).build()
+
+        coEvery {
+            client.verifySoftwareToken(
+                VerifySoftwareTokenRequest {
+                    userCode = code
+                    friendlyDeviceName = deviceName
+                    accessToken = "access token"
+                }
+            )
+        } returns VerifySoftwareTokenResponse { status = VerifySoftwareTokenResponseType.Success }
+
+        shouldNotThrow<Exception> {
+            useCase.execute(code, options)
+        }
+    }
+
+    @Test
+    fun `verifyTOTP on error`() = runTest {
+        val code = "123456"
+        val errorMessage = "Invalid code"
+        val options = AWSCognitoAuthVerifyTOTPSetupOptions.builder().build()
+
+        coEvery {
+            client.verifySoftwareToken(
+                VerifySoftwareTokenRequest {
+                    userCode = code
+                    accessToken = "access token"
+                }
+            )
+        } throws CodeMismatchException { message = errorMessage }
+
+        shouldThrowWithMessage<CodeMismatchException>(errorMessage) {
+            useCase.execute(code, options)
+        }
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Moves the TOTP Setup functions into use case classes.
- Fixes some bugs in `setupTotp` where Amplify would hang (never invoke callbacks) in certain scenarios.

*How did you test these changes?*
- Unit test

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
