### PR TITLE
fix(auth): Emit SIGNED_IN event after autoSignIn

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -20,13 +20,11 @@ import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.RealAWSCognitoAuthPlugin
 import com.amplifyframework.auth.cognito.helpers.WebAuthnHelper
 import com.amplifyframework.auth.cognito.requireIdentityProviderClient
-import com.amplifyframework.auth.plugins.core.AuthHubEventEmitter
 
 internal class AuthUseCaseFactory(
     private val plugin: RealAWSCognitoAuthPlugin,
     private val authEnvironment: AuthEnvironment,
-    private val stateMachine: AuthStateMachine,
-    private val hubEmitter: AuthHubEventEmitter = AuthHubEventEmitter()
+    private val stateMachine: AuthStateMachine
 ) {
 
     fun fetchAuthSession() = FetchAuthSessionUseCase(plugin)
@@ -143,8 +141,7 @@ internal class AuthUseCaseFactory(
     )
 
     fun autoSignIn() = AutoSignInUseCase(
-        stateMachine = stateMachine,
-        hubEmitter = hubEmitter
+        stateMachine = stateMachine
     )
 
     fun fetchMfaPreference() = FetchMfaPreferenceUseCase(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AutoSignInUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AutoSignInUseCase.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.flow.transformWhile
 
 internal class AutoSignInUseCase(
     private val stateMachine: AuthStateMachine,
-    private val hubEmitter: AuthHubEventEmitter
+    private val hubEmitter: AuthHubEventEmitter = AuthHubEventEmitter()
 ) {
     suspend fun execute(): AuthSignInResult {
         val authState = waitForSignedOutState()


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #3064

*Description of changes:*
Fixes two issues found in AutoSignInUseCase:
- The hub emitter was being called after emitting the sign in result. This doesn't work because of the use of the `first()` terminal operator, which cancels flow collection as soon as the sign in result is received. This would cancel the suspended coroutine and thus it never resumes to proceed to emitting the hub event.
- The use case was reusing the same hub emitter for multiple instances. This is the wrong pattern and would result in subsequent events potentially not being emitted if there were multiple sign ups within a single app session.

I also changed the transforming function from `transformWhile` to `mapNotNull` to make it more obvious that the collector is cancelled when the result is emitted.

*How did you test these changes?*
- Verified event is emitted using autoSignIn
- Added unit test to ensure event is emitted

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
