### PR TITLE
chore: change exponential backoff to 5s with 4 attempts

### DIFF
--- a/testutils/src/main/java/com/amplifyframework/testutils/rules/RepeatKnownFailuresRule.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/rules/RepeatKnownFailuresRule.kt
@@ -60,6 +60,6 @@ class RepeatKnownFailuresRule : TestRule {
     companion object {
         // One initial attempt and up to 2 retries, for 3 total attempts.
         private const val MAX_ATTEMPTS = 3
-        private val INITIAL_DELAY_MS = 2.seconds // Doubles on each attempt
+        private val INITIAL_DELAY_MS = 20.seconds // Doubles on each attempt
     }
 }

--- a/testutils/src/main/java/com/amplifyframework/testutils/rules/RepeatKnownFailuresRule.kt
+++ b/testutils/src/main/java/com/amplifyframework/testutils/rules/RepeatKnownFailuresRule.kt
@@ -58,8 +58,8 @@ class RepeatKnownFailuresRule : TestRule {
     }
 
     companion object {
-        // One initial attempt and up to 2 retries, for 3 total attempts.
-        private const val MAX_ATTEMPTS = 3
-        private val INITIAL_DELAY_MS = 20.seconds // Doubles on each attempt
+        // One initial attempt and up to 3 retries, for 4 total attempts.
+        private const val MAX_ATTEMPTS = 4
+        private val INITIAL_DELAY_MS = 5.seconds // Doubles on each attempt
     }
 }


### PR DESCRIPTION
 * reverts aws-amplify/amplify-android#3283
 * change exponential backoff to 5s with 4 attempts to allow for long-enough wait time