### PR TITLE
chore: Tell dependabot to ignore Kotlin and AGP version upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,18 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    ignore:
+      # AGP upgrades can be tricky and shouldn't be done by dependabot.
+      # Covers the AGP artifact (com.android.tools.build:gradle) and the
+      # com.android.* Gradle plugin ids, which all share the `agp` version.
+      - dependency-name: "com.android.tools.build:*"
+      - dependency-name: "com.android.*"
+      # Kotlin language version upgrades are potentially costly to customers and shouldn't be done
+      # without careful consideration. Covers the compiler/stdlib/reflect/test artifacts
+      # (org.jetbrains.kotlin:*) and the org.jetbrains.kotlin.* plugin ids,
+      # which all share the `kotlin` version.
+      - dependency-name: "org.jetbrains.kotlin:*"
+      - dependency-name: "org.jetbrains.kotlin.*"
   # Check for updates to GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
- [ ] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
