### PR TITLE
fix(auth): Prevent crash if KeyStore not available (ex: instant app)

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/LegacyKeyProvider.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/LegacyKeyProvider.kt
@@ -73,7 +73,6 @@ internal object LegacyKeyProvider {
             return Result.failure(CredentialStoreError("Failed to connect to KeyStore"))
         }
 
-
         val key: Key? = keyStore.getKey(keyAlias, null)
         return if (key != null) {
             Result.success(key)
@@ -90,7 +89,7 @@ internal object LegacyKeyProvider {
 
         try {
             keyStore.deleteEntry(keyAlias)
-        } catch(exception: Exception) {
+        } catch (exception: Exception) {
             // KeyStore unreachable
         }
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/LegacyKeyProvider.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/LegacyKeyProvider.kt
@@ -31,12 +31,16 @@ internal object LegacyKeyProvider {
         val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE_NAME)
         keyStore.load(null)
 
-        if (keyStore.containsAlias(keyAlias)) {
-            return Result.failure(
-                CredentialStoreError(
-                    "Key already exists for the keyAlias: $keyAlias in $ANDROID_KEY_STORE_NAME"
+        try {
+            if (keyStore.containsAlias(keyAlias)) {
+                return Result.failure(
+                    CredentialStoreError(
+                        "Key already exists for the keyAlias: $keyAlias in $ANDROID_KEY_STORE_NAME"
+                    )
                 )
-            )
+            }
+        } catch (exception: Exception) {
+            return Result.failure(CredentialStoreError("Failed to connect to KeyStore"))
         }
 
         val parameterSpec =
@@ -60,10 +64,15 @@ internal object LegacyKeyProvider {
         val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE_NAME)
         keyStore.load(null)
 
-        if (!keyStore.containsAlias(keyAlias)) {
-            val message = "Key does not exists for the keyAlias: $keyAlias in $ANDROID_KEY_STORE_NAME"
-            return Result.failure(CredentialStoreError(message))
+        try {
+            if (!keyStore.containsAlias(keyAlias)) {
+                val message = "Key does not exists for the keyAlias: $keyAlias in $ANDROID_KEY_STORE_NAME"
+                return Result.failure(CredentialStoreError(message))
+            }
+        } catch (exception: Exception) {
+            return Result.failure(CredentialStoreError("Failed to connect to KeyStore"))
         }
+
 
         val key: Key? = keyStore.getKey(keyAlias, null)
         return if (key != null) {
@@ -79,6 +88,10 @@ internal object LegacyKeyProvider {
         val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE_NAME)
         keyStore.load(null)
 
-        keyStore.deleteEntry(keyAlias)
+        try {
+            keyStore.deleteEntry(keyAlias)
+        } catch(exception: Exception) {
+            // KeyStore unreachable
+        }
     }
 }


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/2991

*Description of changes:*
Prevents uncaught exception that occurs in legacy keystore migration when a keystore isn't available (ex: in an Instant App Launch). Verified that Auth + Authenticator will allow in memory sign in's with these changes.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
