### PR TITLE
chore: Use codecov token for code report uploads

### DIFF
--- a/.github/workflows/codecov_code_coverage.yml
+++ b/.github/workflows/codecov_code_coverage.yml
@@ -8,11 +8,9 @@ on:
   push:
     branches:
       - 'main'
-      - 'v1'
   pull_request:
     branches:
       - 'main'
-      - 'v1'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/codecov_code_coverage.yml
+++ b/.github/workflows/codecov_code_coverage.yml
@@ -42,7 +42,9 @@ jobs:
         run: cp -r /home/runner/work/amplify-android/amplify-android/**/build/reports/kover/xml/*.xml /home/runner/work/amplify-android/amplify-android/code-coverage/
 
       - name: Upload Test Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           name: report
           files: code-coverage/*.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Use configured codecov token to upload coverage reports to avoid rate limiting.

*How did you test these changes?*

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
