### PR TITLE
fix(auth): UserCancelledException occurrence on sign-in after sign-out

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/HostedUIClient.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/HostedUIClient.kt
@@ -60,6 +60,8 @@ internal class HostedUIClient private constructor(
 
     @Throws(RuntimeException::class)
     fun launchCustomTabsSignIn(hostedUIOptions: HostedUIOptions) {
+        session = client?.newSession(null)
+
         launchCustomTabs(
             uri = createAuthorizeUri(hostedUIOptions),
             activity = hostedUIOptions.callingActivity,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/3167

*Description of changes:*
This change makes the webview create a new session every time a new sign-in window gets launched. This way, a browser-session is not used for multiple Cognito sessions.

*How did you test these changes?*
I created a simple app for logging in with Cognito and a SAML provider.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
