### PR TITLE
chore: Increase test timeouts to avoid appsync event websocket timeouts in tests

### DIFF
--- a/appsync/aws-sdk-appsync-events/src/androidTest/java/com/amazonaws/sdk/appsync/events/EventsWebSocketClientTests.kt
+++ b/appsync/aws-sdk-appsync-events/src/androidTest/java/com/amazonaws/sdk/appsync/events/EventsWebSocketClientTests.kt
@@ -47,6 +47,10 @@ import org.junit.After
 import org.junit.Test
 
 internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
+    companion object {
+        private val TEST_TIMEOUT = 30.seconds
+    }
+
     private val eventsConfig = getEventsConfig(InstrumentationRegistry.getInstrumentation().targetContext)
     private val apiKeyAuthorizer = ApiKeyAuthorizer(eventsConfig.apiKey)
     private val badApiKeyAuthorizer = ApiKeyAuthorizer("bad-api-key")
@@ -73,33 +77,33 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
 
     @After
     fun tearDown() {
-        runBlockingWithTimeout {
+        runBlockingWithTimeout(TEST_TIMEOUT) {
             webSocketClient.disconnect(flushEvents = false)
         }
     }
 
     @Test
-    fun testSinglePrimitivePublish() = runBlockingWithTimeout {
+    fun testSinglePrimitivePublish() = runBlockingWithTimeout(TEST_TIMEOUT) {
         testSinglePublish(JsonPrimitive(true))
     }
 
     @Test
-    fun testSingleArrayPublish() = runBlockingWithTimeout {
+    fun testSingleArrayPublish() = runBlockingWithTimeout(TEST_TIMEOUT) {
         testSinglePublish(JsonArray(listOf(JsonPrimitive(true), JsonPrimitive(false))))
     }
 
     @Test
-    fun testSingleObjectPublish() = runBlockingWithTimeout {
+    fun testSingleObjectPublish() = runBlockingWithTimeout(TEST_TIMEOUT) {
         testSinglePublish(json.encodeToJsonElement(TestMessage()))
     }
 
     @Test
-    fun testMultiplePrimitivePublish() = runBlockingWithTimeout {
+    fun testMultiplePrimitivePublish() = runBlockingWithTimeout(TEST_TIMEOUT) {
         testMultiplePublish(listOf(JsonPrimitive(true), JsonPrimitive(false)))
     }
 
     @Test
-    fun testMultipleArrayPublish() = runBlockingWithTimeout {
+    fun testMultipleArrayPublish() = runBlockingWithTimeout(TEST_TIMEOUT) {
         testMultiplePublish(
             listOf(
                 JsonArray(listOf(JsonPrimitive(true), JsonPrimitive(false))),
@@ -109,7 +113,7 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     @Test
-    fun testMultipleObjectPublish() = runBlockingWithTimeout {
+    fun testMultipleObjectPublish() = runBlockingWithTimeout(TEST_TIMEOUT) {
         testMultiplePublish(
             listOf(
                 json.encodeToJsonElement(TestMessage(messageId = "1", content = "hi")),
@@ -119,16 +123,16 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     @Test
-    fun testConnectionFailure() = runBlockingWithTimeout {
-        turbineScope(timeout = 10.seconds) {
-            badWebSocketClient.subscribe(defaultChannel).test(timeout = 10.seconds) {
+    fun testConnectionFailure() = runBlockingWithTimeout(TEST_TIMEOUT) {
+        turbineScope(timeout = TEST_TIMEOUT) {
+            badWebSocketClient.subscribe(defaultChannel).test(timeout = TEST_TIMEOUT) {
                 awaitError() shouldBe ConnectException(UnauthorizedException())
             }
         }
     }
 
     @Test
-    fun testPublishWithBadAuth(): Unit = runBlockingWithTimeout {
+    fun testPublishWithBadAuth(): Unit = runBlockingWithTimeout(TEST_TIMEOUT) {
         // Publish the message
         val webSocketClient = events.createWebSocketClient(apiKeyAuthorizer, apiKeyAuthorizer, apiKeyAuthorizer)
         val result = webSocketClient.publish(
@@ -147,7 +151,7 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     @Test
-    fun testPublishWithTooManyEvents(): Unit = runBlockingWithTimeout {
+    fun testPublishWithTooManyEvents(): Unit = runBlockingWithTimeout(TEST_TIMEOUT) {
         val sendEvents = (0 until 6).map { JsonPrimitive(true) }
         // Publish the message
         val webSocketClient = events.createWebSocketClient(apiKeyAuthorizer, apiKeyAuthorizer, apiKeyAuthorizer)
@@ -164,7 +168,7 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     @Test
-    fun testPublishToNonConfiguredChannel(): Unit = runBlockingWithTimeout {
+    fun testPublishToNonConfiguredChannel(): Unit = runBlockingWithTimeout(TEST_TIMEOUT) {
         // Publish the message
         val webSocketClient = events.createWebSocketClient(apiKeyAuthorizer, apiKeyAuthorizer, apiKeyAuthorizer)
         val result = webSocketClient.publish(
@@ -180,7 +184,7 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     @Test
-    fun testWebSocketFlowLifecycle(): Unit = runBlockingWithTimeout(15.seconds) {
+    fun testWebSocketFlowLifecycle(): Unit = runBlockingWithTimeout(TEST_TIMEOUT) {
         val expectedLogs = listOf(
             "Opening Websocket Connection",
             "onOpen: sending connection init",
@@ -191,8 +195,8 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
             "emit ${WebSocketMessage.Closed::class.java}"
         )
 
-        turbineScope(timeout = 10.seconds) {
-            webSocketClient.subscribe(defaultChannel).test(timeout = 10.seconds) {
+        turbineScope(timeout = TEST_TIMEOUT) {
+            webSocketClient.subscribe(defaultChannel).test(timeout = TEST_TIMEOUT) {
                 // Wait for subscription to return success
                 webSocketLogCapture.messages.filter {
                     it == "Successfully subscribed to: $defaultChannel"
@@ -234,7 +238,7 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     @Test
-    fun channelsOnlyReceiveEventsFromTheirChannel(): Unit = runBlockingWithTimeout {
+    fun channelsOnlyReceiveEventsFromTheirChannel(): Unit = runBlockingWithTimeout(TEST_TIMEOUT) {
         val expectedCustomMessage = JsonPrimitive(false)
         val expectedDefaultMessage = JsonPrimitive(true)
 
@@ -278,7 +282,7 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     @Test
-    fun testWebSocketRecreateScenario(): Unit = runBlockingWithTimeout {
+    fun testWebSocketRecreateScenario(): Unit = runBlockingWithTimeout(TEST_TIMEOUT) {
         testSinglePublish(JsonPrimitive(true))
 
         // websocket has disconnected at this point
@@ -297,8 +301,8 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     private suspend fun testSinglePublish(jsonItem: JsonElement) {
-        turbineScope(timeout = 10.seconds) {
-            webSocketClient.subscribe(defaultChannel).test(timeout = 10.seconds) {
+        turbineScope(timeout = TEST_TIMEOUT) {
+            webSocketClient.subscribe(defaultChannel).test(timeout = TEST_TIMEOUT) {
                 // Wait for subscription to return success
                 webSocketLogCapture.messages.filter {
                     it == "Successfully subscribed to: $defaultChannel"
@@ -334,8 +338,8 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
     }
 
     private suspend fun testMultiplePublish(jsonItems: List<JsonElement>) {
-        turbineScope(timeout = 10.seconds) {
-            webSocketClient.subscribe(defaultChannel).test(timeout = 10.seconds) {
+        turbineScope(timeout = TEST_TIMEOUT) {
+            webSocketClient.subscribe(defaultChannel).test(timeout = TEST_TIMEOUT) {
                 // Wait for subscription to return success
                 webSocketLogCapture.messages.filter {
                     it == "Successfully subscribed to: $defaultChannel"


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* Increase test timeouts for appsync event websocket tests timing out

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
