### PR TITLE
fix(all): Add additional consumer proguard rules for missing classes

### DIFF
--- a/configuration/consumer-rules.pro
+++ b/configuration/consumer-rules.pro
@@ -5,3 +5,9 @@
 
 # We check for specific engine classes on the classpath to determine whether Amplify should use OkHttp4 instead of OkHttp5
 -keepnames class aws.smithy.kotlin.runtime.http.engine.okhttp4.*
+
+# OkHttp4 will not be present if not explicitly added by the customer, don't warn if it's missing
+-dontwarn aws.smithy.kotlin.runtime.http.engine.okhttp4.OkHttp4Engine
+
+# This Tink annotation is missing from an upstream dependency
+-dontwarn com.google.errorprone.annotations.Immutable


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #2998

*Description of changes:*
Add consumer rules to skip warnings introduced in 2.26.0. The OkHttp4Engine is only referenced safely by Amplify so this is OK, and the `Immutable` reference is for a static linting annotation and can safely be ignored.

*How did you test these changes?*
Verified r8 no longer produces warnings for these missing classes.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
