### PR TITLE
chore: add retry and throttle resilience to canary script

### DIFF
--- a/scripts/run_canary_in_devicefarm.sh
+++ b/scripts/run_canary_in_devicefarm.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Retry on Device Farm API throttling (~60s total backoff)
+export AWS_MAX_ATTEMPTS=8
+
 project_arn=$DEVICEFARM_PROJECT_ARN
 max_devices=$NUMBER_OF_DEVICES_TO_TEST
 module_name=$1
@@ -16,38 +20,69 @@ if [[ -z "${max_devices}" ]]; then
   max_devices=1
 fi
 
-# Function to setup the app uploads in device farm
-function createUpload {
+# Function to setup the app uploads in device farm.
+# Retries with random jitter on throttling failures.
+function createUploadWithRetry {
   test_type=$1
-  upload_response=`aws devicefarm create-upload --type $test_type \
-                             --content-type="application/octet-stream" \
-                             --project-arn="$project_arn" \
-                             --name="$file_name" \
-                             --query="upload.[url, arn]" \
-                             --region="us-west-2" \
-                             --output=text`
-  echo $upload_response
+  max_upload_attempts=3
+  for upload_attempt in $(seq 1 $max_upload_attempts); do
+    upload_response=`aws devicefarm create-upload --type $test_type \
+                               --content-type="application/octet-stream" \
+                               --project-arn="$project_arn" \
+                               --name="$file_name" \
+                               --query="upload.[url, arn]" \
+                               --region="us-west-2" \
+                               --output=text 2>&1`
+    # Check if we got a valid response (URL + ARN)
+    read -a parts <<< "$upload_response"
+    if [[ -n "${parts[1]}" && "${parts[1]}" == arn:* ]]; then
+      echo "$upload_response"
+      return 0
+    fi
+    if [ $upload_attempt -lt $max_upload_attempts ]; then
+      jitter=$((30 + RANDOM % 60))
+      echo "[RUN_IN_DEVICEFARM] CreateUpload throttled (attempt $upload_attempt/$max_upload_attempts). Retrying in ${jitter}s..." >&2
+      sleep $jitter
+    fi
+  done
+  echo "[RUN_IN_DEVICEFARM] CreateUpload failed after $max_upload_attempts attempts" >&2
+  echo ""
+  return 1
 }
 
 echo 'Uploading test package'
-# Create an upload for the instrumentation test package
-read -a result <<< $(createUpload "INSTRUMENTATION_TEST_PACKAGE")
+read -a result <<< $(createUploadWithRetry "INSTRUMENTATION_TEST_PACKAGE")
 test_package_url=${result[0]}
 test_package_upload_arn=${result[1]}
-# Upload the apk
+if [[ -z "$test_package_upload_arn" ]]; then
+  echo "Failed to create test package upload (see logs above). Exiting."
+  exit 1
+fi
 curl -H "Content-Type:application/octet-stream" -T $full_path $test_package_url
 
-# Create an upload for the app package (They're the same, but they have to be setup in device farm)
 echo 'Uploading app package'
-read -a result <<< $(createUpload "ANDROID_APP")
+read -a result <<< $(createUploadWithRetry "ANDROID_APP")
 app_package_url=${result[0]}
 app_package_upload_arn=${result[1]}
-# Upload the apk
+if [[ -z "$app_package_upload_arn" ]]; then
+  echo "Failed to create app package upload (see logs above). Exiting."
+  exit 1
+fi
 curl -H "Content-Type:application/octet-stream" -T $full_path $app_package_url
 
-# Wait to make sure the upload completes. This should actually make a get-upload call and check the status.
-echo "Waiting for uploads to complete"
-sleep 10
+# Wait for uploads to complete
+for arn in "$test_package_upload_arn" "$app_package_upload_arn"; do
+  while true; do
+    upload_status=$(aws devicefarm get-upload --arn "$arn" --region="us-west-2" --query="upload.status" --output text)
+    if [ "$upload_status" = "SUCCEEDED" ]; then
+      break
+    elif [ "$upload_status" = "FAILED" ]; then
+      echo "Upload failed for $arn"
+      exit 1
+    fi
+    sleep 5
+  done
+done
 
 # Get oldest device we can test against.
 minDevice=$(aws devicefarm list-devices \
@@ -109,44 +144,74 @@ function stopDuplicates {
 }
 stopDuplicates
 
-# Schedule the test run in device farm
-echo "Scheduling test run"
-run_arn=$(aws devicefarm schedule-run --project-arn=$project_arn \
-                                      --app-arn="$app_package_upload_arn" \
-                                      --device-selection-configuration='{
-                                          "filters": [
-                                            {"attribute": "ARN", "operator":"IN", "values":["'$minDevice'", "'$middleDevice'", "'$latestDevice'"]}
-                                          ],
-                                          "maxDevices": '$max_devices'
-                                      }' \
-                                      --name="$file_name-$CODEBUILD_SOURCE_VERSION" \
-                                      --test="type=INSTRUMENTATION,testPackageArn=$test_package_upload_arn,filter=$canary_test_name" \
-                                      --execution-configuration="jobTimeoutMinutes=30,videoCapture=false" \
-                                      --query="run.arn" \
-                                      --output=text \
-                                      --region="us-west-2")
+# Most modules complete within 30 minutes
+job_timeout=30
 
-status='NONE'
-result='NONE'
-# Wait for the test to complete
-while true; do
-  run_status_response=`aws devicefarm get-run --arn="$run_arn" --region="us-west-2" --query="run.[status, result]" --output text`
-  read -a result_arr <<< $run_status_response
-  status=${result_arr[0]}
-  result=${result_arr[1]}
-  if [ "$status" = "COMPLETED" ]
-  then
+# Retry the Device Farm test run on failure.
+max_run_attempts=2
+final_result='NONE'
+
+for run_attempt in $(seq 1 $max_run_attempts); do
+  echo "============================================================"
+  echo "[RUN_IN_DEVICEFARM] Canary attempt $run_attempt/$max_run_attempts for $module_name"
+  echo "============================================================"
+
+  echo "[RUN_IN_DEVICEFARM] Scheduling canary test run..."
+  run_arn=$(aws devicefarm schedule-run --project-arn=$project_arn \
+    --app-arn="$app_package_upload_arn" \
+    --device-selection-configuration='{
+        "filters": [
+          {"attribute": "ARN", "operator":"IN", "values":["'$minDevice'", "'$middleDevice'", "'$latestDevice'"]}
+        ],
+        "maxDevices": '$max_devices'
+    }' \
+    --name="$file_name-$CODEBUILD_SOURCE_VERSION" \
+    --test="type=INSTRUMENTATION,testPackageArn=$test_package_upload_arn,filter=$canary_test_name" \
+    --execution-configuration="jobTimeoutMinutes=$job_timeout,videoCapture=false" \
+    --query="run.arn" \
+    --output=text \
+    --region="us-west-2")
+
+  echo "[RUN_IN_DEVICEFARM] Run ARN: $run_arn"
+  echo "[RUN_IN_DEVICEFARM] Waiting for canary test run to complete..."
+
+  status='NONE'
+  result='NONE'
+  while true; do
+    run_status_response=`aws devicefarm get-run --arn="$run_arn" --region="us-west-2" --query="run.[status, result]" --output text`
+    read -a result_arr <<< $run_status_response
+    status=${result_arr[0]}
+    result=${result_arr[1]}
+    if [ "$status" = "COMPLETED" ]; then
+      break
+    fi
+    sleep 30
+  done
+
+  final_result=$result
+  echo "[RUN_IN_DEVICEFARM] Canary attempt $run_attempt/$max_run_attempts: Status=$status Result=$result"
+
+  if [ "$result" = "PASSED" ]; then
+    if [ $run_attempt -gt 1 ]; then
+      echo "[RUN_IN_DEVICEFARM] Canary passed on retry (attempt $run_attempt)"
+    fi
     break
   fi
-  sleep 30
+
+  if [ $run_attempt -lt $max_run_attempts ]; then
+    echo "[RUN_IN_DEVICEFARM] Canary did not pass (result=$result). Will retry..."
+  else
+    echo "[RUN_IN_DEVICEFARM] Canary did not pass after $max_run_attempts attempts."
+  fi
 done
-echo "Status = $status Result = $result"
+
+echo "============================================================"
+echo "[RUN_IN_DEVICEFARM] Final canary result for $module_name: $final_result"
+echo "============================================================"
 
 ./scripts/generate_df_testrun_report --run_arn="$run_arn" --module_name="$module_name" --pr="$CODEBUILD_SOURCE_VERSION" --output_path="build/allTests/$module_name/"
-# If the result is PASSED, then exit with a return code 0
-if [ "$result" = "PASSED" ]
-then
+
+if [ "$final_result" = "PASSED" ]; then
   exit 0
 fi
-# Otherwise, exit with a non-zero.
 exit 1


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:* add retry and throttle resilience to canary script

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
