### PR TITLE
chore: Fix pinpoint stresstest by just increasing timeout not expected event count

### DIFF
--- a/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsStressTest.kt
+++ b/aws-analytics-pinpoint/src/androidTest/java/com/amplifyframework/analytics/pinpoint/PinpointAnalyticsStressTest.kt
@@ -169,13 +169,14 @@ class PinpointAnalyticsStressTest : DeviceFarmTestBase() {
     }
 
     /**
-     * Calls Analytics.recordEvent on an event with 40 attributes 50 times
+     * Calls Analytics.recordEvent on an event with 50 attributes 50 times.
+     * Timeout accounts for auto-flush interval (30s) needed to submit all events.
      */
     @Test
     fun testLargeMultipleRecordEvent() {
         var eventName: String
         val hubAccumulator =
-            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsChannelEventName.FLUSH_EVENTS, 5).start()
+            HubAccumulator.create(HubChannel.ANALYTICS, AnalyticsChannelEventName.FLUSH_EVENTS, 2).start()
 
         repeat(50) {
             eventName = "Amplify-event" + UUID.randomUUID().toString()
@@ -189,7 +190,7 @@ class PinpointAnalyticsStressTest : DeviceFarmTestBase() {
         }
 
         Amplify.Analytics.flushEvents()
-        val hubEvents = hubAccumulator.await(30, TimeUnit.SECONDS)
+        val hubEvents = hubAccumulator.await(35, TimeUnit.SECONDS)
         val submittedEvents = combineAndFilterEvents(hubEvents)
         Assert.assertEquals(50, submittedEvents.size.toLong())
     }


### PR DESCRIPTION

- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:* Fix pinpoint stresstest by just increasing timeout not expected event count

A previous PR https://github.com/aws-amplify/amplify-android/pull/3281 broke the test by increasing the expected event count

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
