### PR TITLE
fix(auth): Select first non http(s) redirect

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthConfiguration.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.auth.cognito
 import androidx.annotation.IntRange
 import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.helpers.HostedUIHelper
 import com.amplifyframework.auth.cognito.options.AuthFlowType
 import com.amplifyframework.auth.exceptions.ConfigurationException
 import com.amplifyframework.core.configuration.AmplifyOutputsData
@@ -150,11 +151,9 @@ data class AuthConfiguration internal constructor(
                     appSecret = null, // Not supported in Gen2
                     domain = it.domain,
                     scopes = it.scopes.toSet(),
-                    // Note: Gen2 config gives an array for these values, while Gen1 is just a String. In Gen1
-                    // if you specify multiple URIs the CLI will join them to a comma-delimited string in the json.
-                    // We are matching that behaviour here for Gen2.
-                    signInRedirectURI = it.redirectSignInUri.joinToString(","),
-                    signOutRedirectURI = it.redirectSignOutUri.joinToString(",")
+                    // For sign-in, prefer a non-HTTP/HTTPS URI if available (for mobile apps)
+                    signInRedirectURI = HostedUIHelper.selectRedirectUri(it.redirectSignInUri) ?: "",
+                    signOutRedirectURI = HostedUIHelper.selectRedirectUri(it.redirectSignOutUri) ?: ""
                 )
             }
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/HostedUIHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/HostedUIHelper.kt
@@ -37,4 +37,24 @@ internal object HostedUIHelper {
         ),
         browserPackage = (options as? AWSCognitoAuthWebUISignInOptions)?.browserPackage
     )
+
+    /**
+     * Selects a redirect URI from the list, preferring a non-HTTP/HTTPS URI if available.
+     * If no suitable URI is found, falls back to the first URI in the list.
+     *
+     * @param redirectUris List of redirect URIs
+     * @return The selected redirect URI, or first if not empty
+     */
+    fun selectRedirectUri(redirectUris: List<String>): String? {
+        if (redirectUris.isEmpty()) return null
+
+        // First try to find a non-HTTP/HTTPS URI (app scheme URI)
+        val nonWebUri = redirectUris.find { uri ->
+            val scheme = uri.substringBefore("://", "").lowercase()
+            scheme != "http" && scheme != "https" && scheme.isNotEmpty()
+        }
+
+        // Return the non-web URI if found, otherwise use the first URI
+        return nonWebUri ?: redirectUris.firstOrNull()
+    }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/OauthConfiguration.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/OauthConfiguration.kt
@@ -16,6 +16,7 @@
 package com.amplifyframework.statemachine.codegen.data
 
 import com.amplifyframework.annotations.InternalAmplifyApi
+import com.amplifyframework.auth.cognito.helpers.HostedUIHelper
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -58,8 +59,15 @@ data class OauthConfiguration internal constructor(
                     }
                     scopesSet
                 }
-                val signInRedirectURI = optString(SIGN_IN_REDIRECT_URI).takeUnless { it.isNullOrEmpty() }
-                val signOutRedirectURI = optString(SIGN_OUT_REDIRECT_URI).takeUnless { it.isNullOrEmpty() }
+                // Get redirect URIs and split by comma if multiple URIs are provided
+                val signInRedirectURIs =
+                    optString(SIGN_IN_REDIRECT_URI).takeUnless { it.isNullOrEmpty() }?.split(",") ?: emptyList()
+                val signOutRedirectURIs =
+                    optString(SIGN_OUT_REDIRECT_URI).takeUnless { it.isNullOrEmpty() }?.split(",") ?: emptyList()
+
+                // Select appropriate redirect URIs (prefer non-HTTP/HTTPS URIs for mobile)
+                val signInRedirectURI = HostedUIHelper.selectRedirectUri(signInRedirectURIs)
+                val signOutRedirectURI = HostedUIHelper.selectRedirectUri(signOutRedirectURIs)
 
                 return if (appClient != null &&
                     domain != null &&

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/codegen/data/OauthConfigurationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/codegen/data/OauthConfigurationTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.data
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+class OauthConfigurationTest {
+
+    @Test
+    fun `fromJson with single redirect URI`() {
+        val json = JSONObject().apply {
+            put("AppClientId", "testClientId")
+            put("WebDomain", "testDomain")
+            put("Scopes", JSONArray(listOf("openid")))
+            put("SignInRedirectURI", "https://example.com/signin")
+            put("SignOutRedirectURI", "https://example.com/signout")
+        }
+
+        val config = OauthConfiguration.fromJson(json)
+        assertNotNull(config)
+        assertEquals("https://example.com/signin", config.signInRedirectURI)
+        assertEquals("https://example.com/signout", config.signOutRedirectURI)
+    }
+
+    @Test
+    fun `fromJson with multiple redirect URIs prefers non-HTTP scheme`() {
+        val json = JSONObject().apply {
+            put("AppClientId", "testClientId")
+            put("WebDomain", "testDomain")
+            put("Scopes", JSONArray(listOf("openid")))
+            put("SignInRedirectURI", "https://example.com/signin,myapp://signin")
+            put("SignOutRedirectURI", "myapp://signout,https://example.com/signout")
+        }
+
+        val config = OauthConfiguration.fromJson(json)
+        assertNotNull(config)
+        assertEquals("myapp://signin", config.signInRedirectURI)
+        assertEquals("myapp://signout", config.signOutRedirectURI)
+    }
+
+    @Test
+    fun `fromJson with multiple HTTP URIs uses first one`() {
+        val json = JSONObject().apply {
+            put("AppClientId", "testClientId")
+            put("WebDomain", "testDomain")
+            put("Scopes", JSONArray(listOf("openid")))
+            put("SignInRedirectURI", "https://example.com/signin,http://localhost/callback")
+            put("SignOutRedirectURI", "https://example.com/signout,http://localhost/logout")
+        }
+
+        val config = OauthConfiguration.fromJson(json)
+        assertNotNull(config)
+        assertEquals("https://example.com/signin", config.signInRedirectURI)
+        assertEquals("https://example.com/signout", config.signOutRedirectURI)
+    }
+
+    @Test
+    fun `fromJson with missing redirect URIs returns null`() {
+        val json = JSONObject().apply {
+            put("AppClientId", "testClientId")
+            put("WebDomain", "testDomain")
+            put("Scopes", JSONArray(listOf("openid")))
+            // No redirect URIs
+        }
+
+        val config = OauthConfiguration.fromJson(json)
+        assertNull(config)
+    }
+}


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/3078

*Description of changes:*
Multiple redirect uris can't be passed to Cognito. We need to select one. We will attempt to select the first app redirect scheme (non http, https).

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
