### PR TITLE
fix(auth): Fix passkey usage on Android < 13 devices

### DIFF
--- a/aws-auth-cognito/build.gradle.kts
+++ b/aws-auth-cognito/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.androidx.security)
     implementation(libs.androidx.browser)
     implementation(libs.androidx.credentials)
+    implementation(libs.androidx.credentials.play.services)
 
     implementation(libs.aws.http)
     implementation(libs.aws.cognitoidentity)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
@@ -19,7 +19,7 @@ package com.amplifyframework.auth.cognito.exceptions.webauthn
  * Exception that is thrown because WebAuthn is not supported on the device. This indicates that either the device
  * did not ship with WebAuthn support, or that your application is missing a required dependency or service.
  */
-class WebAuthnNotSupportedException internal constructor(cause: Throwable? = null) :
+class WebAuthnNotSupportedException internal constructor(cause: Throwable?) :
     WebAuthnFailedException(
         message = "WebAuthn is not supported on this device",
         recoverySuggestion = TODO_RECOVERY_SUGGESTION,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
@@ -19,7 +19,7 @@ package com.amplifyframework.auth.cognito.exceptions.webauthn
  * Exception that is thrown because WebAuthn is not supported on the device. This indicates that either the device
  * did not ship with WebAuthn support, or that your application is missing a required dependency or service.
  */
-class WebAuthnNotSupportedException internal constructor(cause: Throwable?) :
+class WebAuthnNotSupportedException internal constructor(cause: Throwable? = null) :
     WebAuthnFailedException(
         message = "WebAuthn is not supported on this device",
         recoverySuggestion = TODO_RECOVERY_SUGGESTION,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
@@ -19,9 +19,15 @@ package com.amplifyframework.auth.cognito.exceptions.webauthn
  * Exception that is thrown because WebAuthn is not supported on the device. This indicates that either the device
  * did not ship with WebAuthn support, or that your application is missing a required dependency or service.
  */
-class WebAuthnNotSupportedException internal constructor(cause: Throwable?) :
-    WebAuthnFailedException(
-        message = "WebAuthn is not supported on this device",
-        recoverySuggestion = TODO_RECOVERY_SUGGESTION,
-        cause = cause
-    )
+class WebAuthnNotSupportedException internal constructor(
+    message: String,
+    cause: Throwable? = null
+) : WebAuthnFailedException(
+    message = message,
+    recoverySuggestion = TODO_RECOVERY_SUGGESTION,
+    cause = cause
+) {
+    internal constructor(
+        cause: Throwable?
+    ) : this(message = "WebAuthn is not supported on this device", cause = cause)
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelper.kt
@@ -95,7 +95,7 @@ internal class WebAuthnHelper(
                 throw e.toAuthException()
             }
         } else {
-            throw WebAuthnNotSupportedException(cause = null)
+            throw WebAuthnNotSupportedException("Passkeys are only supported on API 28 and above")
         }
     }
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelper.kt
@@ -95,7 +95,7 @@ internal class WebAuthnHelper(
                 throw e.toAuthException()
             }
         } else {
-            throw WebAuthnNotSupportedException()
+            throw WebAuthnNotSupportedException(cause = null)
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -191,6 +191,11 @@ fun Project.configureAndroid() {
 
         dependencies {
             add("coreLibraryDesugaring", libs.android.desugartools)
+            constraints {
+                add("implementation", libs.androidx.annotation.experimental) {
+                    because("Fixes a lint bug with RequiresOptIn")
+                }
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ androidx-browser = { module = "androidx.browser:browser", version.ref = "android
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref="androidx-credentials" }
+androidx-credentials-play-services = { module = "androidx.credentials:credentials-play-services-auth", version.ref="androidx-credentials" }
 androidx-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junit-ktx" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidx-lifecycle" }
 androidx-nav-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "navigation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.4.0"
 androidx-activity = "1.2.0"
 androidx-annotation = "1.9.1"
+androidx-annotation-experimental = "1.4.1"
 androidx-appcompat = "1.2.0"
 androidx-browser = "1.4.0"
 androidx-concurrent = "1.1.0"
@@ -57,6 +58,7 @@ turbine = "1.1.0"
 android-desugartools = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
+androidx-annotation-experimental = { module = "androidx.annotation:annotation-experimental", version.ref = "androidx-annotation-experimental" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref="androidx-appcompat" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Passkeys use credential manager, which require the play services dependency if running on pre-Android 13 devices. Previously customers had to add this dependency themselves, but we should have done it.

*How did you test these changes?*
- Verified passkey usage works on device running Android 10

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
