### PR TITLE
fix(foundation): re-throw CancellationException from resultCatching

### DIFF
--- a/foundation/src/androidHostTest/kotlin/com/amplifyframework/foundation/result/ResultCatchingTest.kt
+++ b/foundation/src/androidHostTest/kotlin/com/amplifyframework/foundation/result/ResultCatchingTest.kt
@@ -17,6 +17,9 @@ package com.amplifyframework.foundation.result
 
 import com.amplifyframework.testutils.assertions.shouldBeFailure
 import com.amplifyframework.testutils.assertions.shouldBeSuccess
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlin.coroutines.cancellation.CancellationException
 import org.junit.Test
 
 class ResultCatchingTest {
@@ -37,5 +40,31 @@ class ResultCatchingTest {
         }
 
         result shouldBeFailure exception
+    }
+
+    @Test
+    fun `resultCatching rethrows CancellationException`() {
+        val exception = CancellationException("cancelled")
+
+        val thrown = shouldThrow<CancellationException> {
+            resultCatching {
+                throw exception
+            }
+        }
+
+        thrown shouldBe exception
+    }
+
+    @Test
+    fun `resultCatching does not catch Errors`() {
+        val error = OutOfMemoryError("no memory")
+
+        val thrown = shouldThrow<OutOfMemoryError> {
+            resultCatching {
+                throw error
+            }
+        }
+
+        thrown shouldBe error
     }
 }

--- a/foundation/src/commonMain/kotlin/com/amplifyframework/foundation/result/Catch.kt
+++ b/foundation/src/commonMain/kotlin/com/amplifyframework/foundation/result/Catch.kt
@@ -18,19 +18,25 @@ package com.amplifyframework.foundation.result
 import com.amplifyframework.annotations.InternalAmplifyApi
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
- * Runs the supplied block and returns the return value as a Result.Success. If an exception is thrown it returns
+ * Runs the supplied block and returns the return value as a Result.Success. If an [Exception] is thrown it returns
  * it as a Result.Failure.
+ *
+ * [CancellationException] is re-thrown so that coroutine cancellation is not swallowed, and [Error]s are not caught
+ * at all as they indicate unrecoverable conditions.
  */
 @InternalAmplifyApi
-inline fun <T> resultCatching(block: () -> T): Result<T, Throwable> {
+inline fun <T> resultCatching(block: () -> T): Result<T, Exception> {
     contract {
         callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
     return try {
         Result.Success(block())
-    } catch (e: Throwable) {
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
         Result.Failure(e)
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:*

`resultCatching` in the `foundation` module caught `Throwable`, which had two problems:

- It swallowed `CancellationException`, so coroutine cancellation could be accidentally interrupted and turned into a `Result.Failure`.
- It surfaced unrecoverable `Error`s (e.g. `OutOfMemoryError`) as a `Result`.

It now re-throws `CancellationException`, only catches `Exception`, and returns `Result<T, Exception>`.

No caller changes were required — `Result<out T, out E>` is covariant, so existing `Result<T, Throwable>` declarations still compile.

*How did you test these changes?*

Added unit tests covering `CancellationException` and `Error` propagation. Ran `:foundation:testAndroidHostTest`, `:foundation:ktlintCheck`, `:foundation:apiCheck`, and `:aws-kinesis:compileDebugKotlin` — all pass.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
