### PR TITLE
fix(auth): Remove online check from getCurrentUser

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/SessionHelper.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/helpers/SessionHelper.kt
@@ -77,3 +77,5 @@ internal object SessionHelper {
             )
     }
 }
+
+internal fun CognitoUserPoolTokens.isValid() = SessionHelper.isValidTokens(this)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AuthUseCaseFactory.kt
@@ -93,7 +93,6 @@ internal class AuthUseCaseFactory(
     )
 
     fun getCurrentUser() = GetCurrentUserUseCase(
-        fetchAuthSession = fetchAuthSession(),
         stateMachine = stateMachine
     )
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCase.kt
@@ -18,20 +18,12 @@ package com.amplifyframework.auth.cognito.usecases
 import com.amplifyframework.auth.AuthUser
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.requireSignedInState
-import com.amplifyframework.auth.exceptions.SessionExpiredException
-import com.amplifyframework.util.throwIf
 
 internal class GetCurrentUserUseCase(
-    private val fetchAuthSession: FetchAuthSessionUseCase,
     private val stateMachine: AuthStateMachine
 ) {
     suspend fun execute(): AuthUser {
         val state = stateMachine.requireSignedInState()
-
-        // Throw exception if session is expired
-        val result = fetchAuthSession.execute().userPoolTokensResult
-        result.error.throwIf<SessionExpiredException>()
-
         return AuthUser(
             state.signedInData.userId,
             state.signedInData.username

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/GetCurrentUserUseCaseTest.kt
@@ -18,7 +18,6 @@ package com.amplifyframework.auth.cognito.usecases
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.mockSignedInData
 import com.amplifyframework.auth.exceptions.InvalidStateException
-import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import io.kotest.assertions.throwables.shouldThrow
@@ -29,10 +28,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class GetCurrentUserUseCaseTest {
-    private val fetchAuthSession: FetchAuthSessionUseCase = mockk {
-        coEvery { execute().userPoolTokensResult.error } returns null
-    }
-
     private val stateMachine: AuthStateMachine = mockk {
         coEvery { getCurrentState().authNState } returns AuthenticationState.SignedIn(
             signedInData = mockSignedInData(username = "username", userId = "sub"),
@@ -41,7 +36,6 @@ class GetCurrentUserUseCaseTest {
     }
 
     private val useCase = GetCurrentUserUseCase(
-        fetchAuthSession = fetchAuthSession,
         stateMachine = stateMachine
     )
 
@@ -67,14 +61,5 @@ class GetCurrentUserUseCaseTest {
         shouldThrow<SignedOutException> {
             useCase.execute()
         }
-    }
-
-    @Test
-    fun `throws exception for expired session`() = runTest {
-        val error = SessionExpiredException()
-        coEvery { fetchAuthSession.execute().userPoolTokensResult.error } returns error
-        shouldThrow<SessionExpiredException> {
-            useCase.execute()
-        } shouldBe error
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #3118

*Description of changes:*
Removes the check for expired refresh tokens from the `getCurrentUser` call. None of the other Amplify platforms had this check, so this better aligns with their implementations.

Now `getCurrentUser` will be a simple offline-only check to see if there are cached credentials on the device. If there are, we return the user data.

This does mean that in cases where you were signed in but your refresh tokens have expired (or were revoked) `getCurrentUser` will now succeed, where previously it would have failed.

*How did you test these changes?*
- Revoked users tokens, ensured that `getCurrentUser` still succeeds.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
