### PR TITLE
docs: fix contributing license link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -569,7 +569,7 @@ do **not** create a public GitHub issue.
 ## Licensing
 
 See the
-[LICENSE](https://github.com/awslabs/amplify-android/blob/master/LICENSE)
+[LICENSE](LICENSE)
 for more information. We will ask you to confirm the licensing of your
 contribution.
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

None — this is a one-line broken-link correction found by comparing the guide with the repository's current organization and branches.

*Description of changes:*

The Licensing section still points to the repository's former organization and removed branch:

```markdown
https://github.com/awslabs/amplify-android/blob/master/LICENSE
```

The project now lives at `aws-amplify/amplify-android`, its default branch is `main`, and no `master` ref exists. Replace the stale absolute URL with `[LICENSE](LICENSE)`. The relative target resolves in the current repository, in forks, and after any future organization or default-branch change.

*How did you test these changes?*

- verified default branch is `main`
- verified `master` ref is absent
- verified `LICENSE` exists at repository root on `main`
- verified `CONTRIBUTING.md` and `LICENSE` are siblings, so the relative link resolves
- ran `git diff --check` successfully

*Documentation update required?*
- [x] No — this PR is itself the complete documentation correction; no separate documentation repository is involved.
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests — not applicable to a Markdown-only link correction
- [ ] Added Integration Tests — not applicable to a Markdown-only link correction
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc.)
- [x] Ensure commit message has the appropriate scope (`docs(all)`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
