### PR TITLE
chore: Skip issue triage labeling for pull request comments

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -23,13 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    # These triage labels only apply to issues. The GITHUB_TOKEN also lacks
+    # pull-requests: write, so labeling a PR would fail.
+    if: ${{ !github.event.issue.pull_request }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       REPOSITORY_NAME: ${{ github.event.repository.full_name }}
     steps:
       - name: remove pending-community-response when new comment received
-        if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) && !github.event.issue.pull_request }}
+        if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
         shell: bash
         run: |
           gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --remove-label "pending-community-response"


### PR DESCRIPTION
`adjust-labels` ran on PR comments, where the token only has `issues: write`, so it exited 1 with `Resource not accessible by integration`. Latest failure: #3399, [run 32994778127](https://github.com/aws-amplify/amplify-android/actions/runs/32994778127).

Restores the job-level `!github.event.issue.pull_request` guard that #2892 dropped. Issue behavior unchanged.