### PR TITLE
fix(apollo): Remove connect suffix from websocket connection url

### DIFF
--- a/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/ApolloExtensions.kt
+++ b/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/ApolloExtensions.kt
@@ -48,7 +48,7 @@ internal fun ApolloRequest<*>.toJson() =
  */
 fun WebSocketNetworkTransport.Builder.appSync(endpoint: AppSyncEndpoint, authorizer: AppSyncAuthorizer) = apply {
     // Set the connection URL
-    serverUrl(endpoint.websocketConnection.toString())
+    serverUrl(endpoint.realtime.toString())
 
     // Add User-agent header
     addHeader(UserAgentHeader.NAME, UserAgentHeader.value)

--- a/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/AppSyncEndpoint.kt
+++ b/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/AppSyncEndpoint.kt
@@ -43,7 +43,7 @@ class AppSyncEndpoint(serverUrl: String) {
     }
 
     // See SubscriptionEndpoint.buildConnectionRequestUrl
-    private val realtime by lazy {
+    internal val realtime by lazy {
         if (standardEndpointRegex.matches(urlString)) {
             // For standard URLs we insert "realtime" into the domain
             URL(urlString.replace("appsync-api", "appsync-realtime-api"))
@@ -51,11 +51,6 @@ class AppSyncEndpoint(serverUrl: String) {
             // For custom URLs we append "realtime" to the path
             URL("$urlString/realtime")
         }
-    }
-
-    internal val websocketConnection by lazy {
-        // See SubscriptionEndpoint.buildConnectionRequestUrl
-        URL("$realtime/connect")
     }
 
     /**
@@ -67,7 +62,7 @@ class AppSyncEndpoint(serverUrl: String) {
         val headers = mapOf("host" to serverUrl.host) + authorizer.getWebsocketConnectionHeaders(this)
         val authorization = headers.base64()
 
-        val url = websocketConnection.toHttpUrlOrNull() ?: error("Invalid endpoint url")
+        val url = realtime.toHttpUrlOrNull() ?: error("Invalid endpoint url")
 
         return url.newBuilder()
             .addQueryParameter("header", authorization)

--- a/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/authorizers/IamAuthorizer.kt
+++ b/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/authorizers/IamAuthorizer.kt
@@ -54,7 +54,7 @@ class IamAuthorizer(private val generateSignatureHeaders: suspend (HttpRequest) 
     // See SubscriptionAuthorizer.forIam
     override suspend fun getWebsocketConnectionHeaders(endpoint: AppSyncEndpoint): Map<String, String> {
         val request = createHttpRequestForSigning(
-            url = endpoint.websocketConnection.toString(),
+            url = endpoint.realtime.toString() + "/connect",
             host = endpoint.serverUrl.host,
             json = "{}"
         )

--- a/apollo/apollo-appsync/src/test/java/com/amplifyframework/apollo/appsync/ApolloExtensionsTest.kt
+++ b/apollo/apollo-appsync/src/test/java/com/amplifyframework/apollo/appsync/ApolloExtensionsTest.kt
@@ -82,7 +82,7 @@ class ApolloExtensionsTest {
 
         verify {
             transportBuilder.serverUrl(
-                "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com/graphql/connect"
+                "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com/graphql"
             )
         }
     }

--- a/apollo/apollo-appsync/src/test/java/com/amplifyframework/apollo/appsync/AppSyncEndpointTest.kt
+++ b/apollo/apollo-appsync/src/test/java/com/amplifyframework/apollo/appsync/AppSyncEndpointTest.kt
@@ -46,21 +46,21 @@ class AppSyncEndpointTest {
     @Test
     fun `uses expected realtime URL for standard endpoint`() {
         val endpoint = AppSyncEndpoint(standardAppSyncUrl)
-        endpoint.websocketConnection.toString() shouldBe
-            "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com/graphql/connect"
+        endpoint.realtime.toString() shouldBe
+            "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com/graphql"
     }
 
     @Test
     fun `uses expected realtime URL for standard endpoint in China`() {
         val endpoint = AppSyncEndpoint(standardAppSyncUrlChina)
-        endpoint.websocketConnection.toString() shouldBe
-            "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com.cn/graphql/connect"
+        endpoint.realtime.toString() shouldBe
+            "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com.cn/graphql"
     }
 
     @Test
     fun `uses expected realtime URL for custom endpoint`() {
         val endpoint = AppSyncEndpoint(customAppSyncUrl)
-        endpoint.websocketConnection.toString() shouldBe "https://api.example.com/graphql/realtime/connect"
+        endpoint.realtime.toString() shouldBe "https://api.example.com/graphql/realtime"
     }
 
     @Test

--- a/apollo/apollo-appsync/src/test/java/com/amplifyframework/apollo/appsync/authorizers/IamAuthorizerTest.kt
+++ b/apollo/apollo-appsync/src/test/java/com/amplifyframework/apollo/appsync/authorizers/IamAuthorizerTest.kt
@@ -20,9 +20,11 @@ import com.amplifyframework.apollo.appsync.toJson
 import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.http.HttpRequest
 import io.kotest.matchers.maps.shouldContainAll
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -33,6 +35,21 @@ class IamAuthorizerTest {
     private val delegate: (
         HttpRequest
     ) -> Map<String, String> = { mapOf("header1" to "header1Value", "header2" to "header2Value") }
+
+    @Test
+    fun `appends connect to realtime url`() = runTest {
+        val mockDelegate: (HttpRequest) -> Map<String, String> = mockk(relaxed = true)
+        val authorizer = IamAuthorizer(generateSignatureHeaders = mockDelegate)
+        authorizer.getWebsocketConnectionHeaders(endpoint)
+        verify {
+            mockDelegate(
+                withArg {
+                    it.url shouldBe
+                        "https://example1234567890123456789.appsync-realtime-api.us-east-1.amazonaws.com/graphql/connect"
+                }
+            )
+        }
+    }
 
     @Test
     fun `returns authorization header for HTTP requests`() = runTest {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #3102

*Description of changes:*
The "connect" suffix was being applied to the actual websocket subscription connection URL, and not just in the IAM signature generation logic as intended. This could cause connection issues as in the linked issue. This change removes the "connect" suffix from the connection url and only applies it when calculating the signature for the request.

*How did you test these changes?*
- Verified subscriptions work as expected with IAM and other authorization modes.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
