### PR TITLE
chore: Remove inconsistent test

### DIFF
--- a/.github/workflows/codecov_code_coverage.yml
+++ b/.github/workflows/codecov_code_coverage.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - 'main'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -30,3 +31,11 @@ jobs:
           name: report
           files: build/reports/kover/report.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: failure()
+        with:
+          name: test-reports
+          path: '**/reports/tests/**'
+          retention-days: 7

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineListenerTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineListenerTests.kt
@@ -23,7 +23,6 @@ import com.amplifyframework.statemachine.state.CounterStateMachine
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.newSingleThreadContext
@@ -127,23 +126,5 @@ class StateMachineListenerTests {
         stateMachine.cancel(token)
         stateMachine.send(Counter.Event("2", eventType = Increment))
         assertTrue { listenLatch.await(5, TimeUnit.SECONDS) }
-    }
-
-    @Test
-    fun testNoNotifyImmediateCancel() {
-        stateMachine.send(Counter.Event("1", eventType = Increment))
-        val listenLatch = CountDownLatch(1)
-        val token = StateChangeListenerToken()
-        stateMachine.listen(
-            token,
-            {
-                listenLatch.countDown()
-            },
-            null
-        )
-
-        stateMachine.cancel(token)
-        stateMachine.send(Counter.Event("2", eventType = Increment))
-        assertFalse { listenLatch.await(5, TimeUnit.SECONDS) }
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Removes the `testNoNotifyImmediateCancel` test. This test has a threading race condition (easily verifiable by adding a `Thread.sleep(100)` call to the test body) causing it to inconsistently fail on CI.

Also updated the code coverage workflow to save test results if the job fails, allowing us to see the particular failure which will help in tracking down other test issues.

*How did you test these changes?*

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
