### PR TITLE
fix(auth): Better align AuthorizationState with Swift implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ aws-datastore/src/androidTest/res/raw/amplifyconfigurationupdated.json
 
 # Agent files
 .kiro
+.claude

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginSignInChallengeTests.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginSignInChallengeTests.kt
@@ -108,6 +108,7 @@ class AWSCognitoAuthPluginSignInChallengeTests : DeviceFarmTestBase() {
         // Sign in and reach MFA challenge state
         var signInResult = synchronousAuth.signIn(username, password)
         signInResult.nextStep.signInStep shouldBe AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP
+        subscription.blockForCode(username)
 
         // Call signOut to cancel the in-progress sign-in
         val signOutResult = synchronousAuth.signOut()

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginSignInChallengeTests.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginSignInChallengeTests.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.api.aws.AWSApiPlugin
+import com.amplifyframework.auth.AuthUserAttribute
+import com.amplifyframework.auth.AuthUserAttributeKey
+import com.amplifyframework.auth.cognito.result.AWSCognitoAuthSignOutResult
+import com.amplifyframework.auth.cognito.test.R
+import com.amplifyframework.auth.cognito.testutils.blockForCode
+import com.amplifyframework.auth.cognito.testutils.blockUntilEstablished
+import com.amplifyframework.auth.cognito.testutils.createMfaSubscription
+import com.amplifyframework.auth.options.AuthSignUpOptions
+import com.amplifyframework.auth.result.step.AuthSignInStep
+import com.amplifyframework.core.configuration.AmplifyOutputs
+import com.amplifyframework.core.configuration.AmplifyOutputsData
+import com.amplifyframework.datastore.generated.model.MfaInfo
+import com.amplifyframework.testutils.DeviceFarmTestBase
+import com.amplifyframework.testutils.api.SubscriptionHolder
+import com.amplifyframework.testutils.sync.SynchronousAuth
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.Random
+import java.util.UUID
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests that fetchAuthSession and signOut behave correctly when called during an in-progress
+ * sign-in with MFA challenge. This reproduces the bug where navigating away from an MFA screen
+ * and back causes InvalidStateException because the state machine is still in a signing-in state.
+ */
+class AWSCognitoAuthPluginSignInChallengeTests : DeviceFarmTestBase() {
+
+    private val password = "${UUID.randomUUID()}BleepBloop1234!"
+    private val username = "test${Random().nextInt()}"
+    private val email = "$username@amplify-swift-gamma.awsapps.com"
+
+    private var authPlugin = AWSCognitoAuthPlugin()
+    private var apiPlugin = AWSApiPlugin()
+    private lateinit var synchronousAuth: SynchronousAuth
+    private lateinit var subscription: SubscriptionHolder<MfaInfo>
+
+    @Before
+    fun initializePlugin() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val config = AmplifyOutputsData
+            .deserialize(context, AmplifyOutputs.fromResource(R.raw.amplify_outputs_email_or_totp_mfa))
+
+        authPlugin.configure(config, context)
+        apiPlugin.configure(config, context)
+        synchronousAuth = SynchronousAuth.delegatingTo(authPlugin)
+
+        subscription = apiPlugin.createMfaSubscription()
+    }
+
+    @After
+    fun tearDown() {
+        subscription.cancel()
+        try {
+            synchronousAuth.deleteUser()
+        } catch (_: Exception) {
+            // User may not be signed in if the test didn't complete sign-in
+        }
+    }
+
+    @Test
+    fun signIn_succeeds_after_fetchAuthSession_during_mfa_challenge() {
+        signUpNewUser()
+        subscription.blockUntilEstablished()
+
+        // Sign in and reach MFA challenge state
+        var signInResult = synchronousAuth.signIn(username, password)
+        signInResult.nextStep.signInStep shouldBe AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP
+
+        // Call fetchAuthSession (simulates what AuthenticatorViewModel does on re-creation)
+        val session = synchronousAuth.fetchAuthSession()
+        session.isSignedIn.shouldBeFalse()
+
+        // Confirm sign-in can still complete with the MFA code
+        val mfaCode = subscription.blockForCode(username)
+        signInResult = synchronousAuth.confirmSignIn(mfaCode)
+        signInResult.nextStep.signInStep shouldBe AuthSignInStep.DONE
+    }
+
+    @Test
+    fun signIn_succeeds_after_signOut_during_mfa_challenge() {
+        signUpNewUser()
+        subscription.blockUntilEstablished()
+
+        // Sign in and reach MFA challenge state
+        var signInResult = synchronousAuth.signIn(username, password)
+        signInResult.nextStep.signInStep shouldBe AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP
+
+        // Call signOut to cancel the in-progress sign-in
+        val signOutResult = synchronousAuth.signOut()
+        signOutResult.shouldBeInstanceOf<AWSCognitoAuthSignOutResult.CompleteSignOut>()
+
+        // Start a fresh sign-in and complete it
+        signInResult = synchronousAuth.signIn(username, password)
+        signInResult.nextStep.signInStep shouldBe AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP
+
+        val mfaCode = subscription.blockForCode(username)
+        signInResult = synchronousAuth.confirmSignIn(mfaCode)
+        signInResult.nextStep.signInStep shouldBe AuthSignInStep.DONE
+    }
+
+    private fun signUpNewUser() {
+        val options = AuthSignUpOptions.builder()
+            .userAttributes(listOf(AuthUserAttribute(AuthUserAttributeKey.email(), email)))
+            .build()
+        synchronousAuth.signUp(username, password, options)
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCase.kt
@@ -49,7 +49,8 @@ internal class FetchAuthSessionUseCase(
 
         return when (val authZState = currentState.authZState) {
             is AuthorizationState.Configured -> {
-                waitForSession(AuthorizationEvent(AuthorizationEvent.EventType.FetchUnAuthSession))
+                val event = AuthorizationEvent(AuthorizationEvent.EventType.FetchUnAuthSession)
+                waitForSession(event)
             }
             is AuthorizationState.SessionEstablished -> {
                 val credential = authZState.amplifyCredential

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/SignOutUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/SignOutUseCase.kt
@@ -56,6 +56,12 @@ internal class SignOutUseCase(
                     sendHubEvent = true
                 )
             }
+            is AuthenticationState.SigningIn -> {
+                completeSignOut(
+                    event = AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn()),
+                    sendHubEvent = false
+                )
+            }
             is AuthenticationState.FederatedToIdentityPool -> {
                 AWSCognitoAuthSignOutResult.FailedSignOut(
                     InvalidStateException(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
@@ -38,7 +38,6 @@ import com.amplifyframework.statemachine.codegen.events.SignOutEvent
 internal sealed class AuthorizationState : State {
     data class NotConfigured(val id: String = "") : AuthorizationState()
     data class Configured(val id: String = "") : AuthorizationState()
-    data class SigningIn(val id: String = "") : AuthorizationState()
     data class SigningOut(val amplifyCredential: AmplifyCredential) : AuthorizationState()
     data class FetchingAuthSession(
         val signedInData: SignedInData,
@@ -85,12 +84,18 @@ internal sealed class AuthorizationState : State {
             val deleteUserEvent = event.isDeleteUserEvent()
             val defaultResolution = StateResolution(oldState)
 
-            if (authenticationEvent is AuthenticationEvent.EventType.SignInCompleted) {
-                val action = authorizationActions.initializeFetchAuthSession(authenticationEvent.signedInData)
-                return StateResolution(
-                    FetchingAuthSession(authenticationEvent.signedInData, FetchAuthSessionState.NotStarted()),
-                    listOf(action)
-                )
+            when (authenticationEvent) {
+                is AuthenticationEvent.EventType.SignInCompleted -> {
+                    val action = authorizationActions.initializeFetchAuthSession(authenticationEvent.signedInData)
+                    return StateResolution(
+                        FetchingAuthSession(authenticationEvent.signedInData, FetchAuthSessionState.NotStarted()),
+                        listOf(action)
+                    )
+                }
+                is AuthenticationEvent.EventType.CancelSignIn -> {
+                    return StateResolution(Configured())
+                }
+                else -> Unit // no-op
             }
 
             return when (oldState) {
@@ -125,7 +130,6 @@ internal sealed class AuthorizationState : State {
                         )
                         StateResolution(newState, listOf(action))
                     }
-                    authenticationEvent is AuthenticationEvent.EventType.SignInRequested -> StateResolution(SigningIn())
                     else -> defaultResolution
                 }
                 is StoringCredentials -> when (authEvent) {
@@ -137,17 +141,6 @@ internal sealed class AuthorizationState : State {
                         }
                     }
                     is AuthEvent.EventType.CachedCredentialsFailed -> StateResolution(NotConfigured())
-                    else -> defaultResolution
-                }
-                is SigningIn -> when (authenticationEvent) {
-                    is AuthenticationEvent.EventType.SignInCompleted -> {
-                        val action = authorizationActions.initializeFetchAuthSession(authenticationEvent.signedInData)
-                        StateResolution(
-                            FetchingAuthSession(authenticationEvent.signedInData, FetchAuthSessionState.NotStarted()),
-                            listOf(action)
-                        )
-                    }
-                    is AuthenticationEvent.EventType.CancelSignIn -> StateResolution(Configured())
                     else -> defaultResolution
                 }
                 is SigningOut -> when {
@@ -265,7 +258,6 @@ internal sealed class AuthorizationState : State {
                     }
                 }
                 is SessionEstablished -> when {
-                    authenticationEvent is AuthenticationEvent.EventType.SignInRequested -> StateResolution(SigningIn())
                     authenticationEvent is AuthenticationEvent.EventType.SignOutRequested ||
                         authenticationEvent is AuthenticationEvent.EventType.ClearFederationToIdentityPool -> {
                         StateResolution(SigningOut(oldState.amplifyCredential))
@@ -300,7 +292,6 @@ internal sealed class AuthorizationState : State {
                     else -> defaultResolution
                 }
                 is Error -> when {
-                    authenticationEvent is AuthenticationEvent.EventType.SignInRequested -> StateResolution(SigningIn())
                     authenticationEvent is AuthenticationEvent.EventType.SignOutRequested -> StateResolution(
                         SigningOut(AmplifyCredential.Empty)
                     )

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/authstategenerators/AuthStateJsonGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/authstategenerators/AuthStateJsonGenerator.kt
@@ -111,7 +111,7 @@ object AuthStateJsonGenerator : SerializableProvider {
                 )
             )
         ),
-        AuthorizationState.SigningIn(),
+        AuthorizationState.Configured(),
         SignUpState.NotStarted()
     )
 
@@ -211,7 +211,7 @@ object AuthStateJsonGenerator : SerializableProvider {
                 )
             )
         ),
-        AuthorizationState.SigningIn(),
+        AuthorizationState.Configured(),
         SignUpState.NotStarted()
     )
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/serializers/AuthStatesSerializer.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/serializers/AuthStatesSerializer.kt
@@ -106,7 +106,6 @@ internal data class AuthStatesProxy(
                 }
             } as T
         }
-        "AuthorizationState.SigningIn" -> AuthorizationState.SigningIn() as T
         "SignInState.ResolvingChallenge" -> SignInState.ResolvingChallenge(signInChallengeState) as T
         "SignInChallengeState.WaitingForAnswer" -> authChallenge?.let {
             SignInChallengeState.WaitingForAnswer(it, signInMethod!!)
@@ -171,9 +170,6 @@ internal data class AuthStatesProxy(
                     is AuthorizationState.SessionEstablished -> AuthStatesProxy(
                         type = "AuthorizationState.SessionEstablished",
                         amplifyCredential = authState.amplifyCredential
-                    )
-                    is AuthorizationState.SigningIn -> AuthStatesProxy(
-                        type = "AuthorizationState.SigningIn"
                     )
                     is AuthorizationState.SigningOut -> TODO()
                     is AuthorizationState.StoringCredentials -> TODO()

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/SignOutUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/SignOutUseCaseTest.kt
@@ -122,7 +122,7 @@ class SignOutUseCaseTest {
 
     @Test
     fun `fails if in unexpected state`() = runTest {
-        stateFlow.value = authState(authNState = AuthenticationState.SigningIn())
+        stateFlow.value = authState(authNState = AuthenticationState.SigningOut())
 
         val result = useCase.execute()
 
@@ -161,6 +161,23 @@ class SignOutUseCaseTest {
 
     @Test
     fun `returns complete result`() = runTest {
+        val deferred = backgroundScope.async { useCase.execute() }
+        runCurrent()
+
+        val signedOutData = SignedOutData()
+
+        stateFlow.value = authState(
+            authNState = AuthenticationState.SignedOut(signedOutData),
+            authZState = AuthorizationState.Configured()
+        )
+
+        val result = deferred.await()
+        result shouldBe AWSCognitoAuthSignOutResult.CompleteSignOut
+    }
+
+    @Test
+    fun `returns complete result from signingIn state`() = runTest {
+        stateFlow.value = authState(authNState = AuthenticationState.SigningIn())
         val deferred = backgroundScope.async { useCase.execute() }
         runCurrent()
 

--- a/aws-auth-cognito/src/test/resources/feature-test/states/CustomSignIn_SigningIn.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/CustomSignIn_SigningIn.json
@@ -25,7 +25,7 @@
     }
   },
   "AuthorizationState": {
-    "type": "AuthorizationState.SigningIn"
+    "type": "AuthorizationState.Configured"
   },
   "SignUpState": {
     "type": "SignUpState.NotStarted"

--- a/aws-auth-cognito/src/test/resources/feature-test/states/CustomSignIn_SigningIn_Password_Challenge.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/CustomSignIn_SigningIn_Password_Challenge.json
@@ -25,7 +25,7 @@
     }
   },
   "AuthorizationState": {
-    "type": "AuthorizationState.SigningIn"
+    "type": "AuthorizationState.Configured"
   },
   "SignUpState": {
     "type": "SignUpState.NotStarted"

--- a/aws-auth-cognito/src/test/resources/feature-test/states/CustomSignIn_SigningIn_With_Alias.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/CustomSignIn_SigningIn_With_Alias.json
@@ -25,7 +25,7 @@
     }
   },
   "AuthorizationState": {
-    "type": "AuthorizationState.SigningIn"
+    "type": "AuthorizationState.Configured"
   },
   "SignUpState": {
     "type": "SignUpState.NotStarted"

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_CustomChallenge.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_CustomChallenge.json
@@ -24,7 +24,7 @@
         }
     },
     "AuthorizationState": {
-        "type": "AuthorizationState.SigningIn"
+        "type": "AuthorizationState.Configured"
     },
     "SignUpState": {
         "type": "SignUpState.NotStarted"

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_EmailOtp.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_EmailOtp.json
@@ -23,7 +23,7 @@
         }
     },
     "AuthorizationState": {
-        "type": "AuthorizationState.SigningIn"
+        "type": "AuthorizationState.Configured"
     },
     "SignUpState": {
         "type": "SignUpState.NotStarted"

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SelectChallenge.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SelectChallenge.json
@@ -25,7 +25,7 @@
         }
     },
     "AuthorizationState": {
-        "type": "AuthorizationState.SigningIn"
+        "type": "AuthorizationState.Configured"
     },
     "SignUpState": {
         "type": "SignUpState.NotStarted"

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SigningIn.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SigningIn.json
@@ -23,7 +23,7 @@
         }
     },
     "AuthorizationState": {
-        "type": "AuthorizationState.SigningIn"
+        "type": "AuthorizationState.Configured"
     },
     "SignUpState": {
         "type": "SignUpState.NotStarted"

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SigningIn_Custom.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SigningIn_Custom.json
@@ -23,7 +23,7 @@
         }
     },
     "AuthorizationState": {
-        "type": "AuthorizationState.SigningIn"
+        "type": "AuthorizationState.Configured"
     },
     "SignUpState": {
         "type": "SignUpState.NotStarted"

--- a/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SmsOtp.json
+++ b/aws-auth-cognito/src/test/resources/feature-test/states/SigningIn_SmsOtp.json
@@ -23,7 +23,7 @@
         }
     },
     "AuthorizationState": {
-        "type": "AuthorizationState.SigningIn"
+        "type": "AuthorizationState.Configured"
     },
     "SignUpState": {
         "type": "SignUpState.NotStarted"


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* https://github.com/aws-amplify/amplify-ui-android/issues/320

## Summary

Remove `AuthorizationState.SigningIn` from the auth state machine, aligning Android's authorization behavior with Swift and Flutter.

On Android, when a sign-in begins, `AuthorizationState` transitions to `SigningIn` — a state that only handles `SignInCompleted` and `CancelSignIn`. This creates a trap: if a caller invokes `fetchAuthSession()` or `signOut()`  while a sign-in challenge is pending (e.g., MFA confirmation), they both throw `InvalidStateException` because `SigningIn` is not a handled case.

In contrast, Swift's `AuthorizationState` has no equivalent state — it stays in `.configured` during sign-in, allowing session fetches to proceed normally as unauthenticated requests.

  ## Motivation

  When using the Authenticator composable with Compose Navigation, navigating away from an MFA challenge screen and back creates a new `AuthenticatorViewModel` that calls `fetchAuthSession()`. The singleton state machine is still in
  `AuthorizationState.SigningIn` from the abandoned challenge, causing `InvalidStateException`. The user is then stuck — `signOut()` also fails for the same reason.

## Description of changes:

  - **`AuthorizationState.kt`**: Removed the `SigningIn` data class and its resolver case. Moved `SignInCompleted` and `CancelSignIn` handling into a global `when(authenticationEvent)` block that fires from any state (mirroring Swift's
  top-level event check). Removed `SignInRequested → SigningIn()` transitions from `Configured`, `SessionEstablished`, and `Error`.

  - **`FetchAuthSessionUseCase.kt`**: Removed `AuthorizationState.SigningIn` from the `Configured` branch. During sign-in, `AuthorizationState` now stays in `Configured`, so fetching an unauth session works naturally.

  - **`SignOutUseCase.kt`**: Added handling for `AuthenticationState.SigningIn` — cancels the in-progress sign-in and completes sign-out without emitting a hub event (there are no tokens to revoke).

  - **Test fixtures (9 JSON files)**: Updated serialized `AuthorizationState` from `"AuthorizationState.SigningIn"` to `"AuthorizationState.Configured"`.

  ## Expected impact

  | Scenario | Before | After |
  |----------|--------|-------|
  | `fetchAuthSession()` during sign-in challenge | `InvalidStateException` | Returns unauthenticated session |
  | `signOut()` during sign-in challenge | `FailedSignOut(InvalidStateException)` | Cancels sign-in, returns success |
  | Sign-in completes normally | `SigningIn` → `FetchingAuthSession` | `Configured` → `FetchingAuthSession` (same end state) |
  | Sign-in cancelled | `SigningIn` → `Configured` | `Configured` → `Configured` (no-op) |

*How did you test these changes?*
- Verified the fix for the user issue linked above.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [x] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
