### PR TITLE
chore: expose aws-api-appsync from the AppSync client

### DIFF
--- a/aws-appsync/build.gradle.kts
+++ b/aws-appsync/build.gradle.kts
@@ -27,8 +27,6 @@ dependencies {
     api(libs.okhttp)
     api(project(":foundation"))
 
-    // api, not implementation: the model helpers (ModelQuery, ModelMutation, ModelSubscription) live
-    // in this module, and consumers of the client need them to build requests.
     api(project(":aws-api-appsync"))
     implementation(libs.gson)
     implementation(libs.kotlin.coroutines)

--- a/aws-appsync/build.gradle.kts
+++ b/aws-appsync/build.gradle.kts
@@ -27,7 +27,9 @@ dependencies {
     api(libs.okhttp)
     api(project(":foundation"))
 
-    implementation(project(":aws-api-appsync"))
+    // api, not implementation: the model helpers (ModelQuery, ModelMutation, ModelSubscription) live
+    // in this module, and consumers of the client need them to build requests.
+    api(project(":aws-api-appsync"))
     implementation(libs.gson)
     implementation(libs.kotlin.coroutines)
     implementation(project(":foundation-bridge"))

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncClientAuthorizer.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncClientAuthorizer.kt
@@ -22,8 +22,8 @@ import com.amplifyframework.foundation.credentials.AwsCredentialsProvider
  * Each subtype encodes its [AppSyncAuthMode] and holds the provider needed to
  * produce authorization credentials for that mode.
  *
- * These are configuration objects — the actual header generation and request signing
- * is handled internally by the plugin infrastructure via [AuthProviderBridge].
+ * These are configuration objects — the client generates authorization headers and signs
+ * requests internally, and does not expose that machinery.
  */
 @ExperimentalAmplifyApi
 sealed class AppSyncClientAuthorizer(


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

No issue. PR 3 of 3 in Phase 1 of the V3 AppSync client work, completing it. Follows #3384 and #3391.

*Description of changes:*

### The gap this closes

#3391 moved the model helpers into `aws-api-appsync` so both the plugin and the new client could reach them. But `aws-appsync` declared that module as `implementation`, which keeps it off the compile classpath of anything depending on the client. So the helpers were reachable from *inside* `aws-appsync` and invisible to its *consumers* — which defeats the purpose of moving them.

This flips it to `api(project(":aws-api-appsync"))`.

### Verified, not assumed

The observable effect is in the published POM. Generated `pom-default.xml` before and after:

| | `aws-api-appsync` scope |
|---|---|
| before | `runtime` |
| after | `compile` |

`compile` is what puts it on a consumer's compile classpath — the same scope `core` already has. `kotlinx-coroutines-core`, still `implementation`, remains `runtime`, which is the contrast.

### The KDoc example needed no change

The example on `AmplifyAppSyncClient` calling `ModelQuery.get(Todo::class.java, "id-123")` sits inside a fenced code block, so it was never a broken KDoc *link* — it was an accurate-looking example that a consumer could not have compiled. It becomes truthful as a consequence of this change rather than needing an edit, which is worth stating since the example is the clearest illustration of what the flip buys.

### One drive-by doc fix

`AppSyncClientAuthorizer`'s KDoc referenced `[AuthProviderBridge]`. **No such class exists anywhere in the repo** — it is a leftover from #3307, which #3377 reverted. The surrounding sentence also described the old architecture, where the client delegated to plugin infrastructure; per #3377 the client reimplements privately what it needs. Both are corrected in one line.

Unrelated to the dependency flip, and flagged here rather than buried: it is a dangling reference actively describing the wrong design, and it lives in the same module.

### Still outstanding, deliberately not here

`SubscriptionEvent`'s KDoc has a dangling `[ApiException]` (not imported in that file) and references `[Connection.Connecting]` / `[Connection.Connected]`. Both are left alone because Phase 2 changes those types anyway — `ApiException` becomes `AppSyncException`, and the `Connection` nesting is flattened. Fixing them now would only mean editing the same lines twice.

*How did you test these changes?*

All tasks with `--rerun-tasks`:

- `:aws-appsync:generatePomFileForMavenPublication` — inspected the POM before and after, confirming the scope change above. This is the actual verification; a compile check alone cannot show it, because `implementation` already satisfies the module's own sources.
- `:aws-appsync:compileDebugKotlin`, `:aws-appsync:compileReleaseKotlin`, `:aws-appsync:apiCheck`, `:aws-appsync:ktlintCheck`, `:aws-appsync:licensee`.
- `:aws-api-appsync:apiCheck` and `:aws-api:apiCheck` — unchanged, as expected; widening a dependency configuration does not alter either module's own surface.
- `:aws-api:testDebugUnitTest` (161) and `:aws-api-appsync:testDebugUnitTest` (99) — both 0 failures, confirming no regression from the change.

No new tests. The change is a build-configuration widening whose effect is only observable in published metadata, which the POM check covers directly; `aws-appsync` still has no test source set, and adding one to assert a Gradle configuration would test Gradle rather than this repo.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests — not applicable; see the testing note above
- [ ] Added Integration Tests — not applicable
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
