### PR TITLE
fix(all): Publish dependencies under proper scoping

### DIFF
--- a/appsync/aws-sdk-appsync-events/build.gradle.kts
+++ b/appsync/aws-sdk-appsync-events/build.gradle.kts
@@ -35,9 +35,11 @@ android {
 dependencies {
     api(project(":aws-sdk-appsync-core"))
 
-    implementation(libs.okhttp)
-    implementation(libs.kotlin.serializationJson)
-    implementation(libs.kotlin.coroutines)
+    // These types appear in this module's public API (OkHttpClient, kotlinx.serialization
+    // serializers, Flow), so declare them as api rather than relying on transitive resolution.
+    api(libs.okhttp)
+    api(libs.kotlin.serializationJson)
+    api(libs.kotlin.coroutines)
 
     testImplementation(libs.bundles.test.unit)
     testImplementation(libs.test.kotest.assertions.json)

--- a/aws-analytics-pinpoint/build.gradle.kts
+++ b/aws-analytics-pinpoint/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     api(project(":aws-pinpoint-core"))
 
     implementation(libs.androidx.appcompat)
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     api(libs.aws.pinpoint)
     implementation(libs.kotlin.serializationJson)
 

--- a/aws-analytics-pinpoint/build.gradle.kts
+++ b/aws-analytics-pinpoint/build.gradle.kts
@@ -26,13 +26,13 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(project(":aws-core"))
-    implementation(project(":aws-pinpoint-core"))
+    api(project(":aws-pinpoint-core"))
 
     implementation(libs.androidx.appcompat)
     implementation(platform(libs.aws.bom))
-    implementation(libs.aws.pinpoint)
+    api(libs.aws.pinpoint)
     implementation(libs.kotlin.serializationJson)
 
     testImplementation(libs.bundles.test.unit)

--- a/aws-api-appsync/build.gradle.kts
+++ b/aws-api-appsync/build.gradle.kts
@@ -25,12 +25,12 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(project(":aws-core"))
 
-    implementation(libs.androidx.annotation)
+    api(libs.androidx.annotation)
     implementation(libs.androidx.core)
-    implementation(libs.gson)
+    api(libs.gson)
 
     testImplementation(libs.bundles.test.unit)
     testImplementation(libs.bundles.test.unit.android)

--- a/aws-api/build.gradle.kts
+++ b/aws-api/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     api(project(":aws-api-appsync"))
 
     implementation(libs.androidx.appcompat)
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     api(libs.aws.signing)
     // Smithy types leak into this module's public API: CredentialsProvider (ApiAuthProviders,
     // IamRequestDecorator) and HttpRequest (AWS4Signer.sign).

--- a/aws-api/build.gradle.kts
+++ b/aws-api/build.gradle.kts
@@ -26,14 +26,18 @@ android {
 
 dependencies {
     api(project(":core"))
-    api(project(":aws-core"))
-    implementation(project(":aws-api-appsync"))
+    implementation(project(":aws-core"))
+    api(project(":aws-api-appsync"))
 
     implementation(libs.androidx.appcompat)
     implementation(platform(libs.aws.bom))
-    implementation(libs.aws.signing)
+    api(libs.aws.signing)
+    // Smithy types leak into this module's public API: CredentialsProvider (ApiAuthProviders,
+    // IamRequestDecorator) and HttpRequest (AWS4Signer.sign).
+    api(libs.aws.credentials)
+    api(libs.aws.smithy.http)
     implementation(libs.gson)
-    implementation(libs.okhttp)
+    api(libs.okhttp)
 
     testImplementation(libs.bundles.test.unit)
     testImplementation(libs.bundles.test.unit.android)

--- a/aws-auth-cognito/build.gradle.kts
+++ b/aws-auth-cognito/build.gradle.kts
@@ -29,8 +29,8 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":aws-core"))
+    api(project(":core"))
+    api(project(":aws-core"))
     implementation(project(":aws-auth-plugins-core"))
     implementation(libs.kotlin.coroutines)
     implementation(libs.kotlin.serializationJson)
@@ -42,8 +42,8 @@ dependencies {
 
     implementation(platform(libs.aws.bom))
     implementation(libs.aws.http)
-    implementation(libs.aws.cognitoidentity)
-    implementation(libs.aws.cognitoidentityprovider)
+    api(libs.aws.cognitoidentity)
+    api(libs.aws.cognitoidentityprovider)
 
     testImplementation(project(":testutils"))
     testImplementation(project(":core"))

--- a/aws-auth-cognito/build.gradle.kts
+++ b/aws-auth-cognito/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.play.services)
 
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     implementation(libs.aws.http)
     api(libs.aws.cognitoidentity)
     api(libs.aws.cognitoidentityprovider)

--- a/aws-auth-plugins-core/build.gradle.kts
+++ b/aws-auth-plugins-core/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     api(project(":core"))
     implementation(project(":aws-core"))
 
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     implementation(libs.aws.http)
     implementation(libs.aws.credentials)
     api(libs.aws.cognitoidentity)

--- a/aws-auth-plugins-core/build.gradle.kts
+++ b/aws-auth-plugins-core/build.gradle.kts
@@ -26,15 +26,15 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(project(":aws-core"))
 
     implementation(platform(libs.aws.bom))
     implementation(libs.aws.http)
     implementation(libs.aws.credentials)
-    implementation(libs.aws.cognitoidentity)
+    api(libs.aws.cognitoidentity)
 
-    implementation(libs.kotlin.serializationJson)
+    api(libs.kotlin.serializationJson)
 
     testImplementation(libs.bundles.test.unit)
     testImplementation(libs.bundles.test.unit.android)

--- a/aws-connect/build.gradle.kts
+++ b/aws-connect/build.gradle.kts
@@ -26,8 +26,8 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":foundation"))
+    api(project(":core"))
+    api(project(":foundation"))
     implementation(project(":foundation-bridge"))
 
     implementation(libs.androidx.annotation)

--- a/aws-core/build.gradle.kts
+++ b/aws-core/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.coroutines)
 
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     implementation(libs.aws.smithy.http)
     compileOnly(libs.aws.smithy.okhttp4)
 

--- a/aws-core/build.gradle.kts
+++ b/aws-core/build.gradle.kts
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.coroutines)
 
@@ -33,7 +33,11 @@ dependencies {
     implementation(libs.aws.smithy.http)
     compileOnly(libs.aws.smithy.okhttp4)
 
-    implementation(libs.aws.credentials)
+    api(libs.aws.credentials)
+    // Smithy runtime-core types (Instant, Attributes) appear in this module's public API
+    // (e.g. AWSTemporaryCredentials, CognitoCredentialsProvider), so declare it directly as api
+    // rather than relying on transitive resolution.
+    api(libs.aws.smithy.runtime.core)
     // slf4j dependency is added to fix https://github.com/awslabs/aws-sdk-kotlin/issues/993#issuecomment-1678885524
     implementation(libs.slf4j)
 

--- a/aws-datastore/build.gradle.kts
+++ b/aws-datastore/build.gradle.kts
@@ -25,14 +25,17 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(project(":aws-core"))
-    implementation(project(":aws-api-appsync"))
+    api(project(":aws-api-appsync"))
 
     implementation(libs.androidx.appcompat)
-    implementation(libs.gson)
+    // androidx.core's Supplier leaks into the public API (Orchestrator constructor); declare
+    // androidx.core directly as api rather than relying on transitive resolution via appcompat.
+    api(libs.androidx.core)
+    api(libs.gson)
     implementation(libs.kotlin.coroutines.rx3)
-    implementation(libs.rxjava)
+    api(libs.rxjava)
     implementation(libs.uuidgen)
 
     testImplementation(libs.bundles.test.unit)

--- a/aws-geo-location/build.gradle.kts
+++ b/aws-geo-location/build.gradle.kts
@@ -26,7 +26,7 @@ android {
 dependencies {
     api(project(":core"))
     implementation(project(":aws-core"))
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     api(libs.aws.location)
 
     testImplementation(project(":testutils"))

--- a/aws-geo-location/build.gradle.kts
+++ b/aws-geo-location/build.gradle.kts
@@ -24,10 +24,10 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(project(":aws-core"))
     implementation(platform(libs.aws.bom))
-    implementation(libs.aws.location)
+    api(libs.aws.location)
 
     testImplementation(project(":testutils"))
     testImplementation(libs.bundles.test.unit)

--- a/aws-kinesis/build.gradle.kts
+++ b/aws-kinesis/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     api(project(":foundation-bridge"))
 
     implementation(libs.androidx.appcompat)
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     api(libs.aws.kinesis)
     api(libs.aws.firehose)
     implementation(libs.aws.http)

--- a/aws-kinesis/build.gradle.kts
+++ b/aws-kinesis/build.gradle.kts
@@ -26,13 +26,13 @@ android {
 }
 
 dependencies {
-    implementation(project(":foundation"))
-    implementation(project(":foundation-bridge"))
+    api(project(":foundation"))
+    api(project(":foundation-bridge"))
 
     implementation(libs.androidx.appcompat)
     implementation(platform(libs.aws.bom))
-    implementation(libs.aws.kinesis)
-    implementation(libs.aws.firehose)
+    api(libs.aws.kinesis)
+    api(libs.aws.firehose)
     implementation(libs.aws.http)
     implementation(libs.kotlin.serializationJson)
     implementation(libs.androidx.sqlite)

--- a/aws-logging-cloudwatch/build.gradle.kts
+++ b/aws-logging-cloudwatch/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     implementation(project(":aws-core"))
 
     implementation(libs.androidx.security)
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     implementation(libs.aws.signing)
     api(libs.okhttp)
     api(libs.aws.cloudwatchlogs)

--- a/aws-logging-cloudwatch/build.gradle.kts
+++ b/aws-logging-cloudwatch/build.gradle.kts
@@ -26,17 +26,21 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(project(":aws-core"))
 
     implementation(libs.androidx.security)
     implementation(platform(libs.aws.bom))
     implementation(libs.aws.signing)
-    implementation(libs.okhttp)
-    implementation(libs.aws.cloudwatchlogs)
+    api(libs.okhttp)
+    api(libs.aws.cloudwatchlogs)
     implementation(libs.sqlcipher)
     implementation(libs.androidx.sqlite)
-    implementation(libs.kotlin.serializationJson)
+    api(libs.kotlin.serializationJson)
+    // CredentialsProvider and CoroutineDispatcher leak into this module's public API
+    // (DefaultRemoteLoggingConstraintProvider constructor); declare both directly as api.
+    api(libs.aws.credentials)
+    api(libs.kotlin.coroutines)
     implementation(libs.androidx.workmanager)
     implementation(libs.kotlin.futures)
 

--- a/aws-logging-cloudwatch/src/main/java/com/amplifyframework/logging/cloudwatch/CloudWatchLogManager.kt
+++ b/aws-logging-cloudwatch/src/main/java/com/amplifyframework/logging/cloudwatch/CloudWatchLogManager.kt
@@ -15,6 +15,7 @@
 package com.amplifyframework.logging.cloudwatch
 
 import android.content.Context
+import androidx.core.content.edit
 import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
@@ -226,7 +227,7 @@ internal class CloudWatchLogManager(
             context.getSharedPreferences(
                 AWSCloudWatchLoggingPlugin.SHARED_PREFERENCE_FILENAME,
                 Context.MODE_PRIVATE
-            ).edit().remove(LoggingConstraintsResolver.REMOTE_LOGGING_CONSTRAINTS_KEY).apply()
+            ).edit { remove(LoggingConstraintsResolver.REMOTE_LOGGING_CONSTRAINTS_KEY) }
         }
     }
 
@@ -276,7 +277,7 @@ internal class CloudWatchLogManager(
         val sharedPreferences =
             context.getSharedPreferences(AWSCloudWatchLoggingPlugin.SHARED_PREFERENCE_FILENAME, Context.MODE_PRIVATE)
         return sharedPreferences.getString(deviceIdKey, null) ?: UUID.randomUUID().toString().also { id ->
-            sharedPreferences.edit().putString(deviceIdKey, id).apply()
+            sharedPreferences.edit { putString(deviceIdKey, id) }
         }
     }
 

--- a/aws-logging-cloudwatch/src/main/java/com/amplifyframework/logging/cloudwatch/LoggingConstraintsResolver.kt
+++ b/aws-logging-cloudwatch/src/main/java/com/amplifyframework/logging/cloudwatch/LoggingConstraintsResolver.kt
@@ -16,6 +16,7 @@ package com.amplifyframework.logging.cloudwatch
 
 import android.content.Context
 import android.util.Log
+import androidx.core.content.edit
 import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
@@ -112,8 +113,9 @@ internal class LoggingConstraintsResolver internal constructor(
         context?.let {
             val sharedPreferences =
                 it.getSharedPreferences(AWSCloudWatchLoggingPlugin.SHARED_PREFERENCE_FILENAME, Context.MODE_PRIVATE)
-            sharedPreferences.edit()
-                .putString(REMOTE_LOGGING_CONSTRAINTS_KEY, LoggingConstraints.toJsonString(loggingConstraint)).apply()
+            sharedPreferences.edit {
+                putString(REMOTE_LOGGING_CONSTRAINTS_KEY, LoggingConstraints.toJsonString(loggingConstraint))
+            }
         }
     }
 

--- a/aws-logging-cloudwatch/src/main/java/com/amplifyframework/logging/cloudwatch/db/CloudWatchLoggingDatabase.kt
+++ b/aws-logging-cloudwatch/src/main/java/com/amplifyframework/logging/cloudwatch/db/CloudWatchLoggingDatabase.kt
@@ -20,6 +20,7 @@ import android.content.UriMatcher
 import android.database.Cursor
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
+import androidx.core.net.toUri
 import com.amplifyframework.core.store.AmplifyKeyValueRepository
 import com.amplifyframework.logging.cloudwatch.models.CloudWatchLogEvent
 import java.util.UUID
@@ -52,7 +53,7 @@ internal class CloudWatchLoggingDatabase(
 
     init {
         val authority = context.applicationContext.packageName
-        contentUri = Uri.parse("content://$authority/$basePath")
+        contentUri = "content://$authority/$basePath".toUri()
         uriMatcher = UriMatcher(UriMatcher.NO_MATCH)
         // The Uri of LOG_EVENTS is for all records in the LogEventTable table.
         uriMatcher.addURI(authority, basePath, logEvents)
@@ -111,7 +112,7 @@ internal class CloudWatchLoggingDatabase(
         contentValues.put(LogEventTable.COLUMN_TIMESTAMP, event.timestamp)
         contentValues.put(LogEventTable.COLUMN_MESSAGE, event.message)
         val id = database.insertOrThrow(LogEventTable.TABLE_LOG_EVENT, null, contentValues)
-        return Uri.parse("$basePath/$id")
+        return "$basePath/$id".toUri()
     }
 
     private fun query(

--- a/aws-pinpoint-core/build.gradle.kts
+++ b/aws-pinpoint-core/build.gradle.kts
@@ -26,12 +26,12 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
 
     implementation(libs.androidx.appcompat)
     implementation(platform(libs.aws.bom))
     implementation(libs.aws.pinpoint)
-    implementation(libs.kotlin.serializationJson)
+    api(libs.kotlin.serializationJson)
 
     testImplementation(libs.bundles.test.unit)
     testImplementation(libs.bundles.test.unit.android)

--- a/aws-predictions-tensorflow/build.gradle.kts
+++ b/aws-predictions-tensorflow/build.gradle.kts
@@ -25,10 +25,10 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(project(":aws-core"))
     implementation(libs.androidx.appcompat)
-    implementation(libs.litert)
+    api(libs.litert)
 
     testImplementation(project(":testutils"))
     testImplementation(libs.test.junit)

--- a/aws-predictions/build.gradle.kts
+++ b/aws-predictions/build.gradle.kts
@@ -26,15 +26,19 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":aws-core"))
+    api(project(":core"))
+    api(project(":aws-core"))
     implementation(libs.androidx.appcompat)
     implementation(platform(libs.aws.bom))
-    implementation(libs.aws.comprehend)
-    implementation(libs.aws.polly)
-    implementation(libs.aws.rekognition)
-    implementation(libs.aws.textract)
-    implementation(libs.aws.translate)
+    api(libs.aws.comprehend)
+    api(libs.aws.polly)
+    api(libs.aws.rekognition)
+    api(libs.aws.textract)
+    api(libs.aws.translate)
+    // Smithy types leak into this module's public API: CredentialsProvider (AWSPredictionsService,
+    // PresignedSynthesizeSpeechUrlOptions) and SdkClientConfig (AmazonPollyPresigningClient).
+    api(libs.aws.credentials)
+    api(libs.aws.smithy.client)
     implementation(libs.kotlin.serializationJson)
     implementation(libs.okhttp)
 

--- a/aws-predictions/build.gradle.kts
+++ b/aws-predictions/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     api(project(":core"))
     api(project(":aws-core"))
     implementation(libs.androidx.appcompat)
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     api(libs.aws.comprehend)
     api(libs.aws.polly)
     api(libs.aws.rekognition)

--- a/aws-push-notifications-pinpoint-common/build.gradle.kts
+++ b/aws-push-notifications-pinpoint-common/build.gradle.kts
@@ -25,14 +25,14 @@ android {
 }
 
 dependencies {
-    implementation(project(":annotations"))
+    api(project(":annotations"))
     api(project(":common-core"))
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.activity)
+    api(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.annotation)
-    implementation(libs.androidx.core)
+    api(libs.androidx.core)
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)

--- a/aws-push-notifications-pinpoint/build.gradle.kts
+++ b/aws-push-notifications-pinpoint/build.gradle.kts
@@ -26,10 +26,10 @@ android {
 
 dependencies {
 
-    implementation(project(":core"))
+    api(project(":core"))
     implementation(project(":aws-core"))
-    implementation(project(":common-core"))
-    implementation(project(":aws-pinpoint-core"))
+    api(project(":common-core"))
+    api(project(":aws-pinpoint-core"))
 
     implementation(project(":aws-push-notifications-pinpoint-common"))
 
@@ -38,7 +38,7 @@ dependencies {
 
     implementation(platform(libs.aws.bom))
     implementation(libs.aws.http)
-    implementation(libs.aws.pinpoint)
+    api(libs.aws.pinpoint)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/aws-push-notifications-pinpoint/build.gradle.kts
+++ b/aws-push-notifications-pinpoint/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     api(platform(libs.firebase.bom))
     api(libs.firebase.messaging)
 
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     implementation(libs.aws.http)
     api(libs.aws.pinpoint)
 

--- a/aws-storage-s3/build.gradle.kts
+++ b/aws-storage-s3/build.gradle.kts
@@ -25,12 +25,12 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":aws-core"))
+    api(project(":core"))
+    api(project(":aws-core"))
 
     implementation(libs.androidx.appcompat)
     implementation(platform(libs.aws.bom))
-    implementation(libs.aws.s3)
+    api(libs.aws.s3)
     implementation(libs.androidx.workmanager)
     implementation(libs.kotlin.futures)
     implementation(libs.gson)

--- a/aws-storage-s3/build.gradle.kts
+++ b/aws-storage-s3/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     api(project(":aws-core"))
 
     implementation(libs.androidx.appcompat)
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     api(libs.aws.s3)
     implementation(libs.androidx.workmanager)
     implementation(libs.kotlin.futures)

--- a/build-logic/plugins/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/PublishingConventionPlugin.kt
@@ -1,14 +1,11 @@
 
 import com.android.build.gradle.LibraryExtension
-import groovy.util.Node
-import groovy.util.NodeList
 import java.net.URI
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.get
@@ -107,14 +104,6 @@ class PublishingConventionPlugin : Plugin<Project> {
                         configurePom(this@configureMavenPublishing)
                     }
                 }
-
-                if (useLegacyPublishingConventions) {
-                    // Turn off Gradle metadata. This is to maintain compatibility with the way Amplify V2 has
-                    // been published historically. For v3 we should remove this and publish the gradle metadata.
-                    tasks.withType<GenerateModuleMetadata>().configureEach {
-                        enabled = false
-                    }
-                }
             }
 
             repositories {
@@ -170,20 +159,6 @@ class PublishingConventionPlugin : Plugin<Project> {
                     id.set(POM_DEVELOPER_ID)
                     organizationUrl.set(POM_DEVELOPER_ORGANIZATION_URL)
                     roles.set(listOf("developer"))
-                }
-            }
-
-            if (project.useLegacyPublishingConventions) {
-                // Remove the scope information for all dependencies. This puts
-                // everything at "compile" scope, which matches the way Amplify V2 has been
-                // published historically. For v3 we should remove this and include the
-                // scope information for our dependencies.
-                withXml {
-                    val dependencies = asNode().childNodes("dependencies").first()
-                    for (dependency in dependencies.childNodes("dependency")) {
-                        val scope = dependency.childNodes("scope").first()
-                        dependency.remove(scope)
-                    }
                 }
             }
         }
@@ -248,15 +223,6 @@ class PublishingConventionPlugin : Plugin<Project> {
     private fun Project.getPropertyOrDefault(property: String, default: String) = propertyString(property) ?: default
 
     private fun Project.propertyString(property: String) = properties[property]?.toString()
-
-    // This check should be controlled from the module's build.gradle.kts via extension instead of by looking at
-    // the project name
-    private val Project.useLegacyPublishingConventions: Boolean
-        get() = !name.startsWith("apollo") &&
-            !name.startsWith("aws-sdk-appsync") &&
-            !isKotlinMultiplatform
-
-    private fun Node.childNodes(name: String) = (get(name) as? NodeList)?.filterIsInstance<Node>() ?: emptyList()
 
     private val Project.isKotlinMultiplatform: Boolean
         get() = pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")

--- a/core-kotlin/build.gradle.kts
+++ b/core-kotlin/build.gradle.kts
@@ -24,10 +24,10 @@ android {
 
 dependencies {
     implementation(libs.kotlin.stdlib)
-    implementation(libs.kotlin.coroutines)
+    api(libs.kotlin.coroutines)
     implementation(libs.androidx.core.ktx)
-    implementation(project(":core"))
-    implementation(project(":common-core"))
+    api(project(":core"))
+    api(project(":common-core"))
 
     testImplementation(libs.bundles.test.unit)
     testImplementation(project(":testmodels"))

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -28,11 +28,11 @@ android {
 dependencies {
     api(project(":annotations"))
     implementation(libs.androidx.v4support)
-    implementation(libs.androidx.annotation)
+    api(libs.androidx.annotation)
     implementation(libs.androidx.nav.fragment)
     implementation(libs.androidx.nav.ui)
     implementation(libs.androidx.security)
-    implementation(libs.kotlin.serializationJson)
+    api(libs.kotlin.serializationJson)
 
     api(project(":common-core"))
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
     api(libs.androidx.annotation)
     implementation(libs.androidx.nav.fragment)
     implementation(libs.androidx.nav.ui)
+    // Fragment / FragmentActivity appear in this module's public API; declare directly as api
+    // so consumers can compile against those signatures.
+    api(libs.androidx.fragment)
     implementation(libs.androidx.security)
     api(libs.kotlin.serializationJson)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,9 +91,11 @@ aws-polly = { module = "aws.sdk.kotlin:polly" }
 aws-rekognition = { module = "aws.sdk.kotlin:rekognition" }
 aws-s3 = { module = "aws.sdk.kotlin:s3" }
 aws-signing = { module = "aws.smithy.kotlin:aws-signing-default" }
+aws-smithy-client = { module = "aws.smithy.kotlin:smithy-client" }
 aws-smithy-http = { module = "aws.smithy.kotlin:http-client" }
 aws-smithy-http-kmp = { module = "aws.smithy.kotlin:http-client" }
 aws-smithy-okhttp4 = { module = "aws.smithy.kotlin:http-client-engine-okhttp4" }
+aws-smithy-runtime-core = { module = "aws.smithy.kotlin:runtime-core" }
 aws-textract = { module = "aws.sdk.kotlin:textract" }
 aws-translate = { module = "aws.sdk.kotlin:translate" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,10 @@ androidx-annotation-experimental = "1.4.1"
 androidx-appcompat = "1.2.0"
 androidx-browser = "1.9.0"
 androidx-concurrent = "1.1.0"
+androidx-coordinatorlayout = "1.1.0"
 androidx-core = "1.5.0"
 androidx-credentials = "1.3.0"
+androidx-fragment = "1.2.4"
 androidx-legacy = "1.0.0"
 androidx-lifecycle = "2.4.1"
 androidx-security = "1.0.0"
@@ -61,10 +63,12 @@ androidx-annotation = { module = "androidx.annotation:annotation", version.ref =
 androidx-annotation-experimental = { module = "androidx.annotation:annotation-experimental", version.ref = "androidx-annotation-experimental" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref="androidx-appcompat" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
+androidx-coordinatorlayout = { module = "androidx.coordinatorlayout:coordinatorlayout", version.ref = "androidx-coordinatorlayout" }
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref="androidx-credentials" }
 androidx-credentials-play-services = { module = "androidx.credentials:credentials-play-services-auth", version.ref="androidx-credentials" }
+androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidx-lifecycle" }
 androidx-nav-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "navigation" }
 androidx-nav-ui = { module = "androidx.navigation:navigation-ui", version.ref = "navigation" }

--- a/maplibre-adapter/build.gradle.kts
+++ b/maplibre-adapter/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
     implementation(libs.kotlin.coroutines)
 
     api(libs.androidx.lifecycle.runtime)
+    // CoordinatorLayout is a supertype of the public AmplifyMapView; declare directly as api.
+    api(libs.androidx.coordinatorlayout)
     implementation(libs.google.material)
 
     compileOnly(libs.aws.location)

--- a/maplibre-adapter/build.gradle.kts
+++ b/maplibre-adapter/build.gradle.kts
@@ -29,17 +29,17 @@ android {
 
 dependencies {
     implementation(project(":aws-auth-cognito"))
-    implementation(project(":aws-geo-location"))
-    implementation(project(":core"))
+    api(project(":aws-geo-location"))
+    api(project(":core"))
     implementation(platform(libs.aws.bom))
     implementation(libs.aws.signing)
-    implementation(libs.maplibre.sdk)
-    implementation(libs.gson) // forces maplibre to pull at least the same gson version as other amplify libs
-    implementation(libs.maplibre.annotations)
+    api(libs.maplibre.sdk)
+    api(libs.gson) // forces maplibre to pull at least the same gson version as other amplify libs
+    api(libs.maplibre.annotations)
     implementation(libs.okhttp)
     implementation(libs.kotlin.coroutines)
 
-    implementation(libs.androidx.lifecycle.runtime)
+    api(libs.androidx.lifecycle.runtime)
     implementation(libs.google.material)
 
     compileOnly(libs.aws.location)

--- a/rxbindings/build.gradle.kts
+++ b/rxbindings/build.gradle.kts
@@ -25,11 +25,11 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":common-core"))
-    implementation(libs.androidx.annotation)
+    api(project(":core"))
+    api(project(":common-core"))
+    api(libs.androidx.annotation)
     implementation(libs.androidx.appcompat)
-    implementation(libs.rxjava)
+    api(libs.rxjava)
 
     testImplementation(project(":testutils"))
     testImplementation(libs.bundles.test.unit)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
This PR introduces significant changes to the scoping applied to declared dependencies when publishing Amplify libraries.

Historically, Amplify libraries were published to Maven with a POM file that did not set scopes for any dependencies, and also did not publish a Gradle metadata file. This meant that all of Amplify's transitive dependencies would appear on the customer's compile classpath, whether or not they actually needed to be there.

Gradle dependency configurations are supposed to relate to Maven scopes and application classpaths like this:

| Gradle Dep Config | Purpose | Maven Dep Scope | Consumer Classpath | Actual behaviour |
| --- | --- | --- | --- | --- |
| api | Dependency contributes types that form part of your public API | compile | compile | Customer's app can reference types |
| implementation | Dependency is for internal implementation details | runtime | runtime | Customer's app cannot reference types |

But Amplify has always published like this:

| Gradle Dep Config | Purpose | Maven Dep Scope | Consumer Classpath | Actual behaviour |
| --- | --- | --- | --- | --- |
| api | Dependency contributes types that form part of your public API | compile | compile | Customer's app can reference types |
| implementation | Dependency is for internal implementation details | compile | compile | Customer's app can reference types |

This is an anti-pattern that pollutes the compile classpath and can lead to issues such as customers incorrectly referencing symbols that are really internal implementation details of Amplify, and subject to change at any time.

This issue was difficult to resolve when initial discovered because any fix would necessarily remove some types from the compile classpath. The application of proper dependency configuration (`api` vs `implementation`) was haphazard throughout the codebase so simply flipping the switch to fix the publishing part was not an option. We first had to audit all of the public APIs to enumerate the referenced types, determine which dependency was supplying that type, and ensure that all such dependencies were declared in the api configuration.

Therefore this PR does two things:
- Ensures any dependency that contributes a public API type is applied in the `api` configuration (many were incorrectly set to `implementation`).
- Adds explicit `api` dependencies where previously types may have be accessible only through transitive dependencies - this is Gradle best practice to avoid problems down the line as transitive dependencies change.
- Removes the workaround publishing code that applied compile scope to implementation configuration dependencies and disabled publishing for gradle metadata.

**Caveats** 
- Some customers may have been using types that were inadvertently available to them via transitive Amplify dependencies that will become hidden with this change. In such cases they will have to add an explicit dependency on the artifact that provides the type. This is **not** a breaking change (Amplify's APIs are unaffected) but a **fix** (extra types are no longer leaked).
- The number of `api` dependencies remains higher than it _should_ be, because there are many legacy parts of the Amplify codebase that have technically-public internals. The auditing done to prepare this PR simply looked at all types that are part of the published public API, and did not consider whether they _should_ be public or not. This change makes these cases easier to find and correct in a future improvement iteration.

*How did you test these changes?*
Created a script that explicitly checks that all types referenced in a module's `.api` file are resolvable by customers, by checking that they appear on the customer's compile classpath. This verifies that everything needed to use Amplify APIs is on the correct classpath.

The script _also_ checks that all dependencies declared in the `api` scope contribute at least one type to the public API (if not, they should be `implementation`). There was only one instance of this in the existing build files.

This script will be included in a follow up PR as part of a CI check to validate that there are no future regressions in having accessible types.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
