### PR TITLE
chore(auth): Fix race conditions in read state machine states

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AutoSignInUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/AutoSignInUseCase.kt
@@ -32,9 +32,10 @@ import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.AuthorizationState
 import com.amplifyframework.statemachine.codegen.states.SignInState
 import com.amplifyframework.statemachine.codegen.states.SignUpState
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.transformWhile
 
 internal class AutoSignInUseCase(
@@ -84,11 +85,12 @@ internal class AutoSignInUseCase(
             signUpData.userId
         )
 
-        val result = stateMachine.stateTransitions
-            .onStart {
+        val result = stateMachine.state
+            .onSubscription {
                 val event = AuthenticationEvent(AuthenticationEvent.EventType.SignInRequested(signInData))
                 stateMachine.send(event)
             }
+            .drop(1)
             .mapNotNull { authState ->
                 val authNState = authState.authNState
                 val authZState = authState.authZState

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/DeleteUserUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/DeleteUserUseCase.kt
@@ -26,7 +26,7 @@ import com.amplifyframework.statemachine.codegen.events.DeleteUserEvent
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.AuthorizationState
 import com.amplifyframework.statemachine.codegen.states.DeleteUserState
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.onSubscription
 
 internal class DeleteUserUseCase(
     private val fetchAuthSession: FetchAuthSessionUseCase,
@@ -41,7 +41,7 @@ internal class DeleteUserUseCase(
 
         var deleteUserException: Exception? = null
         stateMachine.state
-            .onStart {
+            .onSubscription {
                 val event = DeleteUserEvent(DeleteUserEvent.EventType.DeleteUser(accessToken = token))
                 stateMachine.send(event)
             }.collectWhile { authState ->


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
- Use `onSubscription` instead of `onStart` to trigger state machine events while collecting. `onStart` does not guarantee that emissions generated from the block are visible in downstream collectors when used on a SharedFlow.
- Use SharedFlow for emitting states instead of a StateFlow because StateFlow will conflate emitted values, which can skip required intermediate states in subscribers.

These changes shouldn't effect production behaviour, but in unit tests this resolves some race conditions that happened when states update too quickly.

*How did you test these changes?*
- Tests should pass

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
