### PR TITLE
chore: Add CI gate to ensure API types are accessible to consumers

### DIFF
--- a/.github/workflows/verify_api_scopes.yml
+++ b/.github/workflows/verify_api_scopes.yml
@@ -1,0 +1,34 @@
+# Verifies that every external type in each published module's public API surface is
+# resolvable on the compile classpath a downstream consumer assembles from the published
+# artifact. A failure means a dependency supplying a public-API type is scoped
+# `implementation` (runtime) but must be `api` (compile).
+
+name: Verify API Scopes
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scope-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
+      - name: Verify API scopes
+        run: scripts/verify_api_scopes.sh

--- a/build-logic/plugins/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/PublishingConventionPlugin.kt
@@ -8,6 +8,7 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.extra
+import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
@@ -47,6 +48,23 @@ class PublishingConventionPlugin : Plugin<Project> {
         target.afterEvaluate {
             configureMavenPublishing()
             configureSigning()
+            registerPrintPublishedCoordinates()
+        }
+    }
+
+    // Registers a task that prints the published Maven coordinates (group:artifact:version) for
+    // every MavenPublication this project produces, one per line. Reading straight off the
+    // publications is authoritative: it reflects the exact coordinates that get published,
+    // including modules that override the group (e.g. com.amazonaws) or version, and KMP modules
+    // that publish multiple coordinates.
+    private fun Project.registerPrintPublishedCoordinates() {
+        val publishing = extensions.findByType<PublishingExtension>() ?: return
+        tasks.register("printPublishedCoordinates") {
+            doLast {
+                publishing.publications.withType<MavenPublication>().forEach {
+                    println("${it.groupId}:${it.artifactId}:${it.version}")
+                }
+            }
         }
     }
 

--- a/scripts/scope-check-consumer/build.gradle.kts
+++ b/scripts/scope-check-consumer/build.gradle.kts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// A minimal Android library that depends on ONE published Amplify artifact (passed via
+// -PmoduleCoords=group:artifact:version) and dumps its resolved release compile classpath.
+// Android variant attributes are required to resolve aar artifacts and to apply api/implementation
+// scope filtering the way a real consumer does — which is why this must be a Gradle/AGP build and
+// cannot be replicated by reading POMs alone.
+// Plugin versions are resolved in settings.gradle.kts from -Pagp/-Pkgp (injected by the CI
+// driver, sourced from the root gradle/libs.versions.toml so they never drift).
+plugins {
+    id("com.android.library")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.amplifyframework.scopecheck"
+    compileSdk = 36
+    defaultConfig { minSdk = 24 }
+}
+
+val moduleCoords: String = providers.gradleProperty("moduleCoords").get()
+
+dependencies {
+    "implementation"(moduleCoords)
+}
+
+// Emit the resolved RELEASE compile classpath (aar/jar files), one absolute path per line.
+tasks.register("dumpCompileClasspath") {
+    doLast {
+        val cfg = configurations.getByName("releaseCompileClasspath")
+        val out = layout.buildDirectory.file("compile-classpath.txt").get().asFile
+        out.parentFile.mkdirs()
+        out.writeText(
+            cfg.incoming.artifactView { isLenient = true }
+                .artifacts.artifactFiles.files.joinToString("\n") { it.absolutePath }
+        )
+        println("WROTE ${out.absolutePath}")
+    }
+}

--- a/scripts/scope-check-consumer/gradle.properties
+++ b/scripts/scope-check-consumer/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+org.gradle.jvmargs=-Xmx2g

--- a/scripts/scope-check-consumer/settings.gradle.kts
+++ b/scripts/scope-check-consumer/settings.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Standalone synthetic consumer used by scripts/verify_api_scopes.py to resolve the compile
+// classpath a real downstream project would assemble from a PUBLISHED Amplify artifact. It is
+// intentionally NOT part of the main build (not in the root settings.gradle.kts) so that it
+// resolves artifacts from a repository (mavenLocal) rather than via in-repo project substitution
+// — the whole point is to exercise the published POM/Gradle-metadata scopes.
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    // Plugin versions are injected via -Pagp/-Pkgp by scripts/verify_api_scopes.sh, sourced from
+    // the root gradle/libs.versions.toml so they never drift from the versions the libraries build
+    // with. settings.gradle.kts (unlike a build script's plugins{} block) can resolve providers.
+    val agp = providers.gradleProperty("agp").get()
+    val kgp = providers.gradleProperty("kgp").get()
+    plugins {
+        id("com.android.library") version agp
+        id("org.jetbrains.kotlin.android") version kgp
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
+    }
+}
+rootProject.name = "scope-check-consumer"

--- a/scripts/scope-check-consumer/src/main/AndroidManifest.xml
+++ b/scripts/scope-check-consumer/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest/>

--- a/scripts/verify_api_scopes.py
+++ b/scripts/verify_api_scopes.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Publishing-scope containment checker.
+
+Asserts, for one published module, that every EXTERNAL type appearing in the
+module's public API surface (its binary-validator .api dump) is present on the
+compile classpath that a consumer assembles from the module's PUBLISHED artifact
+plus its `api`-scoped transitive closure.
+
+Any public-API type that is NOT on that consumer compile classpath is a scoping
+bug: a dependency that supplies a public-API type is scoped `implementation`
+(runtime) instead of `api` (compile), so downstream consumers cannot compile
+against that part of the module's API.
+
+This script is the pure set-logic half. A Gradle task resolves the consumer
+compile classpath (aar/jar files) and invokes this script per module with:
+    --api-file    <module>/api/<module>.api
+    --classpath   file listing one resolved artifact path per line
+    --module      human-readable module name (for reporting)
+
+Exit code 0 = all public-API types resolvable; 1 = violations found.
+"""
+import argparse
+import re
+import sys
+import zipfile
+
+# Package roots that never need declaring as `api` because they are always present on a
+# consumer's compile classpath without any Amplify dependency supplying them:
+#  - java/*        JDK, always on every classpath
+#  - kotlin/*      Kotlin stdlib, always `api` via the Kotlin plugin
+#  - android/*     Android framework, provided by the platform android.jar (never published)
+#  - org/json/*    bundled INTO android.jar by the platform (JSONObject etc.) — same as android/*
+#  - org/w3c/, org/xml/, javax/xml/  also bundled into android.jar
+# These are matched as path prefixes against '/'-separated binary names.
+IGNORED_PREFIXES = (
+    "java/", "kotlin/", "android/",
+    "org/json/", "org/w3c/", "org/xml/", "javax/xml/",
+)
+
+# Match every `Lpackage/sub/Class;` type token in a .api file (member descriptors)
+TYPE_TOKEN = re.compile(r"L([a-zA-Z][a-zA-Z0-9/$_]*);")
+# Match class declaration lines to capture supertypes/interfaces after the ':'
+CLASS_DECL = re.compile(r"^(?:public|protected).*?class\s+([a-zA-Z0-9/$_]+)(?:\s*:\s*(.*?))?\s*\{?\s*$")
+
+
+def normalize(binary_name):
+    """Reduce a JVM binary name to its outer class, '/'-separated, no '$' nesting.
+    A nested type is available iff its enclosing top-level class is on the classpath,
+    so we compare at outer-class granularity."""
+    return binary_name.split("$", 1)[0]
+
+
+def types_in_api(api_path):
+    """Return the set of external outer-class binary names referenced in the .api file,
+    and the set of types this module DEFINES (to exclude self-references)."""
+    referenced = set()
+    defined = set()
+    with open(api_path, encoding="utf-8") as f:
+        for line in f:
+            m = CLASS_DECL.match(line.strip())
+            if m:
+                defined.add(normalize(m.group(1)))
+                # supertype + interfaces listed after ':' are also references. They are
+                # comma- and/or whitespace-separated, e.g. ":  A, B {" — split on both.
+                if m.group(2):
+                    for tok in re.split(r"[,\s]+", m.group(2)):
+                        tok = tok.strip().rstrip("{").strip()
+                        if tok and "/" in tok:
+                            referenced.add(normalize(tok))
+            for tok in TYPE_TOKEN.findall(line):
+                referenced.add(normalize(tok))
+    external = {
+        t for t in referenced
+        if not t.startswith(IGNORED_PREFIXES) and t not in defined
+    }
+    return external, defined
+
+
+def classes_on_classpath(classpath_listing):
+    """Return the set of outer-class binary names available across all artifacts.
+    Handles jars directly and aars (classes live in classes.jar inside the aar)."""
+    available = set()
+    with open(classpath_listing, encoding="utf-8") as f:
+        artifacts = [ln.strip() for ln in f if ln.strip()]
+    for art in artifacts:
+        try:
+            if art.endswith(".jar"):
+                _collect_jar_classes(art, available)
+            elif art.endswith(".aar"):
+                _collect_aar_classes(art, available)
+        except (zipfile.BadZipFile, FileNotFoundError, KeyError) as e:
+            print(f"  warning: could not read artifact {art}: {e}", file=sys.stderr)
+    return available
+
+
+def _collect_jar_classes(jar_path, out):
+    with zipfile.ZipFile(jar_path) as z:
+        for name in z.namelist():
+            if name.endswith(".class"):
+                out.add(normalize(name[:-len(".class")]))
+
+
+def _collect_aar_classes(aar_path, out):
+    with zipfile.ZipFile(aar_path) as aar:
+        for entry in aar.namelist():
+            # aar bundles compiled code in classes.jar (and occasionally libs/*.jar)
+            if entry == "classes.jar" or (entry.startswith("libs/") and entry.endswith(".jar")):
+                with aar.open(entry) as jar_stream:
+                    with zipfile.ZipFile(jar_stream) as z:
+                        for name in z.namelist():
+                            if name.endswith(".class"):
+                                out.add(normalize(name[:-len(".class")]))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--api-file", required=True)
+    ap.add_argument("--classpath", required=True, help="file listing resolved artifact paths")
+    ap.add_argument("--module", required=True)
+    args = ap.parse_args()
+
+    required, _ = types_in_api(args.api_file)
+    available = classes_on_classpath(args.classpath)
+
+    missing = sorted(t for t in required if t not in available)
+
+    if missing:
+        print(f"FAIL [{args.module}]: {len(missing)} public-API type(s) not on consumer compile classpath:")
+        for t in missing:
+            print(f"    {t.replace('/', '.')}")
+        print(f"  -> a dependency supplying these is scoped `implementation` but must be `api`.")
+        return 1
+    print(f"OK   [{args.module}]: all {len(required)} external public-API types resolvable by consumers.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_api_scopes.sh
+++ b/scripts/verify_api_scopes.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Publishing-scope regression gate.
+#
+# For every published module, verifies that every external type in the module's public API
+# surface (its binary-validator .api dump) is resolvable on the compile classpath a downstream
+# consumer assembles from the PUBLISHED artifact. A failure means a dependency supplying a
+# public-API type is scoped `implementation` (runtime) but must be `api` (compile) — otherwise
+# consumers cannot compile against that part of the module's API.
+#
+# Pipeline:
+#   1. publish all modules to mavenLocal under an isolated version
+#   2. ask each module for its authoritative published coordinates (printPublishedCoordinates)
+#   3. per coordinate: resolve a synthetic consumer's release compile classpath
+#   4. per module: run verify_api_scopes.py (.api surface  ⊆  consumer compile classpath)
+#
+# Usage: scripts/verify_api_scopes.sh
+# Exit: 0 = all modules OK; 1 = at least one scoping violation.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+CONSUMER="$REPO/scripts/scope-check-consumer"
+PYCHECK="$REPO/scripts/verify_api_scopes.py"
+VER="0.0.0-scopecheck"           # isolated version so nothing shadows via project substitution
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Plugin versions for the standalone consumer, sourced from the catalog so they never drift.
+AGP=$(grep -E '^agp = ' "$REPO/gradle/libs.versions.toml" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+KGP=$(grep -E '^kotlin = ' "$REPO/gradle/libs.versions.toml" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+
+echo "== Publishing all modules to mavenLocal (version $VER) =="
+# Note: modules that override VERSION_NAME (apollo/appsync) publish under their own version;
+# printPublishedCoordinates reports whatever they actually publish, so both are handled.
+(cd "$REPO" && ./gradlew publishToMavenLocal -PVERSION_NAME="$VER" -x signMavenPublication --quiet)
+
+echo "== Discovering published coordinates =="
+# One authoritative coordinate list, straight from the publications. Format: group:artifact:version
+# Map each artifactId back to its .api file via a second query pairing project path + api dir.
+COORDS_FILE="$WORK/coords.txt"
+: > "$COORDS_FILE"
+
+# Collect (projectPath -> coordinate) by running the task across all projects at once.
+(cd "$REPO" && ./gradlew -q printPublishedCoordinates 2>/dev/null) \
+  | grep -E '^[a-z0-9.]+:[a-z0-9-]+:' | sort -u > "$COORDS_FILE" || true
+
+if [ ! -s "$COORDS_FILE" ]; then
+  echo "ERROR: no published coordinates discovered" >&2
+  exit 2
+fi
+
+# Locate the <name>.api file for an artifactId (exactly one per module, outside build dirs).
+# KMP modules publish a "-android" coordinate carrying the same classes as the base module, so
+# fall back to the base name's .api for those. Kept as a function to stay Bash 3.2 compatible
+# (macOS ships 3.2, which lacks associative arrays).
+find_api_file() {
+  local artifact="$1" f
+  f=$(find "$REPO" -type f -path '*/api/'"$artifact"'.api' ! -path '*/build/*' | head -1)
+  if [ -z "$f" ] && [ "${artifact%-android}" != "$artifact" ]; then
+    f=$(find "$REPO" -type f -path '*/api/'"${artifact%-android}"'.api' ! -path '*/build/*' | head -1)
+  fi
+  printf '%s' "$f"
+}
+
+PASS=0; FAIL=0; SKIP=0; FAILED=""
+while IFS= read -r coord; do
+  group="${coord%%:*}"; rest="${coord#*:}"; artifact="${rest%%:*}"; version="${rest##*:}"
+
+  api="$(find_api_file "$artifact")"
+  if [ -z "$api" ]; then
+    echo "SKIP [$coord]: no matching .api file"; SKIP=$((SKIP+1)); continue
+  fi
+
+  # Drive the standalone consumer build with the repo's Gradle wrapper via -p (the consumer dir
+  # has no wrapper of its own, and this guarantees the same Gradle version as the main build).
+  if ! "$REPO/gradlew" -p "$CONSUMER" dumpCompileClasspath \
+        -PmoduleCoords="$coord" -Pagp="$AGP" -Pkgp="$KGP" \
+        --rerun-tasks --quiet > "$WORK/resolve-$artifact.log" 2>&1; then
+    echo "SKIP [$coord]: consumer failed to resolve (see $WORK/resolve-$artifact.log)"
+    SKIP=$((SKIP+1)); continue
+  fi
+
+  if python3 "$PYCHECK" --api-file "$api" \
+       --classpath "$CONSUMER/build/compile-classpath.txt" --module "$coord"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1)); FAILED="$FAILED $coord"
+  fi
+done < "$COORDS_FILE"
+
+echo ""
+echo "==== SCOPE CHECK: pass=$PASS fail=$FAIL skip=$SKIP ===="
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAILED:$FAILED"
+  exit 1
+fi


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
Adds a PR check that executes the `verify_api_scopes` script. The purpose of this script is explained in its header commment:

> For every published module, verifies that every external type in the module's public API
surface (its binary-validator .api dump) is resolvable on the compile classpath a downstream
consumer assembles from the PUBLISHED artifact. A failure means a dependency supplying a
public-API type is scoped `implementation` (runtime) but must be `api` (compile) — otherwise
consumers cannot compile against that part of the module's API.

This is to avoid bugs where part of the API is inaccessible to customers because of a dependency scoping issue.

*How did you test these changes?*
- Verified script runs successfully on main
- Verified that script fails if a scoping bug (changing an `api` dependency to `implementation`) is intentionally introduced.

The output of a failed check looks like this:
```
== Publishing all modules to mavenLocal (version 0.0.0-scopecheck) ==
== Discovering published coordinates ==
FAIL [com.amazonaws:aws-sdk-appsync-amplify:1.0.1]: 2 public-API type(s) not on consumer compile classpath:
    com.amazonaws.sdk.appsync.core.AppSyncAuthorizer
    com.amazonaws.sdk.appsync.core.AppSyncRequest
  -> a dependency supplying these is scoped `implementation` but must be `api`.
OK   [com.amazonaws:aws-sdk-appsync-core:1.0.1]: all 0 external public-API types resolvable by consumers.
OK   [com.amazonaws:aws-sdk-appsync-events:1.0.1]: all 10 external public-API types resolvable by consumers.
OK   [com.amplifyframework:annotations:2.39.0]: all 0 external public-API types resolvable by consumers.
OK   [com.amplifyframework:apollo-appsync-amplify:1.2.1]: all 6 external public-API types resolvable by consumers.
OK   [com.amplifyframework:apollo-appsync:1.2.1]: all 9 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-analytics-pinpoint:2.39.0]: all 6 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-api-appsync:2.39.0]: all 26 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-api:2.39.0]: all 23 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-auth-cognito:2.39.0]: all 38 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-auth-plugins-core:2.39.0]: all 7 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-connect:2.39.0]: all 3 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-core:2.39.0]: all 7 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-datastore:2.39.0]: all 47 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-geo-location:2.39.0]: all 10 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-kinesis:2.39.0]: all 5 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-logging-cloudwatch:2.39.0]: all 15 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-pinpoint-core:2.39.0]: all 6 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-predictions-tensorflow:2.39.0]: all 16 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-predictions:2.39.0]: all 54 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-push-notifications-pinpoint-common:2.39.0]: all 5 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-push-notifications-pinpoint:2.39.0]: all 9 external public-API types resolvable by consumers.
OK   [com.amplifyframework:aws-storage-s3:2.39.0]: all 25 external public-API types resolvable by consumers.
OK   [com.amplifyframework:common-core:2.39.0]: all 0 external public-API types resolvable by consumers.
OK   [com.amplifyframework:core-kotlin:2.39.0]: all 68 external public-API types resolvable by consumers.
OK   [com.amplifyframework:core:2.39.0]: all 10 external public-API types resolvable by consumers.
OK   [com.amplifyframework:foundation-android:2.39.0]: all 0 external public-API types resolvable by consumers.
OK   [com.amplifyframework:foundation-bridge-android:2.39.0]: all 4 external public-API types resolvable by consumers.
OK   [com.amplifyframework:foundation-bridge:2.39.0]: all 4 external public-API types resolvable by consumers.
OK   [com.amplifyframework:foundation:2.39.0]: all 0 external public-API types resolvable by consumers.
OK   [com.amplifyframework:maplibre-adapter:2.39.0]: all 15 external public-API types resolvable by consumers.
OK   [com.amplifyframework:rxbindings:2.39.0]: all 60 external public-API types resolvable by consumers.

==== SCOPE CHECK: pass=31 fail=1 skip=0 ====
FAILED: com.amazonaws:aws-sdk-appsync-amplify:1.0.1
```

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
