### PR TITLE
chore: Increase turbine scope test timeout for events e2e

### DIFF
--- a/appsync/aws-sdk-appsync-events/src/androidTest/java/com/amazonaws/sdk/appsync/events/EventsWebSocketClientTests.kt
+++ b/appsync/aws-sdk-appsync-events/src/androidTest/java/com/amazonaws/sdk/appsync/events/EventsWebSocketClientTests.kt
@@ -242,9 +242,9 @@ internal class EventsWebSocketClientTests : DeviceFarmTestBase() {
         val expectedCustomMessage = JsonPrimitive(false)
         val expectedDefaultMessage = JsonPrimitive(true)
 
-        turbineScope {
-            webSocketClient.subscribe(defaultChannel).test {
-                webSocketClient.subscribe(customChannel).test {
+        turbineScope(timeout = TEST_TIMEOUT) {
+            webSocketClient.subscribe(defaultChannel).test(timeout = TEST_TIMEOUT) {
+                webSocketClient.subscribe(customChannel).test(timeout = TEST_TIMEOUT) {
                     // Wait for subscription to return success
                     webSocketLogCapture.messages.filter {
                         it == "Successfully subscribed to: $defaultChannel" ||


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:* Increase turbine scope test timeout for events e2e

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
