### PR TITLE
chore(auth): Fix problem of global signout tests causing failures in other tests

### DIFF
--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTest.kt
@@ -246,7 +246,10 @@ class AuthCanaryTest {
 
     @Test
     fun globalSignOut() {
-        signInUser(username, password)
+        signUpUser(tempUsername, tempPassword)
+        confirmTemporaryUserSignUp(tempUsername)
+        signInUser(tempUsername, tempPassword)
+
         val options = AuthSignOutOptions.builder()
             .globalSignOut(true)
             .build()
@@ -279,6 +282,7 @@ class AuthCanaryTest {
             .userAttribute(AuthUserAttributeKey.email(), "my@email.com")
             .build()
         syncAuth.signUp(user, pass, options)
+        signedUpNewUser = true
     }
 
     private fun signInUser(user: String, pass: String) {

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTestGen2.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTestGen2.kt
@@ -253,7 +253,10 @@ class AuthCanaryTestGen2 {
 
     @Test
     fun globalSignOut() {
-        signInUser(username, password)
+        signUpUser(tempUsername, tempPassword)
+        confirmTemporaryUserSignUp(tempUsername)
+        signInUser(tempUsername, tempPassword)
+
         val options = AuthSignOutOptions.builder()
             .globalSignOut(true)
             .build()
@@ -286,6 +289,7 @@ class AuthCanaryTestGen2 {
             .userAttribute(AuthUserAttributeKey.email(), "my@email.com")
             .build()
         syncAuth.signUp(user, pass, options)
+        signedUpNewUser = true
     }
 
     private fun signInUser(user: String, pass: String) {


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
The global signout tests could cause failures when running tests on multiple devices concurrently. This is because the tests used the single shared user, which could sign out the shared user while it was in the middle of being used in a test on another device.

Updated to user the temporary user that is unique to that test run instead.

Also fixed issue where temporary users were not always being deleted.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
