### PR TITLE
fix(auth): recover device metadata keyed by a pre-2.30.3 username

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthEnvironment.kt
@@ -106,12 +106,40 @@ internal class AuthEnvironment internal constructor(
         return userContextDataProvider?.getEncodedContextData(username, deviceId)
     }
 
-    suspend fun getDeviceMetadata(username: String): DeviceMetadata.Metadata? {
-        var deviceCredentials =
+    /**
+     * Loads device metadata for [username].
+     *
+     * SDK versions <= 2.30.2 keyed device metadata by the value the user typed at sign-in (an alias
+     * such as an email) rather than by the Cognito username. On those installs the metadata is
+     * unreachable under the current key, so the DeviceKey is omitted from refresh and Cognito
+     * rejects it with "Invalid Refresh Token.". [legacyUsernames] are alias values taken from the
+     * user's own tokens; the first match is migrated to [username] so this happens at most once.
+     */
+    suspend fun getDeviceMetadata(
+        username: String,
+        legacyUsernames: List<String> = emptyList()
+    ): DeviceMetadata.Metadata? {
+        loadDeviceMetadata(username)?.let { return it }
+
+        for (legacyUsername in legacyUsernames.filter { it != username }) {
+            val legacyMetadata = loadDeviceMetadata(legacyUsername) ?: continue
+            logger.info("Migrating device metadata stored by an earlier SDK version.")
+            credentialStoreClient.storeCredentials(
+                CredentialType.Device(username),
+                AmplifyCredential.DeviceData(legacyMetadata)
+            )
+            credentialStoreClient.clearCredentials(CredentialType.Device(legacyUsername))
+            return legacyMetadata
+        }
+        return null
+    }
+
+    private suspend fun loadDeviceMetadata(username: String): DeviceMetadata.Metadata? {
+        val deviceCredentials =
             credentialStoreClient.loadCredentials(CredentialType.Device(username)) as? AmplifyCredential.DeviceData
         if (deviceCredentials == null) {
             logger.warn("loadCredentials returned unexpected AmplifyCredential Type.")
-            deviceCredentials = AmplifyCredential.DeviceData(DeviceMetadata.Empty)
+            return null
         }
         return deviceCredentials.deviceMetadata as? DeviceMetadata.Metadata
     }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
@@ -44,7 +44,9 @@ internal object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
             val evt = try {
                 val username = signedInData.username
                 val tokens = signedInData.cognitoUserPoolTokens
-                val deviceMetadata: DeviceMetadata.Metadata? = getDeviceMetadata(username)
+                // Alias candidates let us recover device metadata keyed by an older SDK version.
+                val deviceMetadata: DeviceMetadata.Metadata? =
+                    getDeviceMetadata(username, tokens.idToken?.signInAliases ?: emptyList())
 
                 val response = cognitoAuthService.cognitoIdentityProviderClient?.getTokensFromRefreshToken {
                     refreshToken = tokens.refreshToken?.tokenValue

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/Tokens.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/Tokens.kt
@@ -76,7 +76,10 @@ internal abstract class Jwt {
         UserSub("sub"),
         Username("username"), // username claim in the access token
         TokenRevocationId("origin_jti"),
-        CognitoUsername("cognito:username") // username claim in the identity token
+        CognitoUsername("cognito:username"), // username claim in the identity token
+        Email("email"),
+        PhoneNumber("phone_number"),
+        PreferredUsername("preferred_username")
     }
 }
 
@@ -87,6 +90,19 @@ internal class IdToken(override val tokenValue: String) : Jwt() {
         get() = getClaim(Claim.UserSub)
     val username: String?
         get() = getClaim(Claim.CognitoUsername)
+
+    // Sign-in aliases. Used to locate device metadata written by older SDK versions, which keyed it
+    // by the value the user typed at sign-in rather than by the Cognito username. Never throws: a
+    // token we cannot parse simply yields no candidates.
+    val signInAliases: List<String>
+        get() = runCatching {
+            listOfNotNull(
+                getClaim(Claim.Email),
+                getClaim(Claim.PhoneNumber),
+                getClaim(Claim.PreferredUsername)
+            )
+        }.getOrDefault(emptyList())
+
     val expiration: Instant? by lazy {
         getClaim(Claim.Expiration)?.let { Instant.ofEpochSecond(it.toLong()) }
     }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthEnvironmentDeviceMetadataTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthEnvironmentDeviceMetadataTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito
+
+import android.content.Context
+import com.amplifyframework.logging.Logger
+import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
+import com.amplifyframework.statemachine.codegen.data.CredentialType
+import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AuthEnvironmentDeviceMetadataTest {
+
+    private val credentialStoreClient = mockk<StoreClientBehavior>(relaxed = true)
+    private val logger = mockk<Logger>(relaxed = true)
+
+    private val username = "0f9a6b1c-uuid"
+    private val email = "user@example.com"
+    private val metadata = DeviceMetadata.Metadata("device-key", "device-group-key", "device-secret")
+
+    private val environment = AuthEnvironment(
+        mockk<Context>(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        credentialStoreClient,
+        null,
+        null,
+        logger
+    )
+
+    private fun storeContains(vararg entries: Pair<String, DeviceMetadata>) {
+        val byUsername = entries.toMap()
+        coEvery { credentialStoreClient.loadCredentials(any()) } answers {
+            val requested = (firstArg<CredentialType>() as CredentialType.Device).username
+            AmplifyCredential.DeviceData(byUsername[requested] ?: DeviceMetadata.Empty)
+        }
+    }
+
+    @Test
+    fun `returns metadata stored under the current username`() = runTest {
+        storeContains(username to metadata)
+
+        environment.getDeviceMetadata(username, listOf(email)) shouldBe metadata
+    }
+
+    @Test
+    fun `returns null when no metadata is stored under any key`() = runTest {
+        storeContains()
+
+        environment.getDeviceMetadata(username, listOf(email)) shouldBe null
+    }
+
+    @Test
+    fun `falls back to metadata stored under a legacy alias key`() = runTest {
+        storeContains(email to metadata)
+
+        environment.getDeviceMetadata(username, listOf(email)) shouldBe metadata
+    }
+
+    @Test
+    fun `migrates legacy metadata to the current username and clears the legacy entry`() = runTest {
+        storeContains(email to metadata)
+
+        environment.getDeviceMetadata(username, listOf(email))
+
+        coVerify {
+            credentialStoreClient.storeCredentials(
+                CredentialType.Device(username),
+                AmplifyCredential.DeviceData(metadata)
+            )
+            credentialStoreClient.clearCredentials(CredentialType.Device(email))
+        }
+    }
+
+    @Test
+    fun `does not migrate when metadata already exists under the current username`() = runTest {
+        storeContains(username to metadata, email to metadata)
+
+        environment.getDeviceMetadata(username, listOf(email))
+
+        coVerify(exactly = 0) { credentialStoreClient.storeCredentials(any(), any()) }
+        coVerify(exactly = 0) { credentialStoreClient.clearCredentials(any()) }
+    }
+
+    @Test
+    fun `does not consult the store twice when the alias equals the current username`() = runTest {
+        storeContains()
+
+        environment.getDeviceMetadata(username, listOf(username)) shouldBe null
+
+        coVerify(exactly = 1) { credentialStoreClient.loadCredentials(CredentialType.Device(username)) }
+    }
+
+    @Test
+    fun `no legacy candidates behaves like a plain lookup`() = runTest {
+        storeContains(email to metadata)
+
+        environment.getDeviceMetadata(username) shouldBe null
+    }
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/codegen/data/IdTokenSignInAliasesTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/codegen/data/IdTokenSignInAliasesTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.statemachine.codegen.data
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.util.Base64
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class IdTokenSignInAliasesTest {
+
+    private fun idTokenWith(claims: Map<String, String>): IdToken {
+        val payload = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(JSONObject(claims).toString().toByteArray())
+        return IdToken("header.$payload.signature")
+    }
+
+    @Test
+    fun `returns email phone and preferred username`() {
+        val token = idTokenWith(
+            mapOf(
+                "email" to "user@example.com",
+                "phone_number" to "+15550100",
+                "preferred_username" to "alias-name"
+            )
+        )
+
+        token.signInAliases shouldContainExactly listOf("user@example.com", "+15550100", "alias-name")
+    }
+
+    @Test
+    fun `omits absent claims`() {
+        val token = idTokenWith(mapOf("email" to "user@example.com"))
+
+        token.signInAliases shouldContainExactly listOf("user@example.com")
+    }
+
+    @Test
+    fun `returns empty list when no alias claims are present`() {
+        idTokenWith(mapOf("sub" to "abc")).signInAliases shouldBe emptyList()
+    }
+
+    @Test
+    fun `returns empty list for an unparseable token instead of throwing`() {
+        IdToken("not-a-jwt").signInAliases shouldBe emptyList()
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* n/a

*Description of changes:*

Device metadata was keyed in the credential store by the value typed at sign-in until 2.30.2, and by the Cognito username from 2.30.3 onward (#3149). On a device-tracking pool where users sign in with an alias (e.g. an email), upgrading an app across that boundary orphans the stored entry: the refresh path looks it up under the Cognito username, misses, omits `DeviceKey`, and Cognito rejects the call with `NotAuthorizedException: Invalid Refresh Token.` That surfaces as `SessionExpiredException`, so every affected user is signed out once and has to re-authenticate.

On a lookup miss, the refresh path now retries the alias values from the user's own id token (`email`, `phone_number`, `preferred_username`), migrates the entry to the canonical key and clears the stale one. Affected installs self-heal on their next refresh. Alias values come from the user's own token, so a migrated entry always belongs to that user. `signInAliases` never throws, so a token that cannot be parsed simply yields no candidates and refresh behaves as before.

*How did you test these changes?*

- 11 new unit tests (`AuthEnvironmentDeviceMetadataTest`, `IdTokenSignInAliasesTest`); full `:aws-auth-cognito:testDebugUnitTest` suite green (551 tests), plus `ktlintCheck` and `apiCheck`.
- On an emulator against a device-tracking user pool, with an identical pre-upgrade state (sign in on 2.30.0 + one refresh): an in-place upgrade to unpatched `main` fails the next refresh with `Invalid Refresh Token.`, while the patched build succeeds and logs the migration once. Two further refreshes also succeed, confirming the migration persisted.
- Regression checks: clean install is unaffected (no migration, refreshes succeed), and a genuinely forgotten device still fails with `Invalid Refresh Token.` — the fallback does not mask real device-binding failures.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
