### PR TITLE
fix(auth): report why Cognito rejected a refresh token

### DIFF
--- a/aws-auth-cognito/api/aws-auth-cognito.api
+++ b/aws-auth-cognito/api/aws-auth-cognito.api
@@ -267,6 +267,24 @@ public class com/amplifyframework/auth/cognito/exceptions/service/UsernameExists
 public final class com/amplifyframework/auth/cognito/exceptions/service/WebAuthnNotEnabledException : com/amplifyframework/auth/exceptions/ServiceException {
 }
 
+public final class com/amplifyframework/auth/cognito/exceptions/session/AWSCognitoSessionExpiredException : com/amplifyframework/auth/exceptions/SessionExpiredException {
+	public final fun getReason ()Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public final fun getServiceMessage ()Ljava/lang/String;
+}
+
+public final class com/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason : java/lang/Enum {
+	public static final field DeviceBindingFailed Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public static final field Expired Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public static final field Invalid Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public static final field Revoked Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public static final field Unknown Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public static final field UserDeleted Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public static final field UserDisabled Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+	public static fun values ()[Lcom/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason;
+}
+
 public final class com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnCredentialAlreadyExistsException : com/amplifyframework/auth/cognito/exceptions/webauthn/WebAuthnFailedException {
 }
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
@@ -20,8 +20,8 @@ import aws.sdk.kotlin.services.cognitoidentity.model.GetIdRequest
 import aws.sdk.kotlin.services.cognitoidentityprovider.getTokensFromRefreshToken
 import aws.smithy.kotlin.runtime.time.Instant
 import com.amplifyframework.auth.cognito.AuthEnvironment
+import com.amplifyframework.auth.cognito.exceptions.session.AWSCognitoSessionExpiredException
 import com.amplifyframework.auth.exceptions.NotAuthorizedException
-import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.FetchAuthSessionActions
@@ -79,7 +79,13 @@ internal object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                 }
             } catch (notAuthorized: aws.sdk.kotlin.services.cognitoidentityprovider.model.NotAuthorizedException) {
                 logger.error("$id Failed to refresh user pool tokens: NotAuthorizedException", notAuthorized)
-                val error = SessionExpiredException(cause = notAuthorized)
+                // Cognito distinguishes refresh rejections only by message, so classify it and pass
+                // it through instead of reporting every rejection as a plain expired session.
+                val error = AWSCognitoSessionExpiredException(
+                    reason = AWSCognitoSessionExpiredException.classify(notAuthorized.message),
+                    serviceMessage = notAuthorized.message,
+                    cause = notAuthorized
+                )
                 AuthorizationEvent(AuthorizationEvent.EventType.ThrowError(error))
             } catch (e: Exception) {
                 logger.error("$id Failed to refresh user pool tokens", e)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/session/AWSCognitoSessionExpiredException.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/session/AWSCognitoSessionExpiredException.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.exceptions.session
+
+import com.amplifyframework.auth.exceptions.SessionExpiredException
+
+/**
+ * Thrown when Cognito rejects a refresh token. Subclasses [SessionExpiredException] so existing
+ * handling keeps working, and adds [reason] plus [serviceMessage] so an app can tell a recoverable
+ * device-binding failure apart from a genuine expiry or a revocation instead of treating every
+ * rejection as an expired session.
+ */
+class AWSCognitoSessionExpiredException internal constructor(
+    /** Best-effort classification of the rejection. */
+    val reason: RefreshFailureReason,
+    /** The message returned by Cognito, unmodified. Null if the service supplied none. */
+    val serviceMessage: String?,
+    cause: Throwable? = null
+) : SessionExpiredException(cause = cause) {
+
+    internal companion object {
+        /**
+         * Cognito signals the cause of a refresh rejection only through the NotAuthorizedException
+         * message, so classification is by text. Matching is lenient because these strings are
+         * service-controlled and have varied (for example "Invalid Refresh Token." is returned with
+         * a trailing period for a device-binding failure and without one when the token itself
+         * cannot be validated).
+         */
+        fun classify(serviceMessage: String?): RefreshFailureReason {
+            val message = serviceMessage?.trim() ?: return RefreshFailureReason.Unknown
+            return when {
+                message.contains("has expired", ignoreCase = true) -> RefreshFailureReason.Expired
+                message.contains("has been revoked", ignoreCase = true) -> RefreshFailureReason.Revoked
+                message.contains("been deleted", ignoreCase = true) -> RefreshFailureReason.UserDeleted
+                message.contains("is disabled", ignoreCase = true) -> RefreshFailureReason.UserDisabled
+                // The trailing period distinguishes a device-binding failure from a token that
+                // could not be validated at all.
+                message.equals("Invalid Refresh Token.", ignoreCase = true) ->
+                    RefreshFailureReason.DeviceBindingFailed
+                message.contains("Invalid Refresh Token", ignoreCase = true) -> RefreshFailureReason.Invalid
+                else -> RefreshFailureReason.Unknown
+            }
+        }
+    }
+}

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/exceptions/session/RefreshFailureReason.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.exceptions.session
+
+/**
+ * Why Cognito rejected a refresh token. Cognito returns every rejection as a NotAuthorizedException
+ * and distinguishes the cause only by the message text, so these values are a best-effort
+ * classification of that text. [Unknown] is used for anything unrecognised, and the raw service
+ * message always remains available.
+ */
+enum class RefreshFailureReason {
+    /** The refresh token is past the validity that was in force when it was issued. */
+    Expired,
+
+    /** The refresh token was revoked, e.g. by RevokeToken or a global sign out. */
+    Revoked,
+
+    /**
+     * The token is bound to a device record that could not be validated: the device was forgotten,
+     * ConfirmDevice never completed, or the DeviceKey sent did not match the binding. Signing in
+     * again establishes a new device binding.
+     */
+    DeviceBindingFailed,
+
+    /** The token could not be validated for this app client at all. */
+    Invalid,
+
+    /** The user account is disabled. */
+    UserDisabled,
+
+    /** The user account was deleted. */
+    UserDeleted,
+
+    /** The service message was not recognised. Inspect the service message for detail. */
+    Unknown
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/exceptions/session/AWSCognitoSessionExpiredExceptionTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/exceptions/session/AWSCognitoSessionExpiredExceptionTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.auth.cognito.exceptions.session
+
+import com.amplifyframework.auth.exceptions.SessionExpiredException
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+
+/**
+ * The expected strings below are the messages Cognito actually returned for each scenario when
+ * exercised against a device-tracking user pool.
+ */
+class AWSCognitoSessionExpiredExceptionTest {
+
+    private fun classify(message: String?) = AWSCognitoSessionExpiredException.classify(message)
+
+    @Test
+    fun `classifies genuine expiry`() {
+        classify("Refresh Token has expired") shouldBe RefreshFailureReason.Expired
+    }
+
+    @Test
+    fun `classifies revocation`() {
+        classify("Refresh Token has been revoked") shouldBe RefreshFailureReason.Revoked
+    }
+
+    @Test
+    fun `classifies device binding failure by the trailing period`() {
+        classify("Invalid Refresh Token.") shouldBe RefreshFailureReason.DeviceBindingFailed
+    }
+
+    @Test
+    fun `classifies an unvalidatable token, which has no trailing period`() {
+        classify("Invalid Refresh Token") shouldBe RefreshFailureReason.Invalid
+    }
+
+    @Test
+    fun `classifies a disabled user`() {
+        classify("User is disabled.") shouldBe RefreshFailureReason.UserDisabled
+    }
+
+    @Test
+    fun `classifies a deleted user`() {
+        classify("The user has been deleted for the associated refresh token") shouldBe
+            RefreshFailureReason.UserDeleted
+    }
+
+    @Test
+    fun `unrecognised and absent messages are Unknown`() {
+        classify("Something new from the service") shouldBe RefreshFailureReason.Unknown
+        classify(null) shouldBe RefreshFailureReason.Unknown
+        classify("") shouldBe RefreshFailureReason.Unknown
+    }
+
+    @Test
+    fun `retains the raw service message`() {
+        val exception = AWSCognitoSessionExpiredException(
+            reason = RefreshFailureReason.DeviceBindingFailed,
+            serviceMessage = "Invalid Refresh Token.",
+            cause = null
+        )
+
+        exception.serviceMessage shouldBe "Invalid Refresh Token."
+        exception.reason shouldBe RefreshFailureReason.DeviceBindingFailed
+    }
+
+    @Test
+    fun `remains catchable as SessionExpiredException so existing handling keeps working`() {
+        val exception = AWSCognitoSessionExpiredException(
+            reason = RefreshFailureReason.Expired,
+            serviceMessage = "Refresh Token has expired",
+            cause = null
+        )
+
+        exception.shouldBeInstanceOf<SessionExpiredException>()
+        exception.message shouldBe "Your session has expired."
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* n/a

*Description of changes:*

Cognito rejects a refresh token with `NotAuthorizedException` for several unrelated reasons and distinguishes them only by the message text. `FetchAuthSessionCognitoActions` caught all of them and reported a plain `SessionExpiredException`, so app code could not tell a recoverable device-binding failure from a genuine expiry, a revocation, or a disabled/deleted user without string matching the cause. In practice apps treat them all as an expired session and sign the user out, which is wrong for the recoverable cases and gives no signal for diagnosing the rest.

Refresh failures now raise `AWSCognitoSessionExpiredException`, which extends `SessionExpiredException` so existing `catch` blocks and behaviour are unchanged, and adds:
- `reason: RefreshFailureReason` — `Expired`, `Revoked`, `DeviceBindingFailed`, `Invalid`, `UserDisabled`, `UserDeleted`, `Unknown`
- `serviceMessage: String?` — the service message, unmodified

Classification is by message text because that is all the service provides; it is lenient, documented as best-effort, and anything unrecognised maps to `Unknown` with the raw message still available. API change is additive only.

Note this exposes the reason, it does not prevent the rejection: a refresh that Cognito refuses still fails.

*How did you test these changes?*

- 9 new unit tests covering each reason, plus unknown/empty/null input and that the exception is still catchable as `SessionExpiredException`. The expected strings are the messages Cognito actually returned when each scenario was exercised against a device-tracking user pool. Full `:aws-auth-cognito:testDebugUnitTest` suite green (549 tests), `ktlintCheck` and `apiCheck` pass.
- On an emulator against a device-tracking pool: forgetting the device then refreshing yields `reason=DeviceBindingFailed` with service message `Invalid Refresh Token.`, while `AdminUserGlobalSignOut` then refreshing yields `reason=Revoked` with `Refresh Token has been revoked` — so the reasons are distinguished rather than collapsed.
- A sample app branching on `reason` re-authenticated silently for `DeviceBindingFailed` and recovered a working session with no user-visible logout, took the non-recoverable path for `Revoked`, and reported a healthy session unchanged (no false positives).
- On the unpatched build the same app sees only `com.amplifyframework.auth.exceptions.SessionExpiredException` with no reason available.

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
