### PR TITLE
fix(all): resolve UnsafeOptInUsage and UseKtx errors from newer androidx lint

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/auth/IamRequestDecorator.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/auth/IamRequestDecorator.java
@@ -15,6 +15,8 @@
 
 package com.amplifyframework.api.aws.auth;
 
+import android.annotation.SuppressLint;
+
 import com.amplifyframework.api.ApiException.ApiAuthException;
 import com.amplifyframework.api.aws.AppSyncSigningException;
 import com.amplifyframework.api.aws.sigv4.AWS4Signer;
@@ -67,6 +69,8 @@ public class IamRequestDecorator implements RequestDecorator {
      * @return A new instance of the request containing the signature headers.
      * @throws ApiAuthException If the signing process fails.
      */
+    // Uses the smithy runtime's internal Headers builder API to construct the request to sign.
+    @SuppressLint("UnsafeOptInUsageError")
     public final okhttp3.Request decorate(okhttp3.Request req) throws ApiAuthException {
         //set the request body
         final byte[] bodyBytes = getBytes(req.body());

--- a/aws-connect/build.gradle.kts
+++ b/aws-connect/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(project(":foundation-bridge"))
 
     implementation(libs.androidx.annotation)
+    implementation(libs.androidx.core.ktx)
     implementation(libs.kotlin.coroutines)
     implementation(libs.okhttp)
     implementation(libs.kotlin.serializationJson)

--- a/aws-connect/src/main/java/com/amplifyframework/connect/internal/DeviceIdStore.kt
+++ b/aws-connect/src/main/java/com/amplifyframework/connect/internal/DeviceIdStore.kt
@@ -16,6 +16,7 @@ package com.amplifyframework.connect.internal
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import java.util.UUID
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -58,7 +59,7 @@ internal class DeviceIdStore(
             existing
         } else {
             val newId = UUID.randomUUID().toString()
-            prefs.edit().putString(DEVICE_ID_KEY, newId).apply()
+            prefs.edit { putString(DEVICE_ID_KEY, newId) }
             newId
         }
     }
@@ -75,7 +76,7 @@ internal class DeviceIdStore(
      * Clears the persisted device ID.
      */
     suspend fun clear() = withContext(dispatcher) {
-        prefs.edit().remove(DEVICE_ID_KEY).apply()
+        prefs.edit { remove(DEVICE_ID_KEY) }
     }
 
     internal companion object {

--- a/aws-event-enrichment/build.gradle.kts
+++ b/aws-event-enrichment/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     api(project(":foundation"))
 
     implementation(libs.androidx.annotation)
+    implementation(libs.androidx.core.ktx)
     implementation(libs.kotlin.coroutines)
     implementation(libs.kotlin.datetime)
     implementation(libs.kotlin.serializationJson)

--- a/aws-event-enrichment/src/main/java/com/amplifyframework/eventenrichment/clientid/SharedPreferencesClientIdProvider.kt
+++ b/aws-event-enrichment/src/main/java/com/amplifyframework/eventenrichment/clientid/SharedPreferencesClientIdProvider.kt
@@ -15,6 +15,7 @@
 package com.amplifyframework.eventenrichment.clientid
 
 import android.content.Context
+import androidx.core.content.edit
 import com.amplifyframework.annotations.ExperimentalAmplifyApi
 import java.util.UUID
 
@@ -53,7 +54,7 @@ internal class SharedPreferencesClientIdProvider(context: Context) : ClientIdPro
         val existing = preferences.getString(CLIENT_ID_STORAGE_KEY, null)
         if (!existing.isNullOrEmpty()) return existing
         val id = UUID.randomUUID().toString()
-        preferences.edit().putString(CLIENT_ID_STORAGE_KEY, id).apply()
+        preferences.edit { putString(CLIENT_ID_STORAGE_KEY, id) }
         return id
     }
 

--- a/aws-pinpoint-core/build.gradle.kts
+++ b/aws-pinpoint-core/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 dependencies {
     api(project(":core"))
 
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(platform(libs.aws.bom))
     implementation(libs.aws.pinpoint)

--- a/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/database/PinpointDatabase.kt
+++ b/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/database/PinpointDatabase.kt
@@ -22,6 +22,7 @@ import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteQueryBuilder
 import android.net.Uri
+import androidx.core.net.toUri
 import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.pinpoint.core.models.PinpointEvent
 import kotlinx.coroutines.CoroutineDispatcher
@@ -48,7 +49,7 @@ class PinpointDatabase(
 
     init {
         val authority = context.applicationContext.packageName
-        contentUri = Uri.parse("content://$authority/$basePath")
+        contentUri = "content://$authority/$basePath".toUri()
         uriMatcher = UriMatcher(UriMatcher.NO_MATCH)
         // The Uri of EVENTS is for all records in the Event table.
         uriMatcher.addURI(authority, basePath, events)
@@ -98,7 +99,7 @@ class PinpointDatabase(
                 throw IllegalArgumentException("Unknown Uri: $uri")
             }
         }
-        return Uri.parse("$basePath/$id")
+        return "$basePath/$id".toUri()
     }
 
     /*@Synchronized

--- a/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/util/SharedPreferencesUtil.kt
+++ b/aws-pinpoint-core/src/main/java/com/amplifyframework/pinpoint/core/util/SharedPreferencesUtil.kt
@@ -17,6 +17,7 @@
 package com.amplifyframework.pinpoint.core.util
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.category.CategoryType
 import java.util.UUID
@@ -24,9 +25,7 @@ import java.util.UUID
 private val LOG = Amplify.Logging.logger(CategoryType.ANALYTICS, "amplify:aws-analytics-pinpoint")
 internal fun SharedPreferences.putString(key: String, value: String) {
     try {
-        val editor = this.edit()
-        editor.putString(key, value)
-        editor.apply()
+        edit { putString(key, value) }
     } catch (ex: Exception) {
         // Do not log ex due to potentially sensitive information
         LOG.error("There was an exception when trying to store the unique id into the Preferences.")

--- a/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -72,6 +72,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             }
 
             lint {
+                lintConfig = rootProject.file("lint.xml")
                 warningsAsErrors = true
                 abortOnError = true
                 enable += listOf("UnusedResources")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 dependencies {
     api(project(":annotations"))
     implementation(libs.androidx.v4support)
+    implementation(libs.androidx.core.ktx)
     api(libs.androidx.annotation)
     implementation(libs.androidx.nav.fragment)
     implementation(libs.androidx.nav.ui)

--- a/core/src/main/java/com/amplifyframework/auth/TOTPSetupDetails.kt
+++ b/core/src/main/java/com/amplifyframework/auth/TOTPSetupDetails.kt
@@ -15,6 +15,7 @@
 package com.amplifyframework.auth
 
 import android.net.Uri
+import androidx.core.net.toUri
 
 /**
  * Details of TOTP Setup that help launch into TOTP manager.
@@ -36,5 +37,5 @@ data class TOTPSetupDetails(
      */
     @JvmOverloads
     fun getSetupURI(appName: String, accountName: String = username): Uri =
-        Uri.parse("otpauth://totp/$appName:$accountName?secret=$sharedSecret&issuer=$appName")
+        "otpauth://totp/$appName:$accountName?secret=$sharedSecret&issuer=$appName".toUri()
 }

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+<lint>
+    <!--
+      Amplify's own @RequiresOptIn marker annotations are opted into project-wide, so that
+      first-party code may use first-party internal APIs without a per-call-site @OptIn. This
+      mirrors the Kotlin compiler's global opt-in configured via `-opt-in=` in the convention
+      plugins (see optInAnnotations in build-logic/plugins/src/main/kotlin/Util.kt). Android Lint's
+      UnsafeOptInUsage check is a separate mechanism that does not read the Kotlin compiler flag and
+      also applies to Java sources, so it must be configured here as well. The published
+      @RequiresOptIn markers still enforce opt-in for third-party consumers of the library. Keep
+      this list in sync with optInAnnotations.
+    -->
+    <issue id="UnsafeOptInUsageError">
+        <option
+            name="opt-in"
+            value="com.amplifyframework.annotations.InternalApiWarning,com.amplifyframework.annotations.InternalAmplifyApi,com.amplifyframework.annotations.AmplifyFlutterApi,com.amplifyframework.annotations.ExperimentalAmplifyApi" />
+    </issue>
+    <issue id="UnsafeOptInUsageWarning">
+        <option
+            name="opt-in"
+            value="com.amplifyframework.annotations.InternalApiWarning,com.amplifyframework.annotations.InternalAmplifyApi,com.amplifyframework.annotations.AmplifyFlutterApi,com.amplifyframework.annotations.ExperimentalAmplifyApi" />
+    </issue>
+</lint>


### PR DESCRIPTION
### Summary

Bumping `androidx.fragment` 1.2.4 → 1.9.0 (#3380) pulls in a newer `androidx.annotation-experimental` transitively, which **activates two Android Lint checks that were previously dormant** across the codebase. This PR resolves both so #3380 (and any future dependency bump that drags in the newer lint) passes `static-analysis`. The fragment bump itself stays in #3380 — this PR contains only the lint fixes.

### 1. `UnsafeOptInUsageError` — Amplify's own opt-in markers (88+ sites)

`@InternalAmplifyApi` (and the other Amplify markers) are `@RequiresOptIn` markers used pervasively for cross-module-internal APIs. Amplify already opts into them **globally for the Kotlin compiler** via `-opt-in=` (`optInAnnotations` in `build-logic/.../Util.kt`) — but Android Lint's `UnsafeOptInUsage` is a *separate* enforcement mechanism that does not read the Kotlin compiler flag, and also applies to **Java** sources.

Fix: add a root **`lint.xml`** configuring project-wide opt-in for the Amplify marker annotations, wired in via `lintConfig` in `AndroidLibraryConventionPlugin`. This is the lint-side mirror of the existing compiler opt-in. The published `@RequiresOptIn` markers still enforce opt-in for third-party consumers of the library (lint.xml only applies when building amplify-android itself).

### 2. `UnsafeOptInUsageError` — third-party smithy `InternalApi` (1 site)

`IamRequestDecorator.java` uses smithy's internal `Headers` builder. This third-party marker is **not** added to the global opt-in (so lint keeps catching unintended third-party opt-in usage). Instead it's opted into locally with `@SuppressLint("UnsafeOptInUsageError")`, matching the existing per-call-site pattern used for smithy `InternalApi` elsewhere in the repo (`AWS4Signer.kt`, `AWSS3StoragePlugin.java`, …).

### 3. `UseKtx` — idiomatic KTX conversions

The newer lint enables `UseKtx`, which flags `SharedPreferences.edit()` / `Uri.parse()` where androidx KTX extensions exist. Converted each site to the idiomatic `edit { }` / `String.toUri()` and added `androidx.core-ktx` where needed:
- `aws-connect/DeviceIdStore.kt` (×2)
- `aws-event-enrichment/SharedPreferencesClientIdProvider.kt`
- `aws-pinpoint-core/PinpointDatabase.kt` (×2), `SharedPreferencesUtil.kt`
- `core/TOTPSetupDetails.kt`

### Verification

Temporarily bumped `androidx.fragment` to 1.9.0 (reproducing #3380) and ran the full CI static-analysis gate:

```
./gradlew ktlintCheck checkstyle apiCheck lint --continue --rerun-tasks
BUILD SUCCESSFUL — 0 errors across all modules
```

(Confirmed the uncached `--rerun-tasks` sweep to avoid lint's incremental per-file caching hiding sites.) The temporary bump was reverted; this PR ships only the lint fixes.

### Next step

Once merged, comment `@dependabot rebase` on #3380 to re-run its `static-analysis` job green.