### PR TITLE
test: add Event Enrichment client unit tests

### DIFF
--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EnrichedEventTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EnrichedEventTest.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.eventenrichment
+
+import com.amplifyframework.eventenrichment.metadata.AppMetadata
+import com.amplifyframework.eventenrichment.metadata.DeviceMetadata
+import com.amplifyframework.eventenrichment.metadata.SdkMetadata
+import com.amplifyframework.eventenrichment.session.Session
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Test
+
+class EnrichedEventTest {
+
+    private fun event(
+        eventType: String = "button_clicked",
+        eventTimestamp: Long = 1_700_000_000_000L,
+        session: Session = Session(
+            id = "my-app12-abcdef12-20260706-195159839",
+            startTimestamp = "2026-07-06T19:51:59.839Z"
+        ),
+        attributes: Map<String, String> = emptyMap(),
+        metrics: Map<String, Double> = emptyMap(),
+        device: DeviceMetadata = DeviceMetadata(),
+        app: AppMetadata = AppMetadata(appId = "my-app"),
+        sdk: SdkMetadata = SdkMetadata(name = "amplify-android", version = "2.0.0"),
+        clientId: String = "device-uuid",
+        userId: String? = null
+    ) = EnrichedEvent(
+        eventId = "event-uuid",
+        eventType = eventType,
+        eventTimestamp = eventTimestamp,
+        session = session,
+        attributes = attributes,
+        metrics = metrics,
+        device = device,
+        app = app,
+        sdk = sdk,
+        clientId = clientId,
+        userId = userId
+    )
+
+    @Test
+    fun `toJson emits the full 3_1 envelope with all fields`() {
+        val json = event(
+            attributes = mapOf("screen" to "home"),
+            metrics = mapOf("load_time" to 2.5),
+            device = DeviceMetadata(
+                platform = "Android",
+                platformVersion = "14",
+                manufacturer = "Google",
+                model = "Pixel",
+                locale = "en_US"
+            ),
+            app = AppMetadata(
+                appId = "my-app",
+                packageName = "com.example.app",
+                versionName = "1.0",
+                versionCode = "42",
+                title = "Example"
+            ),
+            userId = "user-1"
+        ).toJson()
+
+        json shouldEqualJson """
+            {
+              "event_type": "button_clicked",
+              "event_timestamp": 1700000000000,
+              "arrival_timestamp": 1700000000000,
+              "event_version": "3.1",
+              "application": {
+                "app_id": "my-app",
+                "package_name": "com.example.app",
+                "version_name": "1.0",
+                "version_code": "42",
+                "title": "Example",
+                "sdk": { "name": "amplify-android", "version": "2.0.0" }
+              },
+              "client": { "client_id": "device-uuid", "user_id": "user-1" },
+              "device": {
+                "platform": { "name": "Android", "version": "14" },
+                "make": "Google",
+                "model": "Pixel",
+                "locale": { "code": "en_US" }
+              },
+              "session": {
+                "id": "my-app12-abcdef12-20260706-195159839",
+                "start_timestamp": "2026-07-06T19:51:59.839Z"
+              },
+              "attributes": { "screen": "home" },
+              "metrics": { "load_time": 2.5 }
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `arrival_timestamp mirrors event_timestamp`() {
+        val obj = Json.parseToJsonElement(event(eventTimestamp = 123456789L).toJson()).jsonObject
+        obj["event_timestamp"] shouldBe JsonPrimitive(123456789L)
+        obj["arrival_timestamp"] shouldBe JsonPrimitive(123456789L)
+    }
+
+    @Test
+    fun `device is always present even when empty`() {
+        val obj = Json.parseToJsonElement(event(device = DeviceMetadata()).toJson()).jsonObject
+        obj.containsKey("device") shouldBe true
+        obj.getValue("device").jsonObject.size shouldBe 0
+    }
+
+    @Test
+    fun `platform sub-object is omitted when platform fields are null`() {
+        val obj = Json.parseToJsonElement(
+            event(device = DeviceMetadata(manufacturer = "Google", model = "Pixel")).toJson()
+        ).jsonObject
+        val device = obj.getValue("device").jsonObject
+        device.containsKey("platform") shouldBe false
+        device.getValue("make").jsonPrimitive.content shouldBe "Google"
+        device.getValue("model").jsonPrimitive.content shouldBe "Pixel"
+    }
+
+    @Test
+    fun `platform sub-object is present when only platform name is set`() {
+        val obj = Json.parseToJsonElement(
+            event(device = DeviceMetadata(platform = "Android")).toJson()
+        ).jsonObject
+        val platform = obj.getValue("device").jsonObject.getValue("platform").jsonObject
+        platform.getValue("name").jsonPrimitive.content shouldBe "Android"
+        platform.containsKey("version") shouldBe false
+    }
+
+    @Test
+    fun `locale sub-object is omitted when locale is null`() {
+        val obj = Json.parseToJsonElement(
+            event(device = DeviceMetadata(platform = "Android")).toJson()
+        ).jsonObject
+        obj.getValue("device").jsonObject.containsKey("locale") shouldBe false
+    }
+
+    @Test
+    fun `optional application fields are omitted when null`() {
+        val obj = Json.parseToJsonElement(event(app = AppMetadata(appId = "my-app")).toJson()).jsonObject
+        val application = obj.getValue("application").jsonObject
+        application.getValue("app_id").jsonPrimitive.content shouldBe "my-app"
+        application.containsKey("package_name") shouldBe false
+        application.containsKey("version_name") shouldBe false
+        application.containsKey("version_code") shouldBe false
+        application.containsKey("title") shouldBe false
+        application.containsKey("sdk") shouldBe true
+    }
+
+    @Test
+    fun `user_id is omitted when null`() {
+        val obj = Json.parseToJsonElement(event(userId = null).toJson()).jsonObject
+        val client = obj.getValue("client").jsonObject
+        client.getValue("client_id").jsonPrimitive.content shouldBe "device-uuid"
+        client.containsKey("user_id") shouldBe false
+    }
+
+    @Test
+    fun `empty attributes and metrics maps are omitted`() {
+        val obj = Json.parseToJsonElement(event().toJson()).jsonObject
+        obj.containsKey("attributes") shouldBe false
+        obj.containsKey("metrics") shouldBe false
+    }
+
+    @Test
+    fun `session stop_timestamp and duration are present when set`() {
+        val obj = Json.parseToJsonElement(
+            event(
+                session = Session(
+                    id = "sid",
+                    startTimestamp = "2026-07-06T19:51:59.839Z",
+                    stopTimestamp = "2026-07-06T19:52:09.839Z",
+                    duration = 10_000L
+                )
+            ).toJson()
+        ).jsonObject
+        val session = obj.getValue("session").jsonObject
+        session.getValue("stop_timestamp").jsonPrimitive.content shouldBe "2026-07-06T19:52:09.839Z"
+        session.getValue("duration") shouldBe JsonPrimitive(10_000L)
+    }
+
+    @Test
+    fun `session stop_timestamp and duration are omitted while active`() {
+        val obj = Json.parseToJsonElement(event().toJson()).jsonObject
+        val session = obj.getValue("session").jsonObject
+        session.containsKey("stop_timestamp") shouldBe false
+        session.containsKey("duration") shouldBe false
+    }
+
+    @Test
+    fun `no caps are applied to attribute or metric count`() {
+        val attributes = (0 until 1_000).associate { "attr_$it" to "value_$it" }
+        val metrics = (0 until 1_000).associate { "metric_$it" to it.toDouble() }
+
+        val obj = Json.parseToJsonElement(event(attributes = attributes, metrics = metrics).toJson()).jsonObject
+        obj.getValue("attributes").jsonObject.size shouldBe 1_000
+        obj.getValue("metrics").jsonObject.size shouldBe 1_000
+    }
+
+    @Test
+    fun `no caps are applied to attribute value length`() {
+        val longValue = "x".repeat(50_000)
+        val obj = Json.parseToJsonElement(event(attributes = mapOf("big" to longValue)).toJson()).jsonObject
+        obj.getValue("attributes").jsonObject.getValue("big").jsonPrimitive.content shouldBe longValue
+    }
+
+    @Test
+    fun `event_version is 3_1`() {
+        val obj: JsonObject = Json.parseToJsonElement(event().toJson()).jsonObject
+        obj.getValue("event_version").jsonPrimitive.content shouldBe "3.1"
+    }
+}

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientAutoResolveTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientAutoResolveTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.eventenrichment
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.eventenrichment.clientid.SharedPreferencesClientIdProvider
+import com.amplifyframework.eventenrichment.metadata.AppMetadata
+import com.amplifyframework.eventenrichment.metadata.SdkMetadata
+import com.amplifyframework.foundation.result.Result
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class EventEnrichmentClientAutoResolveTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val sdkMetadata = SdkMetadata(name = "amplify-android", version = "2.0.0")
+
+    private fun options(autoSessionTracking: Boolean = false) = EventEnrichmentClientOptions {
+        this.autoSessionTracking = autoSessionTracking
+    }
+
+    @Test
+    fun `auto-resolves real device metadata rather than shipping empty device info`() {
+        val client = EventEnrichmentClient(
+            context = context,
+            appId = "my-app",
+            sdkMetadata = sdkMetadata,
+            options = options()
+        )
+
+        val event = (client.record("x") as Result.Success).data
+        event.device.platform shouldBe "Android"
+    }
+
+    @Test
+    fun `auto-resolves the client id from the shared SharedPreferences key`() {
+        val client = EventEnrichmentClient(
+            context = context,
+            appId = "my-app",
+            sdkMetadata = sdkMetadata,
+            options = options()
+        )
+
+        val event = (client.record("x") as Result.Success).data
+        val stored = context
+            .getSharedPreferences(SharedPreferencesClientIdProvider.PREFERENCES_NAME, Context.MODE_PRIVATE)
+            .getString(SharedPreferencesClientIdProvider.CLIENT_ID_STORAGE_KEY, null)
+
+        event.clientId shouldBe stored
+    }
+
+    @Test
+    fun `throws when appMetadata appId does not match the appId`() {
+        shouldThrow<IllegalArgumentException> {
+            EventEnrichmentClient(
+                context = context,
+                appId = "my-app",
+                sdkMetadata = sdkMetadata,
+                options = options(),
+                appMetadata = AppMetadata(appId = "different-app")
+            )
+        }
+    }
+
+    @Test
+    fun `accepts a matching appMetadata`() {
+        val client = EventEnrichmentClient(
+            context = context,
+            appId = "my-app",
+            sdkMetadata = sdkMetadata,
+            options = options(),
+            appMetadata = AppMetadata(appId = "my-app", title = "My App")
+        )
+
+        val event = (client.record("x") as Result.Success).data
+        event.app.title shouldBe "My App"
+    }
+}

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientAutoResolveTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientAutoResolveTest.kt
@@ -19,7 +19,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.amplifyframework.eventenrichment.clientid.SharedPreferencesClientIdProvider
 import com.amplifyframework.eventenrichment.metadata.AppMetadata
 import com.amplifyframework.eventenrichment.metadata.SdkMetadata
-import com.amplifyframework.foundation.result.Result
+import com.amplifyframework.foundation.result.get
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -45,7 +45,7 @@ class EventEnrichmentClientAutoResolveTest {
             options = options()
         )
 
-        val event = (client.record("x") as Result.Success).data
+        val event = client.record("x").get()
         event.device.platform shouldBe "Android"
     }
 
@@ -58,7 +58,7 @@ class EventEnrichmentClientAutoResolveTest {
             options = options()
         )
 
-        val event = (client.record("x") as Result.Success).data
+        val event = client.record("x").get()
         val stored = context
             .getSharedPreferences(SharedPreferencesClientIdProvider.PREFERENCES_NAME, Context.MODE_PRIVATE)
             .getString(SharedPreferencesClientIdProvider.CLIENT_ID_STORAGE_KEY, null)
@@ -89,7 +89,7 @@ class EventEnrichmentClientAutoResolveTest {
             appMetadata = AppMetadata(appId = "my-app", title = "My App")
         )
 
-        val event = (client.record("x") as Result.Success).data
+        val event = client.record("x").get()
         event.app.title shouldBe "My App"
     }
 }

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientOptionsTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientOptionsTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.eventenrichment
+
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Test
+
+class EventEnrichmentClientOptionsTest {
+
+    @Test
+    fun `defaults enable auto session tracking with a five second timeout`() {
+        val options = EventEnrichmentClientOptions.defaults()
+        options.autoSessionTracking shouldBe true
+        options.sessionTimeout shouldBe 5.seconds
+    }
+
+    @Test
+    fun `builder overrides are applied`() {
+        val options = EventEnrichmentClientOptions.builder()
+            .autoSessionTracking(false)
+            .sessionTimeout(30.seconds)
+            .build()
+
+        options.autoSessionTracking shouldBe false
+        options.sessionTimeout shouldBe 30.seconds
+    }
+
+    @Test
+    fun `dsl invoke configures options`() {
+        val options = EventEnrichmentClientOptions {
+            autoSessionTracking = false
+            sessionTimeout = 10.seconds
+        }
+
+        options.autoSessionTracking shouldBe false
+        options.sessionTimeout shouldBe 10.seconds
+    }
+}

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.eventenrichment
+
+import com.amplifyframework.eventenrichment.exception.EventEnrichmentClosedException
+import com.amplifyframework.eventenrichment.metadata.AppMetadata
+import com.amplifyframework.eventenrichment.metadata.DeviceMetadata
+import com.amplifyframework.eventenrichment.metadata.SdkMetadata
+import com.amplifyframework.eventenrichment.session.SessionManager
+import com.amplifyframework.eventenrichment.session.SessionState
+import com.amplifyframework.foundation.result.Result
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.time.Instant
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Test
+
+class EventEnrichmentClientTest {
+
+    private class CapturingSink : EventSink {
+        val events = mutableListOf<EnrichedEvent>()
+        override fun send(event: EnrichedEvent) {
+            events += event
+        }
+    }
+
+    private val sink = CapturingSink()
+    private var clock = Instant.parse("2026-07-06T19:51:59.839Z")
+    private var idSequence = 0
+
+    private fun sessionManager(appId: String = "my-app") = SessionManager(
+        appId = appId,
+        sessionTimeout = 5.seconds,
+        now = { clock },
+        generateId = { "session${idSequence++}0-1111-2222-3333-444455556666" }
+    )
+
+    private fun client(
+        appMetadata: AppMetadata = AppMetadata(appId = "my-app"),
+        deviceMetadata: DeviceMetadata = DeviceMetadata(platform = "Android"),
+        autoSessionTracking: Boolean = true,
+        manager: SessionManager = sessionManager()
+    ) = EventEnrichmentClient(
+        appMetadata = appMetadata,
+        deviceMetadata = deviceMetadata,
+        sdkMetadata = SdkMetadata(name = "amplify-android", version = "2.0.0"),
+        clientId = "device-uuid",
+        sink = sink,
+        sessionManager = manager,
+        autoSessionTracking = autoSessionTracking,
+        application = null,
+        clock = { clock },
+        generateEventId = { "event${idSequence++}" }
+    )
+
+    @Test
+    fun `record returns the enriched event and forwards it to the sink`() {
+        val client = client()
+        val result = client.record("button_clicked")
+
+        result.shouldBeInstanceOf<Result.Success<EnrichedEvent>>()
+        result.data.eventType shouldBe "button_clicked"
+        result.data.clientId shouldBe "device-uuid"
+        sink.events shouldHaveSize 1
+        sink.events.first().eventType shouldBe "button_clicked"
+    }
+
+    @Test
+    fun `record on a closed client returns a closed failure`() {
+        val client = client()
+        client.close()
+
+        val result = client.record("late_event")
+        result.shouldBeInstanceOf<Result.Failure<*>>()
+        result.error.shouldBeInstanceOf<EventEnrichmentClosedException>()
+        // No event is emitted after close.
+        sink.events.none { it.eventType == "late_event" } shouldBe true
+    }
+
+    @Test
+    fun `record starts a fresh session after a stop instead of reusing the stopped one`() {
+        val client = client(autoSessionTracking = true)
+
+        val first = (client.record("first") as Result.Success).data
+        val firstSessionId = first.session.id
+
+        client.stopSession()
+        clock = clock.plusMillis(1_000)
+
+        val second = (client.record("second") as Result.Success).data
+
+        // A new session is started, and the stopped session is not stamped
+        // onto the new event.
+        second.session.id shouldNotBe firstSessionId
+        second.session.stopTimestamp shouldBe null
+        second.session.duration shouldBe null
+    }
+
+    @Test
+    fun `autoSessionTracking false defers session start until first record`() {
+        val manager = sessionManager()
+        val client = client(autoSessionTracking = false, manager = manager)
+
+        manager.state shouldBe SessionState.STOPPED
+        manager.session shouldBe null
+
+        client.record("first")
+
+        manager.state shouldBe SessionState.ACTIVE
+        manager.session.shouldNotBeNull()
+    }
+
+    @Test
+    fun `global attributes and metrics are stamped on every event`() {
+        val client = client()
+        client.addGlobalAttribute("app_theme", "dark")
+        client.addGlobalMetric("battery", 0.8)
+
+        val event = (client.record("open") as Result.Success).data
+        event.attributes["app_theme"] shouldBe "dark"
+        event.metrics["battery"] shouldBe 0.8
+    }
+
+    @Test
+    fun `per-event fields override global fields`() {
+        val client = client()
+        client.addGlobalAttribute("screen", "home")
+
+        val event = (client.record("nav", attributes = mapOf("screen" to "settings")) as Result.Success).data
+        event.attributes["screen"] shouldBe "settings"
+    }
+
+    @Test
+    fun `removeGlobalAttribute and removeGlobalMetric drop the field`() {
+        val client = client()
+        client.addGlobalAttribute("a", "1")
+        client.addGlobalMetric("m", 1.0)
+        client.removeGlobalAttribute("a")
+        client.removeGlobalMetric("m")
+
+        val event = (client.record("x") as Result.Success).data
+        event.attributes.containsKey("a") shouldBe false
+        event.metrics.containsKey("m") shouldBe false
+    }
+
+    @Test
+    fun `setUserId stamps the user id on subsequent events`() {
+        val client = client()
+        client.setUserId("user-42")
+
+        val event = (client.record("x") as Result.Success).data
+        event.userId shouldBe "user-42"
+    }
+
+    @Test
+    fun `record applies no caps to attribute and metric counts`() {
+        val client = client()
+        val attributes = (0 until 500).associate { "a$it" to "v$it" }
+        val metrics = (0 until 500).associate { "m$it" to it.toDouble() }
+
+        val event = (client.record("x", attributes = attributes, metrics = metrics) as Result.Success).data
+        event.attributes.size shouldBe 500
+        event.metrics.size shouldBe 500
+    }
+
+    @Test
+    fun `close marks the client closed and clears the session`() {
+        val manager = sessionManager()
+        val client = client(manager = manager)
+        client.record("x")
+
+        client.close()
+
+        client.isClosed shouldBe true
+        manager.state shouldBe SessionState.STOPPED
+        manager.session shouldBe null
+    }
+}

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientTest.kt
@@ -12,6 +12,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
 package com.amplifyframework.eventenrichment
 
 import com.amplifyframework.eventenrichment.exception.EventEnrichmentClosedException
@@ -20,14 +22,18 @@ import com.amplifyframework.eventenrichment.metadata.DeviceMetadata
 import com.amplifyframework.eventenrichment.metadata.SdkMetadata
 import com.amplifyframework.eventenrichment.session.SessionManager
 import com.amplifyframework.eventenrichment.session.SessionState
+import com.amplifyframework.eventenrichment.session.TimeoutHandle
+import com.amplifyframework.eventenrichment.session.TimeoutScheduler
 import com.amplifyframework.foundation.result.Result
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import java.time.Instant
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlinx.coroutines.Dispatchers
 import org.junit.Test
 
 class EventEnrichmentClientTest {
@@ -47,7 +53,8 @@ class EventEnrichmentClientTest {
         appId = appId,
         sessionTimeout = 5.seconds,
         now = { clock },
-        generateId = { "session${idSequence++}0-1111-2222-3333-444455556666" }
+        generateId = { "session${idSequence++}0-1111-2222-3333-444455556666" },
+        scheduler = TimeoutScheduler { _, _ -> TimeoutHandle { } }
     )
 
     private fun client(
@@ -65,7 +72,9 @@ class EventEnrichmentClientTest {
         autoSessionTracking = autoSessionTracking,
         application = null,
         clock = { clock },
-        generateEventId = { "event${idSequence++}" }
+        generateEventId = { "event${idSequence++}" },
+        // Unconfined keeps the async sink delivery synchronous for assertions.
+        sinkDispatcher = Dispatchers.Unconfined
     )
 
     @Test
@@ -100,7 +109,7 @@ class EventEnrichmentClientTest {
         val firstSessionId = first.session.id
 
         client.stopSession()
-        clock = clock.plusMillis(1_000)
+        clock += 1_000.milliseconds
 
         val second = (client.record("second") as Result.Success).data
 

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/EventEnrichmentClientTest.kt
@@ -25,6 +25,7 @@ import com.amplifyframework.eventenrichment.session.SessionState
 import com.amplifyframework.eventenrichment.session.TimeoutHandle
 import com.amplifyframework.eventenrichment.session.TimeoutScheduler
 import com.amplifyframework.foundation.result.Result
+import com.amplifyframework.foundation.result.get
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -105,13 +106,13 @@ class EventEnrichmentClientTest {
     fun `record starts a fresh session after a stop instead of reusing the stopped one`() {
         val client = client(autoSessionTracking = true)
 
-        val first = (client.record("first") as Result.Success).data
+        val first = client.record("first").get()
         val firstSessionId = first.session.id
 
         client.stopSession()
         clock += 1_000.milliseconds
 
-        val second = (client.record("second") as Result.Success).data
+        val second = client.record("second").get()
 
         // A new session is started, and the stopped session is not stamped
         // onto the new event.
@@ -140,7 +141,7 @@ class EventEnrichmentClientTest {
         client.addGlobalAttribute("app_theme", "dark")
         client.addGlobalMetric("battery", 0.8)
 
-        val event = (client.record("open") as Result.Success).data
+        val event = client.record("open").get()
         event.attributes["app_theme"] shouldBe "dark"
         event.metrics["battery"] shouldBe 0.8
     }
@@ -150,7 +151,7 @@ class EventEnrichmentClientTest {
         val client = client()
         client.addGlobalAttribute("screen", "home")
 
-        val event = (client.record("nav", attributes = mapOf("screen" to "settings")) as Result.Success).data
+        val event = client.record("nav", attributes = mapOf("screen" to "settings")).get()
         event.attributes["screen"] shouldBe "settings"
     }
 
@@ -162,7 +163,7 @@ class EventEnrichmentClientTest {
         client.removeGlobalAttribute("a")
         client.removeGlobalMetric("m")
 
-        val event = (client.record("x") as Result.Success).data
+        val event = client.record("x").get()
         event.attributes.containsKey("a") shouldBe false
         event.metrics.containsKey("m") shouldBe false
     }
@@ -172,7 +173,7 @@ class EventEnrichmentClientTest {
         val client = client()
         client.setUserId("user-42")
 
-        val event = (client.record("x") as Result.Success).data
+        val event = client.record("x").get()
         event.userId shouldBe "user-42"
     }
 
@@ -182,7 +183,7 @@ class EventEnrichmentClientTest {
         val attributes = (0 until 500).associate { "a$it" to "v$it" }
         val metrics = (0 until 500).associate { "m$it" to it.toDouble() }
 
-        val event = (client.record("x", attributes = attributes, metrics = metrics) as Result.Success).data
+        val event = client.record("x", attributes = attributes, metrics = metrics).get()
         event.attributes.size shouldBe 500
         event.metrics.size shouldBe 500
     }

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/clientid/SharedPreferencesClientIdProviderTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/clientid/SharedPreferencesClientIdProviderTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.eventenrichment.clientid
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SharedPreferencesClientIdProviderTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun preferences() =
+        context.getSharedPreferences(SharedPreferencesClientIdProvider.PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    @Test
+    fun `uses the shared cross-package storage key`() {
+        SharedPreferencesClientIdProvider.CLIENT_ID_STORAGE_KEY shouldBe "com.amplifyframework.device_id"
+    }
+
+    @Test
+    fun `creates and persists a new client id when none exists`() {
+        val provider = SharedPreferencesClientIdProvider(context)
+
+        val id = provider.getClientId()
+        id.shouldNotBeEmpty()
+
+        // Persisted under the shared key so other Amplify clients read the same id.
+        preferences().getString(SharedPreferencesClientIdProvider.CLIENT_ID_STORAGE_KEY, null) shouldBe id
+    }
+
+    @Test
+    fun `returns the existing client id on subsequent reads`() {
+        val provider = SharedPreferencesClientIdProvider(context)
+        val first = provider.getClientId()
+        val second = provider.getClientId()
+        second shouldBe first
+    }
+
+    @Test
+    fun `reads an id written under the shared key by another client`() {
+        preferences().edit()
+            .putString(SharedPreferencesClientIdProvider.CLIENT_ID_STORAGE_KEY, "existing-shared-id")
+            .apply()
+
+        SharedPreferencesClientIdProvider(context).getClientId() shouldBe "existing-shared-id"
+    }
+}

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/metadata/AndroidDeviceMetadataProviderTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/metadata/AndroidDeviceMetadataProviderTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.eventenrichment.metadata
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidDeviceMetadataProviderTest {
+
+    @Test
+    fun `resolves real device metadata instead of an empty object`() {
+        val metadata = AndroidDeviceMetadataProvider().getDeviceMetadata()
+
+        // Guards against the "empty device" regression: platform is always set.
+        metadata.platform shouldBe "Android"
+        metadata.platformVersion.shouldNotBeNull()
+        metadata.manufacturer.shouldNotBeNull()
+        metadata.model.shouldNotBeNull()
+        metadata.locale.shouldNotBeNull()
+    }
+}

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/session/SessionManagerTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/session/SessionManagerTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.eventenrichment.session
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldMatch
+import java.time.Instant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Test
+
+class SessionManagerTest {
+
+    /** Captures the scheduled timeout action so tests can fire it on demand. */
+    private class FakeScheduler : TimeoutScheduler {
+        var scheduledAction: (() -> Unit)? = null
+        var cancelled = false
+
+        override fun schedule(delay: Duration, action: () -> Unit): TimeoutHandle {
+            scheduledAction = action
+            cancelled = false
+            return TimeoutHandle { cancelled = true }
+        }
+
+        fun fireTimeout() {
+            scheduledAction?.invoke()
+        }
+    }
+
+    private var clock = Instant.parse("2026-07-06T19:51:59.839Z")
+    private val fakeScheduler = FakeScheduler()
+    private var idSequence = 0
+
+    private fun manager(appId: String = "my-app-id", sessionTimeout: Duration = 5.seconds) = SessionManager(
+        appId = appId,
+        sessionTimeout = sessionTimeout,
+        now = { clock },
+        generateId = { "abcdef${idSequence++}0-1111-2222-3333-444455556666" },
+        scheduler = fakeScheduler
+    )
+
+    @Test
+    fun `starts stopped with no session`() {
+        val manager = manager()
+        manager.state shouldBe SessionState.STOPPED
+        manager.session shouldBe null
+    }
+
+    @Test
+    fun `startSession activates a session with an ISO-8601 UTC start timestamp`() {
+        val manager = manager()
+        manager.startSession()
+
+        manager.state shouldBe SessionState.ACTIVE
+        val session = manager.session.shouldNotBeNull()
+        session.startTimestamp shouldBe "2026-07-06T19:51:59.839Z"
+        session.stopTimestamp shouldBe null
+        session.duration shouldBe null
+    }
+
+    @Test
+    fun `session id follows appId-uuid-date format`() {
+        val manager = manager(appId = "my-app-id")
+        manager.startSession()
+
+        // {appId first 8}-{uuid first 8}-{yyyyMMdd-HHmmssSSS UTC}
+        manager.session.shouldNotBeNull().id shouldMatch Regex("^my-app-i-[a-f0-9]{8}-20260706-195159839$")
+    }
+
+    @Test
+    fun `short appId is left-padded with underscores to 8 chars`() {
+        val manager = manager(appId = "abc")
+        manager.startSession()
+        manager.session.shouldNotBeNull().id shouldMatch Regex("^_____abc-[a-f0-9]{8}-.*$")
+    }
+
+    @Test
+    fun `stopSession records stop timestamp and duration`() {
+        val manager = manager()
+        manager.startSession()
+        clock = clock.plusMillis(10_000)
+        manager.stopSession()
+
+        manager.state shouldBe SessionState.STOPPED
+        val session = manager.session.shouldNotBeNull()
+        session.stopTimestamp shouldBe "2026-07-06T19:52:09.839Z"
+        session.duration shouldBe 10_000L
+    }
+
+    @Test
+    fun `clearSession drops the session entirely`() {
+        val manager = manager()
+        manager.startSession()
+        manager.clearSession()
+        manager.state shouldBe SessionState.STOPPED
+        manager.session shouldBe null
+    }
+
+    @Test
+    fun `handleAppPaused moves an active session to paused and schedules the timeout`() {
+        val manager = manager()
+        manager.startSession()
+        manager.handleAppPaused()
+
+        manager.state shouldBe SessionState.PAUSED
+        fakeScheduler.scheduledAction.shouldNotBeNull()
+    }
+
+    @Test
+    fun `handleAppResumed within timeout resumes the same session`() {
+        val manager = manager()
+        manager.startSession()
+        val originalId = manager.session.shouldNotBeNull().id
+
+        manager.handleAppPaused()
+        manager.handleAppResumed()
+
+        manager.state shouldBe SessionState.ACTIVE
+        manager.session.shouldNotBeNull().id shouldBe originalId
+        fakeScheduler.cancelled shouldBe true
+    }
+
+    @Test
+    fun `timeout expiry while paused stops the session`() {
+        val manager = manager()
+        manager.startSession()
+        manager.handleAppPaused()
+        fakeScheduler.fireTimeout()
+
+        manager.state shouldBe SessionState.STOPPED
+    }
+
+    @Test
+    fun `handleAppResumed after timeout starts a fresh session`() {
+        val manager = manager()
+        manager.startSession()
+        val firstId = manager.session.shouldNotBeNull().id
+
+        manager.handleAppPaused()
+        fakeScheduler.fireTimeout()
+        manager.handleAppResumed()
+
+        manager.state shouldBe SessionState.ACTIVE
+        manager.session.shouldNotBeNull().id shouldNotBe firstId
+    }
+
+    @Test
+    fun `startSession while active stops the previous session first`() {
+        val manager = manager()
+        manager.startSession()
+        val firstId = manager.session.shouldNotBeNull().id
+        clock = clock.plusMillis(1_000)
+        manager.startSession()
+
+        val session = manager.session.shouldNotBeNull()
+        session.id shouldNotBe firstId
+        // The new session is active and carries no stop metadata.
+        session.stopTimestamp shouldBe null
+        session.duration shouldBe null
+    }
+}

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/session/SessionManagerTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/session/SessionManagerTest.kt
@@ -12,15 +12,18 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
 package com.amplifyframework.eventenrichment.session
 
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldMatch
-import java.time.Instant
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import org.junit.Test
 
 class SessionManagerTest {
@@ -92,7 +95,7 @@ class SessionManagerTest {
     fun `stopSession records stop timestamp and duration`() {
         val manager = manager()
         manager.startSession()
-        clock = clock.plusMillis(10_000)
+        clock += 10_000.milliseconds
         manager.stopSession()
 
         manager.state shouldBe SessionState.STOPPED
@@ -163,7 +166,7 @@ class SessionManagerTest {
         val manager = manager()
         manager.startSession()
         val firstId = manager.session.shouldNotBeNull().id
-        clock = clock.plusMillis(1_000)
+        clock += 1_000.milliseconds
         manager.startSession()
 
         val session = manager.session.shouldNotBeNull()

--- a/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/session/SessionManagerTest.kt
+++ b/aws-event-enrichment/src/test/java/com/amplifyframework/eventenrichment/session/SessionManagerTest.kt
@@ -40,7 +40,9 @@ class SessionManagerTest {
         }
 
         fun fireTimeout() {
-            scheduledAction?.invoke()
+            // Assert a timeout is actually scheduled so the test cannot fire
+            // it in an invalid situation.
+            scheduledAction.shouldNotBeNull().invoke()
         }
     }
 


### PR DESCRIPTION
## Summary

Unit tests for the `aws-event-enrichment` module. These are split into their own branch stacked on the package branch so the implementation and its tests can be reviewed independently

Based this on `feat/event-enrichment-client`

## Coverage

47 tests across the module:

- Envelope parity: `EnrichedEvent.toJson` emits the full `event_version` 3.1 envelope and honors the presence rules (optional fields omitted, empty attribute and metric maps omitted, device object always present, platform and locale sub-objects omitted when their contents are null, `arrival_timestamp` mirrors `event_timestamp`).
- Fresh session after stop: a stopped session is never reused. The next `record()` starts a new session with no stop metadata. Verified at both the `SessionManager` and the client level.
- Client id: `SharedPreferencesClientIdProvider` read-or-create semantics under the shared `com.amplifyframework.device_id` key, including reading an id written by another client.
- App id assertion: a mismatched `AppMetadata` app id is rejected at construction.
- No caps: large attribute and metric counts and long values pass through unchanged.
- Session lifecycle: session id format, short app id padding, pause and resume within the timeout, timeout expiry, and start-over after timeout, driven by an injected clock and scheduler.
- Device metadata: `AndroidDeviceMetadataProvider` resolves real values rather than an empty object.
- Options: defaults (auto session tracking on, 5 second timeout) and builder overrides.

All tests pass. The module is clean under `ktlintCheck`.
