### PR TITLE
fix(auth): Fix losing session identifier when incorrect otp code is entered during confirm sign up

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignUpEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignUpEvent.kt
@@ -38,7 +38,7 @@ internal class SignUpEvent(
 
         data class SignedUp(val signUpData: SignUpData, val signUpResult: AuthSignUpResult) : EventType()
 
-        data class ThrowError(val exception: Exception) : EventType()
+        data class ThrowError(val signUpData: SignUpData, val exception: Exception) : EventType()
     }
 
     override val type: String = eventType.javaClass.simpleName

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignUpState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignUpState.kt
@@ -31,7 +31,11 @@ internal sealed class SignUpState : State {
     data class AwaitingUserConfirmation(val signUpData: SignUpData, val signUpResult: AuthSignUpResult) : SignUpState()
     data class ConfirmingSignUp(val signUpData: SignUpData) : SignUpState()
     data class SignedUp(val signUpData: SignUpData, val signUpResult: AuthSignUpResult) : SignUpState()
-    data class Error(val exception: Exception, var hasNewResponse: Boolean = true) : SignUpState()
+    data class Error(
+        val signUpData: SignUpData,
+        val exception: Exception,
+        var hasNewResponse: Boolean = true
+    ) : SignUpState()
 
     class Resolver(private val signUpActions: SignUpActions) :
         StateMachineResolver<SignUpState> {
@@ -56,7 +60,7 @@ internal sealed class SignUpState : State {
                         )
                     }
                     is SignUpEvent.EventType.ThrowError -> {
-                        StateResolution(Error(signUpEvent.exception))
+                        StateResolution(Error(signUpEvent.signUpData, signUpEvent.exception))
                     }
                     else -> defaultResolution
                 }
@@ -82,7 +86,7 @@ internal sealed class SignUpState : State {
                         )
                     }
                     is SignUpEvent.EventType.ThrowError -> {
-                        StateResolution(Error(signUpEvent.exception))
+                        StateResolution(Error(signUpEvent.signUpData, signUpEvent.exception))
                     }
                     else -> defaultResolution
                 }
@@ -100,7 +104,7 @@ internal sealed class SignUpState : State {
                         )
                     }
                     is SignUpEvent.EventType.ThrowError -> {
-                        StateResolution(Error(signUpEvent.exception))
+                        StateResolution(Error(signUpEvent.signUpData, signUpEvent.exception))
                     }
                     else -> defaultResolution
                 }
@@ -121,7 +125,7 @@ internal sealed class SignUpState : State {
                         StateResolution(SignedUp(signUpEvent.signUpData, signUpEvent.signUpResult))
                     }
                     is SignUpEvent.EventType.ThrowError -> {
-                        StateResolution(Error(signUpEvent.exception))
+                        StateResolution(Error(signUpEvent.signUpData, signUpEvent.exception))
                     }
                     else -> defaultResolution
                 }
@@ -143,4 +147,13 @@ internal sealed class SignUpState : State {
             }
         }
     }
+}
+
+internal fun SignUpState.getSignUpData(): SignUpData? = when (this) {
+    is SignUpState.AwaitingUserConfirmation -> this.signUpData
+    is SignUpState.ConfirmingSignUp -> this.signUpData
+    is SignUpState.Error -> this.signUpData
+    is SignUpState.InitiatingSignUp -> this.signUpData
+    is SignUpState.NotStarted -> null
+    is SignUpState.SignedUp -> this.signUpData
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ConfirmSignUpUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/ConfirmSignUpUseCaseTest.kt
@@ -22,11 +22,13 @@ import com.amplifyframework.auth.cognito.testUtil.withSignUpEvent
 import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.step.AuthNextSignUpStep
 import com.amplifyframework.auth.result.step.AuthSignUpStep
+import com.amplifyframework.statemachine.codegen.data.SignUpData
 import com.amplifyframework.statemachine.codegen.events.SignUpEvent
 import com.amplifyframework.statemachine.codegen.states.AuthState
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
 import com.amplifyframework.statemachine.codegen.states.SignUpState
 import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -34,8 +36,10 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -49,6 +53,14 @@ class ConfirmSignUpUseCaseTest {
         every { state } returns stateFlow
     }
     private val useCase = ConfirmSignUpUseCase(stateMachine = stateMachine)
+
+    private val signUpData = SignUpData(
+        username = "username",
+        validationData = mapOf("key" to "value"),
+        clientMetadata = mapOf("meta" to "data"),
+        session = "session",
+        userId = "userId"
+    )
 
     @Test
     fun `fails if not configured`() = runTest {
@@ -75,7 +87,7 @@ class ConfirmSignUpUseCaseTest {
 
         runCurrent()
         stateFlow.emit(mockAuthState(SignUpState.ConfirmingSignUp(mockk())))
-        stateFlow.emit(mockAuthState(SignUpState.Error(exception)))
+        stateFlow.emit(mockAuthState(SignUpState.Error(mockk(), exception)))
     }
 
     @Test
@@ -83,22 +95,88 @@ class ConfirmSignUpUseCaseTest {
         coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
         coEvery { stateMachine.getCurrentState().authSignUpState } returns null
 
-        launch {
-            useCase.execute("user", "pass")
+        executeUseCaseToCompletion()
 
-            coVerify {
-                stateMachine.send(
-                    withSignUpEvent<SignUpEvent.EventType.ConfirmSignUp> { event ->
-                        event.signUpData.username shouldBe "user"
-                        event.confirmationCode shouldBe "pass"
-                    }
-                )
-            }
+        coVerify {
+            stateMachine.send(
+                withSignUpEvent<SignUpEvent.EventType.ConfirmSignUp> { event ->
+                    event.signUpData.username shouldBe "user"
+                    event.confirmationCode shouldBe "pass"
+                }
+            )
         }
+    }
 
-        runCurrent()
-        stateFlow.emit(mockAuthState(SignUpState.ConfirmingSignUp(mockk())))
-        stateFlow.emit(mockAuthState(SignUpState.SignedUp(mockk(), mockk())))
+    @Test
+    fun `uses signUpData values from existing error state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns
+            SignUpState.Error(signUpData = signUpData, exception = mockk())
+
+        executeUseCaseToCompletion(username = signUpData.username)
+
+        coVerify {
+            stateMachine.send(
+                withSignUpEvent<SignUpEvent.EventType.ConfirmSignUp> { event ->
+                    event.signUpData.run {
+                        username shouldBe signUpData.username
+                        validationData shouldBe signUpData.validationData
+                        clientMetadata.shouldBeNull() // was not passed in options
+                        session shouldBe signUpData.session
+                        userId shouldBe signUpData.userId
+                    }
+                    event.confirmationCode shouldBe "pass"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `uses session value from existing AwaitingConfirmation state`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns
+            SignUpState.AwaitingUserConfirmation(signUpData = signUpData, signUpResult = mockk())
+
+        executeUseCaseToCompletion(username = signUpData.username)
+
+        coVerify {
+            stateMachine.send(
+                withSignUpEvent<SignUpEvent.EventType.ConfirmSignUp> { event ->
+                    event.signUpData.run {
+                        username shouldBe signUpData.username
+                        validationData shouldBe signUpData.validationData
+                        clientMetadata.shouldBeNull() // was not passed in options
+                        session shouldBe signUpData.session
+                        userId shouldBe signUpData.userId
+                    }
+                    event.confirmationCode shouldBe "pass"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `does not use values from existing state if username does not match`() = runTest {
+        coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
+        coEvery { stateMachine.getCurrentState().authSignUpState } returns
+            SignUpState.AwaitingUserConfirmation(signUpData = signUpData, signUpResult = mockk())
+
+        executeUseCaseToCompletion(username = "bob")
+
+        coVerify {
+            stateMachine.send(
+                withSignUpEvent<SignUpEvent.EventType.ConfirmSignUp> { event ->
+                    event.signUpData.run {
+                        username shouldBe "bob"
+                        validationData.shouldBeNull()
+                        clientMetadata.shouldBeNull() // was not passed in options
+                        session.shouldBeNull()
+                        userId.shouldBeNull()
+                    }
+                    event.confirmationCode shouldBe "pass"
+                }
+            )
+        }
     }
 
     @Test
@@ -116,17 +194,24 @@ class ConfirmSignUpUseCaseTest {
         coEvery { stateMachine.getCurrentState().authNState } returns AuthenticationState.Configured()
         coEvery { stateMachine.getCurrentState().authSignUpState } returns null
 
-        launch {
-            val result = useCase.execute("user", "pass")
-            result shouldBe expectedResult
-        }
-
-        runCurrent()
-        stateFlow.emit(mockAuthState(SignUpState.ConfirmingSignUp(mockk())))
-        stateFlow.emit(mockAuthState(SignUpState.SignedUp(mockk(), expectedResult)))
+        val result = executeUseCaseToCompletion(signUpResult = expectedResult)
+        result shouldBe expectedResult
     }
 
     private fun mockAuthState(signUpState: SignUpState): AuthState = mockk {
         coEvery { authSignUpState } returns signUpState
+    }
+
+    @Suppress("SuspendFunctionOnCoroutineScope")
+    private suspend fun TestScope.executeUseCaseToCompletion(
+        username: String = "user",
+        confirmationCode: String = "pass",
+        signUpResult: AuthSignUpResult = mockk()
+    ): AuthSignUpResult {
+        val result = async { useCase.execute(username, confirmationCode) }
+        runCurrent()
+        stateFlow.emit(mockAuthState(SignUpState.ConfirmingSignUp(mockk())))
+        stateFlow.emit(mockAuthState(SignUpState.SignedUp(mockk(), signUpResult)))
+        return result.await()
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/SignUpUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/SignUpUseCaseTest.kt
@@ -74,7 +74,7 @@ class SignUpUseCaseTest {
         }
 
         runCurrent()
-        stateFlow.emit(mockAuthState(SignUpState.Error(exception)))
+        stateFlow.emit(mockAuthState(SignUpState.Error(mockk(), exception)))
     }
 
     @Test


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #3135

*Description of changes:*
Fixes one of the issues identified in the linked bug. When a user entered an incorrect confirmation code during `confirmSignUp` we would enter an Error state. During a correct subsequent `confirmSignUp` call we would not pass the existing Cognito `session` identifier. If there are no passwordless options enabled for the user pool, this would result in Cognito throwing a `SelectChallenge` which would cause Amplify to hang.

This fix retains the `signUpData` during the error state so that the `session` can be continued on subsequent calls to `confirmSignUp`. This allows Cognito to recognize the password entered during initial sign up, allowing `autoSignIn` to succeed. 

Fixing `autoSignIn` hanging on `SelectChallenge` is a much larger fix that will be tackled separately.

*How did you test these changes?*
- Verified that autoSignIn works as expected after entering an incorrect confirmation code after creating an account.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
