### PR TITLE
feat(api): add AppSyncException hierarchy and endpoint parser

### DIFF
--- a/aws-appsync/api/aws-appsync.api
+++ b/aws-appsync/api/aws-appsync.api
@@ -44,6 +44,11 @@ public final class com/amazonaws/appsync/AmplifyAppSyncClient$Configuration$Comp
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/amazonaws/appsync/AmplifyAppSyncClient$Configuration;
 }
 
+public abstract class com/amazonaws/appsync/AppSyncAuthException : com/amazonaws/appsync/AppSyncException {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class com/amazonaws/appsync/AppSyncAuthMode : java/lang/Enum {
 	public static final field API_KEY Lcom/amazonaws/appsync/AppSyncAuthMode;
 	public static final field IAM Lcom/amazonaws/appsync/AppSyncAuthMode;
@@ -82,6 +87,11 @@ public final class com/amazonaws/appsync/AppSyncAuthorization$Single : com/amazo
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/amazonaws/appsync/AppSyncAuthorizationClaimException : com/amazonaws/appsync/AppSyncAuthException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public abstract class com/amazonaws/appsync/AppSyncClientAuthorizer {
 	public synthetic fun <init> (Lcom/amazonaws/appsync/AppSyncAuthMode;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAuthMode ()Lcom/amazonaws/appsync/AppSyncAuthMode;
@@ -106,6 +116,116 @@ public final class com/amazonaws/appsync/AppSyncClientAuthorizer$Oidc : com/amaz
 
 public final class com/amazonaws/appsync/AppSyncClientAuthorizer$UserPools : com/amazonaws/appsync/AppSyncClientAuthorizer {
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract class com/amazonaws/appsync/AppSyncConfigurationException : com/amazonaws/appsync/AppSyncException {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncConnectionException : com/amazonaws/appsync/AppSyncSubscriptionException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncDeserializationException : com/amazonaws/appsync/AppSyncResponseException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncEndpointResolutionException : com/amazonaws/appsync/AppSyncConfigurationException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract class com/amazonaws/appsync/AppSyncException : com/amplifyframework/foundation/exceptions/AmplifyException {
+	public static final field Companion Lcom/amazonaws/appsync/AppSyncException$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncException$Companion {
+}
+
+public final class com/amazonaws/appsync/AppSyncGraphQLErrorException : com/amazonaws/appsync/AppSyncResponseException {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getErrors ()Ljava/util/List;
+}
+
+public final class com/amazonaws/appsync/AppSyncInvalidConfigException : com/amazonaws/appsync/AppSyncConfigurationException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncLimitExceededException : com/amazonaws/appsync/AppSyncSubscriptionException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncNetworkException : com/amazonaws/appsync/AppSyncException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncProviderNotConfiguredException : com/amazonaws/appsync/AppSyncAuthException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract class com/amazonaws/appsync/AppSyncRequestException : com/amazonaws/appsync/AppSyncException {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract class com/amazonaws/appsync/AppSyncResponseException : com/amazonaws/appsync/AppSyncException {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncSchemaException : com/amazonaws/appsync/AppSyncRequestException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncSigningException : com/amazonaws/appsync/AppSyncAuthException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract class com/amazonaws/appsync/AppSyncSubscriptionException : com/amazonaws/appsync/AppSyncException {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncTimeoutException : com/amazonaws/appsync/AppSyncSubscriptionException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncTokenExpiredException : com/amazonaws/appsync/AppSyncAuthException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncTokenFetchException : com/amazonaws/appsync/AppSyncAuthException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncTokenParsingException : com/amazonaws/appsync/AppSyncAuthException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncUnknownException : com/amazonaws/appsync/AppSyncException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncValidationException : com/amazonaws/appsync/AppSyncRequestException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/amazonaws/appsync/BuildConfig {
@@ -135,13 +255,13 @@ public final class com/amazonaws/appsync/ConnectionState$Connecting : com/amazon
 
 public final class com/amazonaws/appsync/ConnectionState$Disconnected : com/amazonaws/appsync/ConnectionState {
 	public fun <init> ()V
-	public fun <init> (Lcom/amplifyframework/api/ApiException;)V
-	public synthetic fun <init> (Lcom/amplifyframework/api/ApiException;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/amplifyframework/api/ApiException;
-	public final fun copy (Lcom/amplifyframework/api/ApiException;)Lcom/amazonaws/appsync/ConnectionState$Disconnected;
-	public static synthetic fun copy$default (Lcom/amazonaws/appsync/ConnectionState$Disconnected;Lcom/amplifyframework/api/ApiException;ILjava/lang/Object;)Lcom/amazonaws/appsync/ConnectionState$Disconnected;
+	public fun <init> (Lcom/amazonaws/appsync/AppSyncException;)V
+	public synthetic fun <init> (Lcom/amazonaws/appsync/AppSyncException;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/amazonaws/appsync/AppSyncException;
+	public final fun copy (Lcom/amazonaws/appsync/AppSyncException;)Lcom/amazonaws/appsync/ConnectionState$Disconnected;
+	public static synthetic fun copy$default (Lcom/amazonaws/appsync/ConnectionState$Disconnected;Lcom/amazonaws/appsync/AppSyncException;ILjava/lang/Object;)Lcom/amazonaws/appsync/ConnectionState$Disconnected;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCause ()Lcom/amplifyframework/api/ApiException;
+	public final fun getCause ()Lcom/amazonaws/appsync/AppSyncException;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -149,18 +269,15 @@ public final class com/amazonaws/appsync/ConnectionState$Disconnected : com/amaz
 public abstract class com/amazonaws/appsync/SubscriptionEvent {
 }
 
-public abstract class com/amazonaws/appsync/SubscriptionEvent$Connection : com/amazonaws/appsync/SubscriptionEvent {
-}
-
-public final class com/amazonaws/appsync/SubscriptionEvent$Connection$Connected : com/amazonaws/appsync/SubscriptionEvent$Connection {
-	public static final field INSTANCE Lcom/amazonaws/appsync/SubscriptionEvent$Connection$Connected;
+public final class com/amazonaws/appsync/SubscriptionEvent$Connected : com/amazonaws/appsync/SubscriptionEvent {
+	public static final field INSTANCE Lcom/amazonaws/appsync/SubscriptionEvent$Connected;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/amazonaws/appsync/SubscriptionEvent$Connection$Connecting : com/amazonaws/appsync/SubscriptionEvent$Connection {
-	public static final field INSTANCE Lcom/amazonaws/appsync/SubscriptionEvent$Connection$Connecting;
+public final class com/amazonaws/appsync/SubscriptionEvent$Connecting : com/amazonaws/appsync/SubscriptionEvent {
+	public static final field INSTANCE Lcom/amazonaws/appsync/SubscriptionEvent$Connecting;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
@@ -18,6 +18,7 @@ import com.amplifyframework.annotations.ExperimentalAmplifyApi
 import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.GraphQLResponse
 import com.amplifyframework.foundation.result.Result
+import com.amplifyframework.foundation.result.getOrThrow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import okhttp3.OkHttpClient
@@ -143,9 +144,6 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
                 require(::endpoint.isInitialized) { "endpoint is required" }
                 require(::authorization.isInitialized) { "authorization is required" }
                 val resolvedRegion = region ?: inferRegion(endpoint)
-                requireNotNull(resolvedRegion) {
-                    "region is required. Either set it explicitly or use a standard AppSync endpoint URL."
-                }
                 return Configuration(
                     endpoint = endpoint,
                     authorization = authorization,
@@ -167,7 +165,8 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
              * Expected format: `https://{id}.appsync-api.{region}.{dnsSuffix}/graphql`, across the
              * commercial, China and GovCloud partitions.
              */
-            internal fun inferRegion(endpoint: String): String? = AppSyncEndpointParser.regionOrNull(endpoint)
+            internal fun inferRegion(endpoint: String): String =
+                AppSyncEndpointParser.parse(endpoint).getOrThrow().region
         }
     }
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
@@ -15,7 +15,6 @@
 package com.amazonaws.appsync
 
 import com.amplifyframework.annotations.ExperimentalAmplifyApi
-import com.amplifyframework.api.ApiException
 import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.GraphQLResponse
 import com.amplifyframework.foundation.result.Result
@@ -59,18 +58,18 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
      * Execute a GraphQL query.
      *
      * @param request The GraphQL request. Use model helpers or construct manually.
-     * @return [Result.Success] with the typed GraphQL response, or [Result.Failure] with an [ApiException].
+     * @return [Result.Success] with the typed GraphQL response, or [Result.Failure] with an [AppSyncException].
      */
-    suspend fun <T> query(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, ApiException> =
+    suspend fun <T> query(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, AppSyncException> =
         TODO("Query implementation will be added in a follow-up PR")
 
     /**
      * Execute a GraphQL mutation.
      *
      * @param request The GraphQL request. Use model helpers or construct manually.
-     * @return [Result.Success] with the typed GraphQL response, or [Result.Failure] with an [ApiException].
+     * @return [Result.Success] with the typed GraphQL response, or [Result.Failure] with an [AppSyncException].
      */
-    suspend fun <T> mutate(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, ApiException> =
+    suspend fun <T> mutate(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, AppSyncException> =
         TODO("Mutation implementation will be added in a follow-up PR")
 
     /**
@@ -165,12 +164,10 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
 
             /**
              * Infer the AWS region from an AppSync endpoint URL.
-             * Expected format: `https://{id}.appsync-api.{region}.amazonaws.com/graphql`
+             * Expected format: `https://{id}.appsync-api.{region}.{dnsSuffix}/graphql`, across the
+             * commercial, China and GovCloud partitions.
              */
-            internal fun inferRegion(endpoint: String): String? {
-                val regex = Regex("""\.appsync-api\.([a-z0-9-]+)\.amazonaws\.com""")
-                return regex.find(endpoint)?.groupValues?.get(1)
-            }
+            internal fun inferRegion(endpoint: String): String? = AppSyncEndpointParser.regionOrNull(endpoint)
         }
     }
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.foundation.result.Result
+
+/**
+ * An AppSync GraphQL endpoint, decomposed into the parts the client needs.
+ *
+ * The realtime host is derived rather than assumed, because it differs by partition: in the standard
+ * partitions the `appsync-api` label becomes `appsync-realtime-api`, but China endpoints end in
+ * `.amazonaws.com.cn` rather than `.amazonaws.com`, so a parser that assumes a `.amazonaws.com`
+ * suffix produces a host that does not resolve.
+ *
+ * @param region The AWS region the endpoint is in.
+ * @param host The HTTP host, used for queries and mutations.
+ * @param realtimeHost The WebSocket host, used for subscriptions.
+ * @param dnsSuffix The partition's DNS suffix, e.g. `amazonaws.com` or `amazonaws.com.cn`.
+ */
+internal data class AppSyncEndpoint(
+    val region: String,
+    val host: String,
+    val realtimeHost: String,
+    val dnsSuffix: String
+)
+
+/**
+ * Parses AppSync GraphQL endpoint URLs into an [AppSyncEndpoint].
+ *
+ * Replaces the unanchored region regex this client started with. That regex did extract the right
+ * region for China endpoints by accident, since it was unanchored — but it gave no realtime host and
+ * no partition, both of which subscriptions and SigV4 signing need.
+ *
+ * Handles the standard AppSync form:
+ * ```
+ * https://{apiId}.appsync-api.{region}.{dnsSuffix}/graphql
+ * ```
+ * across the commercial, China and GovCloud partitions. A custom domain does not carry a region in
+ * its host, so [parse] fails for one and the caller must supply the region explicitly.
+ */
+internal object AppSyncEndpointParser {
+
+    private const val API_LABEL = "appsync-api"
+    private const val REALTIME_LABEL = "appsync-realtime-api"
+
+    /**
+     * Parses [endpoint].
+     *
+     * @return the parsed endpoint, or a failure describing why it could not be parsed.
+     */
+    fun parse(endpoint: String): Result<AppSyncEndpoint, AppSyncEndpointResolutionException> {
+        val host = hostOf(endpoint)
+            ?: return failure("Could not read a host from the endpoint URL '$endpoint'.")
+
+        // {apiId}.appsync-api.{region}.{dnsSuffix...}
+        val labels = host.split('.')
+        val apiLabelIndex = labels.indexOf(API_LABEL)
+
+        if (apiLabelIndex < 1) {
+            return failure(
+                "The endpoint host '$host' is not a standard AppSync endpoint: expected a " +
+                    "'$API_LABEL' label, as in {apiId}.$API_LABEL.{region}.amazonaws.com."
+            )
+        }
+
+        val regionIndex = apiLabelIndex + 1
+        if (regionIndex >= labels.lastIndex) {
+            return failure("The endpoint host '$host' has no region label after '$API_LABEL'.")
+        }
+
+        val region = labels[regionIndex]
+        if (!isRegionLike(region)) {
+            return failure("'$region' in the endpoint host '$host' is not a valid AWS region.")
+        }
+
+        val dnsSuffix = labels.drop(regionIndex + 1).joinToString(".")
+        if (dnsSuffix.isEmpty()) {
+            return failure("The endpoint host '$host' has no DNS suffix after the region.")
+        }
+
+        // Swap only the api label, preserving apiId, region and the partition's suffix. This is what
+        // keeps China (amazonaws.com.cn) and GovCloud working without special-casing either.
+        val realtimeLabels = labels.toMutableList()
+        realtimeLabels[apiLabelIndex] = REALTIME_LABEL
+
+        return Result.Success(
+            AppSyncEndpoint(
+                region = region,
+                host = host,
+                realtimeHost = realtimeLabels.joinToString("."),
+                dnsSuffix = dnsSuffix
+            )
+        )
+    }
+
+    /**
+     * Resolves just the region from [endpoint], for callers that only need that.
+     *
+     * @return the region, or null if the endpoint is not a standard AppSync URL.
+     */
+    fun regionOrNull(endpoint: String): String? = (parse(endpoint) as? Result.Success)?.data?.region
+
+    private fun hostOf(endpoint: String): String? {
+        val withoutScheme = endpoint.substringAfter("://", missingDelimiterValue = endpoint)
+        val host = withoutScheme
+            .substringBefore('/')
+            .substringBefore('?')
+            .substringBefore('#')
+            .substringBefore(':') // strip any port
+            .lowercase()
+        return host.ifEmpty { null }
+    }
+
+    // Region labels are of the form {partition}-{area}-{number}, e.g. us-east-1, cn-north-1,
+    // us-gov-west-1, ap-southeast-4. Deliberately structural rather than an allowlist, so a region
+    // launched after this ships still parses.
+    private fun isRegionLike(candidate: String): Boolean = Regex("""^[a-z]{2,}(-[a-z]+)+-\d+$""").matches(candidate)
+
+    private fun failure(message: String) = Result.Failure(AppSyncEndpointResolutionException(message))
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
@@ -55,6 +55,7 @@ internal object AppSyncEndpointParser {
 
     private const val API_LABEL = "appsync-api"
     private const val REALTIME_LABEL = "appsync-realtime-api"
+    private val REGION_REGEX = """^[a-z]{2,}(-[a-z]+)+-\d+$""".toRegex()
 
     /**
      * Parses [endpoint].
@@ -126,7 +127,7 @@ internal object AppSyncEndpointParser {
     // Region labels are of the form {partition}-{area}-{number}, e.g. us-east-1, cn-north-1,
     // us-gov-west-1, ap-southeast-4. Deliberately structural rather than an allowlist, so a region
     // launched after this ships still parses.
-    private fun isRegionLike(candidate: String): Boolean = Regex("""^[a-z]{2,}(-[a-z]+)+-\d+$""").matches(candidate)
+    private fun isRegionLike(candidate: String): Boolean = REGION_REGEX.matches(candidate)
 
     private fun failure(message: String) = Result.Failure(AppSyncEndpointResolutionException(message))
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.appsync
 
+import com.amazonaws.appsync.AppSyncEndpointParser.parse
 import com.amplifyframework.foundation.result.Result
 
 /**
@@ -104,13 +105,6 @@ internal object AppSyncEndpointParser {
             )
         )
     }
-
-    /**
-     * Resolves just the region from [endpoint], for callers that only need that.
-     *
-     * @return the region, or null if the endpoint is not a standard AppSync URL.
-     */
-    fun regionOrNull(endpoint: String): String? = (parse(endpoint) as? Result.Success)?.data?.region
 
     private fun hostOf(endpoint: String): String? {
         val withoutScheme = endpoint.substringAfter("://", missingDelimiterValue = endpoint)

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
@@ -69,10 +69,16 @@ internal object AppSyncEndpointParser {
         val labels = host.split('.')
         val apiLabelIndex = labels.indexOf(API_LABEL)
 
-        if (apiLabelIndex < 1) {
+        if (apiLabelIndex < 0) {
             return failure(
                 "The endpoint host '$host' is not a standard AppSync endpoint: expected a " +
-                    "'$API_LABEL' label, as in {apiId}.$API_LABEL.{region}.amazonaws.com."
+                    "'$API_LABEL' label, as in {apiId}.$API_LABEL.{region}.{dnsSuffix}."
+            )
+        }
+
+        if (apiLabelIndex == 0) {
+            return failure(
+                "The endpoint host '$host' has no API id label before '$API_LABEL'."
             )
         }
 

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.annotations.ExperimentalAmplifyApi
+import com.amplifyframework.api.graphql.GraphQLResponse
+import com.amplifyframework.foundation.exceptions.AmplifyException
+import com.amplifyframework.foundation.exceptions.DEFAULT_RECOVERY_SUGGESTION
+import java.io.IOException
+
+/**
+ * Base exception for all AppSync client operations.
+ *
+ * This is a sealed hierarchy with two levels. The intermediate groups are themselves sealed, so a
+ * caller can catch a whole category:
+ *
+ * ```kotlin
+ * when (val result = client.query(request)) {
+ *     is Result.Success -> use(result.data)
+ *     is Result.Failure -> when (val e = result.error) {
+ *         is AppSyncAuthException -> reauthenticate()
+ *         is AppSyncNetworkException -> retryLater()
+ *         else -> report(e)
+ *     }
+ * }
+ * ```
+ *
+ * The groups are [AppSyncAuthException], [AppSyncConfigurationException],
+ * [AppSyncResponseException], [AppSyncSubscriptionException] and [AppSyncRequestException].
+ * [AppSyncNetworkException] and [AppSyncUnknownException] are leaves directly under this base.
+ *
+ * @param message Error message describing what went wrong
+ * @param recoverySuggestion Suggested action to resolve the error
+ * @param cause Underlying cause of the exception
+ */
+@ExperimentalAmplifyApi
+sealed class AppSyncException(
+    message: String,
+    recoverySuggestion: String,
+    cause: Throwable? = null
+) : AmplifyException(message, recoverySuggestion, cause) {
+    companion object {
+        /**
+         * Maps a [Throwable] raised anywhere inside the client into the appropriate
+         * [AppSyncException] subtype. Anything unrecognised becomes [AppSyncUnknownException] rather
+         * than escaping untyped.
+         */
+        internal fun from(error: Throwable): AppSyncException = when (error) {
+            is AppSyncException -> error
+            is IOException -> AppSyncNetworkException(
+                message = error.message ?: "A network error occurred.",
+                cause = error
+            )
+            else -> AppSyncUnknownException(
+                message = error.message ?: "An unknown error occurred.",
+                cause = error
+            )
+        }
+    }
+}
+
+// ── Auth ────────────────────────────────────────────────────────────────
+
+/**
+ * Authorization failures. Catch this to handle every auth problem as one category.
+ */
+@ExperimentalAmplifyApi
+sealed class AppSyncAuthException(
+    message: String,
+    recoverySuggestion: String,
+    cause: Throwable? = null
+) : AppSyncException(message, recoverySuggestion, cause)
+
+/** An authorizer's token or API key supplier failed. */
+@ExperimentalAmplifyApi
+class AppSyncTokenFetchException(
+    message: String,
+    recoverySuggestion: String = "Verify that the token supplier passed to the authorizer succeeds.",
+    cause: Throwable? = null
+) : AppSyncAuthException(message, recoverySuggestion, cause)
+
+/** The supplied token was rejected as expired. */
+@ExperimentalAmplifyApi
+class AppSyncTokenExpiredException(
+    message: String,
+    recoverySuggestion: String = "Refresh the credentials and retry the request.",
+    cause: Throwable? = null
+) : AppSyncAuthException(message, recoverySuggestion, cause)
+
+/** No authorizer was configured for the auth mode a request requires. */
+@ExperimentalAmplifyApi
+class AppSyncProviderNotConfiguredException(
+    message: String,
+    recoverySuggestion: String = "Add an authorizer for this auth mode to the client's AppSyncAuthorization.",
+    cause: Throwable? = null
+) : AppSyncAuthException(message, recoverySuggestion, cause)
+
+/** SigV4 request signing failed. */
+@ExperimentalAmplifyApi
+class AppSyncSigningException(
+    message: String,
+    recoverySuggestion: String = "Verify that the credentials provider returns valid IAM credentials.",
+    cause: Throwable? = null
+) : AppSyncAuthException(message, recoverySuggestion, cause)
+
+/** A token could not be parsed, so its claims could not be read. */
+@ExperimentalAmplifyApi
+class AppSyncTokenParsingException(
+    message: String,
+    recoverySuggestion: String = "Verify that the token supplier returns a well-formed JWT.",
+    cause: Throwable? = null
+) : AppSyncAuthException(message, recoverySuggestion, cause)
+
+/** A claim required to authorize the request was missing from the token. */
+@ExperimentalAmplifyApi
+class AppSyncAuthorizationClaimException(
+    message: String,
+    recoverySuggestion: String = "Verify that the token contains the claim the model's @auth rule requires.",
+    cause: Throwable? = null
+) : AppSyncAuthException(message, recoverySuggestion, cause)
+
+// ── Configuration ───────────────────────────────────────────────────────
+
+/**
+ * The client was configured in a way it cannot use. These are programming errors, surfaced at
+ * construction or on first use rather than silently.
+ */
+@ExperimentalAmplifyApi
+sealed class AppSyncConfigurationException(
+    message: String,
+    recoverySuggestion: String,
+    cause: Throwable? = null
+) : AppSyncException(message, recoverySuggestion, cause)
+
+/** The configuration was rejected. */
+@ExperimentalAmplifyApi
+class AppSyncInvalidConfigException(
+    message: String,
+    recoverySuggestion: String = "Correct the AmplifyAppSyncClient.Configuration and recreate the client.",
+    cause: Throwable? = null
+) : AppSyncConfigurationException(message, recoverySuggestion, cause)
+
+/** The endpoint could not be parsed, or a region could not be resolved from it. */
+@ExperimentalAmplifyApi
+class AppSyncEndpointResolutionException(
+    message: String,
+    recoverySuggestion: String = "Provide a standard AppSync endpoint URL, or set region explicitly.",
+    cause: Throwable? = null
+) : AppSyncConfigurationException(message, recoverySuggestion, cause)
+
+// ── Response ────────────────────────────────────────────────────────────
+
+/** A response arrived but could not be turned into the expected result. */
+@ExperimentalAmplifyApi
+sealed class AppSyncResponseException(
+    message: String,
+    recoverySuggestion: String,
+    cause: Throwable? = null
+) : AppSyncException(message, recoverySuggestion, cause)
+
+/** The response body did not deserialize into the request's response type. */
+@ExperimentalAmplifyApi
+class AppSyncDeserializationException(
+    message: String,
+    recoverySuggestion: String = "Verify that the request's response type matches the shape the API returns.",
+    cause: Throwable? = null
+) : AppSyncResponseException(message, recoverySuggestion, cause)
+
+/**
+ * The service returned GraphQL errors.
+ *
+ * Note this is for the case where errors are terminal. Errors that accompany data in a successful
+ * response are delivered on [GraphQLResponse.errors] instead, not thrown.
+ *
+ * @param errors The GraphQL errors the service returned.
+ */
+@ExperimentalAmplifyApi
+class AppSyncGraphQLErrorException(
+    message: String,
+    val errors: List<GraphQLResponse.Error>,
+    recoverySuggestion: String = "Inspect the errors list for the failures the service reported.",
+    cause: Throwable? = null
+) : AppSyncResponseException(message, recoverySuggestion, cause)
+
+// ── Subscription ────────────────────────────────────────────────────────
+
+/**
+ * A subscription could not be established or was terminated. All subscription errors are terminal:
+ * the stream ends and the consumer must re-subscribe.
+ */
+@ExperimentalAmplifyApi
+sealed class AppSyncSubscriptionException(
+    message: String,
+    recoverySuggestion: String,
+    cause: Throwable? = null
+) : AppSyncException(message, recoverySuggestion, cause)
+
+/** The WebSocket connection failed or was lost. */
+@ExperimentalAmplifyApi
+class AppSyncConnectionException(
+    message: String,
+    recoverySuggestion: String = "Check network connectivity and re-subscribe.",
+    cause: Throwable? = null
+) : AppSyncSubscriptionException(message, recoverySuggestion, cause)
+
+/** Establishing the subscription timed out. */
+@ExperimentalAmplifyApi
+class AppSyncTimeoutException(
+    message: String,
+    recoverySuggestion: String = "Re-subscribe, or raise the timeout via the WebSocket client configurator.",
+    cause: Throwable? = null
+) : AppSyncSubscriptionException(message, recoverySuggestion, cause)
+
+/**
+ * The API's maximum number of concurrent subscriptions was reached.
+ *
+ * Nothing raises this yet — recognising AppSync's `MaxSubscriptionsReachedError` is Phase 5 work.
+ * The type is declared now so the sealed hierarchy is complete and callers can match on it.
+ */
+@ExperimentalAmplifyApi
+class AppSyncLimitExceededException(
+    message: String,
+    recoverySuggestion: String = "Close subscriptions that are no longer needed before opening more.",
+    cause: Throwable? = null
+) : AppSyncSubscriptionException(message, recoverySuggestion, cause)
+
+// ── Request ─────────────────────────────────────────────────────────────
+
+/** The request could not be built or was rejected before being sent. */
+@ExperimentalAmplifyApi
+sealed class AppSyncRequestException(
+    message: String,
+    recoverySuggestion: String,
+    cause: Throwable? = null
+) : AppSyncException(message, recoverySuggestion, cause)
+
+/** A request could not be built from the model's schema. */
+@ExperimentalAmplifyApi
+class AppSyncSchemaException(
+    message: String,
+    recoverySuggestion: String = "Verify the model class was generated by Amplify codegen and is annotated correctly.",
+    cause: Throwable? = null
+) : AppSyncRequestException(message, recoverySuggestion, cause)
+
+/** The request was structurally invalid. */
+@ExperimentalAmplifyApi
+class AppSyncValidationException(
+    message: String,
+    recoverySuggestion: String = "Correct the request and retry.",
+    cause: Throwable? = null
+) : AppSyncRequestException(message, recoverySuggestion, cause)
+
+// ── Ungrouped leaves ────────────────────────────────────────────────────
+
+/** The request could not reach the service. */
+@ExperimentalAmplifyApi
+class AppSyncNetworkException(
+    message: String,
+    recoverySuggestion: String = "Check network connectivity and retry the request.",
+    cause: Throwable? = null
+) : AppSyncException(message, recoverySuggestion, cause)
+
+/** An unexpected or uncategorized error. */
+@ExperimentalAmplifyApi
+class AppSyncUnknownException(
+    message: String,
+    recoverySuggestion: String = DEFAULT_RECOVERY_SUGGESTION,
+    cause: Throwable? = null
+) : AppSyncException(message, recoverySuggestion, cause)

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
@@ -226,8 +226,8 @@ class AppSyncTimeoutException(
 /**
  * The API's maximum number of concurrent subscriptions was reached.
  *
- * Nothing raises this yet — recognising AppSync's `MaxSubscriptionsReachedError` is Phase 5 work.
- * The type is declared now so the sealed hierarchy is complete and callers can match on it.
+ * The type is declared so the sealed hierarchy is complete and callers can match on it.
+ * TODO: nothing raises this yet — recognise AppSync's `MaxSubscriptionsReachedError`.
  */
 @ExperimentalAmplifyApi
 class AppSyncLimitExceededException(

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/ConnectionState.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/ConnectionState.kt
@@ -17,7 +17,7 @@ package com.amazonaws.appsync
 import com.amplifyframework.annotations.ExperimentalAmplifyApi
 
 /**
- * The connection state of the client's shared WebSocket. Replaces Hub events from V2.
+ * The connection state of the client's shared WebSocket.
  * Exposed via [AmplifyAppSyncClient.events].
  */
 @ExperimentalAmplifyApi

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/ConnectionState.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/ConnectionState.kt
@@ -15,7 +15,6 @@
 package com.amazonaws.appsync
 
 import com.amplifyframework.annotations.ExperimentalAmplifyApi
-import com.amplifyframework.api.ApiException
 
 /**
  * The connection state of the client's shared WebSocket. Replaces Hub events from V2.
@@ -34,5 +33,5 @@ sealed class ConnectionState {
      * @param cause The reason for disconnection, or null if this is a clean shutdown
      *   (no subscriptions, client closed, or not yet connected).
      */
-    data class Disconnected(val cause: ApiException? = null) : ConnectionState()
+    data class Disconnected(val cause: AppSyncException? = null) : ConnectionState()
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/SubscriptionEvent.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/SubscriptionEvent.kt
@@ -20,9 +20,12 @@ import com.amplifyframework.api.graphql.GraphQLResponse
 /**
  * Events emitted by a GraphQL subscription flow.
  *
- * Lifecycle: the flow emits [Connection.Connecting] → [Connection.Connected] → [Data]*
- * and then either completes normally (user cancel, server complete, client close) or
- * throws an [ApiException] (network, auth, timeout, etc.).
+ * Lifecycle: the flow emits [Connecting] → [Connected] → [Data]* and then either completes normally
+ * (consumer cancellation, server complete, client close) or throws an [AppSyncException] (network,
+ * auth, timeout). All errors are terminal — the stream ends and the consumer must re-subscribe.
+ *
+ * There is deliberately no `Disconnected` event: a stream ends by completing or throwing, so a
+ * disconnect event would be redundant with termination.
  *
  * For client-wide WebSocket connection state, observe [AmplifyAppSyncClient.events].
  */
@@ -35,14 +38,9 @@ sealed class SubscriptionEvent<out T> {
      */
     data class Data<T>(val response: GraphQLResponse<T>) : SubscriptionEvent<T>()
 
-    /**
-     * Subscription establishment lifecycle events.
-     */
-    sealed class Connection : SubscriptionEvent<Nothing>() {
-        /** The subscription is being established (WebSocket connecting + registration in progress). */
-        data object Connecting : Connection()
+    /** The subscription is being established (WebSocket connecting + registration in progress). */
+    data object Connecting : SubscriptionEvent<Nothing>()
 
-        /** The subscription is established and receiving data. */
-        data object Connected : Connection()
-    }
+    /** The subscription is established and receiving data. */
+    data object Connected : SubscriptionEvent<Nothing>()
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.foundation.result.Result
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+
+/**
+ * Tests [AppSyncEndpointParser].
+ *
+ * The partition matrix is the point of this class. The regex this parser replaced assumed a
+ * `.amazonaws.com` suffix, so it produced a realtime host that does not resolve for China endpoints,
+ * which end in `.amazonaws.com.cn`.
+ */
+class AppSyncEndpointParserTest {
+
+    private fun parsed(endpoint: String) = (AppSyncEndpointParser.parse(endpoint) as Result.Success).data
+
+    // ── Partition matrix (§5.4) ─────────────────────────────────────────
+
+    @Test
+    fun `commercial partition`() {
+        val endpoint = parsed("https://abc123.appsync-api.us-east-1.amazonaws.com/graphql")
+
+        endpoint.region shouldBe "us-east-1"
+        endpoint.host shouldBe "abc123.appsync-api.us-east-1.amazonaws.com"
+        endpoint.realtimeHost shouldBe "abc123.appsync-realtime-api.us-east-1.amazonaws.com"
+        endpoint.dnsSuffix shouldBe "amazonaws.com"
+    }
+
+    @Test
+    fun `china cn-north-1 keeps the com-cn suffix in the realtime host`() {
+        val endpoint = parsed("https://abc123.appsync-api.cn-north-1.amazonaws.com.cn/graphql")
+
+        endpoint.region shouldBe "cn-north-1"
+        endpoint.realtimeHost shouldBe "abc123.appsync-realtime-api.cn-north-1.amazonaws.com.cn"
+        endpoint.dnsSuffix shouldBe "amazonaws.com.cn"
+    }
+
+    @Test
+    fun `china cn-northwest-1 keeps the com-cn suffix in the realtime host`() {
+        val endpoint = parsed("https://abc123.appsync-api.cn-northwest-1.amazonaws.com.cn/graphql")
+
+        endpoint.region shouldBe "cn-northwest-1"
+        endpoint.realtimeHost shouldBe "abc123.appsync-realtime-api.cn-northwest-1.amazonaws.com.cn"
+        endpoint.dnsSuffix shouldBe "amazonaws.com.cn"
+    }
+
+    @Test
+    fun `govcloud`() {
+        val endpoint = parsed("https://abc123.appsync-api.us-gov-west-1.amazonaws.com/graphql")
+
+        endpoint.region shouldBe "us-gov-west-1"
+        endpoint.realtimeHost shouldBe "abc123.appsync-realtime-api.us-gov-west-1.amazonaws.com"
+        endpoint.dnsSuffix shouldBe "amazonaws.com"
+    }
+
+    @Test
+    fun `a region launched after this ships still parses`() {
+        // Structural, not an allowlist — this must not need updating per region launch.
+        parsed("https://abc123.appsync-api.ap-southeast-7.amazonaws.com/graphql").region shouldBe
+            "ap-southeast-7"
+    }
+
+    // ── URL shapes ──────────────────────────────────────────────────────
+
+    @Test
+    fun `tolerates a missing scheme, a port, a query string and a fragment`() {
+        listOf(
+            "abc123.appsync-api.eu-west-2.amazonaws.com/graphql",
+            "https://abc123.appsync-api.eu-west-2.amazonaws.com:443/graphql",
+            "https://abc123.appsync-api.eu-west-2.amazonaws.com/graphql?trace=1",
+            "https://abc123.appsync-api.eu-west-2.amazonaws.com/graphql#frag"
+        ).forEach { parsed(it).region shouldBe "eu-west-2" }
+    }
+
+    @Test
+    fun `host casing is normalised`() {
+        parsed("https://ABC123.AppSync-Api.US-EAST-1.amazonaws.com/graphql").region shouldBe "us-east-1"
+    }
+
+    // ── Failures ────────────────────────────────────────────────────────
+
+    @Test
+    fun `a custom domain fails, because it carries no region`() {
+        val result = AppSyncEndpointParser.parse("https://api.example.com/graphql")
+
+        result.shouldBeInstanceOf<Result.Failure<AppSyncEndpointResolutionException>>()
+        result.error.shouldBeInstanceOf<AppSyncConfigurationException>()
+        result.error.message shouldContain "appsync-api"
+    }
+
+    @Test
+    fun `a non-region label where the region belongs fails`() {
+        val result = AppSyncEndpointParser.parse("https://abc123.appsync-api.notaregion.amazonaws.com/graphql")
+
+        result.shouldBeInstanceOf<Result.Failure<AppSyncEndpointResolutionException>>()
+        result.error.message shouldContain "not a valid AWS region"
+    }
+
+    @Test
+    fun `an endpoint with no apiId label before appsync-api fails`() {
+        AppSyncEndpointParser.parse("https://appsync-api.us-east-1.amazonaws.com/graphql")
+            .shouldBeInstanceOf<Result.Failure<AppSyncEndpointResolutionException>>()
+    }
+
+    @Test
+    fun `an endpoint with nothing after the region fails`() {
+        AppSyncEndpointParser.parse("https://abc123.appsync-api.us-east-1/graphql")
+            .shouldBeInstanceOf<Result.Failure<AppSyncEndpointResolutionException>>()
+    }
+
+    @Test
+    fun `an empty endpoint fails rather than throwing`() {
+        AppSyncEndpointParser.parse("")
+            .shouldBeInstanceOf<Result.Failure<AppSyncEndpointResolutionException>>()
+    }
+
+    // ── regionOrNull, used by Configuration ─────────────────────────────
+
+    @Test
+    fun `regionOrNull returns the region for a standard endpoint`() {
+        AppSyncEndpointParser.regionOrNull(
+            "https://abc123.appsync-api.ap-south-1.amazonaws.com/graphql"
+        ) shouldBe "ap-south-1"
+    }
+
+    @Test
+    fun `regionOrNull returns null for a custom domain, so Configuration can require region`() {
+        AppSyncEndpointParser.regionOrNull("https://api.example.com/graphql") shouldBe null
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
@@ -31,7 +31,7 @@ class AppSyncEndpointParserTest {
 
     private fun parsed(endpoint: String) = (AppSyncEndpointParser.parse(endpoint) as Result.Success).data
 
-    // ── Partition matrix (§5.4) ─────────────────────────────────────────
+    // ── Partition matrix ────────────────────────────────────────────────
 
     @Test
     fun `commercial partition`() {

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
@@ -130,18 +130,4 @@ class AppSyncEndpointParserTest {
         AppSyncEndpointParser.parse("")
             .shouldBeInstanceOf<Result.Failure<AppSyncEndpointResolutionException>>()
     }
-
-    // ── regionOrNull, used by Configuration ─────────────────────────────
-
-    @Test
-    fun `regionOrNull returns the region for a standard endpoint`() {
-        AppSyncEndpointParser.regionOrNull(
-            "https://abc123.appsync-api.ap-south-1.amazonaws.com/graphql"
-        ) shouldBe "ap-south-1"
-    }
-
-    @Test
-    fun `regionOrNull returns null for a custom domain, so Configuration can require region`() {
-        AppSyncEndpointParser.regionOrNull("https://api.example.com/graphql") shouldBe null
-    }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncExceptionTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncExceptionTest.kt
@@ -24,7 +24,7 @@ import java.net.SocketTimeoutException
 import org.junit.Test
 
 /**
- * Tests [AppSyncException]: that the hierarchy has the shape §3.5 specifies, and that
+ * Tests [AppSyncException]: that the hierarchy has the intended shape, and that
  * [AppSyncException.from] maps throwables into it rather than letting anything escape untyped.
  */
 class AppSyncExceptionTest {
@@ -80,7 +80,8 @@ class AppSyncExceptionTest {
 
     @Test
     fun `network and unknown are leaves directly under the base, in no group`() {
-        // Guards the §3.5 shape: these two deliberately have no intermediate group, so a `when` over
+        // Guards the hierarchy shape: these two deliberately have no intermediate group, so a `when`
+        // over
         // the groups must still handle them.
         val network: AppSyncException = AppSyncNetworkException("a")
         val unknown: AppSyncException = AppSyncUnknownException("b")

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncExceptionTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncExceptionTest.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.foundation.exceptions.AmplifyException
+import com.amplifyframework.foundation.exceptions.DEFAULT_RECOVERY_SUGGESTION
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeBlank
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.io.IOException
+import java.net.SocketTimeoutException
+import org.junit.Test
+
+/**
+ * Tests [AppSyncException]: that the hierarchy has the shape §3.5 specifies, and that
+ * [AppSyncException.from] maps throwables into it rather than letting anything escape untyped.
+ */
+class AppSyncExceptionTest {
+
+    // ── Hierarchy shape ─────────────────────────────────────────────────
+
+    @Test
+    fun `extends the foundation AmplifyException, not core's and not ApiException`() {
+        val exception = AppSyncNetworkException("network down")
+
+        exception.shouldBeInstanceOf<AmplifyException>()
+        exception.shouldBeInstanceOf<AppSyncException>()
+    }
+
+    @Test
+    fun `auth leaves are catchable as one group`() {
+        val leaves = listOf(
+            AppSyncTokenFetchException("a"),
+            AppSyncTokenExpiredException("b"),
+            AppSyncProviderNotConfiguredException("c"),
+            AppSyncSigningException("d"),
+            AppSyncTokenParsingException("e"),
+            AppSyncAuthorizationClaimException("f")
+        )
+
+        leaves.forEach { it.shouldBeInstanceOf<AppSyncAuthException>() }
+    }
+
+    @Test
+    fun `configuration leaves are catchable as one group`() {
+        AppSyncInvalidConfigException("a").shouldBeInstanceOf<AppSyncConfigurationException>()
+        AppSyncEndpointResolutionException("b").shouldBeInstanceOf<AppSyncConfigurationException>()
+    }
+
+    @Test
+    fun `response leaves are catchable as one group`() {
+        AppSyncDeserializationException("a").shouldBeInstanceOf<AppSyncResponseException>()
+        AppSyncGraphQLErrorException("b", emptyList()).shouldBeInstanceOf<AppSyncResponseException>()
+    }
+
+    @Test
+    fun `subscription leaves are catchable as one group`() {
+        AppSyncConnectionException("a").shouldBeInstanceOf<AppSyncSubscriptionException>()
+        AppSyncTimeoutException("b").shouldBeInstanceOf<AppSyncSubscriptionException>()
+        AppSyncLimitExceededException("c").shouldBeInstanceOf<AppSyncSubscriptionException>()
+    }
+
+    @Test
+    fun `request leaves are catchable as one group`() {
+        AppSyncSchemaException("a").shouldBeInstanceOf<AppSyncRequestException>()
+        AppSyncValidationException("b").shouldBeInstanceOf<AppSyncRequestException>()
+    }
+
+    @Test
+    fun `network and unknown are leaves directly under the base, in no group`() {
+        // Guards the §3.5 shape: these two deliberately have no intermediate group, so a `when` over
+        // the groups must still handle them.
+        val network: AppSyncException = AppSyncNetworkException("a")
+        val unknown: AppSyncException = AppSyncUnknownException("b")
+
+        listOf(network, unknown).forEach {
+            (it is AppSyncAuthException) shouldBe false
+            (it is AppSyncConfigurationException) shouldBe false
+            (it is AppSyncResponseException) shouldBe false
+            (it is AppSyncSubscriptionException) shouldBe false
+            (it is AppSyncRequestException) shouldBe false
+        }
+    }
+
+    // ── Payload ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `every leaf carries a non-blank default recovery suggestion`() {
+        val leaves = listOf(
+            AppSyncTokenFetchException("a"),
+            AppSyncTokenExpiredException("a"),
+            AppSyncProviderNotConfiguredException("a"),
+            AppSyncSigningException("a"),
+            AppSyncTokenParsingException("a"),
+            AppSyncAuthorizationClaimException("a"),
+            AppSyncInvalidConfigException("a"),
+            AppSyncEndpointResolutionException("a"),
+            AppSyncDeserializationException("a"),
+            AppSyncGraphQLErrorException("a", emptyList()),
+            AppSyncConnectionException("a"),
+            AppSyncTimeoutException("a"),
+            AppSyncLimitExceededException("a"),
+            AppSyncSchemaException("a"),
+            AppSyncValidationException("a"),
+            AppSyncNetworkException("a"),
+            AppSyncUnknownException("a")
+        )
+
+        leaves.size shouldBe 17
+        leaves.forEach { it.recoverySuggestion.shouldNotBeBlank() }
+    }
+
+    @Test
+    fun `message, recovery suggestion and cause are all preserved`() {
+        val cause = IllegalStateException("underlying")
+        val exception = AppSyncTokenFetchException(
+            message = "token supplier threw",
+            recoverySuggestion = "fix the supplier",
+            cause = cause
+        )
+
+        exception.message shouldBe "token supplier threw"
+        exception.recoverySuggestion shouldBe "fix the supplier"
+        exception.cause shouldBe cause
+    }
+
+    @Test
+    fun `GraphQLError exception carries the error list`() {
+        val errors = listOf(com.amplifyframework.api.graphql.GraphQLResponse.Error("boom", null, null, null))
+
+        val exception = AppSyncGraphQLErrorException("service returned errors", errors)
+
+        exception.errors shouldBe errors
+    }
+
+    // ── from() mapping ──────────────────────────────────────────────────
+
+    @Test
+    fun `from returns an AppSyncException unchanged rather than re-wrapping it`() {
+        val original = AppSyncTimeoutException("timed out")
+
+        AppSyncException.from(original) shouldBe original
+    }
+
+    @Test
+    fun `from maps an IOException to a network exception, preserving the cause`() {
+        val cause = IOException("connection reset")
+
+        val mapped = AppSyncException.from(cause)
+
+        mapped.shouldBeInstanceOf<AppSyncNetworkException>()
+        mapped.message shouldBe "connection reset"
+        mapped.cause shouldBe cause
+    }
+
+    @Test
+    fun `from maps an IOException subclass to a network exception`() {
+        // SocketTimeoutException is an IOException, so it must not fall through to Unknown.
+        AppSyncException.from(SocketTimeoutException("read timed out"))
+            .shouldBeInstanceOf<AppSyncNetworkException>()
+    }
+
+    @Test
+    fun `from maps anything unrecognised to unknown with the default recovery suggestion`() {
+        val cause = IllegalArgumentException("bad state")
+
+        val mapped = AppSyncException.from(cause)
+
+        mapped.shouldBeInstanceOf<AppSyncUnknownException>()
+        mapped.recoverySuggestion shouldBe DEFAULT_RECOVERY_SUGGESTION
+        mapped.cause shouldBe cause
+    }
+
+    @Test
+    fun `from substitutes a message when the throwable has none`() {
+        val mapped = AppSyncException.from(RuntimeException())
+
+        mapped.message shouldBe "An unknown error occurred."
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

n/a

*Description of changes:*

### Sealed `AppSyncException` hierarchy

Base extends **foundation's** `AmplifyException` — not `core`'s, and not `ApiException`. `ApiException` is slated for removal in V3, so inheriting it would have made this hierarchy a blocker to deleting it.

Two levels. Five sealed intermediate groups so a caller can catch a category, with flat prefixed top-level leaves:

```kotlin
is Result.Failure -> when (val e = result.error) {
    is AppSyncAuthException -> reauthenticate()      // any of 6 auth leaves
    is AppSyncNetworkException -> retryLater()
    else -> report(e)
}
```

### Partition-aware endpoint parser

Replaces `Configuration.inferRegion`'s regex, which assumed a `.amazonaws.com` suffix. Being unanchored, it extracted the right *region* for China endpoints by accident — but it produced no realtime host and no partition, and a realtime host built on that assumption does not resolve for `.amazonaws.com.cn`.

The parser returns `region`, `host`, `realtimeHost` and `dnsSuffix`. It swaps only the `appsync-api` label for `appsync-realtime-api` and preserves everything after the region, which is why China and GovCloud need no special-casing. Region matching is structural (`^[a-z]{2,}(-[a-z]+)+-\d+$`) rather than an allowlist, so a region launched after this ships still parses. A custom domain carries no region, so it fails and the caller must set `region` explicitly — which `Configuration` already supports.

*How did you test these changes?*

n/a

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests — not applicable; every client method body is still `TODO()`
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
