### PR TITLE
chore: add cloudwatch client integration tests

### DIFF
--- a/aws-cloudwatch/build.gradle.kts
+++ b/aws-cloudwatch/build.gradle.kts
@@ -22,13 +22,6 @@ apply(from = rootProject.file("configuration/checkstyle.gradle"))
 
 android {
     namespace = "com.amplifyframework.cloudwatch"
-
-    // Persist app data across connected test methods so the client's integration tests keep a stable device
-    // id and write to a single CloudWatch stream (one per test otherwise). Overrides the shared convention's
-    // clearPackageData=true; the module's own DB instrumentation test self-cleans in @After.
-    defaultConfig {
-        testInstrumentationRunnerArguments["clearPackageData"] = "false"
-    }
 }
 
 dependencies {

--- a/aws-cloudwatch/build.gradle.kts
+++ b/aws-cloudwatch/build.gradle.kts
@@ -22,6 +22,13 @@ apply(from = rootProject.file("configuration/checkstyle.gradle"))
 
 android {
     namespace = "com.amplifyframework.cloudwatch"
+
+    // Persist app data across connected test methods so the client's integration tests keep a stable device
+    // id and write to a single CloudWatch stream (one per test otherwise). Overrides the shared convention's
+    // clearPackageData=true; the module's own DB instrumentation test self-cleans in @After.
+    defaultConfig {
+        testInstrumentationRunnerArguments["clearPackageData"] = "false"
+    }
 }
 
 dependencies {
@@ -44,4 +51,8 @@ dependencies {
 
     androidTestImplementation(libs.bundles.test.android)
     androidTestImplementation(project(":testutils"))
+    // Integration tests obtain guest AWS credentials via Cognito (identity pool) and Amplify.configure.
+    androidTestImplementation(project(":core"))
+    androidTestImplementation(project(":aws-core"))
+    androidTestImplementation(project(":aws-auth-cognito"))
 }

--- a/aws-cloudwatch/infra/README.md
+++ b/aws-cloudwatch/infra/README.md
@@ -1,0 +1,148 @@
+# CloudWatch Client E2E Test Infrastructure
+
+Instructions for deploying the backend used by the `aws-cloudwatch` integration tests
+(`AmplifyCloudWatchClientInstrumentationTest`).
+
+The infrastructure is not committed to the repo — deploy it from a scratch folder using the snippets
+below. The tests obtain **guest (unauthenticated)** AWS credentials from the provisioned Cognito
+identity pool, so no test user is required.
+
+## Part 1: Deploy the Backend
+
+From a new folder outside this repo, run `npm create amplify@latest`, then replace the generated files
+with the content below.
+
+**amplify/auth/resource.ts**
+
+```ts
+import { defineAuth } from '@aws-amplify/backend';
+
+/**
+ * Define and configure your auth resource
+ * @see https://docs.amplify.aws/gen2/build-a-backend/auth
+ */
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+  },
+});
+```
+
+**amplify/custom/LoggingConstruct/resource.ts**
+
+```ts
+import * as cdk from "aws-cdk-lib"
+import { Construct } from "constructs"
+import * as logs from "aws-cdk-lib/aws-logs"
+import * as iam from "aws-cdk-lib/aws-iam"
+
+export class LoggingConstruct extends Construct {
+  constructor(scope: Construct, id: string, authRoleName: string, unAuthRoleName: string) {
+    super(scope, id)
+
+    const region = cdk.Stack.of(this).region
+    const account = cdk.Stack.of(this).account
+    const logGroupName = "cloudwatch-integration-test-log-group"
+
+    new logs.LogGroup(this, 'Log Group', {
+      logGroupName: logGroupName,
+      retention: logs.RetentionDays.INFINITE
+    })
+
+    const authRole = iam.Role.fromRoleName(this, "Auth-Role", authRoleName)
+    const unAuthRole = iam.Role.fromRoleName(this, "UnAuth-Role", unAuthRoleName)
+    const logResource = `arn:aws:logs:${region}:${account}:log-group:${logGroupName}:log-stream:*`
+    const logIAMPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      resources: [logResource],
+      actions: ["logs:PutLogEvents", "logs:DescribeLogStreams", "logs:CreateLogStream", "logs:FilterLogEvents"]
+    })
+
+    authRole.addToPrincipalPolicy(logIAMPolicy)
+    unAuthRole.addToPrincipalPolicy(logIAMPolicy)
+
+    new cdk.CfnOutput(this, 'CloudWatchLogGroupName', { value: logGroupName });
+    new cdk.CfnOutput(this, 'CloudWatchRegion', { value: region });
+  }
+}
+```
+
+> The test verifies delivery with `FilterLogEvents`, so the policy grants `logs:FilterLogEvents` in
+> addition to the put/describe/create actions the client uses.
+
+**amplify/backend.ts**
+
+```ts
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource';
+import { LoggingConstruct } from './custom/LoggingConstruct/resource';
+
+const backend = defineBackend({
+  auth,
+});
+
+// Auth - sign in with username
+const { cfnUserPool } = backend.auth.resources.cfnResources
+cfnUserPool.usernameAttributes = []
+
+// ============ Logging Stack ===========
+
+new LoggingConstruct(
+  backend.createStack('logging-stack'),
+  'logging-stack',
+  backend.auth.resources.authenticatedUserIamRole.roleName,
+  backend.auth.resources.unauthenticatedUserIamRole.roleName
+);
+```
+
+Deploy with Amplify sandbox:
+
+```bash
+npx ampx sandbox --profile [YOUR_AWS_PROFILE]
+```
+
+This creates:
+- Cognito User Pool + Identity Pool (guest access enabled)
+- CloudWatch log group `cloudwatch-integration-test-log-group`
+- IAM policies granting both the authenticated and unauthenticated roles the CloudWatch Logs actions
+  the tests need
+
+Deployment generates an `amplify_outputs.json` file.
+
+## Part 2: Copy Configuration Files
+
+The tests load two files from `aws-cloudwatch/src/androidTest/res/raw/` (both untracked — supply them
+at test time):
+
+1. Copy the generated Auth config into place:
+
+```bash
+cp amplify_outputs.json \
+  aws-cloudwatch/src/androidTest/res/raw/amplify_outputs.json
+```
+
+2. Create the client configuration file. Set `region` to where the backend was deployed:
+
+```bash
+cat > aws-cloudwatch/src/androidTest/res/raw/amplifyconfiguration_logging.json << 'EOF'
+{
+    "cloudWatchClient": {
+        "region": "<your-region>",
+        "logGroupName": "cloudwatch-integration-test-log-group",
+        "localStoreMaxSizeInMB": 1,
+        "flushIntervalInSeconds": 60,
+        "loggingConstraints": {
+            "defaultLogLevel": "VERBOSE"
+        }
+    }
+}
+EOF
+```
+
+## Part 3: Run the Tests
+
+Run the instrumentation tests against a connected device or emulator:
+
+```bash
+./gradlew :aws-cloudwatch:connectedAndroidTest
+```

--- a/aws-cloudwatch/src/androidTest/kotlin/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientInstrumentationTest.kt
+++ b/aws-cloudwatch/src/androidTest/kotlin/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientInstrumentationTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+@file:OptIn(ExperimentalAmplifyApi::class)
+
+package com.amplifyframework.cloudwatch
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import aws.sdk.kotlin.services.cloudwatchlogs.model.FilterLogEventsRequest
+import com.amplifyframework.annotations.ExperimentalAmplifyApi
+import com.amplifyframework.auth.CognitoCredentialsProvider
+import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
+import com.amplifyframework.cloudwatch.test.R
+import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.configuration.AmplifyOutputs
+import com.amplifyframework.foundation.credentials.AwsCredentials
+import com.amplifyframework.foundation.credentials.AwsCredentialsProvider
+import com.amplifyframework.foundation.credentials.toAwsCredentialsProvider
+import com.amplifyframework.foundation.logging.LogLevel
+import com.amplifyframework.foundation.logging.LogMessage
+import com.amplifyframework.testutils.DeviceFarmTestBase
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldContain
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+
+// Give the async on-device write a moment to land before the first flush.
+private const val SAVE_WAIT_MS = 2_000L
+
+// CloudWatch ingestion is eventually consistent; poll with a re-flush between attempts.
+private const val INGEST_WAIT_MS = 20_000L
+private const val MAX_FLUSH_ATTEMPTS = 6
+
+/**
+ * Integration tests for [AmplifyCloudWatchClient] against a real CloudWatch Logs backend.
+ *
+ * Ported from the Amplify Swift `CloudWatchLoggingClientIntegrationTests`, and structured like the
+ * `:aws-kinesis` client instrumentation tests. Credentials come from the provisioned backend's
+ * Cognito identity pool (guest access — no sign-in required).
+ *
+ * Backend config is supplied at test time (not committed) under `src/androidTest/res/raw/`:
+ * - `amplify_outputs.json` — Auth (Cognito user pool + identity pool)
+ * - `amplifyconfiguration_logging.json` — `{ "cloudWatchClient": { region, logGroupName, ... } }`
+ *
+ * The target log group must be provisioned in the test account.
+ */
+@RunWith(AndroidJUnit4::class)
+class AmplifyCloudWatchClientInstrumentationTest : DeviceFarmTestBase() {
+
+    companion object {
+        private lateinit var credentialsProvider: AwsCredentialsProvider<AwsCredentials>
+        private lateinit var testRegion: String
+        private lateinit var testLogGroupName: String
+        private var testLocalStoreMaxSizeInMB: Int = 1
+        private var testFlushIntervalInSeconds: Long = 60
+        private lateinit var testDefaultLogLevel: LogLevel
+        private var configured = false
+
+        @BeforeClass
+        @JvmStatic
+        fun setUpClass() {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            if (!configured) {
+                Amplify.Auth.addPlugin(AWSCognitoAuthPlugin())
+                Amplify.configure(AmplifyOutputs(R.raw.amplify_outputs), context)
+                configured = true
+            }
+            credentialsProvider = CognitoCredentialsProvider().toAwsCredentialsProvider()
+
+            val json = context.resources.openRawResource(R.raw.amplifyconfiguration_logging)
+                .bufferedReader().use { it.readText() }
+            val config = JSONObject(json).getJSONObject("cloudWatchClient")
+            testRegion = config.getString("region")
+            testLogGroupName = config.getString("logGroupName")
+            testLocalStoreMaxSizeInMB = config.getInt("localStoreMaxSizeInMB")
+            testFlushIntervalInSeconds = config.getLong("flushIntervalInSeconds")
+            testDefaultLogLevel = logLevelOf(config.getJSONObject("loggingConstraints").getString("defaultLogLevel"))
+        }
+
+        // Config stores levels as e.g. "VERBOSE"; map to the LogLevel enum ("Verbose", "Error", ...).
+        private fun logLevelOf(value: String): LogLevel =
+            LogLevel.valueOf(value.lowercase().replaceFirstChar { it.uppercase() })
+    }
+
+    private lateinit var client: AmplifyCloudWatchClient
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        client = AmplifyCloudWatchClient(
+            context = context,
+            region = testRegion,
+            credentialsProvider = credentialsProvider,
+            options = AmplifyCloudWatchClientOptions {
+                logGroupName = testLogGroupName
+                localStoreMaxSizeInMB = testLocalStoreMaxSizeInMB
+                flushStrategy = FlushStrategy.Interval(testFlushIntervalInSeconds.seconds)
+                loggingConstraints = LoggingConstraints(defaultLogLevel = testDefaultLogLevel)
+            }
+        )
+    }
+
+    /** The escape hatch exposes the underlying AWS CloudWatch Logs client. */
+    @Test
+    fun testGetEscapeHatch() {
+        client.getCloudWatchLogsClient().shouldNotBeNull()
+    }
+
+    /** Emitted messages are flushed to CloudWatch and appear in the log group. */
+    @Test
+    fun testFlushLogWithMessages(): Unit = runBlocking {
+        val namespace = UUID.randomUUID().toString()
+        val message = "this is an error message in the integration test ${System.currentTimeMillis()}"
+
+        client.emit(LogMessage(LogLevel.Error, namespace, message, null))
+        client.emit(LogMessage(LogLevel.Debug, namespace, message, null))
+        client.emit(LogMessage(LogLevel.Warn, namespace, message, null))
+        client.emit(LogMessage(LogLevel.Info, namespace, message, null))
+        delay(SAVE_WAIT_MS)
+
+        val events = awaitEvents(message, expectedCount = 4)
+
+        events shouldHaveSize 4
+        events.forEach { event ->
+            event shouldContain message
+            event shouldContain namespace
+        }
+    }
+
+    /** A verbose message emitted while enabled is flushed to CloudWatch. */
+    @Test
+    fun testFlushLogWithVerboseMessageAfterEnabling(): Unit = runBlocking {
+        val namespace = UUID.randomUUID().toString()
+        val message = "this is a verbose message after enabling ${System.currentTimeMillis()}"
+
+        client.enable()
+        client.emit(LogMessage(LogLevel.Verbose, namespace, message, null))
+        delay(SAVE_WAIT_MS)
+
+        val events = awaitEvents(message, expectedCount = 1)
+
+        events shouldHaveSize 1
+        events.first().lowercase() shouldContain "verbose"
+        events.first() shouldContain message
+        events.first() shouldContain namespace
+    }
+
+    /** A verbose message emitted while disabled is dropped and never reaches CloudWatch. */
+    @Test
+    fun testFlushLogWithVerboseMessageAfterDisabling(): Unit = runBlocking {
+        val namespace = UUID.randomUUID().toString()
+        val message = "this is a verbose message after disabling ${System.currentTimeMillis()}"
+
+        client.disable()
+        client.emit(LogMessage(LogLevel.Verbose, namespace, message, null))
+        delay(SAVE_WAIT_MS)
+
+        awaitEvents(message, expectedCount = 0).shouldBeEmpty()
+    }
+
+    // region helpers
+
+    /**
+     * Flushes and polls CloudWatch until at least [expectedCount] events matching [message] are found
+     * (or attempts are exhausted). For [expectedCount] == 0 a single poll after one flush is enough.
+     */
+    private suspend fun awaitEvents(message: String, expectedCount: Int): List<String> {
+        var events = emptyList<String>()
+        repeat(MAX_FLUSH_ATTEMPTS) { attempt ->
+            client.flushLogs()
+            delay(INGEST_WAIT_MS)
+            events = filterEvents(message, windowMinutes = attempt + 2)
+            if (events.size >= expectedCount) return events
+        }
+        return events
+    }
+
+    /** Returns the messages of CloudWatch log events matching [message] within the last [windowMinutes]. */
+    private suspend fun filterEvents(message: String, windowMinutes: Int): List<String> {
+        val group = testLogGroupName
+        val end = System.currentTimeMillis()
+        val start = end - windowMinutes * 60_000L
+        val response = client.getCloudWatchLogsClient().filterLogEvents(
+            FilterLogEventsRequest {
+                logGroupName = group
+                filterPattern = "\"$message\""
+                startTime = start
+                endTime = end
+            }
+        )
+        return response.events?.mapNotNull { it.message } ?: emptyList()
+    }
+
+    // endregion
+}

--- a/aws-cloudwatch/src/androidTest/kotlin/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientInstrumentationTest.kt
+++ b/aws-cloudwatch/src/androidTest/kotlin/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientInstrumentationTest.kt
@@ -23,8 +23,8 @@ import aws.sdk.kotlin.services.cloudwatchlogs.model.FilterLogEventsRequest
 import com.amplifyframework.annotations.ExperimentalAmplifyApi
 import com.amplifyframework.auth.CognitoCredentialsProvider
 import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
-import com.amplifyframework.cloudwatch.test.R
 import com.amplifyframework.core.Amplify
+import com.amplifyframework.core.Resources
 import com.amplifyframework.core.configuration.AmplifyOutputs
 import com.amplifyframework.foundation.credentials.AwsCredentials
 import com.amplifyframework.foundation.credentials.AwsCredentialsProvider
@@ -32,15 +32,16 @@ import com.amplifyframework.foundation.credentials.toAwsCredentialsProvider
 import com.amplifyframework.foundation.logging.LogLevel
 import com.amplifyframework.foundation.logging.LogMessage
 import com.amplifyframework.testutils.DeviceFarmTestBase
+import com.amplifyframework.testutils.assertions.shouldBeSuccess
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
 import java.util.UUID
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.json.JSONObject
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -73,53 +74,35 @@ class AmplifyCloudWatchClientInstrumentationTest : DeviceFarmTestBase() {
         private lateinit var credentialsProvider: AwsCredentialsProvider<AwsCredentials>
         private lateinit var testRegion: String
         private lateinit var testLogGroupName: String
-        private var testLocalStoreMaxSizeInMB: Int = 1
-        private var testFlushIntervalInSeconds: Long = 60
-        private lateinit var testDefaultLogLevel: LogLevel
-        private var configured = false
 
         @BeforeClass
         @JvmStatic
         fun setUpClass() {
             val context = ApplicationProvider.getApplicationContext<Context>()
-            if (!configured) {
-                Amplify.Auth.addPlugin(AWSCognitoAuthPlugin())
-                Amplify.configure(AmplifyOutputs(R.raw.amplify_outputs), context)
-                configured = true
-            }
+            Amplify.Auth.addPlugin(AWSCognitoAuthPlugin())
+            Amplify.configure(
+                AmplifyOutputs(Resources.getRawResourceId(context, "amplify_outputs")),
+                context
+            )
             credentialsProvider = CognitoCredentialsProvider().toAwsCredentialsProvider()
 
-            val json = context.resources.openRawResource(R.raw.amplifyconfiguration_logging)
-                .bufferedReader().use { it.readText() }
-            val config = JSONObject(json).getJSONObject("cloudWatchClient")
+            val config = Resources.readJsonResource(context, "amplifyconfiguration_logging")
+                .getJSONObject("cloudWatchClient")
             testRegion = config.getString("region")
             testLogGroupName = config.getString("logGroupName")
-            testLocalStoreMaxSizeInMB = config.getInt("localStoreMaxSizeInMB")
-            testFlushIntervalInSeconds = config.getLong("flushIntervalInSeconds")
-            testDefaultLogLevel = logLevelOf(config.getJSONObject("loggingConstraints").getString("defaultLogLevel"))
         }
-
-        // Config stores levels as e.g. "VERBOSE"; map to the LogLevel enum ("Verbose", "Error", ...).
-        private fun logLevelOf(value: String): LogLevel =
-            LogLevel.valueOf(value.lowercase().replaceFirstChar { it.uppercase() })
     }
 
     private lateinit var client: AmplifyCloudWatchClient
 
     @Before
     fun setUp() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        client = AmplifyCloudWatchClient(
-            context = context,
-            region = testRegion,
-            credentialsProvider = credentialsProvider,
-            options = AmplifyCloudWatchClientOptions {
-                logGroupName = testLogGroupName
-                localStoreMaxSizeInMB = testLocalStoreMaxSizeInMB
-                flushStrategy = FlushStrategy.Interval(testFlushIntervalInSeconds.seconds)
-                loggingConstraints = LoggingConstraints(defaultLogLevel = testDefaultLogLevel)
-            }
-        )
+        client = newClient()
+    }
+
+    @After
+    fun tearDown() {
+        client.disable()
     }
 
     /** The escape hatch exposes the underlying AWS CloudWatch Logs client. */
@@ -128,23 +111,23 @@ class AmplifyCloudWatchClientInstrumentationTest : DeviceFarmTestBase() {
         client.getCloudWatchLogsClient().shouldNotBeNull()
     }
 
-    /** Emitted messages are flushed to CloudWatch and appear in the log group. */
+    /** Emitted messages at each level are flushed to CloudWatch and appear in the log group. */
     @Test
     fun testFlushLogWithMessages(): Unit = runBlocking {
         val namespace = UUID.randomUUID().toString()
-        val message = "this is an error message in the integration test ${System.currentTimeMillis()}"
-
-        client.emit(LogMessage(LogLevel.Error, namespace, message, null))
-        client.emit(LogMessage(LogLevel.Debug, namespace, message, null))
-        client.emit(LogMessage(LogLevel.Warn, namespace, message, null))
-        client.emit(LogMessage(LogLevel.Info, namespace, message, null))
+        val marker = "flush test ${System.currentTimeMillis()}"
+        // A distinct payload per level so filterLogEvents returns a stable set (not one message x4).
+        val levels = listOf(LogLevel.Error, LogLevel.Debug, LogLevel.Warn, LogLevel.Info)
+        levels.forEach { level ->
+            client.emit(LogMessage(level, namespace, "$marker/$level", null))
+        }
         delay(SAVE_WAIT_MS)
 
-        val events = awaitEvents(message, expectedCount = 4)
+        val events = awaitEvents(marker, expectedCount = levels.size)
 
-        events shouldHaveSize 4
+        events shouldHaveSize levels.size
         events.forEach { event ->
-            event shouldContain message
+            event shouldContain marker
             event shouldContain namespace
         }
     }
@@ -153,7 +136,7 @@ class AmplifyCloudWatchClientInstrumentationTest : DeviceFarmTestBase() {
     @Test
     fun testFlushLogWithVerboseMessageAfterEnabling(): Unit = runBlocking {
         val namespace = UUID.randomUUID().toString()
-        val message = "this is a verbose message after enabling ${System.currentTimeMillis()}"
+        val message = "verbose message after enabling ${System.currentTimeMillis()}"
 
         client.enable()
         client.emit(LogMessage(LogLevel.Verbose, namespace, message, null))
@@ -162,34 +145,67 @@ class AmplifyCloudWatchClientInstrumentationTest : DeviceFarmTestBase() {
         val events = awaitEvents(message, expectedCount = 1)
 
         events shouldHaveSize 1
-        events.first().lowercase() shouldContain "verbose"
+        // The emit format is "$level/$name: $content"; matching the prefix confirms we captured this
+        // exact level, not just any message that happened to include the word "verbose" in its body.
+        events.first() shouldStartWith "verbose/$namespace: "
         events.first() shouldContain message
-        events.first() shouldContain namespace
     }
 
-    /** A verbose message emitted while disabled is dropped and never reaches CloudWatch. */
+    /**
+     * A verbose message emitted while disabled is dropped and never reaches CloudWatch.
+     *
+     * Uses a positive control emitted on the same client BEFORE `disable()` — this proves the flush
+     * pipeline actually works, so the negative assertion below has teeth. Without the control, a
+     * broken client that never emitted anything would pass this test vacuously.
+     */
     @Test
     fun testFlushLogWithVerboseMessageAfterDisabling(): Unit = runBlocking {
         val namespace = UUID.randomUUID().toString()
-        val message = "this is a verbose message after disabling ${System.currentTimeMillis()}"
+        val timestamp = System.currentTimeMillis()
+        val controlMessage = "positive-control error before disable $timestamp"
+        val disabledMessage = "verbose message after disabling $timestamp"
 
-        client.disable()
-        client.emit(LogMessage(LogLevel.Verbose, namespace, message, null))
+        // Positive control: emitted while enabled, must land in CloudWatch.
+        client.emit(LogMessage(LogLevel.Error, namespace, controlMessage, null))
         delay(SAVE_WAIT_MS)
+        awaitEvents(controlMessage, expectedCount = 1) shouldHaveSize 1
 
-        awaitEvents(message, expectedCount = 0).shouldBeEmpty()
+        // Negative case: emit while disabled, flush, and confirm nothing lands.
+        client.disable()
+        client.emit(LogMessage(LogLevel.Verbose, namespace, disabledMessage, null))
+        delay(SAVE_WAIT_MS)
+        client.flushLogs().shouldBeSuccess()
+        delay(INGEST_WAIT_MS)
+
+        filterEvents(disabledMessage, windowMinutes = 3).shouldBeEmpty()
     }
 
     // region helpers
 
+    private fun newClient(): AmplifyCloudWatchClient = AmplifyCloudWatchClient(
+        context = ApplicationProvider.getApplicationContext<Context>(),
+        region = testRegion,
+        credentialsProvider = credentialsProvider,
+        options = AmplifyCloudWatchClientOptions {
+            logGroupName = testLogGroupName
+            // Manual flush only — matches the kinesis integration tests; avoids the interval auto-flush
+            // racing the explicit flushes below.
+            flushStrategy = FlushStrategy.None
+            // Test-only baseline: capture everything (config's default level is unrelated to what
+            // this suite exercises).
+            loggingConstraints = LoggingConstraints(defaultLogLevel = LogLevel.Verbose)
+        }
+    )
+
     /**
      * Flushes and polls CloudWatch until at least [expectedCount] events matching [message] are found
-     * (or attempts are exhausted). For [expectedCount] == 0 a single poll after one flush is enough.
+     * (or attempts are exhausted). Each flush result is asserted to be a success so a broken flush
+     * pipeline can't silently return an empty event list.
      */
     private suspend fun awaitEvents(message: String, expectedCount: Int): List<String> {
         var events = emptyList<String>()
         repeat(MAX_FLUSH_ATTEMPTS) { attempt ->
-            client.flushLogs()
+            client.flushLogs().shouldBeSuccess()
             delay(INGEST_WAIT_MS)
             events = filterEvents(message, windowMinutes = attempt + 2)
             if (events.size >= expectedCount) return events


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

N/A

*Description of changes:*

Adds connected integration tests for the standalone v3 CloudWatch client (`AmplifyCloudWatchClient`), structured after the `:aws-kinesis` client's instrumentation tests. (Stacked on the client implementation — this PR is only the tests.)

- `AmplifyCloudWatchClientInstrumentationTest` (`:aws-cloudwatch/src/androidTest`, extends `DeviceFarmTestBase`) exercises the real client against a provisioned CloudWatch Logs backend:
  - `testGetEscapeHatch` — `getCloudWatchLogsClient()` returns the underlying AWS SDK client.
  - `testFlushLogWithMessages` — emitted messages are flushed and land in the log group.
  - `testFlushLogWithVerboseMessageAfterEnabling` — a verbose message emitted while enabled is delivered.
  - `testFlushLogWithVerboseMessageAfterDisabling` — a verbose message emitted while disabled is dropped (not delivered).

  Delivery is confirmed by reading the log group back via `filterLogEvents`, polling with a re-flush between attempts since CloudWatch ingestion is eventually consistent.
- Credentials come from the provisioned backend's Cognito identity pool (guest access — no sign-in). Backend config is read from two gitignored, CI-injected resources under `src/androidTest/res/raw/`: `amplify_outputs.json` (Auth) and `amplifyconfiguration_logging.json` (region, log group, etc.). The CI test-config step must supply both, and the target log group must be provisioned.
- Adds `:core`, `:aws-core`, and `:aws-auth-cognito` as `androidTestImplementation` dependencies for the Amplify Auth / Cognito credential setup.

*How did you test these changes?*

- Ran `./gradlew :aws-cloudwatch:connectedDebugAndroidTest` on an emulator against the provisioned backend — 10/10 connected tests pass (these 4 client tests plus the module's 6 existing DB instrumentation tests).

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [x] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
