### PR TITLE
feat(api): expose V2 internals with @InternalAmplifyApi for AppSyncClient

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonFactory.java
@@ -26,10 +26,13 @@ import com.amplifyframework.datastore.appsync.SerializedModelAdapter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import com.amplifyframework.annotations.InternalAmplifyApi;
+
 /**
  * Creates a {@link Gson} instance which may be used around the API plugin.
  */
-final class GsonFactory {
+@InternalAmplifyApi
+public final class GsonFactory {
     private static Gson gson = null;
 
     private GsonFactory() {}

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/GsonGraphQLResponseFactory.java
@@ -42,20 +42,25 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.amplifyframework.annotations.InternalAmplifyApi;
+
 /**
  * Converts JSON strings into models of a given type, using Gson.
  */
-final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
+@InternalAmplifyApi
+public final class GsonGraphQLResponseFactory implements GraphQLResponse.Factory {
     private final Gson gson;
 
     private final AWSApiSchemaRegistry schemaRegistry = new AWSApiSchemaRegistry();
 
-    GsonGraphQLResponseFactory() {
+    @InternalAmplifyApi
+    public GsonGraphQLResponseFactory() {
         this(GsonFactory.instance());
     }
 
     @VisibleForTesting
-    GsonGraphQLResponseFactory(Gson gson) {
+    @InternalAmplifyApi
+    public GsonGraphQLResponseFactory(Gson gson) {
         this.gson = gson;
     }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/Iso8601Timestamp.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/Iso8601Timestamp.java
@@ -19,6 +19,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import com.amplifyframework.annotations.InternalAmplifyApi;
+
 /**
  * Utility to create a ISO 8601 compliant timestamps.
  * This utility only created US-locale timestamps. It is intended for
@@ -26,10 +28,12 @@ import java.util.Locale;
  * timestamp returned by this utility should not be displayed to end
  * users in a UI, as it is not localized.
  */
-final class Iso8601Timestamp {
+@InternalAmplifyApi
+public final class Iso8601Timestamp {
     private Iso8601Timestamp() {}
 
-    static String now() {
+    @InternalAmplifyApi
+    public static String now() {
         SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.US);
         return formatter.format(new Date());
     }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthAppSyncGraphQLOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthAppSyncGraphQLOperation.java
@@ -19,6 +19,7 @@ import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import com.amplifyframework.AmplifyException;
+import com.amplifyframework.annotations.InternalAmplifyApi;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiException.ApiAuthException;
 import com.amplifyframework.api.aws.auth.ApiRequestDecoratorFactory;
@@ -152,7 +153,8 @@ public final class MultiAuthAppSyncGraphQLOperation<R> extends AWSGraphQLOperati
         return false;
     }
 
-    static <R> Builder<R> builder() {
+    @InternalAmplifyApi
+    public static <R> Builder<R> builder() {
         return new Builder<>();
     }
 
@@ -202,7 +204,8 @@ public final class MultiAuthAppSyncGraphQLOperation<R> extends AWSGraphQLOperati
         }
     }
 
-    static final class Builder<R> {
+    @InternalAmplifyApi
+    public static final class Builder<R> {
         private String endpoint;
         private OkHttpClient client;
         private GraphQLRequest<R> request;
@@ -213,53 +216,63 @@ public final class MultiAuthAppSyncGraphQLOperation<R> extends AWSGraphQLOperati
         private ExecutorService executorService;
         private String apiName;
 
-        Builder<R> endpoint(@NonNull String endpoint) {
+        @InternalAmplifyApi
+        public Builder<R> endpoint(@NonNull String endpoint) {
             this.endpoint = Objects.requireNonNull(endpoint);
             return this;
         }
 
-        Builder<R> client(@NonNull OkHttpClient client) {
+        @InternalAmplifyApi
+        public Builder<R> client(@NonNull OkHttpClient client) {
             this.client = Objects.requireNonNull(client);
             return this;
         }
 
-        Builder<R> request(@NonNull GraphQLRequest<R> request) {
+        @InternalAmplifyApi
+        public Builder<R> request(@NonNull GraphQLRequest<R> request) {
             this.request = Objects.requireNonNull(request);
             return this;
         }
 
-        Builder<R> responseFactory(@NonNull GraphQLResponse.Factory responseFactory) {
+        @InternalAmplifyApi
+        public Builder<R> responseFactory(@NonNull GraphQLResponse.Factory responseFactory) {
             this.responseFactory = Objects.requireNonNull(responseFactory);
             return this;
         }
 
-        Builder<R> onResponse(@NonNull Consumer<GraphQLResponse<R>> onResponse) {
+        @InternalAmplifyApi
+        public Builder<R> onResponse(@NonNull Consumer<GraphQLResponse<R>> onResponse) {
             this.onResponse = Objects.requireNonNull(onResponse);
             return this;
         }
 
-        Builder<R> onFailure(@NonNull Consumer<ApiException> onFailure) {
+        @InternalAmplifyApi
+        public Builder<R> onFailure(@NonNull Consumer<ApiException> onFailure) {
             this.onFailure = Objects.requireNonNull(onFailure);
             return this;
         }
 
-        Builder<R> apiRequestDecoratorFactory(ApiRequestDecoratorFactory apiRequestDecoratorFactory) {
+        @InternalAmplifyApi
+        public Builder<R> apiRequestDecoratorFactory(ApiRequestDecoratorFactory apiRequestDecoratorFactory) {
             this.apiRequestDecoratorFactory = apiRequestDecoratorFactory;
             return this;
         }
 
-        Builder<R> executorService(ExecutorService executorService) {
+        @InternalAmplifyApi
+        public Builder<R> executorService(ExecutorService executorService) {
             this.executorService = executorService;
             return this;
         }
 
-        Builder<R> apiName(String apiName) {
+        @InternalAmplifyApi
+        public Builder<R> apiName(String apiName) {
             this.apiName = apiName;
             return this;
         }
 
+        @InternalAmplifyApi
         @SuppressLint("SyntheticAccessor")
-        MultiAuthAppSyncGraphQLOperation<R> build() {
+        public MultiAuthAppSyncGraphQLOperation<R> build() {
             return new MultiAuthAppSyncGraphQLOperation<>(this);
         }
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperation.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/MultiAuthSubscriptionOperation.java
@@ -18,6 +18,7 @@ package com.amplifyframework.api.aws;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
+import com.amplifyframework.annotations.InternalAmplifyApi;
 import com.amplifyframework.api.ApiException;
 import com.amplifyframework.api.ApiException.ApiAuthException;
 import com.amplifyframework.api.aws.auth.AuthRuleRequestDecorator;
@@ -37,7 +38,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-final class MultiAuthSubscriptionOperation<T> extends AWSGraphQLOperation<T> {
+@InternalAmplifyApi
+public final class MultiAuthSubscriptionOperation<T> extends AWSGraphQLOperation<T> {
     private static final Logger LOG = Amplify.Logging.logger(CategoryType.API, "amplify:aws-api");
 
     private final SubscriptionEndpoint subscriptionEndpoint;
@@ -68,7 +70,8 @@ final class MultiAuthSubscriptionOperation<T> extends AWSGraphQLOperation<T> {
     }
 
     @NonNull
-    static <T> Builder<T> builder() {
+    @InternalAmplifyApi
+    public static <T> Builder<T> builder() {
         return new Builder<>();
     }
 
@@ -197,7 +200,8 @@ final class MultiAuthSubscriptionOperation<T> extends AWSGraphQLOperation<T> {
         return subscriptionFuture;
     }
 
-    static final class Builder<T> {
+    @InternalAmplifyApi
+    public static final class Builder<T> {
         private SubscriptionEndpoint subscriptionEndpoint;
         private AppSyncGraphQLRequest<T> graphQlRequest;
         private GraphQLResponse.Factory responseFactory;
@@ -210,65 +214,76 @@ final class MultiAuthSubscriptionOperation<T> extends AWSGraphQLOperation<T> {
         private String apiName;
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> subscriptionEndpoint(@NonNull SubscriptionEndpoint subscriptionEndpoint) {
             this.subscriptionEndpoint = Objects.requireNonNull(subscriptionEndpoint);
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> graphQlRequest(@NonNull AppSyncGraphQLRequest<T> graphQlRequest) {
             this.graphQlRequest = Objects.requireNonNull(graphQlRequest);
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> responseFactory(@NonNull GraphQLResponse.Factory responseFactory) {
             this.responseFactory = Objects.requireNonNull(responseFactory);
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> executorService(@NonNull ExecutorService executorService) {
             this.executorService = Objects.requireNonNull(executorService);
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> onSubscriptionStart(@NonNull Consumer<String> onSubscriptionStart) {
             this.onSubscriptionStart = Objects.requireNonNull(onSubscriptionStart);
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> onNextItem(@NonNull Consumer<GraphQLResponse<T>> onNextItem) {
             this.onNextItem = Objects.requireNonNull(onNextItem);
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> onSubscriptionError(@NonNull Consumer<ApiException> onSubscriptionError) {
             this.onSubscriptionError = Objects.requireNonNull(onSubscriptionError);
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> onSubscriptionComplete(@NonNull Action onSubscriptionComplete) {
             this.onSubscriptionComplete = Objects.requireNonNull(onSubscriptionComplete);
             return this;
         }
 
+        @InternalAmplifyApi
         public Builder<T> requestDecorator(AuthRuleRequestDecorator requestDecorator) {
             this.requestDecorator = requestDecorator;
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public Builder<T> apiName(String apiName) {
             this.apiName = apiName;
             return this;
         }
 
         @NonNull
+        @InternalAmplifyApi
         public MultiAuthSubscriptionOperation<T> build() {
             return new MultiAuthSubscriptionOperation<>(this);
         }

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -57,11 +57,14 @@ import okhttp3.Response;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 
+import com.amplifyframework.annotations.InternalAmplifyApi;
+
 /**
  * Manages the lifecycle of a single WebSocket connection,
  * and multiple GraphQL subscriptions that work on top of it.
  */
-final class SubscriptionEndpoint {
+@InternalAmplifyApi
+public final class SubscriptionEndpoint {
     private static final Logger LOG = Amplify.Logging.logger(CategoryType.API, "amplify:aws-api");
     private static final int CONNECTION_ACKNOWLEDGEMENT_TIMEOUT = 30 /* seconds */;
     private static final int NORMAL_CLOSURE_STATUS = 1000;
@@ -104,7 +107,54 @@ final class SubscriptionEndpoint {
         this.okHttpClient = okHttpClientBuilder.build();
     }
 
-    <T> void requestSubscription(
+    /**
+     * Convenience constructor for standalone use outside the plugin. Builds the internal
+     * configuration and authorizer from raw parameters.
+     *
+     * @param endpoint The AppSync GraphQL endpoint URL.
+     * @param region The AWS region.
+     * @param authorizationType The default authorization type.
+     * @param apiKey The API key (required when authorizationType is API_KEY, null otherwise).
+     * @param configurator Optional OkHttp client configurator.
+     * @param responseFactory Factory for deserializing GraphQL responses.
+     * @param authProviders Optional auth providers for token/credential resolution.
+     */
+    @InternalAmplifyApi
+    public SubscriptionEndpoint(
+            @NonNull String endpoint,
+            @NonNull String region,
+            @NonNull AuthorizationType authorizationType,
+            @Nullable String apiKey,
+            @Nullable OkHttpConfigurator configurator,
+            @NonNull GraphQLResponse.Factory responseFactory,
+            @Nullable ApiAuthProviders authProviders
+    ) {
+        this(
+            ApiConfiguration.builder()
+                .endpoint(endpoint)
+                .region(region)
+                .endpointType(EndpointType.GRAPHQL)
+                .authorizationType(authorizationType)
+                .apiKey(apiKey)
+                .build(),
+            configurator,
+            responseFactory,
+            new SubscriptionAuthorizer(
+                ApiConfiguration.builder()
+                    .endpoint(endpoint)
+                    .region(region)
+                    .endpointType(EndpointType.GRAPHQL)
+                    .authorizationType(authorizationType)
+                    .apiKey(apiKey)
+                    .build(),
+                authProviders != null ? authProviders : ApiAuthProviders.noProviderOverrides()
+            ),
+            null
+        );
+    }
+
+    @InternalAmplifyApi
+    public <T> void requestSubscription(
             @NonNull GraphQLRequest<T> request,
             @NonNull AuthorizationType authType,
             @NonNull Consumer<String> onSubscriptionStarted,
@@ -261,7 +311,8 @@ final class SubscriptionEndpoint {
         dispatcher.dispatchNextMessage(data);
     }
 
-    void releaseSubscription(String subscriptionId) throws ApiException {
+    @InternalAmplifyApi
+    public void releaseSubscription(String subscriptionId) throws ApiException {
         // First thing we should do is remove it from the pending subscription collection so
         // the other methods can't grab a hold of the subscription.
         final Subscription<?> subscription = subscriptions.get(subscriptionId);

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionMessageType.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionMessageType.java
@@ -17,13 +17,16 @@ package com.amplifyframework.api.aws;
 
 import androidx.annotation.NonNull;
 
+import com.amplifyframework.annotations.InternalAmplifyApi;
+
 /**
  * An enumeration of the values that are possible in the "type" field
  * of a subscription message.
  * @see <a href="http://bit.ly/gql-ws-message-types">GraphQL Over WebSocket Message Types</a>
  * @see <a href="http://bit.ly/gql-ws-protocol">GraphQL Over WebSocket Protocol</a>
  */
-enum SubscriptionMessageType {
+@InternalAmplifyApi
+public enum SubscriptionMessageType {
 
     /**
      * Client requests initialization of a connection, to the server.

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/TimeoutWatchdog.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/TimeoutWatchdog.java
@@ -21,11 +21,14 @@ import android.os.Looper;
 import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.ApiException;
 
+import com.amplifyframework.annotations.InternalAmplifyApi;
+
 /**
  * Closes the WebSocket connection if the time remaining has elapsed.
  * Enables resetting of the watchdog remaining time.
  */
-final class TimeoutWatchdog {
+@InternalAmplifyApi
+public final class TimeoutWatchdog {
     private final Handler handler;
 
     private Runnable timeoutAction;


### PR DESCRIPTION

- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

Exposes V2 API plugin internals with `@InternalAmplifyApi` so the new standalone AppSync GraphQL client can re-use them


*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
