### PR TITLE
fix(storage): Disable aws-chunked encoding for requests that require progress listening

### DIFF
--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/DownloadWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/DownloadWorker.kt
@@ -70,6 +70,7 @@ internal class DownloadWorker(
         return s3.withConfig {
             interceptors += DownloadProgressListenerInterceptor(downloadProgressListener)
             enableAccelerate = transferRecord.useAccelerateEndpoint == 1
+            enableAwsChunked = false
         }.getObject(getObjectRequest) { response ->
             val totalBytes = (response.body?.contentLength ?: 0L) + downloadedBytes
             transferRecord.bytesTotal = totalBytes

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/PartUploadTransferWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/PartUploadTransferWorker.kt
@@ -55,6 +55,7 @@ internal class PartUploadTransferWorker(
             s3.withConfig {
                 interceptors += UploadProgressListenerInterceptor(partUploadProgressListener)
                 enableAccelerate = transferRecord.useAccelerateEndpoint == 1
+                enableAwsChunked = false
             }.uploadPart {
                 bucket = transferRecord.bucketName
                 key = transferRecord.key

--- a/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/SinglePartUploadWorker.kt
+++ b/aws-storage-s3/src/main/java/com/amplifyframework/storage/s3/transfer/worker/SinglePartUploadWorker.kt
@@ -45,6 +45,7 @@ internal class SinglePartUploadWorker(
         return s3.withConfig {
             interceptors += UploadProgressListenerInterceptor(uploadProgressListener)
             enableAccelerate = transferRecord.useAccelerateEndpoint == 1
+            enableAwsChunked = false
         }.putObject(putObjectRequest).let {
             Result.success(outputData)
         }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* https://github.com/aws-amplify/amplify-android/issues/2869

*Description of changes:* 
The root cause for the issue is that the number of bytes that get transferred when doing a multi-part upload is *larger* than the actual file size. So for transfer that happens over the file size, registers as a 100% status. This is because the default config for the S3 client is to do a chunked upload using AWS Sig v4 [as per these docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html). The signing adds some additional overhead the amount of bytes that are transferred over the wire.

Unfortunately, there doesn't seem to be a reliable way to calculate what that overhead is. In fact, the SDK team suggests disabling it entirely for the purpose of listening to the progress:

> NOTE: A content length is required to implement a meaningful progress listener. Customers will likely need to disable aws-chunked signing and any other SDK abstraction that results in Transfer-Encoding: chunked with no concrete stream length.

[Source](https://github.com/smithy-lang/smithy-kotlin/blob/main/docs/design/interceptors.md#progress-listeners)

As per this PR, "requests with body larger than 1MB will be chunked and uploaded using aws-chunked encoding" so this also affects SinglePart upload (i.e. files smaller than 5MB) as well as Downloads so I disabled the config on those workers as well.

*How did you test these changes?*
Tested with uploading multiple different files before and after this change. Tracked the number of bytes that got sent and compared with the actual file size. Only after this change does the number of bytes match.

I have to round out my testing with verifying download progress so that's pending.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [x] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
