### PR TITLE
fix(api): percent-encode semicolons in REST query parameter values

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/utils/RestRequestFactory.java
@@ -74,8 +74,19 @@ public final class RestRequestFactory {
         }
 
         try {
-            String encodedUrl = builder.build().url().toString();
-            return new URL(Uri.decode(encodedUrl));
+            String decodedUrl = Uri.decode(builder.build().url().toString());
+            // API Gateway treats an unencoded ';' in the query as a parameter delimiter
+            // and drops everything after it, so encode it explicitly (query only).
+            // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-known-issues.html
+            int queryStart = decodedUrl.indexOf('?');
+            if (queryStart >= 0) {
+                int fragmentStart = decodedUrl.indexOf('#', queryStart);
+                int queryEnd = fragmentStart < 0 ? decodedUrl.length() : fragmentStart;
+                decodedUrl = decodedUrl.substring(0, queryStart + 1)
+                    + decodedUrl.substring(queryStart + 1, queryEnd).replace(";", "%3B")
+                    + decodedUrl.substring(queryEnd);
+            }
+            return new URL(decodedUrl);
         } catch (MalformedURLException error) {
             throw new MalformedURLException(error.getMessage());
         }

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestQuerySemicolonEncodingTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestQuerySemicolonEncodingTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws.utils
+
+import com.amplifyframework.api.ApiException
+import com.amplifyframework.api.aws.operation.AWSRestOperation
+import com.amplifyframework.api.rest.HttpMethod
+import com.amplifyframework.api.rest.RestOperationRequest
+import com.amplifyframework.api.rest.RestResponse
+import com.amplifyframework.testutils.Await
+import io.kotest.matchers.shouldBe
+import java.io.IOException
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests that a `;` in a REST query parameter value is percent-encoded. API Gateway
+ * treats a raw `;` as a parameter delimiter and drops everything after it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RestQuerySemicolonEncodingTest {
+    private lateinit var server: MockWebServer
+    private lateinit var baseUrl: HttpUrl
+    private lateinit var client: OkHttpClient
+
+    /**
+     * Starts a mock web server to capture the outgoing request.
+     * @throws IOException On failure to start the server
+     */
+    @Before
+    @Throws(IOException::class)
+    fun setup() {
+        server = MockWebServer()
+        server.start()
+        baseUrl = server.url("/")
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        client = OkHttpClient()
+    }
+
+    /**
+     * Shuts down the mock web server.
+     * @throws IOException On failure to shut down the server
+     */
+    @After
+    @Throws(IOException::class)
+    fun cleanup() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `createURL percent-encodes a semicolon in a query value`() {
+        val url = RestRequestFactory.createURL(
+            "http://amplify-android.com",
+            "/path",
+            mapOf("filter" to "X;Y")
+        )
+        url.toString() shouldBe "http://amplify-android.com/path?filter=X%3BY"
+    }
+
+    @Test
+    fun `createURL preserves a pre-encoded semicolon in a query value`() {
+        val url = RestRequestFactory.createURL(
+            "http://amplify-android.com",
+            "/path",
+            mapOf("filter" to "X%3BY")
+        )
+        url.toString() shouldBe "http://amplify-android.com/path?filter=X%3BY"
+    }
+
+    @Test
+    fun `semicolon in a query value is percent-encoded on the wire`() {
+        val request = RestOperationRequest(HttpMethod.GET, "path", emptyMap(), mapOf("filter" to "X;Y"))
+        Await.result<RestResponse, ApiException> { onResult, onError ->
+            AWSRestOperation(request, baseUrl.toUrl().toString(), client, onResult, onError).start()
+        }
+        server.takeRequest().path shouldBe "/path?filter=X%3BY"
+    }
+}


### PR DESCRIPTION
## Description

`RestRequestFactory` builds the URL then `Uri.decode`s it, and OkHttp leaves `;` unencoded. API Gateway treats a raw `;` as a query delimiter, so a value like `"X;Y"` was truncated to `"X"`. This encodes `;` to `%3B` in the query so the value arrives intact.

Android counterpart of the Swift fix aws-amplify/amplify-swift#4274; raised after @thisisabhash flagged the same gap on Android during that review.

## Testing

- Regression tests (raw and pre-encoded `;`) on the built URL and on the wire via MockWebServer; all fail without the change.
- aws-api unit suite 210/210; `ktlintCheck`/`checkstyle`/`apiCheck` clean.
- Integration tests not run locally (need a provisioned AWS backend).
