### PR TITLE
fix(auth): Remove WindowManager usage from DeviceDataCollector

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/asf/DeviceDataCollector.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/asf/DeviceDataCollector.kt
@@ -17,8 +17,6 @@ package com.amplifyframework.auth.cognito.asf
 
 import android.content.Context
 import android.provider.Settings
-import android.view.Display
-import android.view.WindowManager
 import java.util.Locale
 import java.util.TimeZone
 import java.util.concurrent.TimeUnit
@@ -77,24 +75,19 @@ internal class DeviceDataCollector(private val deviceId: String) : DataCollector
             return (if (hours < 0) "-" else "") + String.format(Locale.US, "%02d:%02d", abs(hours), minutes)
         }
 
-    private fun getDisplay(context: Context): Display {
-        val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-        return windowManager.defaultDisplay
-    }
-
     /**
      * {@inheritDoc}
      */
     override fun collect(context: Context): Map<String, String?> {
-        val display = getDisplay(context)
+        val displayMetrics = context.resources.displayMetrics
         return mapOf(
             TIMEZONE to timezoneOffset,
             PLATFORM_KEY to PLATFORM_VALUE,
             THIRD_PARTY_DEVICE_AGENT to thirdPartyDeviceAgent,
             DEVICE_AGENT to deviceId,
             DEVICE_LANGUAGE to language,
-            DEVICE_HEIGHT to display.height.toString(),
-            DEVICE_WIDTH to display.width.toString()
+            DEVICE_HEIGHT to displayMetrics.heightPixels.toString(),
+            DEVICE_WIDTH to displayMetrics.widthPixels.toString()
         )
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/asf/DeviceDataCollectorTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/asf/DeviceDataCollectorTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.asf
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.auth.cognito.asf.DeviceDataCollector.Companion.DEVICE_AGENT
+import com.amplifyframework.auth.cognito.asf.DeviceDataCollector.Companion.DEVICE_HEIGHT
+import com.amplifyframework.auth.cognito.asf.DeviceDataCollector.Companion.DEVICE_LANGUAGE
+import com.amplifyframework.auth.cognito.asf.DeviceDataCollector.Companion.DEVICE_WIDTH
+import com.amplifyframework.auth.cognito.asf.DeviceDataCollector.Companion.PLATFORM_KEY
+import com.amplifyframework.auth.cognito.asf.DeviceDataCollector.Companion.THIRD_PARTY_DEVICE_AGENT
+import com.amplifyframework.auth.cognito.asf.DeviceDataCollector.Companion.TIMEZONE
+import io.kotest.matchers.maps.shouldContainExactly
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.util.SimpleTimeZone
+import java.util.TimeZone
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "en-rUS-w75dp-h150dp")
+class DeviceDataCollectorTest {
+
+    @Before
+    fun setup() {
+        mockkStatic(TimeZone::class)
+        every { TimeZone.getDefault() } returns SimpleTimeZone(0, "UTC")
+    }
+
+    @After
+    fun teardown() {
+        unmockkStatic(TimeZone::class)
+    }
+
+    @Test
+    fun `returns expected values`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        val collector = DeviceDataCollector("deviceId")
+        val data = collector.collect(context)
+
+        data shouldContainExactly mapOf(
+            TIMEZONE to "00:00",
+            PLATFORM_KEY to "ANDROID",
+            THIRD_PARTY_DEVICE_AGENT to "android_id",
+            DEVICE_AGENT to "deviceId",
+            DEVICE_LANGUAGE to "en_US",
+            DEVICE_HEIGHT to "150",
+            DEVICE_WIDTH to "75"
+        )
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #3057

*Description of changes:*
Use displayMetrics to get the size of the display instead of WindowManager. Added unit tests.

*How did you test these changes?*
Verified that app crashes on signIn if the following strictMode is used, but does not crash afterwards:

```kotlin
StrictMode.setVmPolicy(
    StrictMode.VmPolicy.Builder()
        .detectIncorrectContextUse()
        .penaltyLog()
        .penaltyDeath()
        .build()
)
```

Verified that the same device size is returned before and after the change.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
