### PR TITLE
fix(auth): Update exception handling for devices that don't support passkeys

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnNotSupportedException.kt
@@ -17,14 +17,19 @@ package com.amplifyframework.auth.cognito.exceptions.webauthn
 
 /**
  * Exception that is thrown because WebAuthn is not supported on the device. This indicates that either the device
- * did not ship with WebAuthn support, or that your application is missing a required dependency or service.
+ * is too old or it did not ship with WebAuthn support, or that your application is missing a required dependency
+ * or service.
  */
 class WebAuthnNotSupportedException internal constructor(
     message: String,
     cause: Throwable? = null
 ) : WebAuthnFailedException(
     message = message,
-    recoverySuggestion = TODO_RECOVERY_SUGGESTION,
+    recoverySuggestion = if (cause != null) {
+        RECOVERY_SUGGESTION_WITH_THROWABLE
+    } else {
+        TODO_RECOVERY_SUGGESTION
+    },
     cause = cause
 ) {
     internal constructor(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/WebAuthnHelper.kt
@@ -36,6 +36,7 @@ import androidx.credentials.exceptions.GetCredentialUnsupportedException
 import androidx.credentials.exceptions.domerrors.DataError
 import androidx.credentials.exceptions.domerrors.InvalidStateError
 import androidx.credentials.exceptions.domerrors.NotAllowedError
+import androidx.credentials.exceptions.domerrors.NotSupportedError
 import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
 import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialException
 import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
@@ -123,6 +124,7 @@ internal class WebAuthnHelper(
                 is NotAllowedError -> userCancelledException()
                 is InvalidStateError -> alreadyExists()
                 is DataError -> rpMismatch()
+                is NotSupportedError -> notSupported()
                 else -> unknownException()
             }
         }
@@ -137,6 +139,7 @@ internal class WebAuthnHelper(
             when (this.domError) {
                 is NotAllowedError -> userCancelledException()
                 is DataError -> rpMismatch()
+                is NotSupportedError -> notSupported()
                 else -> unknownException()
             }
         }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
If CredentialManager tells us a device doesn't support passkeys then throw a `WebAuthnNotSupportedException` instead of general `WebAuthnException`.
Added unit tests.

*How did you test these changes?*
Unit tests
Replicate on pre-Android 28 device

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
