### PR TITLE
chore: Fix unclosed databases in WorkManager tests

### DIFF
--- a/aws-logging-cloudwatch/src/test/kotlin/com/amplifyframework/logging/cloudwatch/CloudWatchLogManagerTest.kt
+++ b/aws-logging-cloudwatch/src/test/kotlin/com/amplifyframework/logging/cloudwatch/CloudWatchLogManagerTest.kt
@@ -42,6 +42,7 @@ import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -91,6 +92,11 @@ internal class CloudWatchLogManagerTest {
             customCognitoCredentialsProvider,
             testDispatcher
         )
+    }
+
+    @After
+    fun cleanup() {
+        WorkManagerTestInitHelper.closeWorkDatabase()
     }
 
     @Test

--- a/aws-logging-cloudwatch/src/test/kotlin/com/amplifyframework/logging/cloudwatch/LoggingConstraintsResolverTest.kt
+++ b/aws-logging-cloudwatch/src/test/kotlin/com/amplifyframework/logging/cloudwatch/LoggingConstraintsResolverTest.kt
@@ -34,6 +34,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -45,6 +46,11 @@ internal class LoggingConstraintsResolverTest {
 
     private lateinit var loggingConstraintsResolver: LoggingConstraintsResolver
     private val userId = "USER_ID"
+
+    @After
+    fun cleanup() {
+        WorkManagerTestInitHelper.closeWorkDatabase()
+    }
 
     @Test
     fun `test default logLevel`() {

--- a/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/transfer/worker/ImmediateTaskExecutor.kt
+++ b/aws-storage-s3/src/test/java/com/amplifyframework/storage/s3/transfer/worker/ImmediateTaskExecutor.kt
@@ -14,23 +14,21 @@
  */
 package com.amplifyframework.storage.s3.transfer.worker
 
-import androidx.work.impl.utils.SerialExecutor
 import androidx.work.impl.utils.SynchronousExecutor
+import androidx.work.impl.utils.taskexecutor.SerialExecutor
 import androidx.work.impl.utils.taskexecutor.TaskExecutor
 import java.util.concurrent.Executor
 
 class ImmediateTaskExecutor : TaskExecutor {
     private val mSynchronousExecutor: Executor = SynchronousExecutor()
-    private val mSerialExecutor = SerialExecutor(mSynchronousExecutor)
-    override fun postToMainThread(runnable: Runnable?) {
-        runnable?.run()
-    }
+    private val mSerialExecutor = SerialExecutorImpl(mSynchronousExecutor)
 
     override fun getMainThreadExecutor(): Executor = mSynchronousExecutor
 
-    override fun executeOnBackgroundThread(runnable: Runnable?) {
-        runnable?.let { mSerialExecutor.execute(it) }
-    }
+    override fun getSerialTaskExecutor(): SerialExecutor = mSerialExecutor
 
-    override fun getBackgroundExecutor(): SerialExecutor = mSerialExecutor
+    private class SerialExecutorImpl(val delegate: Executor) : SerialExecutor, Executor by delegate {
+        // There's never any pending tasks since we execute all immediately
+        override fun hasPendingTasks() = false
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ androidx-test-core = "1.3.0"
 androidx-test-junit = "1.1.2"
 androidx-test-orchestrator = "1.4.2"
 androidx-test-runner = "1.3.0"
-androidx-workmanager = "2.7.1"
+androidx-workmanager = "2.9.1"
 apollo = "4.0.0"
 aws-kotlin = "1.3.81" # ensure proper aws-smithy version also set
 aws-sdk = "2.62.2"
@@ -74,7 +74,7 @@ androidx-nav-ui = { module = "androidx.navigation:navigation-ui", version.ref = 
 androidx-security = { module = "androidx.security:security-crypto", version.ref = "androidx-security" }
 androidx-sqlite = { module = "androidx.sqlite:sqlite", version.ref = "androidx-sqlite" }
 androidx-v4support = { module = "androidx.legacy:legacy-support-v4", version.ref = "androidx-legacy" }
-androidx-workmanager = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-workmanager" }
+androidx-workmanager = { module = "androidx.work:work-runtime", version.ref = "androidx-workmanager" }
 apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
 aws-cloudwatchlogs = { module = "aws.sdk.kotlin:cloudwatchlogs", version.ref = "aws-kotlin" }
 aws-cognitoidentity = { module = "aws.sdk.kotlin:cognitoidentity", version.ref = "aws-kotlin" }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Fixes unclosed databases in the unit tests for cloudwatch logging plugin. This was addressed in version **2.9.0** of the WorkManager test artifact, which added the `closeWorkDatabase()` function. (see [here](https://issuetracker.google.com/issues/242026176))

I updated to **2.9.1**, which is the latest version that didn't require adjusting our compile SDK.

I replaced the `workmanager-runtime-ktx` dependency with `workmanager-runtime` because as of version 2.9.0 the KTX functionality was promoted to the main artifact, and `workmanager-runtime-ktx` is now empty.

*How did you test these changes?*
Verified that no error logs emitted by these tests.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
