### PR TITLE
fix(auth): Don't throw if the configuration timeout is exceeded

### DIFF
--- a/aws-auth-cognito/api/aws-auth-cognito.api
+++ b/aws-auth-cognito/api/aws-auth-cognito.api
@@ -10,6 +10,7 @@ public final class com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin : com/
 	public static final field AWS_COGNITO_AUTH_LOG_NAMESPACE Ljava/lang/String;
 	public static final field Companion Lcom/amplifyframework/auth/cognito/AWSCognitoAuthPlugin$Companion;
 	public fun <init> ()V
+	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun autoSignIn (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -77,7 +77,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 
 /**
@@ -127,9 +127,10 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     }
 
     override fun initialize(context: Context) {
-        // Block until the state machine is in the configured state.
+        // Wait up to 10 seconds for the state machine to reach Configured, but do not throw on timeout.
+        // This matches legacy behavior where initialization proceeds regardless of whether configuration completes.
         runBlocking {
-            withTimeout(10.seconds) {
+            withTimeoutOrNull(10.seconds) {
                 suspendWhileConfiguring()
             }
         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -68,6 +68,7 @@ import com.amplifyframework.core.Consumer
 import com.amplifyframework.core.configuration.AmplifyOutputsData
 import com.amplifyframework.statemachine.codegen.events.AuthEvent
 import com.amplifyframework.statemachine.codegen.states.AuthState
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -83,11 +84,15 @@ import org.json.JSONObject
 /**
  * A Cognito implementation of the Auth Plugin.
  */
-class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
+class AWSCognitoAuthPlugin internal constructor(
+    private val configurationTimeout: Duration = 10.seconds
+) : AuthPlugin<AWSCognitoAuthService>() {
     companion object {
         const val AWS_COGNITO_AUTH_LOG_NAMESPACE = "amplify:aws-cognito-auth:%s"
         private const val AWS_COGNITO_AUTH_PLUGIN_KEY = "awsCognitoAuthPlugin"
     }
+
+    constructor() : this(configurationTimeout = 10.seconds)
 
     private val logger = authLogger()
 
@@ -127,10 +132,10 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     }
 
     override fun initialize(context: Context) {
-        // Wait up to 10 seconds for the state machine to reach Configured, but do not throw on timeout.
+        // Wait up to the configured timeout for the state machine to reach Configured, but do not throw on timeout.
         // This matches legacy behavior where initialization proceeds regardless of whether configuration completes.
         runBlocking {
-            withTimeoutOrNull(10.seconds) {
+            withTimeoutOrNull(configurationTimeout) {
                 suspendWhileConfiguring()
             }
         }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -54,12 +54,15 @@ import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
+import com.amplifyframework.statemachine.codegen.states.AuthState
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.MutableSharedFlow
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
@@ -898,5 +901,30 @@ class AWSCognitoAuthPluginTest {
         val useCase = authPlugin.useCaseFactory.webUISignInResponse()
         authPlugin.handleWebUISignInResponse(null)
         coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(null) }
+    }
+
+    @Test
+    fun `initialize completes when state machine reaches Configured`() {
+        val plugin = AWSCognitoAuthPlugin(configurationTimeout = 100.milliseconds)
+        plugin.authStateMachine = mockk(relaxed = true)
+
+        val stateFlow = MutableSharedFlow<AuthState>(replay = 1)
+        stateFlow.tryEmit(AuthState.Configured(null, null, null))
+        every { plugin.authStateMachine.state } returns stateFlow
+
+        plugin.initialize(mockk())
+    }
+
+    @Test
+    fun `initialize does not throw when state machine does not reach Configured within timeout`() {
+        val plugin = AWSCognitoAuthPlugin(configurationTimeout = 100.milliseconds)
+        plugin.authStateMachine = mockk(relaxed = true)
+
+        val stateFlow = MutableSharedFlow<AuthState>(replay = 1)
+        stateFlow.tryEmit(AuthState.ConfiguringAuth())
+        every { plugin.authStateMachine.state } returns stateFlow
+
+        // Should complete without throwing despite the state never reaching Configured
+        plugin.initialize(mockk())
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* #3318

*Description of changes:*
Previously the Auth plugin would wait up to 10 seconds to reach the configured state, but would not actually fail in if the timeout was exceeded. This was most likely a bug - a failure to configure indicates some other issue - but changing that behaviour is a regression. This change restores the previous behaviour of blocking in `initialize` for up to 10 seconds, but then continuing without an error if the timeout is exceeded.

*How did you test these changes?*


*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
