### PR TITLE
chore: Remove special characters before calling xargs in comment notify

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -17,7 +17,7 @@ jobs:
           COMMENT_URL: ${{ github.event.comment.html_url }}
           USER: ${{ github.event.comment.user.login }}
         shell: bash
-        run: echo $BODY | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"body":"{}", "issue":"'$COMMENT_URL'", "user":"'$USER'"}'
+        run: echo $BODY | sed "s/\\\n/. /g; s/\\\r//g; s/[^a-zA-Z0-9 &().,:]//g" | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"body":"{}", "issue":"'$COMMENT_URL'", "user":"'$USER'"}'
 
   adjust-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
This change strips special characters before calling xargs when posting a Slack notification for issue comments, which fixes failures caused by comments that e.g. have quotes in them.

*How did you test these changes?*

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
