### PR TITLE
refactor: decouple lazy loading from request factory internals

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/ApiLazyModelReference.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/ApiLazyModelReference.kt
@@ -24,7 +24,6 @@ import com.amplifyframework.core.Consumer
 import com.amplifyframework.core.NullableConsumer
 import com.amplifyframework.core.model.LazyModelReference
 import com.amplifyframework.core.model.Model
-import com.amplifyframework.core.model.ModelSchema
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -90,22 +89,7 @@ internal class ApiLazyModelReference<M : Model> internal constructor(
             }
 
             return try {
-                val modelSchema = ModelSchema.fromModelClass(clazz)
-                val primaryIndexFields = modelSchema.primaryIndexFields
-                val variables = primaryIndexFields.map { key ->
-                    // Find target field to pull type info
-                    val targetField = requireNotNull(modelSchema.fields[key])
-                    val requiredSuffix = if (targetField.isRequired) "!" else ""
-                    val targetTypeString = "${targetField.targetType}$requiredSuffix"
-                    val value = requireNotNull(keyMap[key])
-                    GraphQLRequestVariable(key, value, targetTypeString)
-                }
-
-                val request: GraphQLRequest<M?> = AppSyncGraphQLRequestFactory.buildQueryInternal(
-                    clazz,
-                    null,
-                    *variables.toTypedArray()
-                )
+                val request: GraphQLRequest<M?> = AppSyncGraphQLRequestFactory.buildQueryFromKeyMap(clazz, keyMap)
 
                 val value = query(
                     apiCategory,

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/ApiModelListTypes.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/ApiModelListTypes.kt
@@ -28,7 +28,6 @@ import com.amplifyframework.core.model.PaginationToken
 import com.amplifyframework.core.model.query.predicate.QueryField
 import com.amplifyframework.core.model.query.predicate.QueryPredicate
 import com.amplifyframework.core.model.query.predicate.QueryPredicates
-import com.amplifyframework.util.TypeMaker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -91,7 +90,7 @@ internal class ApiLazyModelList<out M : Model> constructor(
         AppSyncGraphQLRequestFactory.buildModelPageQuery(
             clazz,
             queryPredicate,
-            TypeMaker.getParameterizedType(ApiModelPage::class.java, clazz),
+            ApiModelPage::class.java,
             (paginationToken as? ApiPaginationToken)?.nextToken
         )
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/ApiModelListTypes.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/ApiModelListTypes.kt
@@ -28,6 +28,7 @@ import com.amplifyframework.core.model.PaginationToken
 import com.amplifyframework.core.model.query.predicate.QueryField
 import com.amplifyframework.core.model.query.predicate.QueryPredicate
 import com.amplifyframework.core.model.query.predicate.QueryPredicates
+import com.amplifyframework.util.TypeMaker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -90,6 +91,7 @@ internal class ApiLazyModelList<out M : Model> constructor(
         AppSyncGraphQLRequestFactory.buildModelPageQuery(
             clazz,
             queryPredicate,
+            TypeMaker.getParameterizedType(ApiModelPage::class.java, clazz),
             (paginationToken as? ApiPaginationToken)?.nextToken
         )
 

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.kt
@@ -15,6 +15,7 @@
 package com.amplifyframework.api.aws
 
 import com.amplifyframework.AmplifyException
+import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.MutationType
 import com.amplifyframework.api.graphql.Operation
@@ -189,7 +190,37 @@ object AppSyncGraphQLRequestFactory {
         }
     }
 
-    internal fun <R, T : Model, P : ModelPath<T>> buildQueryInternal(
+    /**
+     * Creates a [GraphQLRequest] that represents a query for a single value, identified by a map of
+     * primary/sort key field names to values.
+     *
+     * This is the entry point used by lazy loading, where the identifying fields are already known as a
+     * map rather than as a [ModelIdentifier]. The variable types are resolved from the model schema.
+     *
+     * @param modelClass the model class.
+     * @param keyMap the primary index field names mapped to their values.
+     * @param <R> the response type.
+     * @param <T> the concrete model type.
+     * @return a valid [GraphQLRequest] instance.
+     * @throws AmplifyException when a schema cannot be generated for [modelClass].
+     * @throws IllegalStateException when the model schema does not contain the expected information.
+     </T></R> */
+    @JvmStatic
+    @InternalAmplifyApi
+    fun <R, T : Model> buildQueryFromKeyMap(modelClass: Class<T>, keyMap: Map<String, Any>): GraphQLRequest<R> {
+        val modelSchema = ModelSchema.fromModelClass(modelClass)
+        val variables = modelSchema.primaryIndexFields.map { key ->
+            // Find target field to pull type info
+            val targetField = requireNotNull(modelSchema.fields[key])
+            val requiredSuffix = if (targetField.isRequired) "!" else ""
+            val targetTypeString = "${targetField.targetType}$requiredSuffix"
+            val value = requireNotNull(keyMap[key])
+            GraphQLRequestVariable(key, value, targetTypeString)
+        }
+        return buildQueryInternal(modelClass, null, *variables.toTypedArray())
+    }
+
+    private fun <R, T : Model, P : ModelPath<T>> buildQueryInternal(
         modelClass: Class<T>,
         includes: ((P) -> List<PropertyContainerPath>)?,
         vararg variables: GraphQLRequestVariable
@@ -231,14 +262,29 @@ object AppSyncGraphQLRequestFactory {
         return buildListQueryInternal(modelClass, predicate, DEFAULT_QUERY_LIMIT, dataType, null)
     }
 
-    internal fun <R, T : Model> buildModelPageQuery(
+    /**
+     * Creates a [GraphQLRequest] that represents a query for a single page of models.
+     *
+     * The page type is supplied by the caller rather than resolved here, so that this factory does not
+     * depend on the plugin's lazy-loading types.
+     *
+     * @param modelClass the model class.
+     * @param predicate the model predicate.
+     * @param pageType the parameterized type the response should be deserialized into.
+     * @param pageToken the token identifying the page to fetch, or null for the first page.
+     * @param <R> the response type.
+     * @param <T> the concrete model type.
+     * @return a valid [GraphQLRequest] instance.
+     * @throws IllegalStateException when the model schema does not contain the expected information.
+     </T></R> */
+    @JvmStatic
+    @InternalAmplifyApi
+    fun <R, T : Model> buildModelPageQuery(
         modelClass: Class<T>,
         predicate: QueryPredicate,
+        pageType: Type,
         pageToken: String?
-    ): GraphQLRequest<R> {
-        val dataType = TypeMaker.getParameterizedType(ApiModelPage::class.java, modelClass)
-        return buildListQueryInternal(modelClass, predicate, DEFAULT_QUERY_LIMIT, dataType, null, pageToken)
-    }
+    ): GraphQLRequest<R> = buildListQueryInternal(modelClass, predicate, DEFAULT_QUERY_LIMIT, pageType, null, pageToken)
 
     /**
      * Creates a [GraphQLRequest] that represents a query that expects multiple values as a result. The request

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.kt
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactory.kt
@@ -24,6 +24,7 @@ import com.amplifyframework.api.graphql.QueryType
 import com.amplifyframework.api.graphql.SubscriptionType
 import com.amplifyframework.core.model.Model
 import com.amplifyframework.core.model.ModelIdentifier
+import com.amplifyframework.core.model.ModelPage
 import com.amplifyframework.core.model.ModelPath
 import com.amplifyframework.core.model.ModelSchema
 import com.amplifyframework.core.model.PropertyContainerPath
@@ -190,21 +191,7 @@ object AppSyncGraphQLRequestFactory {
         }
     }
 
-    /**
-     * Creates a [GraphQLRequest] that represents a query for a single value, identified by a map of
-     * primary/sort key field names to values.
-     *
-     * This is the entry point used by lazy loading, where the identifying fields are already known as a
-     * map rather than as a [ModelIdentifier]. The variable types are resolved from the model schema.
-     *
-     * @param modelClass the model class.
-     * @param keyMap the primary index field names mapped to their values.
-     * @param <R> the response type.
-     * @param <T> the concrete model type.
-     * @return a valid [GraphQLRequest] instance.
-     * @throws AmplifyException when a schema cannot be generated for [modelClass].
-     * @throws IllegalStateException when the model schema does not contain the expected information.
-     </T></R> */
+    /** Builds a get query for the model identified by [keyMap], resolving variable types from the model schema. */
     @JvmStatic
     @InternalAmplifyApi
     fun <R, T : Model> buildQueryFromKeyMap(modelClass: Class<T>, keyMap: Map<String, Any>): GraphQLRequest<R> {
@@ -262,29 +249,22 @@ object AppSyncGraphQLRequestFactory {
         return buildListQueryInternal(modelClass, predicate, DEFAULT_QUERY_LIMIT, dataType, null)
     }
 
-    /**
-     * Creates a [GraphQLRequest] that represents a query for a single page of models.
-     *
-     * The page type is supplied by the caller rather than resolved here, so that this factory does not
-     * depend on the plugin's lazy-loading types.
-     *
-     * @param modelClass the model class.
-     * @param predicate the model predicate.
-     * @param pageType the parameterized type the response should be deserialized into.
-     * @param pageToken the token identifying the page to fetch, or null for the first page.
-     * @param <R> the response type.
-     * @param <T> the concrete model type.
-     * @return a valid [GraphQLRequest] instance.
-     * @throws IllegalStateException when the model schema does not contain the expected information.
-     </T></R> */
+    /** Builds a query for a single page of models, deserialized into [pageClass] parameterized with [modelClass]. */
     @JvmStatic
     @InternalAmplifyApi
     fun <R, T : Model> buildModelPageQuery(
         modelClass: Class<T>,
         predicate: QueryPredicate,
-        pageType: Type,
+        pageClass: Class<out ModelPage<*>>,
         pageToken: String?
-    ): GraphQLRequest<R> = buildListQueryInternal(modelClass, predicate, DEFAULT_QUERY_LIMIT, pageType, null, pageToken)
+    ): GraphQLRequest<R> = buildListQueryInternal(
+        modelClass,
+        predicate,
+        DEFAULT_QUERY_LIMIT,
+        TypeMaker.getParameterizedType(pageClass, modelClass),
+        null,
+        pageToken
+    )
 
     /**
      * Creates a [GraphQLRequest] that represents a query that expects multiple values as a result. The request

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryKeyMapTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncGraphQLRequestFactoryKeyMapTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.api.aws
+
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.core.model.temporal.Temporal
+import com.amplifyframework.testmodels.cpk.Post
+import com.amplifyframework.testmodels.lazy.Blog
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests [AppSyncGraphQLRequestFactory.buildQueryFromKeyMap], the request-building path used by
+ * lazy loading. Variable names and their GraphQL types are resolved from the model schema, so these
+ * tests pin that resolution for both a single-field and a composite primary key.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppSyncGraphQLRequestFactoryKeyMapTest {
+
+    @Test
+    fun `resolves a single primary key field from the model schema`() {
+        val request: GraphQLRequest<Blog> = AppSyncGraphQLRequestFactory.buildQueryFromKeyMap(
+            Blog::class.java,
+            mapOf("id" to "blog-1")
+        )
+
+        request.variables shouldBe mapOf("id" to "blog-1")
+        request.query shouldContain "\$id: ID!"
+        request.responseType shouldBe Blog::class.java
+    }
+
+    @Test
+    fun `resolves every field of a composite primary key with its schema type`() {
+        val createdAt = Temporal.DateTime("2026-01-01T00:00:00.000Z")
+        val keyMap = mapOf<String, Any>(
+            "postId" to "post-1",
+            "title" to "a title",
+            "createdAt" to createdAt,
+            "rating" to 4.5
+        )
+
+        val request: GraphQLRequest<Post> =
+            AppSyncGraphQLRequestFactory.buildQueryFromKeyMap(Post::class.java, keyMap)
+
+        request.variables shouldBe keyMap
+        // Types come from @ModelField targetType, and every key field on this model is required.
+        request.query shouldContain "\$postId: ID!"
+        request.query shouldContain "\$title: String!"
+        request.query shouldContain "\$createdAt: AWSDateTime!"
+        request.query shouldContain "\$rating: Float!"
+        request.responseType shouldBe Post::class.java
+    }
+
+    @Test
+    fun `builds the same request as the ModelIdentifier overload for a single key`() {
+        val fromKeyMap: GraphQLRequest<Blog> = AppSyncGraphQLRequestFactory.buildQueryFromKeyMap(
+            Blog::class.java,
+            mapOf("id" to "blog-1")
+        )
+        val fromObjectId: GraphQLRequest<Blog> =
+            AppSyncGraphQLRequestFactory.buildQuery(Blog::class.java, "blog-1")
+
+        fromKeyMap.query shouldBe fromObjectId.query
+        fromKeyMap.variables shouldBe fromObjectId.variables
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

No issue. PR 1 of 3 in Phase 1 of the V3 AppSync client work.

*Description of changes:*

### The goal behind it

The new V3 client needs customers to be able to write `client.query(ModelQuery.get(Todo::class.java, "id-123"))`. Today `ModelQuery` and its siblings live in `aws-api` — the old plugin module — and the new client deliberately does not depend on `aws-api`. So those helpers have to move into `aws-api-appsync`, a module both the old plugin and the new client can use.

That move is the follow-up PR. **This PR is what makes it possible.**

### The obstacle

The helpers cannot move on their own, because all three just delegate to `AppSyncGraphQLRequestFactory` — so the factory has to move too. And the factory was stuck.

Two of its methods were marked `internal`, which in Kotlin means "visible only inside this module". Both were called by the lazy-loading code, which has to *stay* in `aws-api` because it is plugin machinery. The moment the factory crosses the module boundary, those calls stop compiling.

One was worse than that. `buildModelPageQuery` referenced `ApiModelPage`, which lives in `aws-api` and cannot move either — it is declared alongside the lazy-loading runtime classes that use `Amplify.API` directly. So the factory needed a type from `aws-api`, and `aws-api` needed a method from the factory. Neither could leave first.

### How this PR solves it

It cuts those ties while leaving every file exactly where it is.

**Moved some duplicated logic into the factory.** The lazy-loading code had its own copy of the "work out the query variables from the model's schema" loop, which the factory already knew how to do. That is now `buildQueryFromKeyMap`, and the lazy code calls it. The useful side effect: the lazy code no longer mentions `GraphQLRequestVariable`, so that type is free to travel with the factory.

**A method became private.** Once the lazy code stopped calling `buildQueryInternal`, nothing outside the factory was using it — so it went from `internal` to `private`. Worth noting because it means this PR *reduces* cross-module surface rather than adding to it.

**Flipped who knows about the page type.** `buildModelPageQuery` no longer mentions `ApiModelPage`. The caller passes the page class and the factory parameterizes it with the model class. The factory now knows nothing whatsoever about lazy loading, and the circle is gone.

Both new entry points are `@InternalAmplifyApi`, which the binary compatibility validator excludes, so `apiCheck` passes with no `apiDump`.

### Why it is a separate PR

So the follow-up is boring. After this lands, moving those six files is a pure relocation — a reviewer can read that diff as "these files changed directory" instead of trying to spot a real behaviour change buried inside a thousand-line move. All the actual thinking is isolated here, in about 30 lines.

### What it does not change

Nothing customer-facing. No behaviour change and no public API change.

One subtlety is deliberate and worth not "fixing". `ModelSchema.fromModelClass` throws a plain `AmplifyException`, and the lazy-loading code has two different `catch` blocks that treat that differently from an `ApiException`. Making it match the factory's sibling overload, which wraps into an unchecked `IllegalStateException`, would silently change which handler fires — so `buildQueryFromKeyMap` intentionally lets it escape unwrapped.

*How did you test these changes?*

All tasks run with `--rerun-tasks`:

- `:aws-api:testDebugUnitTest` — **210 tests, 0 failures**, including the lazy-loading and factory suites that cover the touched paths: `ApiLazyModelListTest` (8), `ApiLazyModelReferenceTest` (6), `AppSyncGraphQLRequestFactoryTest` (16), `AppSyncGraphQLRequestAndResponseCPKTest` (13), `ModelQueryTest` (12), `ModelMutationTest` (10), `ModelSubscriptionTest` (8).
- New `AppSyncGraphQLRequestFactoryKeyMapTest` (3) covers `buildQueryFromKeyMap`, which is now the only request-building path lazy loading takes: a single-field primary key, a composite key asserting each schema-resolved GraphQL type, and equivalence with the `objectId` overload.
- `:aws-api:apiCheck` — passes unmodified, confirming no public API change.
- `:aws-api:ktlintCheck`, `:aws-api:checkstyle`, `:aws-datastore:compileDebugKotlin`, and `:aws-appsync:` compile / test / `apiCheck` / ktlint.

Note for anyone reproducing locally: `./gradlew :aws-api:build` fails at `:core:lintAnalyzeDebugAndroidTest` on a dangling gitignored symlink (`core/src/androidTest/res/raw/amplifyconfiguration.json` → `~/.aws-amplify/...`). It reproduces on the unmodified base branch with these changes stashed, so it is environmental and unrelated.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests — not applicable; internal refactor with no behaviour change
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
