### PR TITLE
feat(predictions): report a distinct exception when a liveness session is interrupted

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/exceptions/FaceLivenessSessionInterruptedException.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/exceptions/FaceLivenessSessionInterruptedException.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.predictions.aws.exceptions
+
+import com.amplifyframework.annotations.InternalAmplifyApi
+import com.amplifyframework.predictions.PredictionsException
+
+/**
+ * Raised when the connection to the face liveness service is lost before the check completes, for example because the
+ * host app was backgrounded long enough for the socket to close, or because the device lost network connectivity.
+ */
+@InternalAmplifyApi
+class FaceLivenessSessionInterruptedException internal constructor(
+    message: String = "The face liveness session was interrupted.",
+    cause: Throwable? = null,
+    recoverySuggestion: String = "Retry the face liveness check."
+) : PredictionsException(message, cause, recoverySuggestion)

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/exceptions/FaceLivenessSessionInterruptedException.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/exceptions/FaceLivenessSessionInterruptedException.kt
@@ -19,8 +19,13 @@ import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.predictions.PredictionsException
 
 /**
- * Raised when the connection to the face liveness service is lost before the check completes, for example because the
- * host app was backgrounded long enough for the socket to close, or because the device lost network connectivity.
+ * Raised when an established connection to the face liveness service is lost before the check completes, for example
+ * because the host app was backgrounded long enough for the socket to close, or because the device lost network
+ * connectivity mid-check.
+ *
+ * Any transport-level [java.io.IOException] other than a protocol violation is reported as this type, so it also
+ * covers read timeouts, DNS failures and TLS teardown. A connection that never opened is not reported as this type,
+ * since that indicates an unreachable or misconfigured endpoint rather than an interruption.
  */
 @InternalAmplifyApi
 class FaceLivenessSessionInterruptedException internal constructor(

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -29,6 +29,7 @@ import com.amplifyframework.core.category.CategoryType
 import com.amplifyframework.predictions.PredictionsException
 import com.amplifyframework.predictions.aws.BuildConfig
 import com.amplifyframework.predictions.aws.exceptions.AccessDeniedException
+import com.amplifyframework.predictions.aws.exceptions.FaceLivenessSessionInterruptedException
 import com.amplifyframework.predictions.aws.exceptions.FaceLivenessSessionNotFoundException
 import com.amplifyframework.predictions.aws.exceptions.FaceLivenessUnsupportedChallengeTypeException
 import com.amplifyframework.predictions.aws.models.liveness.BoundingBox
@@ -48,6 +49,8 @@ import com.amplifyframework.predictions.models.Challenge
 import com.amplifyframework.predictions.models.FaceLivenessChallengeType
 import com.amplifyframework.predictions.models.FaceLivenessSessionInformation
 import com.amplifyframework.util.UserAgent
+import java.io.IOException
+import java.net.ProtocolException
 import java.net.URI
 import java.net.URLDecoder
 import java.nio.ByteBuffer
@@ -247,14 +250,24 @@ internal class LivenessWebSocket(
             LOG.debug("WebSocket onFailure")
             super.onFailure(webSocket, t, response)
             if (!clientStoppedSession) {
-                val faceLivenessException = webSocketError ?: PredictionsException(
-                    "An unknown error occurred during the Liveness flow.",
-                    t,
-                    "See attached exception for more details."
-                )
-                onErrorReceived.accept(faceLivenessException)
+                onErrorReceived.accept(webSocketError ?: classifyConnectionFailure(t))
             }
         }
+    }
+
+    /*
+    A dead transport means the session ended for a reason the customer can act on - the app was backgrounded long
+    enough for the socket to close, or connectivity was lost - so it is reported as a distinct type rather than as an
+    unclassified failure. ProtocolException is excluded because it means the peer sent something malformed, which is
+    not an interruption. Anything else is not something we can attribute, so it keeps the generic message.
+     */
+    private fun classifyConnectionFailure(t: Throwable): PredictionsException = when {
+        t is IOException && t !is ProtocolException -> FaceLivenessSessionInterruptedException(cause = t)
+        else -> PredictionsException(
+            "An unknown error occurred during the Liveness flow.",
+            t,
+            "See attached exception for more details."
+        )
     }
 
     fun start() {

--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/http/LivenessWebSocket.kt
@@ -113,6 +113,16 @@ internal class LivenessWebSocket(
 
     @VisibleForTesting internal var webSocketError: PredictionsException? = null
     internal var clientStoppedSession = false
+
+    /*
+    Whether the socket ever completed its upgrade. A failure before that point is a connection that was never
+    established - an unreachable or misconfigured endpoint, or no network at launch - rather than a session that was
+    interrupted, and the two want different advice.
+
+    Deliberately not cleared when reconnecting, because a reconnect only ever follows a socket that did open and a
+    server that did respond, so a failure on the retry really did interrupt a session that was under way.
+     */
+    private var socketOpened = false
     val json = Json { ignoreUnknownKeys = true }
 
     // Sending events to the websocket requires processing synchronously because we rely on proper ordered
@@ -141,6 +151,7 @@ internal class LivenessWebSocket(
             super.onOpen(webSocket, response)
 
             this@LivenessWebSocket.webSocket = webSocket
+            socketOpened = true
 
             // If offset is > 4 minutes, server may reject the request
             // The real allowed diff from serer is < 5 but we check for 4 to add a buffer
@@ -256,13 +267,15 @@ internal class LivenessWebSocket(
     }
 
     /*
-    A dead transport means the session ended for a reason the customer can act on - the app was backgrounded long
-    enough for the socket to close, or connectivity was lost - so it is reported as a distinct type rather than as an
-    unclassified failure. ProtocolException is excluded because it means the peer sent something malformed, which is
-    not an interruption. Anything else is not something we can attribute, so it keeps the generic message.
+    Losing an established transport means the session ended for a reason the customer can act on - the app was
+    backgrounded long enough for the socket to close, or connectivity was lost - so it is reported as a distinct type
+    rather than as an unclassified failure. ProtocolException is excluded because it means the peer sent something
+    malformed, including a rejected upgrade handshake, which is not an interruption. Anything else is not something we
+    can attribute, so it keeps the generic message.
      */
     private fun classifyConnectionFailure(t: Throwable): PredictionsException = when {
-        t is IOException && t !is ProtocolException -> FaceLivenessSessionInterruptedException(cause = t)
+        socketOpened && t is IOException && t !is ProtocolException ->
+            FaceLivenessSessionInterruptedException(cause = t)
         else -> PredictionsException(
             "An unknown error occurred during the Liveness flow.",
             t,

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
@@ -45,12 +45,12 @@ import com.amplifyframework.predictions.models.FaceLivenessChallengeType
 import com.amplifyframework.predictions.models.FaceLivenessSessionInformation
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.verify
 import java.io.EOFException
+import java.net.ConnectException
 import java.net.ProtocolException
 import java.net.SocketException
 import java.net.SocketTimeoutException
@@ -165,15 +165,8 @@ internal class LivenessWebSocketTest {
     @Test
     fun `onFailure calls onError`() {
         val livenessWebSocket = createLivenessWebSocket()
-        // Response does noted like to be mockk
-        val response = Response.Builder()
-            .code(200)
-            .request(Request.Builder().url(URL("https://amazon.com")).build())
-            .protocol(Protocol.HTTP_2)
-            .message("Response")
-            .build()
 
-        livenessWebSocket.webSocketListener.onFailure(mockk(), mockk(), response)
+        livenessWebSocket.webSocketListener.onFailure(mockk(), mockk(), webSocketResponse())
 
         verify { onErrorReceived.accept(any()) }
     }
@@ -182,107 +175,91 @@ internal class LivenessWebSocketTest {
     fun `onFailure does not call onError if client stopped`() {
         val livenessWebSocket = createLivenessWebSocket()
         livenessWebSocket.clientStoppedSession = true
-        // Response does noted like to be mockk
-        val response = Response.Builder()
-            .code(200)
-            .request(Request.Builder().url(URL("https://amazon.com")).build())
-            .protocol(Protocol.HTTP_2)
-            .message("Response")
-            .build()
 
-        livenessWebSocket.webSocketListener.onFailure(mockk(), mockk(), response)
+        livenessWebSocket.webSocketListener.onFailure(mockk(), mockk(), webSocketResponse())
+
+        verify(exactly = 0) { onErrorReceived.accept(any()) }
+    }
+
+    @Test
+    fun `onFailure does not report an interrupted session if client stopped`() {
+        val livenessWebSocket = createOpenLivenessWebSocket()
+        livenessWebSocket.clientStoppedSession = true
+
+        livenessWebSocket.webSocketListener.onFailure(
+            mockk(),
+            SocketException("Software caused connection abort"),
+            webSocketResponse()
+        )
 
         verify(exactly = 0) { onErrorReceived.accept(any()) }
     }
 
     @Test
     fun `onFailure with a socket exception reports an interrupted session`() {
-        val livenessWebSocket = createLivenessWebSocket()
-        val transportFailure = SocketException("Software caused connection abort")
-
-        livenessWebSocket.webSocketListener.onFailure(mockk(), transportFailure, failureResponse())
-
-        verify {
-            onErrorReceived.accept(
-                withArg {
-                    it.shouldBeInstanceOf<FaceLivenessSessionInterruptedException>()
-                    it.cause shouldBe transportFailure
-                }
-            )
-        }
+        assertInterruptedSession(SocketException("Software caused connection abort"))
     }
 
     @Test
-    fun `onFailure reports an interrupted session for any lost transport`() {
-        listOf(
-            SocketTimeoutException("Read timed out"),
-            UnknownHostException("Unable to resolve host"),
-            SSLException("Connection closed by peer"),
-            EOFException("Peer closed without a close frame")
-        ).forEach { transportFailure ->
-            clearMocks(onErrorReceived)
-            val livenessWebSocket = createLivenessWebSocket()
+    fun `onFailure with a read timeout reports an interrupted session`() {
+        assertInterruptedSession(SocketTimeoutException("Read timed out"))
+    }
 
-            livenessWebSocket.webSocketListener.onFailure(mockk(), transportFailure, failureResponse())
+    @Test
+    fun `onFailure with an unresolvable host reports an interrupted session`() {
+        assertInterruptedSession(UnknownHostException("Unable to resolve host"))
+    }
 
-            verify {
-                onErrorReceived.accept(
-                    withArg {
-                        it.shouldBeInstanceOf<FaceLivenessSessionInterruptedException>()
-                        it.cause shouldBe transportFailure
-                    }
-                )
-            }
-        }
+    @Test
+    fun `onFailure with a TLS failure reports an interrupted session`() {
+        assertInterruptedSession(SSLException("Connection closed by peer"))
+    }
+
+    @Test
+    fun `onFailure with a truncated stream reports an interrupted session`() {
+        assertInterruptedSession(EOFException("Peer closed without a close frame"))
     }
 
     @Test
     fun `onFailure with a non-IO failure reports an unclassified error`() {
-        val livenessWebSocket = createLivenessWebSocket()
-        val unexpectedFailure = IllegalStateException("Something else went wrong")
+        assertUnclassifiedError(IllegalStateException("Something else went wrong"))
+    }
 
-        livenessWebSocket.webSocketListener.onFailure(mockk(), unexpectedFailure, failureResponse())
+    @Test
+    fun `onFailure before the socket opens is not reported as an interrupted session`() {
+        val livenessWebSocket = createLivenessWebSocket()
+        val connectFailure = ConnectException("Failed to connect to rekognition endpoint")
+
+        livenessWebSocket.webSocketListener.onFailure(mockk(), connectFailure, webSocketResponse())
 
         verify {
             onErrorReceived.accept(
                 withArg {
                     it::class shouldBe PredictionsException::class
-                    it.cause shouldBe unexpectedFailure
+                    it.cause shouldBe connectFailure
                 }
             )
         }
     }
 
     @Test
+    fun `onFailure with a protocol exception reports an unclassified error`() {
+        assertUnclassifiedError(ProtocolException("Malformed websocket frame"))
+    }
+
+    @Test
     fun `onFailure does not reclassify an error already reported by the server`() {
-        val livenessWebSocket = createLivenessWebSocket()
+        val livenessWebSocket = createOpenLivenessWebSocket()
         val serverError = FaceLivenessSessionNotFoundException()
         livenessWebSocket.webSocketError = serverError
 
         livenessWebSocket.webSocketListener.onFailure(
             mockk(),
             SocketException("Software caused connection abort"),
-            failureResponse()
+            webSocketResponse()
         )
 
         verify { onErrorReceived.accept(serverError) }
-    }
-
-    @Test
-    fun `onFailure with a protocol exception reports an unclassified error`() {
-        val livenessWebSocket = createLivenessWebSocket()
-        val protocolFailure = ProtocolException("Malformed websocket frame")
-
-        livenessWebSocket.webSocketListener.onFailure(mockk(), protocolFailure, failureResponse())
-
-        verify {
-            onErrorReceived.accept(
-                withArg {
-                    it::class shouldBe PredictionsException::class
-                    it.cause shouldBe protocolFailure
-                }
-            )
-        }
     }
 
     @Test
@@ -750,8 +727,38 @@ internal class LivenessWebSocketTest {
         assertEquals("AWS4-HMAC-SHA256", reconnectRequest.url.queryParameter("X-Amz-Algorithm"))
     }
 
+    private fun assertInterruptedSession(transportFailure: Throwable) {
+        val livenessWebSocket = createOpenLivenessWebSocket()
+
+        livenessWebSocket.webSocketListener.onFailure(mockk(), transportFailure, webSocketResponse())
+
+        verify {
+            onErrorReceived.accept(
+                withArg {
+                    it.shouldBeInstanceOf<FaceLivenessSessionInterruptedException>()
+                    it.cause shouldBe transportFailure
+                }
+            )
+        }
+    }
+
+    private fun assertUnclassifiedError(failure: Throwable) {
+        val livenessWebSocket = createOpenLivenessWebSocket()
+
+        livenessWebSocket.webSocketListener.onFailure(mockk(), failure, webSocketResponse())
+
+        verify {
+            onErrorReceived.accept(
+                withArg {
+                    it::class shouldBe PredictionsException::class
+                    it.cause shouldBe failure
+                }
+            )
+        }
+    }
+
     // Response does not like to be mockk
-    private fun failureResponse() = Response.Builder()
+    private fun webSocketResponse() = Response.Builder()
         .code(200)
         .request(Request.Builder().url(URL("https://amazon.com")).build())
         .protocol(Protocol.HTTP_2)
@@ -766,6 +773,14 @@ internal class LivenessWebSocketTest {
         attemptCount = 1,
         challengeVersions = challengeVersions
     )
+
+    /**
+     * A socket that has completed its upgrade, so a subsequent failure represents a session that was under way rather
+     * than one that never connected.
+     */
+    private fun createOpenLivenessWebSocket() = createLivenessWebSocket().apply {
+        webSocketListener.onOpen(mockk(relaxed = true), webSocketResponse())
+    }
 
     private fun createLivenessWebSocket(
         livenessVersion: String? = null,

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
@@ -23,6 +23,8 @@ import com.amplifyframework.core.Action
 import com.amplifyframework.core.BuildConfig
 import com.amplifyframework.core.Consumer
 import com.amplifyframework.predictions.PredictionsException
+import com.amplifyframework.predictions.aws.exceptions.FaceLivenessSessionInterruptedException
+import com.amplifyframework.predictions.aws.exceptions.FaceLivenessSessionNotFoundException
 import com.amplifyframework.predictions.aws.exceptions.FaceLivenessUnsupportedChallengeTypeException
 import com.amplifyframework.predictions.aws.models.liveness.ChallengeConfig
 import com.amplifyframework.predictions.aws.models.liveness.ChallengeEvent
@@ -41,17 +43,26 @@ import com.amplifyframework.predictions.aws.models.liveness.ValidationException
 import com.amplifyframework.predictions.models.Challenge
 import com.amplifyframework.predictions.models.FaceLivenessChallengeType
 import com.amplifyframework.predictions.models.FaceLivenessSessionInformation
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.verify
+import java.io.EOFException
+import java.net.ProtocolException
+import java.net.SocketException
+import java.net.SocketTimeoutException
 import java.net.URL
+import java.net.UnknownHostException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLException
 import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -182,6 +193,96 @@ internal class LivenessWebSocketTest {
         livenessWebSocket.webSocketListener.onFailure(mockk(), mockk(), response)
 
         verify(exactly = 0) { onErrorReceived.accept(any()) }
+    }
+
+    @Test
+    fun `onFailure with a socket exception reports an interrupted session`() {
+        val livenessWebSocket = createLivenessWebSocket()
+        val transportFailure = SocketException("Software caused connection abort")
+
+        livenessWebSocket.webSocketListener.onFailure(mockk(), transportFailure, failureResponse())
+
+        verify {
+            onErrorReceived.accept(
+                withArg {
+                    it.shouldBeInstanceOf<FaceLivenessSessionInterruptedException>()
+                    it.cause shouldBe transportFailure
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `onFailure reports an interrupted session for any lost transport`() {
+        listOf(
+            SocketTimeoutException("Read timed out"),
+            UnknownHostException("Unable to resolve host"),
+            SSLException("Connection closed by peer"),
+            EOFException("Peer closed without a close frame")
+        ).forEach { transportFailure ->
+            clearMocks(onErrorReceived)
+            val livenessWebSocket = createLivenessWebSocket()
+
+            livenessWebSocket.webSocketListener.onFailure(mockk(), transportFailure, failureResponse())
+
+            verify {
+                onErrorReceived.accept(
+                    withArg {
+                        it.shouldBeInstanceOf<FaceLivenessSessionInterruptedException>()
+                        it.cause shouldBe transportFailure
+                    }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `onFailure with a non-IO failure reports an unclassified error`() {
+        val livenessWebSocket = createLivenessWebSocket()
+        val unexpectedFailure = IllegalStateException("Something else went wrong")
+
+        livenessWebSocket.webSocketListener.onFailure(mockk(), unexpectedFailure, failureResponse())
+
+        verify {
+            onErrorReceived.accept(
+                withArg {
+                    it::class shouldBe PredictionsException::class
+                    it.cause shouldBe unexpectedFailure
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `onFailure does not reclassify an error already reported by the server`() {
+        val livenessWebSocket = createLivenessWebSocket()
+        val serverError = FaceLivenessSessionNotFoundException()
+        livenessWebSocket.webSocketError = serverError
+
+        livenessWebSocket.webSocketListener.onFailure(
+            mockk(),
+            SocketException("Software caused connection abort"),
+            failureResponse()
+        )
+
+        verify { onErrorReceived.accept(serverError) }
+    }
+
+    @Test
+    fun `onFailure with a protocol exception reports an unclassified error`() {
+        val livenessWebSocket = createLivenessWebSocket()
+        val protocolFailure = ProtocolException("Malformed websocket frame")
+
+        livenessWebSocket.webSocketListener.onFailure(mockk(), protocolFailure, failureResponse())
+
+        verify {
+            onErrorReceived.accept(
+                withArg {
+                    it::class shouldBe PredictionsException::class
+                    it.cause shouldBe protocolFailure
+                }
+            )
+        }
     }
 
     @Test
@@ -648,6 +749,14 @@ internal class LivenessWebSocketTest {
         assertEquals("host", reconnectRequest.url.queryParameter("X-Amz-SignedHeaders"))
         assertEquals("AWS4-HMAC-SHA256", reconnectRequest.url.queryParameter("X-Amz-Algorithm"))
     }
+
+    // Response does not like to be mockk
+    private fun failureResponse() = Response.Builder()
+        .code(200)
+        .request(Request.Builder().url(URL("https://amazon.com")).build())
+        .protocol(Protocol.HTTP_2)
+        .message("Response")
+        .build()
 
     private fun createClientSessionInformation(challengeVersions: List<Challenge>) = FaceLivenessSessionInformation(
         videoWidth = 1f,


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* Addresses the predictions half of aws-amplify/amplify-ui-android#332

*Description of changes:*

When the websocket carrying a face liveness check dies mid-session — the user takes a call, or backgrounds the app long enough for the OS to close the socket, or connectivity drops — `LivenessWebSocket.onFailure` wrapped the transport throwable in a generic `PredictionsException("An unknown error occurred during the Liveness flow.")`. The *kind* of failure was never named, so by the time `LivenessCoordinator` in Amplify UI saw it, the only way to identify an interruption was to unwrap `cause` and match on `java.net.SocketException` — a JDK type that is no part of this SDK's contract.

This adds `FaceLivenessSessionInterruptedException` (`@InternalAmplifyApi`, `internal constructor`, matching the three internal siblings in that package — `AccessDeniedException`, the fourth, is public) and classifies a lost transport as that type:

```kotlin
private fun classifyConnectionFailure(t: Throwable): PredictionsException = when {
    socketOpened && t is IOException && t !is ProtocolException ->
        FaceLivenessSessionInterruptedException(cause = t)
    else -> PredictionsException(
        "An unknown error occurred during the Liveness flow.",
        t,
        "See attached exception for more details."
    )
}
```

Three conditions, each earning its place:

- **`socketOpened`** — set in `onOpen`. OkHttp routes both a lost transport *and* a connection that was never established through `onFailure`, and `ConnectException` / `SSLHandshakeException` / a connect-time `UnknownHostException` are all `IOException`. Without this gate a session that never started would be reported as interrupted with advice to retry, which is wrong for a pinning failure, an intercepting proxy, or a bad regional endpoint — all permanent. A connect-time failure keeps the generic message; distinguishing "could not connect" from "unknown" would need its own type and is not what #332 asked for.

  The flag is deliberately **not** cleared on the `ATTEMPT_RECONNECT` path, since a reconnect only follows a socket that did open and a server that did respond, so a failure on the retry really did interrupt a session that was under way.

- **`IOException`** — the family OkHttp reports for a dead transport: `SocketException` (the reported case), `SocketTimeoutException`, `UnknownHostException`, `SSLException`, `EOFException`.

- **`!is ProtocolException`** — a malformed frame is not an interruption. This also excludes a *rejected upgrade handshake*: OkHttp's `RealWebSocket.checkUpgradeSuccess` throws `ProtocolException("Expected HTTP 101 response but was ...")`, so an HTTP-level rejection of the handshake stays in the generic bucket too.

Two existing invariants are deliberately preserved:

- **`webSocketError ?:` keeps precedence**, so a server-sent typed error (validation, throttling, access-denied, session-not-found) can never be reclassified as an interruption. Covered by a test.
- **`clientStoppedSession` keeps its guard**, so a client-initiated close is still silent. A *backgrounded* app never disposes the composable, so the flag stays false and the classification applies exactly where intended. Covered by a test that specifically exercises a `SocketException` after a client stop.

`onClosed` is intentionally left alone. The abnormal-close path fires when the server closes with a non-1000 code without having sent a typed error — a server-side decision, not a lost connection. It is also moot here, since OkHttp reports connection loss (including 1006-style closure with no close frame) through `onFailure`.

The original throwable is still attached as `cause`, so no information is hidden — this adds a contract on top of it.

**Behaviour change:** callers that matched on the generic message string for a mid-session transport failure will no longer see it. The type is `@InternalAmplifyApi` and the public API dump is unchanged, so there is no public API impact.

**Follow-up:** Amplify UI maps this onto a public `FaceLivenessDetectionException.SessionInterruptedException` in aws-amplify/amplify-ui-android#334, which is what closes #332. That name matches the `FaceLivenessDetectionError.sessionInterrupted` iOS shipped in aws-amplify/amplify-ui-swift-liveness#240.

*How did you test these changes?*

`./gradlew :aws-predictions:testDebugUnitTest :aws-predictions:ktlintCheck :aws-predictions:apiCheck` — passes. 78 tests across 8 classes in the module, every class reporting `failures="0"`; `apiCheck` reports no `.api` drift.

`LivenessWebSocketTest` goes from 21 to 31 tests:

- one test per lost-transport type — `SocketException`, `SocketTimeoutException`, `UnknownHostException`, `SSLException`, `EOFException` — each asserting the type and that `cause` is preserved
- `ProtocolException` → generic `PredictionsException`
- a non-`IOException` → generic `PredictionsException`
- a failure **before** the socket opens → generic `PredictionsException`
- a server error already recorded in `webSocketError` is **not** reclassified
- a `SocketException` after `clientStoppedSession` is **not** reported at all

Note that end-to-end confirmation on a device — background a live check until the socket dies and observe the typed error reach `onError`, and confirm a *brief* background still recovers — depends on the Amplify UI mapping and will be verified with #334.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.