### PR TITLE
fix(auth): Improve refresh failure and signed-out session errors

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActions.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.auth.cognito.actions
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.exceptions.ConfigurationException
+import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.AuthorizationActions
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
@@ -44,12 +45,10 @@ internal object AuthorizationCognitoActions : AuthorizationActions {
         val evt = configuration.identityPool?.poolId?.let {
             FetchAuthSessionEvent(FetchAuthSessionEvent.EventType.FetchIdentity(LoginsMapProvider.UnAuthLogins()))
         } ?: AuthorizationEvent(
-            AuthorizationEvent.EventType.ThrowError(
-                ConfigurationException(
-                    "Identity Pool not configured.",
-                    "Please check amplifyconfiguration.json file."
-                )
-            )
+            // No identity pool means guest credentials are impossible, so for a signed-out user the
+            // accurate answer is that they are signed out. Reporting a configuration error here would
+            // suggest the app is misconfigured, when a user pool only configuration is perfectly valid.
+            AuthorizationEvent.EventType.ThrowError(SignedOutException())
         )
         logger.verbose("$id Sending event ${evt.type}")
         dispatcher.send(evt)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
@@ -78,7 +78,10 @@ internal object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                     RefreshSessionEvent(RefreshSessionEvent.EventType.Refreshed(updatedSignedInData))
                 }
             } catch (notAuthorized: aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException) {
-                val error = SessionExpiredException(cause = notAuthorized)
+                val error = SessionExpiredException(
+                    message = refreshRejectedMessage(notAuthorized),
+                    cause = notAuthorized
+                )
                 AuthorizationEvent(AuthorizationEvent.EventType.ThrowError(error))
             } catch (e: Exception) {
                 AuthorizationEvent(AuthorizationEvent.EventType.ThrowError(e))
@@ -170,4 +173,29 @@ internal object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
             logger.verbose("$id Sending event ${evt.type}")
             dispatcher.send(evt)
         }
+
+    /**
+     * Cognito rejects a refresh token with NotAuthorizedException for several distinct reasons: the token
+     * has expired, it has been revoked, or it is no longer valid for the device it is bound to. The reason
+     * is only conveyed in the service message, so include it in the exception message.
+     *
+     * Without it, every rejection is reported as "Your session has expired.", which is inaccurate for
+     * device-binding and revocation failures and leaves all three modes indistinguishable in logs and
+     * crash reports. The originating exception remains available as [Throwable.cause].
+     *
+     * Reads the modeled service message rather than [Throwable.message], which the SDK synthesizes from
+     * error metadata when the service sends no message and would contribute only noise here.
+     */
+    private fun refreshRejectedMessage(
+        notAuthorized: aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException
+    ): String {
+        val reason = notAuthorized.sdkErrorMetadata.errorMessage?.trim()?.takeIf { it.isNotEmpty() }
+        return if (reason == null) {
+            DEFAULT_SESSION_EXPIRED_MESSAGE
+        } else {
+            "$DEFAULT_SESSION_EXPIRED_MESSAGE ($reason)"
+        }
+    }
+
+    private const val DEFAULT_SESSION_EXPIRED_MESSAGE = "Your session has expired."
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActionsTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.actions
+
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.auth.cognito.AWSCognitoAuthService
+import com.amplifyframework.auth.cognito.AuthConfiguration
+import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.StoreClientBehavior
+import com.amplifyframework.auth.exceptions.SignedOutException
+import com.amplifyframework.logging.Logger
+import com.amplifyframework.statemachine.EventDispatcher
+import com.amplifyframework.statemachine.StateMachineEvent
+import com.amplifyframework.statemachine.codegen.data.IdentityPoolConfiguration
+import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
+import com.amplifyframework.statemachine.codegen.events.AuthorizationEvent
+import com.amplifyframework.statemachine.codegen.events.FetchAuthSessionEvent
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AuthorizationCognitoActionsTest {
+
+    private val userPool = mockk<UserPoolConfiguration> {
+        every { poolId } returns "pool_id"
+    }
+    private val logger = mockk<Logger>(relaxed = true)
+    private val capturedEvent = slot<StateMachineEvent>()
+    private val dispatcher = mockk<EventDispatcher> {
+        every { send(capture(capturedEvent)) } just Runs
+    }
+
+    private fun authEnvironment(identityPoolId: String?): AuthEnvironment {
+        val identityPool = identityPoolId?.let {
+            mockk<IdentityPoolConfiguration> { every { poolId } returns it }
+        }
+        val configuration = mockk<AuthConfiguration> {
+            every { this@mockk.userPool } returns this@AuthorizationCognitoActionsTest.userPool
+            every { this@mockk.identityPool } returns identityPool
+        }
+        return AuthEnvironment(
+            ApplicationProvider.getApplicationContext(),
+            configuration,
+            mockk<AWSCognitoAuthService>(relaxed = true),
+            mockk<StoreClientBehavior>(relaxed = true),
+            null,
+            null,
+            logger
+        )
+    }
+
+    @Test
+    fun `initializeFetchUnAuthSession reports signed out when no identity pool is configured`() = runTest {
+        // A user pool only configuration is valid, so a signed-out user must not be told the app is
+        // misconfigured. Reporting a ConfigurationException here surfaced to callers as an opaque
+        // UnknownException("Fetch auth session failed.") instead of a signed-out session.
+        AuthorizationCognitoActions.initializeFetchUnAuthSession()
+            .execute(dispatcher, authEnvironment(identityPoolId = null))
+
+        val event = capturedEvent.captured
+        event.shouldBeInstanceOf<AuthorizationEvent>()
+        val eventType = event.eventType
+        eventType.shouldBeInstanceOf<AuthorizationEvent.EventType.ThrowError>()
+        eventType.exception.shouldBeInstanceOf<SignedOutException>()
+    }
+
+    @Test
+    fun `initializeFetchUnAuthSession fetches identity when an identity pool is configured`() = runTest {
+        AuthorizationCognitoActions.initializeFetchUnAuthSession()
+            .execute(dispatcher, authEnvironment(identityPoolId = "identity_pool_id"))
+
+        val event = capturedEvent.captured
+        event.shouldBeInstanceOf<FetchAuthSessionEvent>()
+        event.eventType.shouldBeInstanceOf<FetchAuthSessionEvent.EventType.FetchIdentity>()
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActionsTest.kt
@@ -25,6 +25,7 @@ import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.StoreClientBehavior
 import com.amplifyframework.auth.cognito.mockSignedInData
+import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.EventDispatcher
 import com.amplifyframework.statemachine.StateMachineEvent
@@ -77,6 +78,37 @@ class FetchAuthSessionCognitoActionsTest {
     }
 
     private lateinit var authEnvironment: AuthEnvironment
+
+    private val notAuthorizedSignedInData = mockSignedInData(
+        username = "username",
+        cognitoUserPoolTokens = CognitoUserPoolTokens(
+            accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                "eyJzdWIiOiJ1c2VySWQiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiZXhwIjoxNTE2MjM5MDIyfQ." +
+                "XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o",
+            idToken = "old_id",
+            refreshToken = "refresh_token",
+            expiration = 0
+        )
+    )
+
+    private fun capturedThrownError(): Exception {
+        val event = capturedEvent.captured
+        event.shouldBeInstanceOf<AuthorizationEvent>()
+        val eventType = event.eventType
+        eventType.shouldBeInstanceOf<AuthorizationEvent.EventType.ThrowError>()
+        return eventType.exception
+    }
+
+    /**
+     * The service message travels in [ServiceErrorMetadata], which the wire deserializer populates and the
+     * generated builder does not, so stub it rather than constructing the exception directly. Note that
+     * NotAuthorizedException.message is synthesized from error metadata and is not the service message.
+     */
+    private fun notAuthorizedWithServiceMessage(serviceMessage: String?) = mockk<NotAuthorizedException> {
+        every { sdkErrorMetadata } returns mockk {
+            every { errorMessage } returns serviceMessage
+        }
+    }
 
     @Before
     fun setup() {
@@ -191,6 +223,61 @@ class FetchAuthSessionCognitoActionsTest {
             .execute(dispatcher, authEnvironment)
 
         capturedEvent.captured.shouldBeInstanceOf<AuthorizationEvent>()
+    }
+
+    @Test
+    fun `refreshUserPoolTokensAction reports the reason Cognito rejected the refresh token`() = runTest {
+        // Cognito uses NotAuthorizedException for several unrelated failures and only distinguishes them in
+        // the service message, so the message must reach the caller for the failures to be told apart.
+        val reasons = listOf(
+            "Refresh Token has expired",
+            "Refresh Token has been revoked",
+            "Invalid Refresh Token."
+        )
+
+        reasons.forEach { reason ->
+            val serviceException = notAuthorizedWithServiceMessage(reason)
+            coEvery {
+                cognitoIdentityProviderClientMock.getTokensFromRefreshToken(any())
+            } throws serviceException
+
+            FetchAuthSessionCognitoActions.refreshUserPoolTokensAction(notAuthorizedSignedInData)
+                .execute(dispatcher, authEnvironment)
+
+            val error = capturedThrownError()
+            error.shouldBeInstanceOf<SessionExpiredException>()
+            error.message shouldBe "Your session has expired. ($reason)"
+            // The originating exception stays reachable for callers that need the raw service error.
+            error.cause shouldBe serviceException
+        }
+    }
+
+    @Test
+    fun `refreshUserPoolTokensAction falls back to the default message when Cognito sends no reason`() = runTest {
+        coEvery {
+            cognitoIdentityProviderClientMock.getTokensFromRefreshToken(any())
+        } throws notAuthorizedWithServiceMessage(null)
+
+        FetchAuthSessionCognitoActions.refreshUserPoolTokensAction(notAuthorizedSignedInData)
+            .execute(dispatcher, authEnvironment)
+
+        val error = capturedThrownError()
+        error.shouldBeInstanceOf<SessionExpiredException>()
+        error.message shouldBe "Your session has expired."
+    }
+
+    @Test
+    fun `refreshUserPoolTokensAction ignores a blank reason from Cognito`() = runTest {
+        coEvery {
+            cognitoIdentityProviderClientMock.getTokensFromRefreshToken(any())
+        } throws notAuthorizedWithServiceMessage("   ")
+
+        FetchAuthSessionCognitoActions.refreshUserPoolTokensAction(notAuthorizedSignedInData)
+            .execute(dispatcher, authEnvironment)
+
+        val error = capturedThrownError()
+        error.shouldBeInstanceOf<SessionExpiredException>()
+        error.message shouldBe "Your session has expired."
     }
 
     @Test


### PR DESCRIPTION
## What was wrong

1. Cognito returns `NotAuthorizedException` for three unrelated refresh failures and distinguishes
   them only in the service message: `Refresh Token has expired`, `Refresh Token has been revoked`,
   and `Invalid Refresh Token.` (device binding). All three became
   `SessionExpiredException("Your session has expired.")`, so an app could not tell a device-binding
   failure from a genuine expiry, and all three collapsed into a single entry in crash reporting.

2. `fetchAuthSession` for a signed-out user on a user pool only configuration threw
   `ConfigurationException("Identity Pool not configured.")`, which reached callers wrapped as
   `UnknownException("Fetch auth session failed.")`. A user pool only configuration is valid, and the
   signed-in path already handles a missing identity pool without error.

## Changes

1. Include the service reason in the message: `Your session has expired. (Invalid Refresh Token.)`.
   The exception type and `cause` are unchanged, so existing `catch` and `when` branches still match.
   The reason is read from `sdkErrorMetadata.errorMessage` rather than `Throwable.message`, because
   the latter is synthesized from error metadata and yields text such as
   `Error type: Client, Protocol response: (empty response)` when the service sends no message.

2. Emit `SignedOutException` from `initializeFetchUnAuthSession` when no identity pool is configured.
   The plugin already maps it to a signed-out session, and the session builder already treats it as
   the signed-out signal. `initializeFetchAuthSession` is left alone: there the user is signed in and
   asking for AWS credentials, so a configuration error is still the right answer.

No public API change; `apiCheck` passes.

## Testing

- 5 new unit tests. Full `aws-auth-cognito` suite: 499 tests, 0 failures. `ktlintCheck` and
  `apiCheck` clean.
- Before the change, all three rejection messages were reproduced against a real user pool with
  device tracking enabled: forgetting the bound device record, revoking with
  `AdminUserGlobalSignOut`, and letting a token pass a 1 hour refresh validity. All three arrived as
  an identical `SessionExpiredException`, which is the bug.
- The new tests stub `sdkErrorMetadata.errorMessage`, so the real path was confirmed separately:
  `ServiceException.getMessage()` is `getDisplayMetadata()` joined, and that list takes the bare
  service message only from `sdkErrorMetadata.errorMessage`. Captured traces show the message was
  exactly `Invalid Refresh Token.` with no `Error type:` prefix, which happens only when that field
  is populated.

## Not addressed

A typed sub-reason (enum or distinct exception per cause) is deliberately not attempted. The
distinction exists only as free text that the service does not contract, so classifying it in the SDK
would mean string-matching messages that can change without notice. A machine-readable error code
from Cognito would be needed for that.

Separately, a non-JSON error body, for example an HTML page returned by an intercepting proxy,
surfaces as an opaque deserialization failure. That behaviour is mostly in `smithy-kotlin` and is out
of scope here.
