### PR TITLE
chore: Remove --full-index from release PR workflow

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         cd scripts
         gem install bundler
-        bundle install --full-index
+        bundle install
     - name: Configure git options
       run: |
         cd scripts


### PR DESCRIPTION
## Problem

The **Prepare Next Release** workflow (`release_pr.yml`) fails on its `bundle install` step with:

```
ArgumentError: undefined class/module YAML::Syck::
  rubygems/specification.rb:1268:in `load'        # Marshal.load of a gemspec
  bundler/fetcher.rb:121:in `fetch_spec'           # fetching a remote spec
  bundler/resolver.rb:267:in `all_versions_for'    # during resolution
```

## Root cause

The failing command was `bundle install --full-index`. The `--full-index` flag forces Bundler to bypass the modern compact index and instead download and `Marshal.load` the **legacy full Marshal index** from rubygems.org. A legacy gemspec in the resolution graph was originally serialized with the long-removed Syck YAML engine, so `Marshal.load`-ing it raises `undefined class/module YAML::Syck` on any modern Ruby.

## Fix

Drop `--full-index` so Bundler uses the compact index, which never `Marshal.load`s those specs. Resolution results are unchanged — the committed `Gemfile.lock` still matches.

## Notes

Ports [aws-amplify/amplify-ui-android#330](https://github.com/aws-amplify/amplify-ui-android/pull/330) to this repo.