### PR TITLE
feat(api): implement query and mutate over HTTP

### DIFF
--- a/aws-appsync/build.gradle.kts
+++ b/aws-appsync/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.kotlin.coroutines)
     implementation(project(":foundation-bridge"))
+    implementation(platform(libs.aws.bom))
     implementation(libs.aws.signing)
     implementation(libs.aws.smithy.http)
 

--- a/aws-appsync/build.gradle.kts
+++ b/aws-appsync/build.gradle.kts
@@ -31,6 +31,11 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.kotlin.coroutines)
     implementation(project(":foundation-bridge"))
+    implementation(libs.aws.signing)
+    implementation(libs.aws.smithy.http)
 
     testImplementation(libs.bundles.test.unit)
+    testImplementation(libs.bundles.test.unit.android)
+    testImplementation(libs.test.mockwebserver)
+    testImplementation(project(":testutils"))
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
@@ -138,8 +138,12 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
         TODO("Subscription implementation will be added in a follow-up PR")
 
     /**
-     * Close the client, cancelling in-flight requests and releasing pooled connections.
+     * Close the client, cancelling enqueued requests and releasing pooled connections.
      * The client cannot be reused after closing.
+     *
+     * A request that has already passed its own closed check can still be dispatched after this
+     * returns, because closing does not lock the send path. Such a request completes normally rather
+     * than being cancelled.
      *
      * TODO: terminate active subscriptions once subscriptions are supported.
      */

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
@@ -54,11 +54,13 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
 
     private val closed = AtomicBoolean(false)
 
-    private val httpClient: OkHttpClient by lazy {
+    private val lazyHttpClient = lazy {
         OkHttpClient.Builder()
             .apply { configuration.httpClientConfigurator?.invoke(this) }
             .build()
     }
+
+    private val httpClient: OkHttpClient by lazyHttpClient
 
     private val transport: AppSyncHttpTransport by lazy {
         AppSyncHttpTransport(
@@ -103,8 +105,10 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
      */
     private suspend fun <T> send(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, AppSyncException> {
         if (closed.get()) {
+            // A lifecycle misuse, not a bad request: AppSyncRequestException would tell the caller to
+            // correct a request that was fine.
             return Result.Failure(
-                AppSyncValidationException(
+                AppSyncInvalidConfigException(
                     message = "This client has been closed and cannot be reused.",
                     recoverySuggestion = "Create a new AmplifyAppSyncClient."
                 )
@@ -115,7 +119,7 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
             Result.Success(withContext(Dispatchers.IO) { transport.execute(request) })
         } catch (cancellation: CancellationException) {
             throw cancellation
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             Result.Failure(AppSyncException.from(error))
         }
     }
@@ -134,11 +138,16 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
         TODO("Subscription implementation will be added in a follow-up PR")
 
     /**
-     * Close the client. Terminates all active subscriptions and releases resources.
+     * Close the client, cancelling in-flight requests and releasing pooled connections.
      * The client cannot be reused after closing.
+     *
+     * TODO: terminate active subscriptions once subscriptions are supported.
      */
     fun close() {
         if (!closed.compareAndSet(false, true)) return
+        // Nothing to release if no request was ever issued, and touching the client here would build
+        // one — running the caller's configurator — purely to cancel an empty dispatcher.
+        if (!lazyHttpClient.isInitialized()) return
         httpClient.dispatcher.cancelAll()
         httpClient.connectionPool.evictAll()
     }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
@@ -19,8 +19,12 @@ import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.GraphQLResponse
 import com.amplifyframework.foundation.result.Result
 import com.amplifyframework.foundation.result.getOrThrow
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 
 /**
@@ -48,6 +52,23 @@ import okhttp3.OkHttpClient
 @ExperimentalAmplifyApi
 class AmplifyAppSyncClient(val configuration: Configuration) {
 
+    private val closed = AtomicBoolean(false)
+
+    private val httpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .apply { configuration.httpClientConfigurator?.invoke(this) }
+            .build()
+    }
+
+    private val transport: AppSyncHttpTransport by lazy {
+        AppSyncHttpTransport(
+            endpoint = configuration.endpoint,
+            client = httpClient,
+            authorization = configuration.authorization,
+            decorator = AppSyncRequestDecorator(configuration.region)
+        )
+    }
+
     /**
      * Per-client connection state flow.
      * Emits [ConnectionState] changes for the shared WebSocket connection.
@@ -61,8 +82,7 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
      * @param request The GraphQL request. Use model helpers or construct manually.
      * @return [Result.Success] with the typed GraphQL response, or [Result.Failure] with an [AppSyncException].
      */
-    suspend fun <T> query(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, AppSyncException> =
-        TODO("Query implementation will be added in a follow-up PR")
+    suspend fun <T> query(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, AppSyncException> = send(request)
 
     /**
      * Execute a GraphQL mutation.
@@ -70,8 +90,35 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
      * @param request The GraphQL request. Use model helpers or construct manually.
      * @return [Result.Success] with the typed GraphQL response, or [Result.Failure] with an [AppSyncException].
      */
-    suspend fun <T> mutate(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, AppSyncException> =
-        TODO("Mutation implementation will be added in a follow-up PR")
+    suspend fun <T> mutate(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, AppSyncException> = send(request)
+
+    /**
+     * Queries and mutations are the same HTTP exchange — AppSync distinguishes them by the operation
+     * in the document, not by transport. They are separate public functions for call-site clarity and
+     * for parity with Swift and Flutter.
+     *
+     * Failures arrive as [Result.Failure] rather than being thrown, so a caller never needs a
+     * try/catch. Coroutine cancellation is deliberately not caught: it must propagate for structured
+     * concurrency to work.
+     */
+    private suspend fun <T> send(request: GraphQLRequest<T>): Result<GraphQLResponse<T>, AppSyncException> {
+        if (closed.get()) {
+            return Result.Failure(
+                AppSyncValidationException(
+                    message = "This client has been closed and cannot be reused.",
+                    recoverySuggestion = "Create a new AmplifyAppSyncClient."
+                )
+            )
+        }
+
+        return try {
+            Result.Success(withContext(Dispatchers.IO) { transport.execute(request) })
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Throwable) {
+            Result.Failure(AppSyncException.from(error))
+        }
+    }
 
     /**
      * Subscribe to a GraphQL subscription. Returns a [Flow] of [SubscriptionEvent].
@@ -91,7 +138,9 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
      * The client cannot be reused after closing.
      */
     fun close() {
-        TODO("Close implementation will be added in a follow-up PR")
+        if (!closed.compareAndSet(false, true)) return
+        httpClient.dispatcher.cancelAll()
+        httpClient.connectionPool.evictAll()
     }
 
     // ── Configuration ───────────────────────────────────────────────────

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
@@ -25,15 +25,12 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 
 /**
- * The client's own Gson instance, deliberately private to this module rather than shared with the API
- * plugin's `GsonFactory`: this module does not depend on `aws-api`, and reimplements what it needs
- * instead.
+ * The Gson instance the client serializes requests and deserializes responses with.
  *
- * It registers the same adapters as the plugin except the two lazy-loading deserializers
- * (`ModelListDeserializer`, `ModelPageDeserializer`), which live in `aws-api` and are therefore out of
- * reach. TODO: register equivalents once lazy model loading is supported.
+ * Private to the client rather than shared, so neither the adapter set nor the null handling below can
+ * be altered from outside.
  *
- * Every adapter used here is in `aws-api-appsync`, which this module already exposes as `api`.
+ * TODO: register deserializers for lazily-loaded model lists and pages, which this set does not cover.
  */
 internal object AppSyncGson {
 
@@ -48,8 +45,8 @@ internal object AppSyncGson {
                 SerializedModelAdapter.register(it)
                 SerializedCustomTypeAdapter.register(it)
             }
-            // Matches the plugin's factories: a mutation that clears a field needs an explicit
-            // `"field": null` in the payload, since AppSync reads an absent field as "leave unchanged".
+            // A mutation that clears a field needs an explicit `"field": null` in the payload, because
+            // AppSync reads an absent field as "leave unchanged" rather than "set to null".
             .serializeNulls()
             .create()
     }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
@@ -25,12 +25,14 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 
 /**
- * The client's own Gson instance, deliberately private to this module rather than shared with the
- * API plugin's `GsonFactory` — per #3377 the client reimplements what it needs instead of depending
- * on `aws-api`.
+ * The client's own Gson instance, deliberately private to this module rather than shared with the API
+ * plugin's `GsonFactory`: this module does not depend on `aws-api`, and reimplements what it needs
+ * instead.
  *
  * It registers the same adapters as the plugin except the two lazy-loading deserializers
- * (`ModelListDeserializer`, `ModelPageDeserializer`), which live in `aws-api` and are Phase 7 work.
+ * (`ModelListDeserializer`, `ModelPageDeserializer`), which live in `aws-api` and are therefore out of
+ * reach. TODO: register equivalents once lazy model loading is supported.
+ *
  * Every adapter used here is in `aws-api-appsync`, which this module already exposes as `api`.
  */
 internal object AppSyncGson {

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.graphql.GsonResponseAdapters
+import com.amplifyframework.core.model.query.predicate.GsonPredicateAdapters
+import com.amplifyframework.core.model.temporal.GsonTemporalAdapters
+import com.amplifyframework.core.model.types.GsonJavaTypeAdapters
+import com.amplifyframework.datastore.appsync.ModelWithMetadataAdapter
+import com.amplifyframework.datastore.appsync.SerializedCustomTypeAdapter
+import com.amplifyframework.datastore.appsync.SerializedModelAdapter
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+
+/**
+ * The client's own Gson instance, deliberately private to this module rather than shared with the
+ * API plugin's `GsonFactory` — per #3377 the client reimplements what it needs instead of depending
+ * on `aws-api`.
+ *
+ * It registers the same adapters as the plugin except the two lazy-loading deserializers
+ * (`ModelListDeserializer`, `ModelPageDeserializer`), which live in `aws-api` and are Phase 7 work.
+ * Every adapter used here is in `aws-api-appsync`, which this module already exposes as `api`.
+ */
+internal object AppSyncGson {
+
+    val instance: Gson by lazy {
+        GsonBuilder()
+            .also {
+                GsonTemporalAdapters.register(it)
+                GsonJavaTypeAdapters.register(it)
+                GsonPredicateAdapters.register(it)
+                GsonResponseAdapters.register(it)
+                ModelWithMetadataAdapter.register(it)
+                SerializedModelAdapter.register(it)
+                SerializedCustomTypeAdapter.register(it)
+            }
+            .create()
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
@@ -48,6 +48,9 @@ internal object AppSyncGson {
                 SerializedModelAdapter.register(it)
                 SerializedCustomTypeAdapter.register(it)
             }
+            // Matches the plugin's factories: a mutation that clears a field needs an explicit
+            // `"field": null` in the payload, since AppSync reads an absent field as "leave unchanged".
+            .serializeNulls()
             .create()
     }
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.api.graphql.GraphQLResponse
+import com.amplifyframework.util.UserAgent
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+
+/**
+ * Executes GraphQL queries and mutations over HTTP.
+ *
+ * A private reimplementation of the plugin's `AppSyncGraphQLOperation`, differing in three ways: it
+ * suspends rather than taking callbacks, it is cancellable through the calling coroutine, and its
+ * failures are typed [AppSyncException]s rather than `ApiException`.
+ *
+ * @param endpoint The AppSync GraphQL endpoint URL.
+ * @param client The OkHttp client to issue requests with.
+ * @param authorization The client's authorizer configuration.
+ * @param decorator Applies credentials to each request.
+ */
+internal class AppSyncHttpTransport(
+    private val endpoint: String,
+    private val client: OkHttpClient,
+    private val authorization: AppSyncAuthorization,
+    private val decorator: AppSyncRequestDecorator
+) {
+
+    /**
+     * Sends [request] and deserializes the response.
+     *
+     * Phase 3 is the single-auth path, so this always uses the default authorizer. Per-request
+     * overrides and `@auth`-rule resolution are Phase 4.
+     */
+    suspend fun <T> execute(request: GraphQLRequest<T>): GraphQLResponse<T> {
+        val httpRequest = Request.Builder()
+            .url(endpoint)
+            .header(ACCEPT_HEADER, CONTENT_TYPE)
+            .header(USER_AGENT_HEADER, UserAgent.string())
+            .post(request.content.toRequestBody(CONTENT_TYPE.toMediaType()))
+            .build()
+
+        val decorated = decorator.decorate(httpRequest, authorization.defaultAuthorizer)
+        val response = client.newCall(decorated).await()
+
+        return response.use { deserialize(request, it) }
+    }
+
+    private fun <T> deserialize(request: GraphQLRequest<T>, response: Response): GraphQLResponse<T> {
+        val body = try {
+            response.body?.string()
+        } catch (error: IOException) {
+            throw AppSyncDeserializationException(
+                message = "The response body could not be read.",
+                cause = error
+            )
+        }
+
+        // AppSync reports GraphQL-level problems with a 4xx and a GraphQL error body. Deserializing it
+        // yields the errors themselves, which is far more useful than the status code alone. This is
+        // where the plugin collapses everything into a generic ApiException.
+        if (response.code in CLIENT_ERROR_CODES) {
+            throw clientError(request, response, body)
+        }
+
+        if (!response.isSuccessful) {
+            throw AppSyncNetworkException(
+                message = "The request failed with HTTP status ${response.code}.",
+                recoverySuggestion = "This is usually transient. Retry the request."
+            )
+        }
+
+        return AppSyncResponseDeserializer.deserialize(request, body)
+    }
+
+    private fun <T> clientError(request: GraphQLRequest<T>, response: Response, body: String?): AppSyncException {
+        val errors = runCatching { AppSyncResponseDeserializer.deserialize(request, body).errors }
+            .getOrNull()
+            ?.takeIf { it.isNotEmpty() }
+
+        return if (errors != null) {
+            AppSyncGraphQLErrorException(
+                message = "The request failed with HTTP status ${response.code}: " +
+                    errors.joinToString("; ") { it.message },
+                errors = errors
+            )
+        } else {
+            AppSyncValidationException(
+                message = "The request was rejected with HTTP status ${response.code}.",
+                recoverySuggestion = "Check the request document and variables, and the API's auth configuration."
+            )
+        }
+    }
+
+    /**
+     * Bridges an OkHttp [Call] to a coroutine. Cancelling the coroutine cancels the call, so a
+     * cancelled `query` does not leave a request in flight.
+     */
+    private suspend fun Call.await(): Response = suspendCancellableCoroutine { continuation ->
+        enqueue(
+            object : Callback {
+                override fun onResponse(call: Call, response: Response) = continuation.resume(response)
+
+                override fun onFailure(call: Call, e: IOException) {
+                    if (continuation.isCancelled) return
+                    continuation.resumeWithException(
+                        AppSyncNetworkException(
+                            message = e.message ?: "The request could not reach the AppSync endpoint.",
+                            cause = e
+                        )
+                    )
+                }
+            }
+        )
+        continuation.invokeOnCancellation { runCatching { cancel() } }
+    }
+
+    private companion object {
+        const val CONTENT_TYPE = "application/json"
+        const val ACCEPT_HEADER = "accept"
+        const val USER_AGENT_HEADER = "User-Agent"
+        val CLIENT_ERROR_CODES = 400..499
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -32,9 +32,8 @@ import okhttp3.Response
 /**
  * Executes GraphQL queries and mutations over HTTP.
  *
- * A private reimplementation of the plugin's `AppSyncGraphQLOperation`, differing in three ways: it
- * suspends rather than taking callbacks, it is cancellable through the calling coroutine, and its
- * failures are typed [AppSyncException]s rather than `ApiException`.
+ * Suspends rather than taking callbacks, cancels along with the calling coroutine, and reports every
+ * failure as a typed [AppSyncException].
  *
  * @param endpoint The AppSync GraphQL endpoint URL.
  * @param client The OkHttp client to issue requests with.
@@ -78,9 +77,8 @@ internal class AppSyncHttpTransport(
             )
         }
 
-        // AppSync reports GraphQL-level problems with a 4xx and a GraphQL error body. Deserializing it
-        // yields the errors themselves, which is far more useful than the status code alone. This is
-        // where the plugin collapses everything into a generic ApiException.
+        // AppSync reports GraphQL-level problems with a 4xx carrying a GraphQL error body. Deserializing
+        // it yields the errors themselves, which say far more than the status code alone.
         if (response.code in CLIENT_ERROR_CODES) {
             throw clientError(request, response, body)
         }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -84,9 +84,17 @@ internal class AppSyncHttpTransport(
         }
 
         if (response.code >= SERVER_ERROR_MIN) {
+            // Only some 5xx statuses describe a condition that can clear on its own. Advising a retry
+            // for the rest — 501 and 505, say — sends a caller round a loop that cannot succeed.
+            val transient = response.code in TRANSIENT_SERVER_ERROR_CODES
             throw AppSyncNetworkException(
                 message = "The request failed with HTTP status ${response.code}.",
-                recoverySuggestion = "This is usually transient. Retry the request."
+                recoverySuggestion = if (transient) {
+                    "This is usually transient. Retry the request."
+                } else {
+                    "Verify that the endpoint URL addresses an AppSync API and that the request is a " +
+                        "POST of a GraphQL document."
+                }
             )
         }
 
@@ -132,7 +140,11 @@ internal class AppSyncHttpTransport(
     private suspend fun Call.await(): Response = suspendCancellableCoroutine { continuation ->
         enqueue(
             object : Callback {
-                override fun onResponse(call: Call, response: Response) = continuation.resume(response)
+                // The response is closed by the resume callback when the continuation has already been
+                // cancelled. A resume into a cancelled continuation is discarded, so the caller never
+                // reaches the `use` block that would otherwise close the body, and the connection leaks.
+                override fun onResponse(call: Call, response: Response) =
+                    continuation.resume(response) { _, closed, _ -> closed.close() }
 
                 override fun onFailure(call: Call, e: IOException) {
                     if (continuation.isCancelled) return
@@ -154,5 +166,9 @@ internal class AppSyncHttpTransport(
         const val USER_AGENT_HEADER = "User-Agent"
         val CLIENT_ERROR_CODES = 400..499
         const val SERVER_ERROR_MIN = 500
+
+        // Internal error, bad gateway, service unavailable and gateway timeout. Each can clear without
+        // the request changing, so a retry is worth suggesting.
+        val TRANSIENT_SERVER_ERROR_CODES = setOf(500, 502, 503, 504)
     }
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -85,10 +85,20 @@ internal class AppSyncHttpTransport(
             throw clientError(request, response, body)
         }
 
-        if (!response.isSuccessful) {
+        if (response.code >= SERVER_ERROR_MIN) {
             throw AppSyncNetworkException(
                 message = "The request failed with HTTP status ${response.code}.",
                 recoverySuggestion = "This is usually transient. Retry the request."
+            )
+        }
+
+        if (!response.isSuccessful) {
+            // A 3xx reaches here when redirects are disabled on the OkHttp client, or on a redirect
+            // OkHttp will not follow. Retrying produces the same response, so it is not suggested.
+            throw AppSyncNetworkException(
+                message = "The request returned an unexpected HTTP status ${response.code}.",
+                recoverySuggestion = "Verify the endpoint URL and any redirect handling configured on " +
+                    "the OkHttp client."
             )
         }
 
@@ -96,6 +106,9 @@ internal class AppSyncHttpTransport(
     }
 
     private fun <T> clientError(request: GraphQLRequest<T>, response: Response, body: String?): AppSyncException {
+        // TODO: classify authorization failures as an AppSyncAuthException. A 401, or an error whose
+        //  extensions carry an Unauthorized errorType, currently arrives as a response or request
+        //  error, so a caller cannot match the whole auth category to re-authenticate.
         val errors = runCatching { AppSyncResponseDeserializer.deserialize(request, body).errors }
             .getOrNull()
             ?.takeIf { it.isNotEmpty() }
@@ -142,5 +155,6 @@ internal class AppSyncHttpTransport(
         const val ACCEPT_HEADER = "accept"
         const val USER_AGENT_HEADER = "User-Agent"
         val CLIENT_ERROR_CODES = 400..499
+        const val SERVER_ERROR_MIN = 500
     }
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -51,8 +51,8 @@ internal class AppSyncHttpTransport(
     /**
      * Sends [request] and deserializes the response.
      *
-     * Phase 3 is the single-auth path, so this always uses the default authorizer. Per-request
-     * overrides and `@auth`-rule resolution are Phase 4.
+     * Always uses the default authorizer. TODO: honour per-request auth overrides and `@auth`-rule
+     * resolution.
      */
     suspend fun <T> execute(request: GraphQLRequest<T>): GraphQLResponse<T> {
         val httpRequest = Request.Builder()

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
@@ -26,6 +26,7 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.net.url.Url
 import aws.smithy.kotlin.runtime.net.url.UrlEncoding
 import com.amplifyframework.foundation.credentials.toSmithyProvider
+import kotlinx.coroutines.CancellationException
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -71,9 +72,14 @@ internal class AppSyncRequestDecorator(private val region: String) {
     /**
      * Invokes a credential supplier, translating any failure into a typed exception. A supplier is
      * customer code, so it can throw anything.
+     *
+     * Cancellation is rethrown rather than translated: on the JVM `CancellationException` is an
+     * `Exception`, so without this a cancelled caller would be reported as a failed token fetch.
      */
     private suspend fun (suspend () -> String).fetch(description: String): String = try {
         this()
+    } catch (cancellation: CancellationException) {
+        throw cancellation
     } catch (error: Exception) {
         throw AppSyncTokenFetchException(
             message = "Fetching the $description failed.",
@@ -99,7 +105,9 @@ internal class AppSyncRequestDecorator(private val region: String) {
             method = HttpMethod.parse(method),
             url = Url.parse(url.toUri().toString(), UrlEncoding.All),
             headers = Headers {
-                this@signed.headers.names().forEach { name -> set(name, this@signed.header(name) ?: "") }
+                this@signed.headers.names().forEach { name ->
+                    appendAll(name, this@signed.headers.values(name))
+                }
                 // The signature covers Host, so it must be present before signing.
                 set(HOST_HEADER, this@signed.url.host)
             },
@@ -116,6 +124,8 @@ internal class AppSyncRequestDecorator(private val region: String) {
                 signedBodyHeader = AwsSignedBodyHeader.X_AMZ_CONTENT_SHA256
             }
             DefaultAwsSigner.sign(signable, config).output
+        } catch (cancellation: CancellationException) {
+            throw cancellation
         } catch (error: Exception) {
             throw AppSyncSigningException(
                 message = "Signing the request with SigV4 failed.",
@@ -123,16 +133,15 @@ internal class AppSyncRequestDecorator(private val region: String) {
             )
         }
 
-        // Rebuild the OkHttp request from the signed one. The content type has to be read back out of
-        // the signed headers and reapplied to the body, because OkHttp derives the Content-Type header
-        // from the body's MediaType and would otherwise overwrite it.
+        // Rebuild the OkHttp request from the signed one. The signed Content-Type is read back out of
+        // the headers and reapplied through the body's MediaType, because OkHttp takes Content-Type
+        // from the body rather than from a header set on the builder.
         val builder = Request.Builder().url(url)
         var contentType = DEFAULT_CONTENT_TYPE
         signed.headers.entries().forEach { (name, values) ->
-            val value = values.firstOrNull() ?: return@forEach
-            builder.addHeader(name, value)
+            values.forEach { value -> builder.addHeader(name, value) }
             if (name.equals(CONTENT_TYPE_HEADER, ignoreCase = true)) {
-                contentType = value
+                values.firstOrNull()?.let { contentType = it }
             }
         }
 

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.auth.awssigning.AwsSignedBodyHeader
+import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningConfig
+import aws.smithy.kotlin.runtime.auth.awssigning.DefaultAwsSigner
+import aws.smithy.kotlin.runtime.http.DeferredHeaders
+import aws.smithy.kotlin.runtime.http.Headers
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.HttpMethod
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.net.url.Url
+import aws.smithy.kotlin.runtime.net.url.UrlEncoding
+import com.amplifyframework.foundation.credentials.toSmithyProvider
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.Buffer
+
+/**
+ * Applies an [AppSyncClientAuthorizer]'s credentials to an outbound HTTP request.
+ *
+ * A private reimplementation of the plugin's `RequestDecorator` family, collapsed into one suspend
+ * function. The plugin needs a decorator hierarchy because its call sites are synchronous and its
+ * token suppliers block; here every credential source is already a suspend function, so the whole
+ * job is one `when`.
+ *
+ * @param region The signing region, resolved by [AppSyncEndpointParser] or set explicitly.
+ */
+internal class AppSyncRequestDecorator(private val region: String) {
+
+    /**
+     * Returns [request] with the authorizer's credentials attached.
+     *
+     * @throws AppSyncTokenFetchException if a token or API key supplier fails.
+     * @throws AppSyncSigningException if SigV4 signing fails.
+     */
+    suspend fun decorate(request: Request, authorizer: AppSyncClientAuthorizer): Request = when (authorizer) {
+        is AppSyncClientAuthorizer.ApiKey ->
+            request.withHeader(API_KEY_HEADER, authorizer.fetchApiKey.fetch("API key"))
+
+        is AppSyncClientAuthorizer.UserPools ->
+            request.withHeader(AUTHORIZATION_HEADER, authorizer.fetchToken.fetch("User Pools token"))
+
+        is AppSyncClientAuthorizer.Oidc ->
+            request.withHeader(AUTHORIZATION_HEADER, authorizer.fetchToken.fetch("OIDC token"))
+
+        is AppSyncClientAuthorizer.Lambda ->
+            request.withHeader(AUTHORIZATION_HEADER, authorizer.fetchToken.fetch("Lambda authorization token"))
+
+        is AppSyncClientAuthorizer.Iam -> request.signed(authorizer)
+    }
+
+    private fun Request.withHeader(name: String, value: String) = newBuilder().header(name, value).build()
+
+    /**
+     * Invokes a credential supplier, translating any failure into a typed exception. A supplier is
+     * customer code, so it can throw anything.
+     */
+    private suspend fun (suspend () -> String).fetch(description: String): String = try {
+        this()
+    } catch (error: Exception) {
+        throw AppSyncTokenFetchException(
+            message = "Fetching the $description failed.",
+            cause = error
+        )
+    }
+
+    /**
+     * Signs the request with SigV4.
+     *
+     * Uses the suspending smithy signer directly. The plugin's `IamRequestDecorator` wraps the same
+     * signer in `runBlocking`, which it needs because it is called from a synchronous decorator; this
+     * client is suspend all the way down and does not.
+     *
+     * `DefaultAwsSigner` is `@InternalApi` in smithy-kotlin. Opting in matches what the plugin's
+     * `AWS4Signer` already does — there is no public signer entry point.
+     */
+    @OptIn(InternalApi::class)
+    private suspend fun Request.signed(authorizer: AppSyncClientAuthorizer.Iam): Request {
+        val bodyBytes = body.toByteArray()
+
+        val signable = HttpRequest(
+            method = HttpMethod.parse(method),
+            url = Url.parse(url.toUri().toString(), UrlEncoding.All),
+            headers = Headers {
+                this@signed.headers.names().forEach { name -> set(name, this@signed.header(name) ?: "") }
+                // The signature covers Host, so it must be present before signing.
+                set(HOST_HEADER, this@signed.url.host)
+            },
+            body = HttpBody.fromBytes(bodyBytes),
+            trailingHeaders = DeferredHeaders.Empty
+        )
+
+        val signed = try {
+            val config = AwsSigningConfig {
+                region = this@AppSyncRequestDecorator.region
+                service = APPSYNC_SERVICE_NAME
+                credentials = authorizer.credentialsProvider.toSmithyProvider().resolve()
+                useDoubleUriEncode = true
+                signedBodyHeader = AwsSignedBodyHeader.X_AMZ_CONTENT_SHA256
+            }
+            DefaultAwsSigner.sign(signable, config).output
+        } catch (error: Exception) {
+            throw AppSyncSigningException(
+                message = "Signing the request with SigV4 failed.",
+                cause = error
+            )
+        }
+
+        // Rebuild the OkHttp request from the signed one. The content type has to be read back out of
+        // the signed headers and reapplied to the body, because OkHttp derives the Content-Type header
+        // from the body's MediaType and would otherwise overwrite it.
+        val builder = Request.Builder().url(url)
+        var contentType = DEFAULT_CONTENT_TYPE
+        signed.headers.entries().forEach { (name, values) ->
+            val value = values.firstOrNull() ?: return@forEach
+            builder.addHeader(name, value)
+            if (name.equals(CONTENT_TYPE_HEADER, ignoreCase = true)) {
+                contentType = value
+            }
+        }
+
+        val mediaType = contentType.toMediaTypeOrDefault()
+        return builder.method(method, body?.let { bodyBytes.toRequestBody(mediaType) }).build()
+    }
+
+    private fun RequestBody?.toByteArray(): ByteArray {
+        if (this == null) return ByteArray(0)
+        return try {
+            Buffer().also { writeTo(it) }.readByteArray()
+        } catch (error: Exception) {
+            throw AppSyncSigningException(
+                message = "The request body could not be read, so the SigV4 signature could not be computed.",
+                cause = error
+            )
+        }
+    }
+
+    private fun String.toMediaTypeOrDefault() = runCatching { toMediaType() }
+        .getOrElse { DEFAULT_CONTENT_TYPE.toMediaType() }
+
+    private companion object {
+        const val API_KEY_HEADER = "x-api-key"
+        const val AUTHORIZATION_HEADER = "authorization"
+        const val HOST_HEADER = "Host"
+        const val CONTENT_TYPE_HEADER = "content-type"
+        const val DEFAULT_CONTENT_TYPE = "application/json"
+        const val APPSYNC_SERVICE_NAME = "appsync"
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
@@ -36,10 +36,8 @@ import okio.Buffer
 /**
  * Applies an [AppSyncClientAuthorizer]'s credentials to an outbound HTTP request.
  *
- * A private reimplementation of the plugin's `RequestDecorator` family, collapsed into one suspend
- * function. The plugin needs a decorator hierarchy because its call sites are synchronous and its
- * token suppliers block; here every credential source is already a suspend function, so the whole
- * job is one `when`.
+ * Every credential source is itself a suspend function, so all five auth modes are covered by a single
+ * `when` rather than one class per mode.
  *
  * @param region The signing region, resolved by [AppSyncEndpointParser] or set explicitly.
  */
@@ -90,12 +88,11 @@ internal class AppSyncRequestDecorator(private val region: String) {
     /**
      * Signs the request with SigV4.
      *
-     * Uses the suspending smithy signer directly. The plugin's `IamRequestDecorator` wraps the same
-     * signer in `runBlocking`, which it needs because it is called from a synchronous decorator; this
-     * client is suspend all the way down and does not.
+     * Calls the suspending smithy signer directly. This path suspends all the way down, so the signer
+     * needs no blocking wrapper.
      *
-     * `DefaultAwsSigner` is `@InternalApi` in smithy-kotlin. Opting in matches what the plugin's
-     * `AWS4Signer` already does — there is no public signer entry point.
+     * `DefaultAwsSigner` is `@InternalApi` in smithy-kotlin, so the opt-in is unavoidable: smithy
+     * exposes no public signer entry point.
      */
     @OptIn(InternalApi::class)
     private suspend fun Request.signed(authorizer: AppSyncClientAuthorizer.Iam): Request {

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
@@ -117,6 +117,8 @@ internal class AppSyncRequestDecorator(private val region: String) {
                 region = this@AppSyncRequestDecorator.region
                 service = APPSYNC_SERVICE_NAME
                 credentials = authorizer.credentialsProvider.toSmithyProvider().resolve()
+                // AppSync expects the path to be URI-encoded twice, as most services do. S3 is the
+                // notable exception, and getting this wrong fails signing with no useful diagnostic.
                 useDoubleUriEncode = true
                 signedBodyHeader = AwsSignedBodyHeader.X_AMZ_CONTENT_SHA256
             }
@@ -130,19 +132,18 @@ internal class AppSyncRequestDecorator(private val region: String) {
             )
         }
 
-        // Rebuild the OkHttp request from the signed one. The signed Content-Type is read back out of
-        // the headers and reapplied through the body's MediaType, because OkHttp takes Content-Type
-        // from the body rather than from a header set on the builder.
+        // Rebuild the OkHttp request from the signed one, reapplying the content type through the body
+        // because OkHttp takes it from the body's MediaType rather than from a header on the builder.
+        //
+        // The content type is not carried on `headers` — OkHttp derives it from the body when the call
+        // is made — so it is neither signed nor recoverable from the signed request, and the value the
+        // caller posted has to be restated here.
         val builder = Request.Builder().url(url)
-        var contentType = DEFAULT_CONTENT_TYPE
         signed.headers.entries().forEach { (name, values) ->
             values.forEach { value -> builder.addHeader(name, value) }
-            if (name.equals(CONTENT_TYPE_HEADER, ignoreCase = true)) {
-                values.firstOrNull()?.let { contentType = it }
-            }
         }
 
-        val mediaType = contentType.toMediaTypeOrDefault()
+        val mediaType = body?.contentType() ?: DEFAULT_CONTENT_TYPE.toMediaType()
         return builder.method(method, body?.let { bodyBytes.toRequestBody(mediaType) }).build()
     }
 
@@ -158,14 +159,10 @@ internal class AppSyncRequestDecorator(private val region: String) {
         }
     }
 
-    private fun String.toMediaTypeOrDefault() = runCatching { toMediaType() }
-        .getOrElse { DEFAULT_CONTENT_TYPE.toMediaType() }
-
     private companion object {
         const val API_KEY_HEADER = "x-api-key"
         const val AUTHORIZATION_HEADER = "authorization"
         const val HOST_HEADER = "Host"
-        const val CONTENT_TYPE_HEADER = "content-type"
         const val DEFAULT_CONTENT_TYPE = "application/json"
         const val APPSYNC_SERVICE_NAME = "appsync"
     }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncResponseDeserializer.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncResponseDeserializer.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.aws.AppSyncGraphQLRequest
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.api.graphql.GraphQLResponse
+import com.amplifyframework.api.graphql.PaginatedResult
+import com.amplifyframework.util.TypeMaker
+import com.google.gson.JsonArray
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+/**
+ * Turns an AppSync JSON response body into a typed [GraphQLResponse].
+ *
+ * A private reimplementation of the plugin's `GsonGraphQLResponseFactory`, minus the lazy-model
+ * deserializers, which are Phase 7. Unlike the plugin's version this reports failure through
+ * [AppSyncDeserializationException] rather than `ApiException`.
+ */
+internal object AppSyncResponseDeserializer {
+
+    private const val ITEMS_KEY = "items"
+    private const val NEXT_TOKEN_KEY = "nextToken"
+
+    /**
+     * Deserializes [responseJson] into a [GraphQLResponse] of the request's response type.
+     *
+     * @throws AppSyncDeserializationException if the body is empty or cannot be parsed.
+     */
+    fun <T> deserialize(request: GraphQLRequest<T>, responseJson: String?): GraphQLResponse<T> {
+        // Gson returns null rather than throwing for an empty string, so this is checked up front.
+        // See https://github.com/google/gson/issues/457
+        if (responseJson.isNullOrEmpty()) {
+            throw AppSyncDeserializationException(
+                message = "The response body was empty, so it could not be deserialized.",
+                cause = JsonParseException("Empty response.")
+            )
+        }
+
+        val responseType = TypeMaker.getParameterizedType(GraphQLResponse::class.java, request.responseType)
+
+        return try {
+            AppSyncGson.instance.newBuilder()
+                .registerTypeHierarchyAdapter(Iterable::class.java, IterableDeserializer(request))
+                .create()
+                .fromJson(responseJson, responseType)
+        } catch (error: JsonParseException) {
+            throw AppSyncDeserializationException(
+                message = "The response could not be deserialized into ${request.responseType}.",
+                cause = error
+            )
+        }
+    }
+
+    /**
+     * Deserializes AppSync's list shape. At the root of a query the result becomes a
+     * [PaginatedResult] carrying the request for the next page; below the root it is a plain list,
+     * because that is what codegen emits for a one-to-many relationship.
+     */
+    private class IterableDeserializer<R>(
+        private val request: GraphQLRequest<R>
+    ) : JsonDeserializer<Iterable<Any>> {
+
+        override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Iterable<Any> {
+            val parameterized = typeOfT as? ParameterizedType
+                ?: throw JsonParseException("Expected a parameterized type during list deserialization.")
+            val templateType = parameterized.actualTypeArguments[0]
+
+            when {
+                json.isJsonObject -> {
+                    val jsonObject = json.asJsonObject
+                    if (!jsonObject.has(ITEMS_KEY) || !jsonObject.get(ITEMS_KEY).isJsonArray) {
+                        throw JsonParseException(
+                            "Expected a JSON array, or an object with an '$ITEMS_KEY' array, for a list " +
+                                "response. Got neither, so it cannot be deserialized."
+                        )
+                    }
+                    val items = toList(jsonObject.get(ITEMS_KEY).asJsonArray, templateType, context)
+                    return if (PaginatedResult::class.java == parameterized.rawType) {
+                        buildPaginatedResult(items, jsonObject.get(NEXT_TOKEN_KEY))
+                    } else {
+                        // A nextToken may be present below the root, but codegen models the field as
+                        // a plain List, so there is nowhere to surface it.
+                        items
+                    }
+                }
+                json.isJsonArray -> return toList(json.asJsonArray, templateType, context)
+                else -> throw JsonParseException(
+                    "Expected a JSON object or array to deserialize into an Iterable."
+                )
+            }
+        }
+
+        private fun toList(jsonArray: JsonArray, type: Type, context: JsonDeserializationContext): List<Any> =
+            jsonArray.map { context.deserialize(it, type) }
+
+        private fun buildPaginatedResult(items: Iterable<Any>, nextTokenElement: JsonElement?): PaginatedResult<Any> {
+            val nextToken = nextTokenElement?.takeIf { it.isJsonPrimitive }?.asJsonPrimitive?.asString
+            val appSyncRequest = request as? AppSyncGraphQLRequest<R>
+
+            val requestForNextPage = if (nextToken != null && appSyncRequest != null) {
+                try {
+                    appSyncRequest.newBuilder()
+                        .variable(NEXT_TOKEN_KEY, "String", nextToken)
+                        .build<PaginatedResult<Any>>()
+                } catch (error: Exception) {
+                    throw JsonParseException("Could not build the request for the next page.", error)
+                }
+            } else {
+                null
+            }
+
+            return PaginatedResult<Any>(items, requestForNextPage)
+        }
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncResponseDeserializer.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncResponseDeserializer.kt
@@ -31,7 +31,7 @@ import java.lang.reflect.Type
  * Turns an AppSync JSON response body into a typed [GraphQLResponse].
  *
  * A private reimplementation of the plugin's `GsonGraphQLResponseFactory`, minus the lazy-model
- * deserializers, which are Phase 7. Unlike the plugin's version this reports failure through
+ * deserializers. Unlike the plugin's version this reports failure through
  * [AppSyncDeserializationException] rather than `ApiException`.
  */
 internal object AppSyncResponseDeserializer {

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncResponseDeserializer.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncResponseDeserializer.kt
@@ -30,9 +30,8 @@ import java.lang.reflect.Type
 /**
  * Turns an AppSync JSON response body into a typed [GraphQLResponse].
  *
- * A private reimplementation of the plugin's `GsonGraphQLResponseFactory`, minus the lazy-model
- * deserializers. Unlike the plugin's version this reports failure through
- * [AppSyncDeserializationException] rather than `ApiException`.
+ * Reports failure as an [AppSyncDeserializationException]. Lazily-loaded model lists and pages are not
+ * covered.
  */
 internal object AppSyncResponseDeserializer {
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -138,8 +138,7 @@ class AmplifyAppSyncClientTest {
 
         error.errors shouldHaveSize 1
         error.errors[0].message shouldContain "unknown field"
-        // The message surfaces the service's reason, not just the status code — this is the detail the
-        // plugin loses by collapsing every 4xx into one generic exception.
+        // The message surfaces the service's own reason, not merely the status code.
         error.message shouldContain "unknown field"
     }
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -22,6 +22,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
@@ -165,6 +166,22 @@ class AmplifyAppSyncClientTest {
     }
 
     @Test
+    fun `an unfollowed redirect is not reported as transient`() = runTest {
+        server.enqueue(
+            jsonResponse("", code = HttpURLConnection.HTTP_MOVED_PERM)
+                .setHeader("Location", "https://example.invalid/graphql")
+        )
+
+        val error = client { httpClientConfigurator = { it.followRedirects(false) } }
+            .query(request()).shouldBeFailure().error
+
+        error.shouldBeInstanceOf<AppSyncNetworkException>()
+        error.message shouldContain "301"
+        // Retrying a redirect the client will not follow produces the same response every time.
+        error.recoverySuggestion shouldNotContain "Retry"
+    }
+
+    @Test
     fun `an unreachable endpoint becomes a network exception`() = runTest {
         // Port 1 is reserved, so nothing is listening.
         val unreachable = AmplifyAppSyncClient(
@@ -225,9 +242,19 @@ class AmplifyAppSyncClientTest {
 
         val error = client.query(request()).shouldBeFailure().error
 
-        error.shouldBeInstanceOf<AppSyncValidationException>()
+        error.shouldBeInstanceOf<AppSyncInvalidConfigException>()
         error.message shouldContain "closed"
         server.requestCount shouldBe 0
+    }
+
+    @Test
+    fun `close on a client that never issued a request does not build the http client`() = runTest {
+        var configured = false
+        val client = client { httpClientConfigurator = { configured = true } }
+
+        client.close()
+
+        configured shouldBe false
     }
 
     @Test

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -36,7 +36,7 @@ import org.robolectric.RobolectricTestRunner
 
 /**
  * End-to-end tests for [AmplifyAppSyncClient.query] and [AmplifyAppSyncClient.mutate] over a
- * [MockWebServer]. These cover the whole Phase 3 path — request construction, auth decoration, HTTP
+ * [MockWebServer]. These cover the whole HTTP path — request construction, auth decoration, transport
  * and deserialization — and are the only place the error mapping is exercised the way a caller sees
  * it, as a `Result.Failure` carrying a specific [AppSyncException] subtype.
  *

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.aws.GsonVariablesSerializer
+import com.amplifyframework.api.graphql.SimpleGraphQLRequest
+import com.amplifyframework.testutils.assertions.shouldBeFailure
+import com.amplifyframework.testutils.assertions.shouldBeSuccess
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.net.HttpURLConnection
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * End-to-end tests for [AmplifyAppSyncClient.query] and [AmplifyAppSyncClient.mutate] over a
+ * [MockWebServer]. These cover the whole Phase 3 path — request construction, auth decoration, HTTP
+ * and deserialization — and are the only place the error mapping is exercised the way a caller sees
+ * it, as a `Result.Failure` carrying a specific [AppSyncException] subtype.
+ *
+ * Robolectric is required because the transport sets a User-Agent, and building it reads
+ * `android.os.Build`, which is a stub on a plain JVM.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AmplifyAppSyncClientTest {
+
+    private val server = MockWebServer()
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    // ── Success ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `query returns the deserialized data`() = runTest {
+        server.enqueue(jsonResponse("""{"data":"hello"}"""))
+
+        val response = client().query(request()).shouldBeSuccess().data
+
+        response.data shouldBe "hello"
+        response.hasErrors() shouldBe false
+    }
+
+    @Test
+    fun `mutate returns the deserialized data`() = runTest {
+        server.enqueue(jsonResponse("""{"data":"created"}"""))
+
+        client().mutate(request()).shouldBeSuccess().data.data shouldBe "created"
+    }
+
+    @Test
+    fun `the request is a POST of the request content with the auth and content-type headers`() = runTest {
+        server.enqueue(jsonResponse("""{"data":"hello"}"""))
+
+        client().query(request()).shouldBeSuccess()
+
+        val recorded = server.awaitRequest()
+        recorded.method shouldBe "POST"
+        recorded.path shouldBe "/graphql"
+        recorded.getHeader("x-api-key") shouldBe "da2-fakekey"
+        recorded.getHeader("accept") shouldBe "application/json"
+        recorded.getHeader("content-type") shouldContain "application/json"
+        recorded.body.readUtf8() shouldContain "getTodo"
+    }
+
+    @Test
+    fun `a user agent is sent`() = runTest {
+        server.enqueue(jsonResponse("""{"data":"hello"}"""))
+
+        client().query(request()).shouldBeSuccess()
+
+        server.awaitRequest().getHeader("User-Agent").isNullOrBlank() shouldBe false
+    }
+
+    @Test
+    fun `the http client configurator is applied`() = runTest {
+        server.enqueue(jsonResponse("""{"data":"hello"}"""))
+        var configured = false
+
+        client { httpClientConfigurator = { configured = true } }.query(request())
+
+        configured shouldBe true
+    }
+
+    // ── GraphQL errors ──────────────────────────────────────────────────
+
+    @Test
+    fun `errors alongside data are a success with errors populated, not a failure`() = runTest {
+        // Partial success: AppSync returns 200 with both. Reporting this as a Failure would discard
+        // the data the service did return.
+        server.enqueue(
+            jsonResponse("""{"data":"partial","errors":[{"message":"Unauthorized on field secret"}]}""")
+        )
+
+        val response = client().query(request()).shouldBeSuccess().data
+
+        response.data shouldBe "partial"
+        response.errors shouldHaveSize 1
+        response.errors[0].message shouldBe "Unauthorized on field secret"
+    }
+
+    @Test
+    fun `a 4xx with a graphql error body becomes a GraphQLError exception carrying the errors`() = runTest {
+        server.enqueue(
+            jsonResponse(
+                """{"errors":[{"message":"Validation error: unknown field 'nope'"}]}""",
+                code = HttpURLConnection.HTTP_BAD_REQUEST
+            )
+        )
+
+        val error = client().query(request()).shouldBeFailure().error
+            .shouldBeInstanceOf<AppSyncGraphQLErrorException>()
+
+        error.errors shouldHaveSize 1
+        error.errors[0].message shouldContain "unknown field"
+        // The message surfaces the service's reason, not just the status code — this is the detail the
+        // plugin loses by collapsing every 4xx into one generic exception.
+        error.message shouldContain "unknown field"
+    }
+
+    @Test
+    fun `a 401 with no parseable body becomes a validation exception`() = runTest {
+        server.enqueue(jsonResponse("Unauthorized", code = HttpURLConnection.HTTP_UNAUTHORIZED))
+
+        val error = client().query(request()).shouldBeFailure().error
+
+        error.shouldBeInstanceOf<AppSyncValidationException>()
+        error.message shouldContain "401"
+    }
+
+    // ── Transport failures ──────────────────────────────────────────────
+
+    @Test
+    fun `a 5xx becomes a network exception, since it is usually transient`() = runTest {
+        server.enqueue(jsonResponse("boom", code = HttpURLConnection.HTTP_INTERNAL_ERROR))
+
+        val error = client().query(request()).shouldBeFailure().error
+
+        error.shouldBeInstanceOf<AppSyncNetworkException>()
+        error.message shouldContain "500"
+    }
+
+    @Test
+    fun `an unreachable endpoint becomes a network exception`() = runTest {
+        // Port 1 is reserved, so nothing is listening.
+        val unreachable = AmplifyAppSyncClient(
+            AmplifyAppSyncClient.Configuration {
+                endpoint = "http://localhost:1/graphql"
+                authorization = AppSyncAuthorization.Single(AppSyncClientAuthorizer.ApiKey("da2-fakekey"))
+                region = "us-east-1"
+            }
+        )
+
+        unreachable.query(request()).shouldBeFailure().error
+            .shouldBeInstanceOf<AppSyncNetworkException>()
+    }
+
+    @Test
+    fun `an empty body becomes a deserialization exception`() = runTest {
+        server.enqueue(jsonResponse(""))
+
+        client().query(request()).shouldBeFailure().error
+            .shouldBeInstanceOf<AppSyncDeserializationException>()
+    }
+
+    @Test
+    fun `a malformed body becomes a deserialization exception`() = runTest {
+        server.enqueue(jsonResponse("{not json at all"))
+
+        client().query(request()).shouldBeFailure().error
+            .shouldBeInstanceOf<AppSyncDeserializationException>()
+    }
+
+    // ── Auth failures reach the caller typed ────────────────────────────
+
+    @Test
+    fun `a failing token supplier surfaces as a token fetch failure without an http call`() = runTest {
+        val failing = AmplifyAppSyncClient(
+            AmplifyAppSyncClient.Configuration {
+                endpoint = server.url("/graphql").toString()
+                authorization = AppSyncAuthorization.Single(
+                    AppSyncClientAuthorizer.UserPools { error("session expired") }
+                )
+                region = "us-east-1"
+            }
+        )
+
+        failing.query(request()).shouldBeFailure().error
+            .shouldBeInstanceOf<AppSyncTokenFetchException>()
+
+        // Nothing was sent — the request never got past decoration.
+        server.requestCount shouldBe 0
+    }
+
+    // ── close() ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `a closed client fails subsequent requests instead of sending them`() = runTest {
+        val client = client()
+        client.close()
+
+        val error = client.query(request()).shouldBeFailure().error
+
+        error.shouldBeInstanceOf<AppSyncValidationException>()
+        error.message shouldContain "closed"
+        server.requestCount shouldBe 0
+    }
+
+    @Test
+    fun `close is idempotent`() = runTest {
+        val client = client()
+
+        client.close()
+        client.close()
+
+        client.query(request()).shouldBeFailure()
+    }
+
+    // ── Configuration ───────────────────────────────────────────────────
+
+    @Test
+    fun `an explicit region overrides inference`() {
+        configuration("https://abc123.appsync-api.us-east-1.amazonaws.com/graphql") {
+            region = "eu-central-1"
+        }.region shouldBe "eu-central-1"
+    }
+
+    @Test
+    fun `the region is inferred from a standard endpoint`() {
+        val config = configuration("https://abc123.appsync-api.ap-south-1.amazonaws.com/graphql")
+
+        config.region shouldBe "ap-south-1"
+        config.httpClientConfigurator.shouldBeNull()
+    }
+
+    @Test
+    fun `a china endpoint infers its region`() {
+        configuration("https://abc123.appsync-api.cn-north-1.amazonaws.com.cn/graphql")
+            .region shouldBe "cn-north-1"
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private fun client(configure: AmplifyAppSyncClient.Configuration.Builder.() -> Unit = {}) = AmplifyAppSyncClient(
+        // The mock server URL carries no region, so it is always set explicitly here.
+        configuration(server.url("/graphql").toString()) {
+            region = "us-east-1"
+            configure()
+        }
+    )
+
+    private fun configuration(url: String, configure: AmplifyAppSyncClient.Configuration.Builder.() -> Unit = {}) =
+        AmplifyAppSyncClient.Configuration {
+            endpoint = url
+            authorization = AppSyncAuthorization.Single(AppSyncClientAuthorizer.ApiKey("da2-fakekey"))
+            configure()
+        }
+
+    private fun request() = SimpleGraphQLRequest<String>(
+        """query { getTodo(id: "1") { id name } }""",
+        emptyMap(),
+        String::class.java,
+        GsonVariablesSerializer()
+    )
+
+    private fun jsonResponse(body: String, code: Int = HttpURLConnection.HTTP_OK) = MockResponse()
+        .setResponseCode(code)
+        .setHeader("content-type", "application/json")
+        .setBody(body)
+
+    /**
+     * Takes the next recorded request, failing if none arrives. The bare `takeRequest()` blocks the
+     * test thread forever when the request was never sent, and because it blocks rather than suspends
+     * `runTest`'s timeout cannot interrupt it — so a bug that stops a request being sent would hang
+     * the build instead of failing it.
+     */
+    private fun MockWebServer.awaitRequest(): RecordedRequest = requireNotNull(
+        takeRequest(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    ) { "Expected a request to reach the server, but none arrived within ${REQUEST_TIMEOUT_SECONDS}s." }
+
+    private companion object {
+        const val REQUEST_TIMEOUT_SECONDS = 5L
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -26,10 +26,14 @@ import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.RecordedRequest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.RecordedRequest
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -264,6 +268,29 @@ class AmplifyAppSyncClientTest {
         client.close()
 
         client.query(request()).shouldBeFailure()
+    }
+
+    // ── Cancellation ────────────────────────────────────────────────────
+
+    @Test
+    fun `cancelling a request in flight stops it without a retry`() = runBlocking<Unit> {
+        // Real socket I/O, so this cannot use runTest: its virtual clock would skip straight past the
+        // body delay the cancellation has to land inside.
+        //
+        // Asserts only what is deterministic. Issuing a second request here to show the client still
+        // works reads well but is not sound: whether it reuses the connection the cancelled call left
+        // mid-response is a timing question, and the assertion fails intermittently. Nor can this force
+        // the narrower ordering the resume callback in AppSyncHttpTransport guards, where a response
+        // arrives after the continuation is already cancelled — that race cannot be provoked on demand.
+        server.enqueue(jsonResponse("""{"data":"slow"}""").setBodyDelay(5, TimeUnit.SECONDS))
+
+        val inFlight = launch(Dispatchers.IO) { client().query(request()) }
+        server.awaitRequest()
+        inFlight.cancelAndJoin()
+
+        inFlight.isCancelled shouldBe true
+        // Cancellation must not be mistaken for a failure worth attempting under another auth mode.
+        server.requestCount shouldBe 1
     }
 
     // ── Configuration ───────────────────────────────────────────────────

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncGsonTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncGsonTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.temporal.Temporal
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+/**
+ * Tests the client's Gson instance, which is configured to match the plugin's factories rather than
+ * shared with them.
+ */
+class AppSyncGsonTest {
+
+    @Test
+    fun `nulls are serialized rather than omitted`() {
+        val json = AppSyncGson.instance.toJson(mapOf("name" to null, "id" to "1"))
+
+        // A mutation that clears a field needs the explicit null: an absent field means "leave
+        // unchanged" to AppSync, which is a different request.
+        json shouldBe """{"name":null,"id":"1"}"""
+    }
+
+    @Test
+    fun `temporal adapters are registered`() {
+        val date = Temporal.Date("2026-01-02")
+
+        AppSyncGson.instance.toJson(date) shouldBe """"2026-01-02""""
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncGsonTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncGsonTest.kt
@@ -19,8 +19,8 @@ import io.kotest.matchers.shouldBe
 import org.junit.Test
 
 /**
- * Tests the client's Gson instance, which is configured to match the plugin's factories rather than
- * shared with them.
+ * Tests the client's Gson instance: the adapter registrations and the null handling that requests and
+ * responses depend on.
  */
 class AppSyncGsonTest {
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncRequestDecoratorTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncRequestDecoratorTest.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.foundation.credentials.AwsCredentials
+import com.amplifyframework.foundation.credentials.AwsCredentialsProvider
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.junit.Test
+
+/**
+ * Tests [AppSyncRequestDecorator] — that each auth mode attaches the credentials AppSync expects, and
+ * that a failing credential supplier becomes a typed exception rather than escaping as whatever the
+ * customer's lambda threw.
+ */
+@OptIn(ExperimentalTime::class)
+class AppSyncRequestDecoratorTest {
+
+    private val decorator = AppSyncRequestDecorator(region = "us-east-1")
+
+    private fun request() = Request.Builder()
+        .url("https://abc123.appsync-api.us-east-1.amazonaws.com/graphql")
+        .post("""{"query":"query { listTodos { items { id } } }"}""".toRequestBody(JSON))
+        .build()
+
+    // ── Header-based modes ──────────────────────────────────────────────
+
+    @Test
+    fun `api key goes in the x-api-key header`() = runTest {
+        val decorated = decorator.decorate(request(), AppSyncClientAuthorizer.ApiKey("da2-fakekey"))
+
+        decorated.header("x-api-key") shouldBe "da2-fakekey"
+        decorated.header("authorization").shouldBeNull()
+    }
+
+    @Test
+    fun `user pools token goes in the authorization header`() = runTest {
+        val decorated = decorator.decorate(
+            request(),
+            AppSyncClientAuthorizer.UserPools { "user-pools-token" }
+        )
+
+        decorated.header("authorization") shouldBe "user-pools-token"
+        decorated.header("x-api-key").shouldBeNull()
+    }
+
+    @Test
+    fun `oidc token goes in the authorization header`() = runTest {
+        decorator.decorate(request(), AppSyncClientAuthorizer.Oidc { "oidc-token" })
+            .header("authorization") shouldBe "oidc-token"
+    }
+
+    @Test
+    fun `lambda token goes in the authorization header`() = runTest {
+        decorator.decorate(request(), AppSyncClientAuthorizer.Lambda { "lambda-token" })
+            .header("authorization") shouldBe "lambda-token"
+    }
+
+    @Test
+    fun `the api key supplier is invoked per request, not cached`() = runTest {
+        // A rotating key must be picked up on the next call, so the supplier cannot be memoised.
+        var calls = 0
+        val authorizer = AppSyncClientAuthorizer.ApiKey { "key-${++calls}" }
+
+        decorator.decorate(request(), authorizer).header("x-api-key") shouldBe "key-1"
+        decorator.decorate(request(), authorizer).header("x-api-key") shouldBe "key-2"
+    }
+
+    @Test
+    fun `the request body and url are left untouched`() = runTest {
+        val original = request()
+
+        val decorated = decorator.decorate(original, AppSyncClientAuthorizer.ApiKey("da2-fakekey"))
+
+        decorated.url shouldBe original.url
+        decorated.method shouldBe "POST"
+        decorated.body?.contentLength() shouldBe original.body?.contentLength()
+    }
+
+    // ── SigV4 ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `iam signing attaches the sigv4 authorization and content sha headers`() = runTest {
+        val decorated = decorator.decorate(request(), iamAuthorizer())
+
+        decorated.signature() shouldStartWith "AWS4-HMAC-SHA256"
+        // AppSync requires this body header on a signed request; without it the signature is rejected.
+        decorated.header("x-amz-content-sha256").shouldNotBeNull()
+        decorated.header("X-Amz-Date").shouldNotBeNull()
+    }
+
+    @Test
+    fun `iam signing scopes the credential to the configured region and the appsync service`() = runTest {
+        AppSyncRequestDecorator(region = "eu-west-2")
+            .decorate(request(), iamAuthorizer())
+            .signature() shouldContain "/eu-west-2/appsync/aws4_request"
+    }
+
+    @Test
+    fun `iam signing carries the session token for temporary credentials`() = runTest {
+        val decorated = decorator.decorate(
+            request(),
+            AppSyncClientAuthorizer.Iam(
+                AwsCredentialsProvider {
+                    AwsCredentials.Temporary(
+                        accessKeyId = "AKIAIOSFODNN7EXAMPLE",
+                        secretAccessKey = "secret",
+                        sessionToken = "session-token-value",
+                        expiration = Instant.DISTANT_FUTURE
+                    )
+                }
+            )
+        )
+
+        decorated.header("X-Amz-Security-Token") shouldBe "session-token-value"
+    }
+
+    @Test
+    fun `iam signing preserves the request body`() = runTest {
+        val original = request()
+
+        val decorated = decorator.decorate(original, iamAuthorizer())
+
+        // Signing rebuilds the OkHttp request from scratch, so this guards against dropping the body.
+        decorated.body.shouldNotBeNull()
+        decorated.body?.contentLength() shouldBe original.body?.contentLength()
+        decorated.url shouldBe original.url
+        decorated.method shouldBe "POST"
+    }
+
+    @Test
+    fun `iam signing keeps the china dns suffix in the signed host`() = runTest {
+        val chinaRequest = Request.Builder()
+            .url("https://abc123.appsync-api.cn-north-1.amazonaws.com.cn/graphql")
+            .post("{}".toRequestBody(JSON))
+            .build()
+
+        val decorated = AppSyncRequestDecorator(region = "cn-north-1")
+            .decorate(chinaRequest, iamAuthorizer())
+
+        decorated.url.host shouldBe "abc123.appsync-api.cn-north-1.amazonaws.com.cn"
+        decorated.signature() shouldContain "/cn-north-1/appsync/aws4_request"
+    }
+
+    // ── Supplier failures ───────────────────────────────────────────────
+
+    @Test
+    fun `a throwing api key supplier becomes a token fetch exception`() = runTest {
+        val boom = IllegalStateException("no key available")
+
+        val error = shouldThrow<AppSyncTokenFetchException> {
+            decorator.decorate(request(), AppSyncClientAuthorizer.ApiKey { throw boom })
+        }
+
+        error.cause shouldBe boom
+        error.message shouldContain "API key"
+    }
+
+    @Test
+    fun `a throwing token supplier becomes a token fetch exception naming the mode`() = runTest {
+        shouldThrow<AppSyncTokenFetchException> {
+            decorator.decorate(request(), AppSyncClientAuthorizer.UserPools { error("expired") })
+        }.message shouldContain "User Pools"
+
+        shouldThrow<AppSyncTokenFetchException> {
+            decorator.decorate(request(), AppSyncClientAuthorizer.Oidc { error("expired") })
+        }.message shouldContain "OIDC"
+
+        shouldThrow<AppSyncTokenFetchException> {
+            decorator.decorate(request(), AppSyncClientAuthorizer.Lambda { error("expired") })
+        }.message shouldContain "Lambda"
+    }
+
+    @Test
+    fun `a throwing credentials provider becomes a signing exception`() = runTest {
+        val error = shouldThrow<AppSyncSigningException> {
+            decorator.decorate(
+                request(),
+                AppSyncClientAuthorizer.Iam(
+                    AwsCredentialsProvider<AwsCredentials> { error("no credentials") }
+                )
+            )
+        }
+
+        error.message shouldContain "SigV4"
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private fun iamAuthorizer() = AppSyncClientAuthorizer.Iam(
+        AwsCredentialsProvider {
+            AwsCredentials.Static(
+                accessKeyId = "AKIAIOSFODNN7EXAMPLE",
+                secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            )
+        }
+    )
+
+    /** The SigV4 Authorization header. Header lookup is case-insensitive in OkHttp. */
+    private fun Request.signature(): String = header("Authorization").shouldNotBeNull()
+
+    private companion object {
+        val JSON = "application/json".toMediaType()
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncRequestDecoratorTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncRequestDecoratorTest.kt
@@ -24,7 +24,10 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldStartWith
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -138,6 +141,21 @@ class AppSyncRequestDecoratorTest {
     }
 
     @Test
+    fun `iam signing preserves every value of a repeated header`() = runTest {
+        val repeated = Request.Builder()
+            .url("https://abc123.appsync-api.us-east-1.amazonaws.com/graphql")
+            .addHeader("x-trace", "first")
+            .addHeader("x-trace", "second")
+            .post("{}".toRequestBody(JSON))
+            .build()
+
+        val decorated = decorator.decorate(repeated, iamAuthorizer())
+
+        // Reading one value per name on the way in or out would silently drop the other.
+        decorated.headers("x-trace") shouldBe listOf("first", "second")
+    }
+
+    @Test
     fun `iam signing preserves the request body`() = runTest {
         val original = request()
 
@@ -207,6 +225,36 @@ class AppSyncRequestDecoratorTest {
         error.message shouldContain "SigV4"
     }
 
+    // ── Cancellation is not mistaken for a credential failure ───────────
+    @Test
+    fun `cancelling while a token supplier suspends propagates the cancellation`() = runTest {
+        // A supplier that never completes, so the only way out is cancellation. If the decorator
+        // translated it the way it translates a supplier failure, this would be a token fetch
+        // exception instead.
+        shouldThrow<TimeoutCancellationException> {
+            withTimeout(CANCELLATION_TIMEOUT_MILLIS) {
+                decorator.decorate(
+                    request(),
+                    AppSyncClientAuthorizer.UserPools { suspendCancellableCoroutine { } }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `cancelling while credentials resolve propagates the cancellation`() = runTest {
+        shouldThrow<TimeoutCancellationException> {
+            withTimeout(CANCELLATION_TIMEOUT_MILLIS) {
+                decorator.decorate(
+                    request(),
+                    AppSyncClientAuthorizer.Iam(
+                        AwsCredentialsProvider<AwsCredentials> { suspendCancellableCoroutine { } }
+                    )
+                )
+            }
+        }
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────
 
     private fun iamAuthorizer() = AppSyncClientAuthorizer.Iam(
@@ -223,5 +271,6 @@ class AppSyncRequestDecoratorTest {
 
     private companion object {
         val JSON = "application/json".toMediaType()
+        const val CANCELLATION_TIMEOUT_MILLIS = 1_000L
     }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncResponseDeserializerTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncResponseDeserializerTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.aws.GsonVariablesSerializer
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.api.graphql.PaginatedResult
+import com.amplifyframework.api.graphql.SimpleGraphQLRequest
+import com.amplifyframework.util.TypeMaker
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.Test
+
+/**
+ * Tests [AppSyncResponseDeserializer].
+ *
+ * The list cases are the substance here. AppSync returns a list as an object wrapping an `items`
+ * array, and the same JSON has to become a `PaginatedResult` at the root of a query but a plain
+ * `List` below it — because that is what codegen emits for a one-to-many relationship.
+ */
+class AppSyncResponseDeserializerTest {
+
+    // ── Scalars and errors ──────────────────────────────────────────────
+
+    @Test
+    fun `deserializes data`() {
+        val response = AppSyncResponseDeserializer.deserialize(stringRequest(), """{"data":"hello"}""")
+
+        response.data shouldBe "hello"
+        response.hasErrors() shouldBe false
+    }
+
+    @Test
+    fun `deserializes errors`() {
+        val response = AppSyncResponseDeserializer.deserialize(
+            stringRequest(),
+            """{"errors":[{"message":"first"},{"message":"second"}]}"""
+        )
+
+        response.errors shouldHaveSize 2
+        response.errors[0].message shouldBe "first"
+        response.data.shouldBeNull()
+    }
+
+    @Test
+    fun `deserializes data and errors together`() {
+        val response = AppSyncResponseDeserializer.deserialize(
+            stringRequest(),
+            """{"data":"partial","errors":[{"message":"a field failed"}]}"""
+        )
+
+        response.data shouldBe "partial"
+        response.errors shouldHaveSize 1
+    }
+
+    @Test
+    fun `preserves error locations and extensions`() {
+        val response = AppSyncResponseDeserializer.deserialize(
+            stringRequest(),
+            """
+            {"errors":[{
+                "message":"Unauthorized",
+                "locations":[{"line":2,"column":5}],
+                "path":["getTodo","secret"],
+                "extensions":{"errorType":"Unauthorized"}
+            }]}
+            """.trimIndent()
+        )
+
+        val error = response.errors[0]
+        error.locations.shouldNotBeNull() shouldHaveSize 1
+        error.path.shouldNotBeNull() shouldHaveSize 2
+        error.extensions.shouldNotBeNull()["errorType"] shouldBe "Unauthorized"
+    }
+
+    // ── Failures ────────────────────────────────────────────────────────
+
+    @Test
+    fun `an empty body fails rather than returning null`() {
+        // Gson returns null instead of throwing for an empty string, so this is guarded explicitly.
+        // See https://github.com/google/gson/issues/457
+        shouldThrow<AppSyncDeserializationException> {
+            AppSyncResponseDeserializer.deserialize(stringRequest(), "")
+        }.message shouldContain "empty"
+    }
+
+    @Test
+    fun `a null body fails`() {
+        shouldThrow<AppSyncDeserializationException> {
+            AppSyncResponseDeserializer.deserialize(stringRequest(), null)
+        }
+    }
+
+    @Test
+    fun `a malformed body fails with the response type in the message`() {
+        shouldThrow<AppSyncDeserializationException> {
+            AppSyncResponseDeserializer.deserialize(stringRequest(), "{not json")
+        }.message shouldContain "String"
+    }
+
+    // ── Lists ───────────────────────────────────────────────────────────
+    //
+    // For an Iterable response type the response deserializer strips the query-name level first, so
+    // `data` must be an object with exactly one field — the query name. What is left below it is what
+    // the Iterable deserializer sees: either AppSync's `{ items: [...] }` wrapper, or a bare array for
+    // a nested field.
+
+    @Test
+    fun `deserializes a list from the items wrapper`() {
+        val response = AppSyncResponseDeserializer.deserialize(
+            listRequest(),
+            """{"data":{"listTodos":{"items":["a","b","c"]}}}"""
+        )
+
+        response.data shouldHaveSize 3
+        response.data shouldBe listOf("a", "b", "c")
+    }
+
+    @Test
+    fun `deserializes a bare json array under the query field`() {
+        val response = AppSyncResponseDeserializer.deserialize(
+            listRequest(),
+            """{"data":{"listTodos":["a","b"]}}"""
+        )
+
+        response.data shouldBe listOf("a", "b")
+    }
+
+    @Test
+    fun `a nextToken below the root is ignored, because codegen models the field as a plain List`() {
+        val response = AppSyncResponseDeserializer.deserialize(
+            listRequest(),
+            """{"data":{"listTodos":{"items":["a"],"nextToken":"tok"}}}"""
+        )
+
+        response.data shouldBe listOf("a")
+    }
+
+    @Test
+    fun `an object that is neither an array nor an items wrapper fails`() {
+        shouldThrow<AppSyncDeserializationException> {
+            AppSyncResponseDeserializer.deserialize(
+                listRequest(),
+                """{"data":{"listTodos":{"unexpected":"shape"}}}"""
+            )
+        }
+    }
+
+    @Test
+    fun `a query with more than one top level field fails`() {
+        shouldThrow<AppSyncDeserializationException> {
+            AppSyncResponseDeserializer.deserialize(
+                listRequest(),
+                """{"data":{"listTodos":["a"],"listOther":["b"]}}"""
+            )
+        }
+    }
+
+    // ── Pagination ──────────────────────────────────────────────────────
+
+    @Test
+    fun `deserializes a PaginatedResult and its items`() {
+        val response = AppSyncResponseDeserializer.deserialize(
+            paginatedRequest(),
+            """{"data":{"listTodos":{"items":["a","b"],"nextToken":"tok"}}}"""
+        )
+
+        response.data.items shouldBe listOf("a", "b")
+    }
+
+    @Test
+    fun `a PaginatedResult has no next page when the request is not an AppSyncGraphQLRequest`() {
+        // Only an AppSyncGraphQLRequest can be rebuilt with a nextToken variable, so a raw request
+        // yields items without a follow-up request rather than failing.
+        val response = AppSyncResponseDeserializer.deserialize(
+            paginatedRequest(),
+            """{"data":{"listTodos":{"items":["a"],"nextToken":"tok"}}}"""
+        )
+
+        response.data.hasNextResult() shouldBe false
+    }
+
+    @Test
+    fun `a PaginatedResult with no nextToken has no next page`() {
+        val response = AppSyncResponseDeserializer.deserialize(
+            paginatedRequest(),
+            """{"data":{"listTodos":{"items":["a"]}}}"""
+        )
+
+        response.data.items shouldBe listOf("a")
+        response.data.hasNextResult() shouldBe false
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private fun stringRequest(): GraphQLRequest<String> = SimpleGraphQLRequest(
+        "query { getTodo { id } }",
+        emptyMap(),
+        String::class.java,
+        GsonVariablesSerializer()
+    )
+
+    private fun listRequest(): GraphQLRequest<List<String>> = SimpleGraphQLRequest(
+        "query { listTodos { items { id } } }",
+        emptyMap(),
+        TypeMaker.getParameterizedType(List::class.java, String::class.java),
+        GsonVariablesSerializer()
+    )
+
+    private fun paginatedRequest(): GraphQLRequest<PaginatedResult<String>> = SimpleGraphQLRequest(
+        "query { listTodos { items { id } nextToken } }",
+        emptyMap(),
+        TypeMaker.getParameterizedType(PaginatedResult::class.java, String::class.java),
+        GsonVariablesSerializer()
+    )
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

n/a

*Description of changes:*

The single-auth HTTP path. Four internal files, **none of which change the public API surface** — `apiCheck` reports no diff, because this only fills in bodies that were `TODO()` and everything new is `internal`.

Per #3377 the client reimplements the plugin internals it needs privately rather than depending on `aws-api`. What that came to:

### `AppSyncRequestDecorator`

Collapses the plugin's six-class `RequestDecorator` hierarchy into a single suspend `when`. The plugin needs that hierarchy because its call sites are synchronous — `IamRequestDecorator` reaches the smithy signer through `AWS4Signer.signBlocking`, which is `runBlocking` under the hood. Every credential source here is already a `suspend` function, so this calls `DefaultAwsSigner.sign` directly and there is nothing to collapse a hierarchy around.

All five auth modes are covered. A credential supplier is customer code and can throw anything, so failures become `AppSyncTokenFetchException` or `AppSyncSigningException` rather than escaping as whatever the lambda raised.

This is the first consumer of the Phase 2 endpoint parser's region output, which is why the parser was in Foundations rather than here.

### `AppSyncHttpTransport`

Bridges OkHttp to a coroutine with `suspendCancellableCoroutine`, so cancelling the calling coroutine cancels the in-flight call instead of orphaning it. The plugin's equivalent takes `Consumer` callbacks and an `ExecutorService`.

### `AppSyncResponseDeserializer` + `AppSyncGson`

Reimplement response parsing. Seven of the nine adapters `GsonFactory` registers already live in `aws-api-appsync`, so they are reused directly; the two that do not — `ModelListDeserializer` and `ModelPageDeserializer` — are lazy-loading and belong to Phase 7.

### `query` / `mutate` / `close`

Both public functions delegate to one private `send()`. AppSync distinguishes a query from a mutation by the operation in the document, not by transport, so there is genuinely one code path; they stay separate public functions for call-site clarity and parity with Swift and Flutter.

`CancellationException` is deliberately rethrown rather than converted to a `Result.Failure` — swallowing it would break structured concurrency. Everything else becomes a `Failure`, so a caller never needs a try/catch.

`close()` cancels in-flight calls, evicts the connection pool, and is idempotent. A closed client fails subsequent requests instead of sending them.

### One deliberate improvement over the plugin

`AppSyncGraphQLOperation` collapses every 4xx into a generic `ApiException("OkHttp client request failed.")`. But AppSync returns validation and authorization failures as a **4xx carrying a GraphQL error body**, so the actionable detail is right there in the response and the plugin discards it. This deserializes it into `AppSyncGraphQLErrorException` with the real errors, and falls back to `AppSyncValidationException` only when the body cannot be parsed.

This is `AppSyncException.from()` gaining its first real mappings — Phase 2 shipped it thin precisely because there were no throw sites yet.

*How did you test these changes?*

**Tests go from 29 to 76**, all passing. Run with `--rerun-tasks`:

- `:aws-appsync:testDebugUnitTest` — **76 tests, 0 failures**
  - `AmplifyAppSyncClientTest` (18) — end-to-end over `MockWebServer`: success, partial success (errors *alongside* data stay a `Success`, since reporting a `Failure` would discard data the service returned), 4xx with and without a parseable error body, 5xx, unreachable endpoint, empty body, malformed body, a failing token supplier (asserting **zero** requests were sent), `close()` semantics, and region inference including a China endpoint.
  - `AppSyncRequestDecoratorTest` (14) — a header assertion per auth mode, that the API key supplier is invoked per request rather than cached, and for SigV4: the `AWS4-HMAC-SHA256` prefix, the `x-amz-content-sha256` body header AppSync requires, credential scoping to the configured region and the `appsync` service, the session token for temporary credentials, body preservation across the signing rebuild, and a China host keeping its `.amazonaws.com.cn` suffix in the signed credential. Plus the four supplier-failure paths.
  - `AppSyncResponseDeserializerTest` (15) — data, errors, both together, error locations/path/extensions, the list shapes, and pagination.
- `:aws-appsync:apiCheck` — **no diff**, as expected for an all-`internal` change.
- `:aws-appsync:ktlintCheck`, `:aws-appsync:compileReleaseKotlin`, `:aws-appsync:licensee`.
- `:aws-api:compileDebugKotlin`, `:aws-api-appsync:compileDebugKotlin`, `:aws-datastore:compileDebugKotlin` as downstream consumers.

**Two test-infrastructure notes worth a reviewer's attention**, because both were bugs I hit rather than choices I planned:

1. **The client tests need Robolectric.** The transport sets a `User-Agent`, and `UserAgent.string()` constructs a `UserAgent` whose constructor reads `android.os.Build.MANUFACTURER` — a `Stub!` throw on a plain JVM. `aws-connect` uses Robolectric for the same reason.
2. **`MockWebServer.takeRequest()` is now called with a timeout.** Before Robolectric was added, the `android.os.Build` throw meant no request was ever sent, and the bare `takeRequest()` blocked the test thread forever. Because it *blocks* rather than suspends, `runTest`'s timeout cannot interrupt it — so the build hung instead of failing. The helper now fails in 5s with a message naming the problem. This guards the failure mode, not just the instance of it.

**One test was passing for the wrong reason** and is worth flagging as a correctness note about the response shape. `GsonResponseAdapters.shouldSkipQueryLevel` strips the query-name level for any `Iterable` response type, so `data` must be an object with exactly one field. My original list fixture was `{"data":{"items":[...]}}`, which passed only because `items` was being consumed *as the query name*. The real shape is `{"data":{"listTodos":{"items":[...]}}}`. Corrected, with the constraint documented in the test file and pagination coverage added.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests — Phase 6 ports the e2e suite; there is no subscription path yet to test against a real endpoint
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
