### PR TITLE
fix(auth): Return signed-out session for User Pool-only apps

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthSession.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthSession.kt
@@ -20,6 +20,7 @@ import com.amplifyframework.auth.AWSCognitoUserPoolTokens
 import com.amplifyframework.auth.AWSCredentials
 import com.amplifyframework.auth.AuthException
 import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
+import com.amplifyframework.auth.cognito.exceptions.service.InvalidAccountTypeException
 import com.amplifyframework.auth.cognito.helpers.SessionHelper
 import com.amplifyframework.auth.exceptions.ConfigurationException
 import com.amplifyframework.auth.exceptions.InvalidStateException
@@ -164,12 +165,26 @@ internal fun AmplifyCredential.getCognitoSession(exception: AuthException? = nul
                 userPoolTokensResult = AuthSessionResult.failure(userPoolException)
             )
         }
-        else -> AWSCognitoAuthSession(
-            false,
-            identityIdResult = AuthSessionResult.failure(exception),
-            awsCredentialsResult = AuthSessionResult.failure(exception),
-            userSubResult = AuthSessionResult.failure(exception),
-            userPoolTokensResult = AuthSessionResult.failure(exception)
-        )
+        else -> {
+            // Signed-out with no Identity Pool: User Pool results are signed-out, while
+            // identity/credentials report the unsupported account type as elsewhere.
+            val identityException = if (this is AmplifyCredential.Empty && exception is SignedOutException) {
+                InvalidAccountTypeException(
+                    ConfigurationException(
+                        "Identity Pool not configured.",
+                        "Please check amplifyconfiguration.json file."
+                    )
+                )
+            } else {
+                exception
+            }
+            AWSCognitoAuthSession(
+                false,
+                identityIdResult = AuthSessionResult.failure(identityException),
+                awsCredentialsResult = AuthSessionResult.failure(identityException),
+                userSubResult = AuthSessionResult.failure(exception),
+                userPoolTokensResult = AuthSessionResult.failure(exception)
+            )
+        }
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActions.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.auth.cognito.actions
 import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.exceptions.ConfigurationException
+import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.AuthorizationActions
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
@@ -41,15 +42,11 @@ internal object AuthorizationCognitoActions : AuthorizationActions {
 
     override fun initializeFetchUnAuthSession() = Action<AuthEnvironment>("InitFetchUnAuthSession") { id, dispatcher ->
         logger.verbose("$id Starting execution")
+        // No Identity Pool means no guest credentials to fetch: a valid signed-out state.
         val evt = configuration.identityPool?.poolId?.let {
             FetchAuthSessionEvent(FetchAuthSessionEvent.EventType.FetchIdentity(LoginsMapProvider.UnAuthLogins()))
         } ?: AuthorizationEvent(
-            AuthorizationEvent.EventType.ThrowError(
-                ConfigurationException(
-                    "Identity Pool not configured.",
-                    "Please check amplifyconfiguration.json file."
-                )
-            )
+            AuthorizationEvent.EventType.ThrowError(SignedOutException())
         )
         logger.verbose("$id Sending event ${evt.type}")
         dispatcher.send(evt)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCase.kt
@@ -65,7 +65,11 @@ internal class FetchAuthSessionUseCase(
             }
             is AuthorizationState.Error -> {
                 when (val error = authZState.exception) {
-                    is SessionError -> waitForSession(getRefreshSessionEvent(error.amplifyCredential))
+                    is SessionError -> when (val exception = error.exception) {
+                        // A signed-out session has no credentials to refresh; return it directly.
+                        is SignedOutException -> error.amplifyCredential.getCognitoSession(exception)
+                        else -> waitForSession(getRefreshSessionEvent(error.amplifyCredential))
+                    }
                     else -> throw InvalidStateException()
                 }
             }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActionsTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActionsTest.kt
@@ -25,6 +25,7 @@ import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.auth.cognito.AuthEnvironment
 import com.amplifyframework.auth.cognito.StoreClientBehavior
 import com.amplifyframework.auth.cognito.mockSignedInData
+import com.amplifyframework.auth.exceptions.SignedOutException
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.EventDispatcher
 import com.amplifyframework.statemachine.StateMachineEvent
@@ -34,6 +35,7 @@ import com.amplifyframework.statemachine.codegen.data.CredentialType
 import com.amplifyframework.statemachine.codegen.data.DeviceMetadata
 import com.amplifyframework.statemachine.codegen.data.UserPoolConfiguration
 import com.amplifyframework.statemachine.codegen.events.AuthorizationEvent
+import com.amplifyframework.statemachine.codegen.events.FetchAuthSessionEvent
 import com.amplifyframework.statemachine.codegen.events.RefreshSessionEvent
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -461,5 +463,26 @@ class FetchAuthSessionCognitoActionsTest {
 
         requestSlot.captured.clientSecret shouldBe "secret"
         capturedEvent.captured.shouldBeInstanceOf<RefreshSessionEvent>()
+    }
+
+    @Test
+    fun `initializeFetchUnAuthSession throws SignedOutException when no Identity Pool is configured`() = runTest {
+        AuthorizationCognitoActions.initializeFetchUnAuthSession().execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<AuthorizationEvent>()
+        val throwError = event.eventType.shouldBeInstanceOf<AuthorizationEvent.EventType.ThrowError>()
+        throwError.exception.shouldBeInstanceOf<SignedOutException>()
+    }
+
+    @Test
+    fun `initializeFetchUnAuthSession fetches identity when Identity Pool is configured`() = runTest {
+        every { configuration.identityPool } returns mockk {
+            every { poolId } returns "identity_pool_id"
+        }
+
+        AuthorizationCognitoActions.initializeFetchUnAuthSession().execute(dispatcher, authEnvironment)
+
+        val event = capturedEvent.captured.shouldBeInstanceOf<FetchAuthSessionEvent>()
+        event.eventType.shouldBeInstanceOf<FetchAuthSessionEvent.EventType.FetchIdentity>()
     }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCaseTest.kt
@@ -410,4 +410,20 @@ class FetchAuthSessionUseCaseTest {
             useCase.execute()
         }
     }
+
+    @Test
+    fun `returns signed-out session without refreshing when resting in SignedOut error`() = runTest {
+        stateFlow.value = authState(
+            authNState = AuthenticationState.SignedOut(SignedOutData()),
+            authZState = AuthorizationState.Error(
+                SessionError(SignedOutException(), AmplifyCredential.Empty)
+            )
+        )
+
+        val result = useCase.execute()
+
+        result.isSignedIn shouldBe false
+        result.identityIdResult.error.shouldBeInstanceOf<SignedOutException>()
+        verify(exactly = 0) { stateMachine.send(any()) }
+    }
 }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/FetchAuthSessionUseCaseTest.kt
@@ -18,6 +18,7 @@ package com.amplifyframework.auth.cognito.usecases
 import com.amplifyframework.auth.AuthChannelEventName
 import com.amplifyframework.auth.cognito.AWSCognitoAuthSession
 import com.amplifyframework.auth.cognito.AuthStateMachine
+import com.amplifyframework.auth.cognito.exceptions.service.InvalidAccountTypeException
 import com.amplifyframework.auth.cognito.isValid
 import com.amplifyframework.auth.cognito.testUtil.authState
 import com.amplifyframework.auth.exceptions.ConfigurationException
@@ -264,7 +265,7 @@ class FetchAuthSessionUseCaseTest {
     }
 
     @Test
-    fun `embeds SignedOutException in session result`() = runTest {
+    fun `first fetch returns User Pool-only signed-out session with aligned typed results`() = runTest {
         stateFlow.value = authState(
             authNState = AuthenticationState.SignedOut(SignedOutData()),
             authZState = AuthorizationState.Configured()
@@ -282,7 +283,11 @@ class FetchAuthSessionUseCaseTest {
 
         val result = deferred.await()
         result.shouldBeInstanceOf<AWSCognitoAuthSession>()
-        result.identityIdResult.error.shouldBeInstanceOf<SignedOutException>()
+        result.isSignedIn shouldBe false
+        result.userSubResult.error.shouldBeInstanceOf<SignedOutException>()
+        result.userPoolTokensResult.error.shouldBeInstanceOf<SignedOutException>()
+        result.identityIdResult.error.shouldBeInstanceOf<InvalidAccountTypeException>()
+        result.awsCredentialsResult.error.shouldBeInstanceOf<InvalidAccountTypeException>()
     }
 
     @Test
@@ -397,6 +402,8 @@ class FetchAuthSessionUseCaseTest {
         val result = deferred.await()
         result.shouldBeInstanceOf<AWSCognitoAuthSession>()
         result.isSignedIn shouldBe false
+        result.identityIdResult.error.shouldBeInstanceOf<InvalidAccountTypeException>()
+        result.userSubResult.error.shouldBeInstanceOf<InvalidAccountTypeException>()
     }
 
     @Test
@@ -412,7 +419,7 @@ class FetchAuthSessionUseCaseTest {
     }
 
     @Test
-    fun `returns signed-out session without refreshing when resting in SignedOut error`() = runTest {
+    fun `repeated fetch returns aligned signed-out results without refreshing`() = runTest {
         stateFlow.value = authState(
             authNState = AuthenticationState.SignedOut(SignedOutData()),
             authZState = AuthorizationState.Error(
@@ -423,7 +430,27 @@ class FetchAuthSessionUseCaseTest {
         val result = useCase.execute()
 
         result.isSignedIn shouldBe false
-        result.identityIdResult.error.shouldBeInstanceOf<SignedOutException>()
+        result.userSubResult.error.shouldBeInstanceOf<SignedOutException>()
+        result.userPoolTokensResult.error.shouldBeInstanceOf<SignedOutException>()
+        result.identityIdResult.error.shouldBeInstanceOf<InvalidAccountTypeException>()
+        result.awsCredentialsResult.error.shouldBeInstanceOf<InvalidAccountTypeException>()
+        verify(exactly = 0) { stateMachine.send(any()) }
+    }
+
+    @Test
+    fun `forceRefresh fetch returns aligned signed-out results without refreshing`() = runTest {
+        stateFlow.value = authState(
+            authNState = AuthenticationState.SignedOut(SignedOutData()),
+            authZState = AuthorizationState.Error(
+                SessionError(SignedOutException(), AmplifyCredential.Empty)
+            )
+        )
+
+        val result = useCase.execute(AuthFetchSessionOptions.builder().forceRefresh(true).build())
+
+        result.isSignedIn shouldBe false
+        result.userSubResult.error.shouldBeInstanceOf<SignedOutException>()
+        result.identityIdResult.error.shouldBeInstanceOf<InvalidAccountTypeException>()
         verify(exactly = 0) { stateMachine.send(any()) }
     }
 }


### PR DESCRIPTION
## What
Return a stable signed-out session for User Pool-only apps. User Pool fields report `SignedOutException`, identity fields report `InvalidAccountTypeException`, and repeated calls no longer refresh empty credentials.

## Why
No Identity Pool is valid for User Pool-only apps. The result split follows Flutter and Swift's distinction between missing Identity Pool data and signed-out User Pool data.

## Testing
- `:aws-auth-cognito:testDebugUnitTest` — 564 tests, 0 failures
- `:aws-auth-cognito:ktlintCheck` and `:aws-auth-cognito:apiCheck`
- Android emulator: first, repeated, and post-restart fetches
