### PR TITLE
chore(auth): Move signup functions to usecases

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -197,14 +197,14 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         options: AuthSignUpOptions,
         onSuccess: Consumer<AuthSignUpResult>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.signUp(username, password, options) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.signUp().execute(username, password, options) }
 
     override fun confirmSignUp(
         username: String,
         confirmationCode: String,
         onSuccess: Consumer<AuthSignUpResult>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.confirmSignUp(username, confirmationCode) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.confirmSignUp().execute(username, confirmationCode) }
 
     override fun confirmSignUp(
         username: String,
@@ -212,7 +212,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         options: AuthConfirmSignUpOptions,
         onSuccess: Consumer<AuthSignUpResult>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.confirmSignUp(username, confirmationCode, options) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.confirmSignUp().execute(username, confirmationCode, options) }
 
     override fun resendSignUpCode(
         username: String,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -218,14 +218,14 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         username: String,
         onSuccess: Consumer<AuthCodeDeliveryDetails>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.resendSignUpCode(username) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.resendSignupCode().execute(username) }
 
     override fun resendSignUpCode(
         username: String,
         options: AuthResendSignUpCodeOptions,
         onSuccess: Consumer<AuthCodeDeliveryDetails>,
         onError: Consumer<AuthException>
-    ) = enqueue(onSuccess, onError) { queueFacade.resendSignUpCode(username, options) }
+    ) = enqueue(onSuccess, onError) { useCaseFactory.resendSignupCode().execute(username, options) }
 
     override fun signIn(
         username: String?,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthStateMachine.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthStateMachine.kt
@@ -32,6 +32,7 @@ import com.amplifyframework.auth.cognito.actions.SignOutCognitoActions
 import com.amplifyframework.auth.cognito.actions.SignUpCognitoActions
 import com.amplifyframework.auth.cognito.actions.UserAuthSignInCognitoActions
 import com.amplifyframework.auth.cognito.actions.WebAuthnSignInCognitoActions
+import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
 import com.amplifyframework.auth.exceptions.InvalidStateException
 import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.statemachine.Environment
@@ -140,10 +141,16 @@ internal suspend inline fun <reified T : AuthenticationState> AuthStateMachine.r
 }
 
 // Returns the SignedInState or throws SignedOutException or InvalidStateException
-internal suspend fun AuthStateMachine.requireSignedInState(): AuthenticationState.SignedIn {
-    return when (val state = getCurrentState().authNState) {
+internal suspend fun AuthStateMachine.requireSignedInState(): AuthenticationState.SignedIn =
+    when (val state = getCurrentState().authNState) {
         is AuthenticationState.SignedIn -> state
         is AuthenticationState.SignedOut -> throw SignedOutException()
         else -> throw InvalidStateException()
+    }
+
+// Throws InvalidUserPoolConfigurationException if the authentication state is NotConfigured
+internal suspend fun AuthStateMachine.throwIfNotConfigured() {
+    if (getCurrentState().authNState is AuthenticationState.NotConfigured) {
+        throw InvalidUserPoolConfigurationException()
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -22,55 +22,17 @@ import com.amplifyframework.auth.AuthSession
 import com.amplifyframework.auth.cognito.options.FederateToIdentityPoolOptions
 import com.amplifyframework.auth.cognito.result.FederateToIdentityPoolResult
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
-import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
 import com.amplifyframework.auth.options.AuthFetchSessionOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
-import com.amplifyframework.auth.options.AuthSignUpOptions
 import com.amplifyframework.auth.options.AuthWebUISignInOptions
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.AuthSignOutResult
-import com.amplifyframework.auth.result.AuthSignUpResult
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuthPlugin) {
-
-    suspend fun signUp(username: String, password: String?, options: AuthSignUpOptions): AuthSignUpResult =
-        suspendCoroutine { continuation ->
-            delegate.signUp(
-                username,
-                password,
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-
-    suspend fun confirmSignUp(username: String, confirmationCode: String): AuthSignUpResult =
-        suspendCoroutine { continuation ->
-            delegate.confirmSignUp(
-                username,
-                confirmationCode,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
-
-    suspend fun confirmSignUp(
-        username: String,
-        confirmationCode: String,
-        options: AuthConfirmSignUpOptions
-    ): AuthSignUpResult = suspendCoroutine { continuation ->
-        delegate.confirmSignUp(
-            username,
-            confirmationCode,
-            options,
-            { continuation.resume(it) },
-            { continuation.resumeWithException(it) }
-        )
-    }
 
     suspend fun signIn(username: String?, password: String?): AuthSignInResult = suspendCoroutine { continuation ->
         delegate.signIn(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -17,7 +17,6 @@ package com.amplifyframework.auth.cognito
 
 import android.app.Activity
 import android.content.Intent
-import com.amplifyframework.auth.AuthCodeDeliveryDetails
 import com.amplifyframework.auth.AuthProvider
 import com.amplifyframework.auth.AuthSession
 import com.amplifyframework.auth.cognito.options.FederateToIdentityPoolOptions
@@ -25,7 +24,6 @@ import com.amplifyframework.auth.cognito.result.FederateToIdentityPoolResult
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
 import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
 import com.amplifyframework.auth.options.AuthFetchSessionOptions
-import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
 import com.amplifyframework.auth.options.AuthSignUpOptions
@@ -73,24 +71,6 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
             { continuation.resumeWithException(it) }
         )
     }
-
-    suspend fun resendSignUpCode(username: String): AuthCodeDeliveryDetails = suspendCoroutine { continuation ->
-        delegate.resendSignUpCode(
-            username,
-            { continuation.resume(it) },
-            { continuation.resumeWithException(it) }
-        )
-    }
-
-    suspend fun resendSignUpCode(username: String, options: AuthResendSignUpCodeOptions): AuthCodeDeliveryDetails =
-        suspendCoroutine { continuation ->
-            delegate.resendSignUpCode(
-                username,
-                options,
-                { continuation.resume(it) },
-                { continuation.resumeWithException(it) }
-            )
-        }
 
     suspend fun signIn(username: String?, password: String?): AuthSignInResult = suspendCoroutine { continuation ->
         delegate.signIn(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -45,7 +45,6 @@ import com.amplifyframework.auth.cognito.exceptions.service.InvalidParameterExce
 import com.amplifyframework.auth.cognito.exceptions.service.UserCancelledException
 import com.amplifyframework.auth.cognito.helpers.HostedUIHelper
 import com.amplifyframework.auth.cognito.helpers.SignInChallengeHelper
-import com.amplifyframework.auth.cognito.helpers.collectWhile
 import com.amplifyframework.auth.cognito.helpers.getAllowedMFATypesFromChallengeParameters
 import com.amplifyframework.auth.cognito.helpers.getMFASetupTypeOrNull
 import com.amplifyframework.auth.cognito.helpers.getMFAType
@@ -54,10 +53,8 @@ import com.amplifyframework.auth.cognito.helpers.identityProviderName
 import com.amplifyframework.auth.cognito.helpers.isMfaSetupSelectionChallenge
 import com.amplifyframework.auth.cognito.helpers.value
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignInOptions
-import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignUpOptions
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignOutOptions
-import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignUpOptions
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthWebUISignInOptions
 import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.auth.cognito.options.FederateToIdentityPoolOptions
@@ -74,15 +71,12 @@ import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.auth.exceptions.UnknownException
 import com.amplifyframework.auth.options.AuthConfirmSignInOptions
-import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
 import com.amplifyframework.auth.options.AuthFetchSessionOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
 import com.amplifyframework.auth.options.AuthSignOutOptions
-import com.amplifyframework.auth.options.AuthSignUpOptions
 import com.amplifyframework.auth.options.AuthWebUISignInOptions
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.auth.result.AuthSignOutResult
-import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.step.AuthNextSignInStep
 import com.amplifyframework.auth.result.step.AuthSignInStep
 import com.amplifyframework.core.Action
@@ -112,7 +106,6 @@ import com.amplifyframework.statemachine.codegen.events.SetupTOTPEvent
 import com.amplifyframework.statemachine.codegen.events.SignInChallengeEvent
 import com.amplifyframework.statemachine.codegen.events.SignInEvent
 import com.amplifyframework.statemachine.codegen.events.SignOutEvent
-import com.amplifyframework.statemachine.codegen.events.SignUpEvent
 import com.amplifyframework.statemachine.codegen.states.AuthState
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.AuthorizationState
@@ -134,8 +127,6 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 
@@ -187,134 +178,6 @@ internal class RealAWSCognitoAuthPlugin(
 
     internal suspend fun suspendWhileConfiguring() {
         authStateMachine.state.takeWhile { it !is AuthState.Configured && it !is AuthState.Error }.collect()
-    }
-
-    fun signUp(
-        username: String,
-        password: String?,
-        options: AuthSignUpOptions,
-        onSuccess: Consumer<AuthSignUpResult>,
-        onError: Consumer<AuthException>
-    ) {
-        authStateMachine.getCurrentState { authState ->
-            when (authState.authNState) {
-                is AuthenticationState.NotConfigured -> onError.accept(
-                    InvalidUserPoolConfigurationException()
-                )
-                else -> GlobalScope.launch {
-                    _signUp(username, password, options, onSuccess, onError)
-                }
-            }
-        }
-    }
-
-    private suspend fun _signUp(
-        username: String,
-        password: String?,
-        options: AuthSignUpOptions,
-        onSuccess: Consumer<AuthSignUpResult>,
-        onError: Consumer<AuthException>
-    ) {
-        authStateMachine.state.onStart {
-            val validationData = (options as? AWSCognitoAuthSignUpOptions)?.validationData
-            val clientMetadata = (options as? AWSCognitoAuthSignUpOptions)?.clientMetadata
-            val signupData = SignUpData(username, validationData, clientMetadata)
-            val event = SignUpEvent(SignUpEvent.EventType.InitiateSignUp(signupData, password, options.userAttributes))
-            authStateMachine.send(event)
-        }.drop(1).collectWhile { authState ->
-            when (val signUpState = authState.authSignUpState) {
-                is SignUpState.AwaitingUserConfirmation -> {
-                    onSuccess.accept(signUpState.signUpResult)
-                    false
-                }
-                is SignUpState.SignedUp -> {
-                    onSuccess.accept(signUpState.signUpResult)
-                    false
-                }
-                is SignUpState.Error -> {
-                    onError.accept(
-                        CognitoAuthExceptionConverter.lookup(signUpState.exception, "Sign up failed.")
-                    )
-                    false
-                }
-                else -> true
-            }
-        }
-    }
-
-    fun confirmSignUp(
-        username: String,
-        confirmationCode: String,
-        onSuccess: Consumer<AuthSignUpResult>,
-        onError: Consumer<AuthException>
-    ) {
-        confirmSignUp(username, confirmationCode, AuthConfirmSignUpOptions.defaults(), onSuccess, onError)
-    }
-
-    fun confirmSignUp(
-        username: String,
-        confirmationCode: String,
-        options: AuthConfirmSignUpOptions,
-        onSuccess: Consumer<AuthSignUpResult>,
-        onError: Consumer<AuthException>
-    ) {
-        authStateMachine.getCurrentState { authState ->
-            when (authState.authNState) {
-                is AuthenticationState.NotConfigured -> onError.accept(
-                    InvalidUserPoolConfigurationException()
-                )
-                else -> GlobalScope.launch {
-                    _confirmSignUp(username, confirmationCode, authState.authSignUpState, options, onSuccess, onError)
-                }
-            }
-        }
-    }
-
-    private suspend fun _confirmSignUp(
-        username: String,
-        confirmationCode: String,
-        authSignUpState: SignUpState?,
-        options: AuthConfirmSignUpOptions,
-        onSuccess: Consumer<AuthSignUpResult>,
-        onError: Consumer<AuthException>
-    ) {
-        val token = StateChangeListenerToken()
-        authStateMachine.listen(
-            token,
-            { authState ->
-                when (val signUpState = authState.authSignUpState) {
-                    // Only process error if new. Existing errors have already been passed to customer
-                    is SignUpState.Error -> {
-                        if (signUpState.hasNewResponse) {
-                            signUpState.hasNewResponse = false
-                            authStateMachine.cancel(token)
-                            onError.accept(
-                                CognitoAuthExceptionConverter.lookup(signUpState.exception, "Sign up failed.")
-                            )
-                        }
-                    }
-                    is SignUpState.SignedUp -> {
-                        authStateMachine.cancel(token)
-                        onSuccess.accept(signUpState.signUpResult)
-                    }
-                    else -> Unit
-                }
-            },
-            {
-                var userId: String? = null
-                var session: String? = null
-                if (authSignUpState is SignUpState.AwaitingUserConfirmation &&
-                    authSignUpState.signUpData.username == username
-                ) {
-                    session = authSignUpState.signUpData.session
-                    userId = authSignUpState.signUpResult.userId
-                }
-                val clientMetadata = (options as? AWSCognitoAuthConfirmSignUpOptions)?.clientMetadata
-                val signupData = SignUpData(username, null, clientMetadata, session, userId)
-                val event = SignUpEvent(SignUpEvent.EventType.ConfirmSignUp(signupData, confirmationCode))
-                authStateMachine.send(event)
-            }
-        )
     }
 
     fun autoSignIn(onSuccess: Consumer<AuthSignInResult>, onError: Consumer<AuthException>) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -126,6 +126,14 @@ internal class AuthUseCaseFactory(
         stateMachine = stateMachine
     )
 
+    fun signUp() = SignUpUseCase(
+        stateMachine = stateMachine
+    )
+
+    fun confirmSignUp() = ConfirmSignUpUseCase(
+        stateMachine = stateMachine
+    )
+
     fun resendSignupCode() = ResendSignupCodeUseCase(
         client = authEnvironment.requireIdentityProviderClient(),
         environment = authEnvironment,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -125,4 +125,10 @@ internal class AuthUseCaseFactory(
         environment = authEnvironment,
         stateMachine = stateMachine
     )
+
+    fun resendSignupCode() = ResendSignupCodeUseCase(
+        client = authEnvironment.requireIdentityProviderClient(),
+        environment = authEnvironment,
+        stateMachine = stateMachine
+    )
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ConfirmSignUpUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ConfirmSignUpUseCase.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.CognitoAuthExceptionConverter
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthConfirmSignUpOptions
+import com.amplifyframework.auth.cognito.throwIfNotConfigured
+import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.statemachine.codegen.data.SignUpData
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
+import com.amplifyframework.statemachine.codegen.states.SignUpState
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformWhile
+
+internal class ConfirmSignUpUseCase(private val stateMachine: AuthStateMachine) {
+    suspend fun execute(
+        username: String,
+        confirmationCode: String,
+        options: AuthConfirmSignUpOptions = AuthConfirmSignUpOptions.defaults()
+    ): AuthSignUpResult {
+        stateMachine.throwIfNotConfigured()
+
+        val startingState = stateMachine.getCurrentState().authSignUpState
+
+        val result = stateMachine.stateTransitions
+            .onStart {
+                var userId: String? = null
+                var session: String? = null
+                if (startingState is SignUpState.AwaitingUserConfirmation &&
+                    startingState.signUpData.username == username
+                ) {
+                    session = startingState.signUpData.session
+                    userId = startingState.signUpResult.userId
+                }
+                val clientMetadata = (options as? AWSCognitoAuthConfirmSignUpOptions)?.clientMetadata
+                val signupData = SignUpData(username, null, clientMetadata, session, userId)
+                val event = SignUpEvent(SignUpEvent.EventType.ConfirmSignUp(signupData, confirmationCode))
+                stateMachine.send(event)
+            }
+            .transformWhile { authState ->
+                when (val signUpState = authState.authSignUpState) {
+                    is SignUpState.Error -> {
+                        throw CognitoAuthExceptionConverter.lookup(signUpState.exception, "Sign up failed.")
+                    }
+                    is SignUpState.SignedUp -> {
+                        emit(signUpState.signUpResult)
+                        false
+                    }
+                    else -> true
+                }
+            }.first()
+
+        return result
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ResendSignupCodeUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/ResendSignupCodeUseCase.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AnalyticsMetadataType
+import aws.sdk.kotlin.services.cognitoidentityprovider.resendConfirmationCode
+import com.amplifyframework.auth.AuthCodeDeliveryDetails
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
+import com.amplifyframework.auth.cognito.helpers.AuthHelper
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthResendSignUpCodeOptions
+import com.amplifyframework.auth.cognito.util.toAuthCodeDeliveryDetails
+import com.amplifyframework.auth.exceptions.InvalidStateException
+import com.amplifyframework.auth.options.AuthResendSignUpCodeOptions
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+
+internal class ResendSignupCodeUseCase(
+    val client: CognitoIdentityProviderClient,
+    val environment: AuthEnvironment,
+    val stateMachine: AuthStateMachine
+) {
+    suspend fun execute(
+        username: String,
+        options: AuthResendSignUpCodeOptions = AuthResendSignUpCodeOptions.defaults()
+    ): AuthCodeDeliveryDetails {
+        stateMachine.requireSignedInOrSignedOutState()
+
+        val metadata = (options as? AWSCognitoAuthResendSignUpCodeOptions)?.metadata
+
+        val encodedContextData = environment.getUserContextData(username)
+        val pinpointEndpointId = environment.getPinpointEndpointId()
+
+        val configuration = environment.configuration
+
+        val response = client.resendConfirmationCode {
+            clientId = configuration.userPool?.appClient
+            this.username = username
+            secretHash = AuthHelper.getSecretHash(
+                username,
+                configuration.userPool?.appClient,
+                configuration.userPool?.appClientSecret
+            )
+            clientMetadata = metadata
+            pinpointEndpointId?.let {
+                this.analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = it }
+            }
+            encodedContextData?.let { this.userContextData { encodedData = it } }
+        }
+
+        return response.codeDeliveryDetails.toAuthCodeDeliveryDetails()
+    }
+}
+
+private suspend fun AuthStateMachine.requireSignedInOrSignedOutState(): AuthenticationState {
+    when (val state = getCurrentState().authNState) {
+        is AuthenticationState.SignedIn, is AuthenticationState.SignedOut -> return state
+        is AuthenticationState.NotConfigured -> throw InvalidUserPoolConfigurationException()
+        else -> throw InvalidStateException()
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/SignUpUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/SignUpUseCase.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.CognitoAuthExceptionConverter
+import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignUpOptions
+import com.amplifyframework.auth.cognito.throwIfNotConfigured
+import com.amplifyframework.auth.options.AuthSignUpOptions
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.statemachine.codegen.data.SignUpData
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
+import com.amplifyframework.statemachine.codegen.states.SignUpState
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformWhile
+
+internal class SignUpUseCase(private val stateMachine: AuthStateMachine) {
+    suspend fun execute(username: String, password: String?, options: AuthSignUpOptions): AuthSignUpResult {
+        stateMachine.throwIfNotConfigured()
+
+        val awsOptions = options as? AWSCognitoAuthSignUpOptions
+
+        val result = stateMachine.stateTransitions.onStart {
+            val validationData = awsOptions?.validationData
+            val clientMetadata = awsOptions?.clientMetadata
+            val signupData = SignUpData(username, validationData, clientMetadata)
+            val event = SignUpEvent(SignUpEvent.EventType.InitiateSignUp(signupData, password, options.userAttributes))
+            stateMachine.send(event)
+        }.transformWhile { authState ->
+            when (val signUpState = authState.authSignUpState) {
+                is SignUpState.AwaitingUserConfirmation -> {
+                    emit(signUpState.signUpResult)
+                    false
+                }
+                is SignUpState.SignedUp -> {
+                    emit(signUpState.signUpResult)
+                    false
+                }
+                is SignUpState.Error -> {
+                    throw CognitoAuthExceptionConverter.lookup(signUpState.exception, "Sign up failed.")
+                }
+                else -> true
+            }
+        }.first()
+
+        return result
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachine.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachine.kt
@@ -22,8 +22,10 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.withContext
@@ -62,6 +64,10 @@ internal open class StateMachine<StateType : State, EnvironmentType : Environmen
     // The current state of the state machine. Consumers can collect or read the current state from the read-only StateFlow
     private val _state = MutableStateFlow(initialState ?: resolver.defaultState)
     val state = _state.asStateFlow()
+
+    // A flow of states that omits the current states - emitting only states that occur after the flow starts.
+    val stateTransitions: Flow<StateType>
+        get() = state.drop(1)
 
     // Private accessor for the current state. Although this is thread-safe to access/mutate, we still want to limit
     // read/write to the single-threaded stateMachineContext for consistency

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -85,10 +85,12 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthSignUpResult> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.signUp()
+
         authPlugin.signUp(expectedUsername, expectedPassword, expectedOptions, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.signUp(expectedUsername, expectedPassword, expectedOptions, any(), any())
+        coVerify(timeout = CHANNEL_TIMEOUT) {
+            useCase.execute(expectedUsername, expectedPassword, expectedOptions)
         }
     }
 
@@ -99,14 +101,14 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthSignUpResult> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.confirmSignUp()
+
         authPlugin.confirmSignUp(expectedUsername, expectedConfirmationCode, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.confirmSignUp(
+        coVerify(timeout = CHANNEL_TIMEOUT) {
+            useCase.execute(
                 expectedUsername,
-                expectedConfirmationCode,
-                any(),
-                any()
+                expectedConfirmationCode
             )
         }
     }
@@ -119,6 +121,8 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthSignUpResult> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.confirmSignUp()
+
         authPlugin.confirmSignUp(
             expectedUsername,
             expectedConfirmationCode,
@@ -127,13 +131,11 @@ class AWSCognitoAuthPluginTest {
             expectedOnError
         )
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.confirmSignUp(
+        coVerify(timeout = CHANNEL_TIMEOUT) {
+            useCase.execute(
                 expectedUsername,
                 expectedConfirmationCode,
-                expectedOptions,
-                any(),
-                any()
+                expectedOptions
             )
         }
     }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -144,9 +144,11 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthCodeDeliveryDetails> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.resendSignupCode()
+
         authPlugin.resendSignUpCode(expectedUsername, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.resendSignUpCode(expectedUsername, any(), any()) }
+        coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(expectedUsername, any()) }
     }
 
     @Test
@@ -156,10 +158,12 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Consumer<AuthCodeDeliveryDetails> { }
         val expectedOnError = Consumer<AuthException> { }
 
+        val useCase = authPlugin.useCaseFactory.resendSignupCode()
+
         authPlugin.resendSignUpCode(expectedUsername, expectedOptions, expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) {
-            realPlugin.resendSignUpCode(expectedUsername, expectedOptions, any(), any())
+        coVerify(timeout = CHANNEL_TIMEOUT) {
+            useCase.execute(expectedUsername, expectedOptions)
         }
     }
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
@@ -31,11 +31,8 @@ import com.amplifyframework.auth.cognito.helpers.AuthHelper
 import com.amplifyframework.auth.cognito.helpers.SRPHelper
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
 import com.amplifyframework.auth.cognito.options.AuthFlowType
-import com.amplifyframework.auth.options.AuthConfirmSignUpOptions
 import com.amplifyframework.auth.options.AuthSignInOptions
-import com.amplifyframework.auth.options.AuthSignUpOptions
 import com.amplifyframework.auth.result.AuthSignInResult
-import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.logging.Logger
@@ -160,23 +157,6 @@ class RealAWSCognitoAuthPluginTest {
     }
 
     @Test
-    fun testSignUpFailsIfNotConfigured() {
-        // GIVEN
-        val onSuccess = mockk<Consumer<AuthSignUpResult>>()
-        val onError = mockk<Consumer<AuthException>>(relaxed = true)
-        val expectedAuthError = InvalidUserPoolConfigurationException()
-
-        setupCurrentAuthState(authNState = AuthenticationState.NotConfigured())
-
-        // WHEN
-        plugin.signUp("user", "pass", AuthSignUpOptions.builder().build(), onSuccess, onError)
-
-        // THEN
-        verify(exactly = 0) { onSuccess.accept(any()) }
-        verify { onError.accept(expectedAuthError) }
-    }
-
-    @Test
     fun testFetchAuthSessionSucceedsIfSignedOut() {
         // GIVEN
         val onSuccess = mockk<Consumer<AuthSession>>()
@@ -212,23 +192,6 @@ class RealAWSCognitoAuthPluginTest {
         )
 
         // THEN
-        verify(exactly = 0) { onSuccess.accept(any()) }
-    }
-
-    @Test
-    fun testConfirmSignUpFailsIfNotConfigured() {
-        // GIVEN
-        val expectedAuthError = InvalidUserPoolConfigurationException()
-        val onSuccess = mockk<Consumer<AuthSignUpResult>>()
-        val onError = ConsumerWithLatch<AuthException>(expect = expectedAuthError)
-
-        setupCurrentAuthState(authNState = AuthenticationState.NotConfigured())
-
-        // WHEN
-        plugin.confirmSignUp("user", "pass", AuthConfirmSignUpOptions.defaults(), onSuccess, onError)
-
-        // THEN
-        onError.shouldBeCalled()
         verify(exactly = 0) { onSuccess.accept(any()) }
     }
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ConfirmSignUpUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ConfirmSignUpUseCaseTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.auth.result.step.AuthNextSignUpStep
+import com.amplifyframework.auth.result.step.AuthSignUpStep
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
+import com.amplifyframework.statemachine.codegen.states.AuthState
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import com.amplifyframework.statemachine.codegen.states.SignUpState
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.justRun
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ConfirmSignUpUseCaseTest {
+
+    private val stateMachine: AuthStateMachine = mockk {
+        justRun { send(any()) }
+    }
+    private val useCase = ConfirmSignUpUseCase(stateMachine = stateMachine)
+
+    @Test
+    fun `fails if not configured`() = runTest {
+        val expectedAuthError = InvalidUserPoolConfigurationException()
+
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrowAny {
+            useCase.execute("user", "pass")
+        } shouldBe expectedAuthError
+    }
+
+    @Test
+    fun `fails if error occurs in state machine`() = runTest {
+        val exception = AuthException("test", "test")
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns null
+
+        coEvery { stateMachine.stateTransitions } returns flowOf(
+            mockAuthState(SignUpState.ConfirmingSignUp(mockk())),
+            mockAuthState(SignUpState.Error(exception))
+        )
+
+        shouldThrowAny {
+            useCase.execute("user", "pass")
+        } shouldBe exception
+    }
+
+    @Test
+    fun `sends expected event`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns null
+
+        coEvery { stateMachine.stateTransitions } returns flowOf(
+            mockAuthState(SignUpState.ConfirmingSignUp(mockk())),
+            mockAuthState(SignUpState.SignedUp(mockk(), mockk()))
+        )
+
+        useCase.execute("user", "pass")
+
+        coVerify {
+            stateMachine.send(
+                withArg { event ->
+                    val type = (event as SignUpEvent).eventType as SignUpEvent.EventType.ConfirmSignUp
+                    type.signUpData.username shouldBe "user"
+                    type.confirmationCode shouldBe "pass"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `returns auth result`() = runTest {
+        val expectedResult = AuthSignUpResult(
+            true,
+            AuthNextSignUpStep(
+                AuthSignUpStep.DONE,
+                emptyMap(),
+                null
+            ),
+            null
+        )
+
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns null
+
+        coEvery { stateMachine.stateTransitions } returns flowOf(
+            mockAuthState(SignUpState.ConfirmingSignUp(mockk())),
+            mockAuthState(SignUpState.SignedUp(mockk(), expectedResult))
+        )
+
+        val result = useCase.execute("user", "pass")
+
+        result shouldBe expectedResult
+    }
+
+    private fun mockAuthState(signUpState: SignUpState): AuthState = mockk {
+        coEvery { authSignUpState } returns signUpState
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ResendSignupCodeUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ResendSignupCodeUseCaseTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AnalyticsMetadataType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ForgotPasswordResponse
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ResendConfirmationCodeRequest
+import aws.sdk.kotlin.services.cognitoidentityprovider.resendConfirmationCode
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.MockAuthHelperRule
+import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
+import com.amplifyframework.auth.cognito.mockSignedInData
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class ResendSignupCodeUseCaseTest {
+    private val client: CognitoIdentityProviderClient = mockk {
+        coEvery { forgotPassword(any()) } returns ForgotPasswordResponse {
+            codeDeliveryDetails = mockk(relaxed = true)
+        }
+    }
+
+    private val environment = mockk<AuthEnvironment> {
+        coEvery { getDeviceMetadata("user")?.deviceKey } returns "test deviceKey"
+        every { getPinpointEndpointId() } returns "pinpointId"
+        coEvery { getUserContextData(any()) } returns null
+        every { configuration.userPool } returns mockk {
+            every { appClient } returns "clientId"
+            every { appClientSecret } returns "clientSecret"
+        }
+    }
+    private val stateMachine: AuthStateMachine = mockk {
+        coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
+            signedInData = mockSignedInData(username = "user"),
+            deviceMetadata = mockk()
+        )
+    }
+
+    private val useCase = ResendSignupCodeUseCase(
+        client = client,
+        environment = environment,
+        stateMachine = stateMachine
+    )
+
+    @get:Rule
+    val authHelperRule = MockAuthHelperRule()
+
+    @Test
+    fun `fails if not configured`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrow<InvalidUserPoolConfigurationException> {
+            useCase.execute("username")
+        }
+    }
+
+    @Test
+    fun `succeeds if signed out`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.SignedOut(mockk())
+        runSuccessTest()
+    }
+
+    @Test
+    fun `succeeds if signed in`() = runTest {
+        runSuccessTest()
+    }
+
+    private suspend fun runSuccessTest() {
+        coEvery { client.resendConfirmationCode(any()) } returns mockk(relaxed = true)
+
+        val username = "user"
+
+        val expectedRequest: ResendConfirmationCodeRequest.Builder.() -> Unit = {
+            clientId = "clientId"
+            this.username = username
+            secretHash = MockAuthHelperRule.DEFAULT_HASH
+            analyticsMetadata = AnalyticsMetadataType.invoke { analyticsEndpointId = "pinpointId" }
+        }
+
+        // WHEN
+        useCase.execute(username)
+
+        coVerify {
+            client.resendConfirmationCode(expectedRequest)
+        }
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/SignUpUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/SignUpUseCaseTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.usecases
+
+import com.amplifyframework.auth.AuthException
+import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
+import com.amplifyframework.auth.options.AuthSignUpOptions
+import com.amplifyframework.auth.result.AuthSignUpResult
+import com.amplifyframework.auth.result.step.AuthNextSignUpStep
+import com.amplifyframework.auth.result.step.AuthSignUpStep
+import com.amplifyframework.statemachine.codegen.events.SignUpEvent
+import com.amplifyframework.statemachine.codegen.states.AuthState
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import com.amplifyframework.statemachine.codegen.states.SignUpState
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.justRun
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SignUpUseCaseTest {
+    private val stateMachine: AuthStateMachine = mockk {
+        justRun { send(any()) }
+    }
+    private val useCase = SignUpUseCase(stateMachine = stateMachine)
+
+    @Test
+    fun `fails if not configured`() = runTest {
+        val expectedAuthError = InvalidUserPoolConfigurationException()
+
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.NotConfigured()
+
+        shouldThrowAny {
+            useCase.execute("user", "pass", AuthSignUpOptions.builder().build())
+        } shouldBe expectedAuthError
+    }
+
+    @Test
+    fun `fails if error occurs in state machine`() = runTest {
+        val exception = AuthException("test", "test")
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns null
+
+        coEvery { stateMachine.stateTransitions } returns flowOf(
+            mockAuthState(SignUpState.Error(exception))
+        )
+
+        shouldThrowAny {
+            useCase.execute("user", "pass", AuthSignUpOptions.builder().build())
+        } shouldBe exception
+    }
+
+    @Test
+    fun `sends expected event`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns null
+
+        coEvery { stateMachine.stateTransitions } returns flowOf(
+            mockAuthState(SignUpState.ConfirmingSignUp(mockk())),
+            mockAuthState(SignUpState.SignedUp(mockk(), mockk()))
+        )
+
+        useCase.execute("user", "pass", AuthSignUpOptions.builder().build())
+
+        coVerify {
+            stateMachine.send(
+                withArg { event ->
+                    val type = (event as SignUpEvent).eventType as SignUpEvent.EventType.InitiateSignUp
+                    type.signUpData.username shouldBe "user"
+                    type.password shouldBe "pass"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `returns auth result`() = runTest {
+        val expectedResult = AuthSignUpResult(
+            true,
+            AuthNextSignUpStep(
+                AuthSignUpStep.DONE,
+                emptyMap(),
+                null
+            ),
+            null
+        )
+
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns null
+
+        coEvery { stateMachine.stateTransitions } returns flowOf(
+            mockAuthState(SignUpState.ConfirmingSignUp(mockk())),
+            mockAuthState(SignUpState.SignedUp(mockk(), expectedResult))
+        )
+
+        val result = useCase.execute("user", "pass", AuthSignUpOptions.builder().build())
+
+        result shouldBe expectedResult
+    }
+
+    private fun mockAuthState(signUpState: SignUpState): AuthState = mockk {
+        coEvery { authSignUpState } returns signUpState
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Moves `signUp`, `confirmSignUp`, and `resendSignupCode` to usecase classes.
This PR adds lines because `signUp` and `confirmSignUp` did not have good unit test coverage, that has been improved in this PR.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
