### PR TITLE
chore: fix cloudwatch client review comments

### DIFF
--- a/aws-cloudwatch/api/aws-cloudwatch.api
+++ b/aws-cloudwatch/api/aws-cloudwatch.api
@@ -91,6 +91,7 @@ public final class com/amplifyframework/cloudwatch/BuildConfig {
 }
 
 public final class com/amplifyframework/cloudwatch/FlushData {
+	public final fun getFlushed ()Z
 }
 
 public abstract class com/amplifyframework/cloudwatch/FlushStrategy {

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/AmplifyCloudWatchClient.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/AmplifyCloudWatchClient.kt
@@ -29,10 +29,12 @@ import com.amplifyframework.foundation.logging.LogSink
 import com.amplifyframework.foundation.logging.Logger
 import com.amplifyframework.foundation.result.Result
 import com.amplifyframework.foundation.useragent.AmplifyUserAgentInterceptor
+import java.security.MessageDigest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -54,8 +56,15 @@ private const val EVENTS_BUFFER_CAPACITY = 64
 private const val CLIENT_DATABASE_NAME_PREFIX = "amplify.cloudwatch.client"
 private const val CLIENT_PASSPHRASE_PREFERENCES_PREFIX = "awscloudwatchclientdb"
 
-/** A filesystem-safe, stable token derived from the log group, used to name the client's on-device store. */
-private fun storeToken(logGroupName: String): String = logGroupName.hashCode().toUInt().toString(16)
+/**
+ * A filesystem-safe, stable token derived from the log group, used to name the client's on-device store.
+ * A truncated SHA-256 is used (rather than [String.hashCode], which is 32-bit and trivially collidable)
+ * so distinct log groups get distinct stores and never mix events.
+ */
+private fun storeToken(logGroupName: String): String = MessageDigest.getInstance("SHA-256")
+    .digest(logGroupName.toByteArray(Charsets.UTF_8))
+    .take(8)
+    .joinToString("") { "%02x".format(it) }
 
 /**
  * A standalone client for sending log events to Amazon CloudWatch Logs.
@@ -157,13 +166,18 @@ class AmplifyCloudWatchClient internal constructor(
     private val logManager = logManagerFactory(cloudWatchLogsClient, eventsFlow)
 
     init {
-        scope.launch { logManager.startSync() }
+        logManager.startSync()
     }
 
     // region LogSink
 
-    /** Returns true if the client is enabled. */
-    override fun isEnabledFor(level: LogLevel): Boolean = isEnabled
+    /**
+     * Returns true if the client is enabled and some configured [LoggingConstraints] threshold could
+     * emit at [level]. This is namespace-agnostic and deliberately permissive (never under-reporting),
+     * so per-namespace filtering in [emit] stays authoritative while lazy messages that no threshold
+     * would ever emit are skipped.
+     */
+    override fun isEnabledFor(level: LogLevel): Boolean = isEnabled && filter.couldLog(level)
 
     /**
      * Receives a log message, filters it against the current [LoggingConstraints], and forwards it
@@ -186,7 +200,7 @@ class AmplifyCloudWatchClient internal constructor(
     fun enable() {
         logger.info { "Enabling CloudWatch logging and automatic flushing" }
         isEnabled = true
-        scope.launch { logManager.startSync() }
+        logManager.startSync()
     }
 
     /**
@@ -202,12 +216,26 @@ class AmplifyCloudWatchClient internal constructor(
 
     /** Flush all pending log entries to CloudWatch. */
     suspend fun flushLogs(): FlushResult = try {
-        logManager.syncLogEventsWithCloudwatch()
-        Result.Success(FlushData())
+        val flushed = logManager.syncLogEventsWithCloudwatch()
+        Result.Success(FlushData(flushed = flushed))
     } catch (error: CancellationException) {
         throw error
     } catch (error: Exception) {
         Result.Failure(AmplifyCloudWatchException.from(error))
+    }
+
+    /**
+     * Releases the resources held by this client: stops automatic flushing, drops the worker-factory
+     * registration, cancels the internal coroutine scope, and closes the underlying SDK client. Any
+     * log entries still buffered locally are preserved on disk. The client must not be used after this.
+     */
+    @InternalAmplifyApi
+    fun close() {
+        logger.info { "Closing CloudWatch client" }
+        isEnabled = false
+        logManager.close()
+        scope.cancel()
+        cloudWatchLogsClient.close()
     }
 
     /** Returns the underlying AWS CloudWatch Logs SDK client. */

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientOptions.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientOptions.kt
@@ -107,12 +107,17 @@ data class AmplifyCloudWatchClientOptions internal constructor(
          * @return Configured options instance
          * @throws IllegalArgumentException if [logGroupName] was not set
          */
-        fun build() = AmplifyCloudWatchClientOptions(
-            requireNotNull(logGroupName) { "logGroupName is required" },
-            localStoreMaxSizeInMB,
-            flushStrategy,
-            loggingConstraints,
-            configureClient
-        )
+        fun build(): AmplifyCloudWatchClientOptions {
+            require(localStoreMaxSizeInMB > 0) {
+                "localStoreMaxSizeInMB must be greater than 0, was $localStoreMaxSizeInMB"
+            }
+            return AmplifyCloudWatchClientOptions(
+                requireNotNull(logGroupName) { "logGroupName is required" },
+                localStoreMaxSizeInMB,
+                flushStrategy,
+                loggingConstraints,
+                configureClient
+            )
+        }
     }
 }

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/CloudWatchLogManager.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/CloudWatchLogManager.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -94,6 +95,10 @@ internal class CloudWatchLogManager(
     private val isSyncInProgress = AtomicBoolean(false)
     private val logger = AmplifyLogging.logger<CloudWatchLogManager>()
 
+    // Log streams already confirmed to exist this process, so a multi-batch flush issues at most one
+    // describeLogStreams per stream instead of one per batch. Only touched while the sync guard is held.
+    private val ensuredStreams = mutableSetOf<String>()
+
     // Key the worker-factory registration and the WorkManager unique work by log group so that two clients
     // targeting different log groups don't hijack each other's delegate factory or scheduled auto-flush (both
     // the factory map and unique-work names are app-global).
@@ -109,14 +114,24 @@ internal class CloudWatchLogManager(
     suspend fun saveLogEvent(event: CloudWatchLogEvent) = withContext(coroutineDispatcher) {
         try {
             cloudWatchLoggingDatabase.saveLogEvent(event)
-            if (isCacheFull()) {
-                syncLogEventsWithCloudwatch()
-            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             logger.error(e) { "Failed to save event" }
             onWriteLogFailure(event.message, e)
+            return@withContext
+        }
+        // A cache-full flush reports its own failures via onFlushLogFailure and rethrows; swallow that
+        // here so an upload problem isn't also surfaced as a WriteLogFailure for an event that was in
+        // fact persisted successfully.
+        if (isCacheFull()) {
+            try {
+                syncLogEventsWithCloudwatch()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn(e) { "Cache-full flush failed" }
+            }
         }
     }
 
@@ -138,7 +153,7 @@ internal class CloudWatchLogManager(
         }
     }
 
-    suspend fun startSync() {
+    fun startSync() {
         stopSync = false
         enqueueSync()
     }
@@ -149,11 +164,22 @@ internal class CloudWatchLogManager(
         logger.debug { "Stopping sync" }
     }
 
-    suspend fun syncLogEventsWithCloudwatch() {
+    /** Cancels the scope and drops the worker-factory registration. */
+    fun close() {
+        stopSync()
+        CloudWatchRouterWorker.workerFactories.remove(workerFactoryKey)
+        coroutineScope.cancel()
+    }
+
+    /**
+     * Attempts to flush all buffered events to CloudWatch. Returns `true` if this call performed the
+     * flush, or `false` if it was skipped because another flush was already in progress.
+     */
+    suspend fun syncLogEventsWithCloudwatch(): Boolean {
         // Atomic guard so overlapping triggers (manual flush, cache-full write, WorkManager) can't
         // run concurrently and delete each other's rows.
         if (!isSyncInProgress.compareAndSet(false, true)) {
-            return
+            return false
         }
         withContext(coroutineDispatcher) {
             var lastAttemptedIds: List<Long> = emptyList()
@@ -176,6 +202,9 @@ internal class CloudWatchLogManager(
                         if (batch.events.isEmpty()) continue
 
                         createLogStreamIfNotCreated(streamName, logGroupName, client)
+                        // Record the ids we're about to send *before* the call, so the cache-full
+                        // recovery valve in the catch block drops this batch if putLogEvents throws.
+                        lastAttemptedIds = batch.sendableIds
                         val response = client.putLogEvents(
                             PutLogEventsRequest {
                                 logEvents = batch.events
@@ -188,7 +217,6 @@ internal class CloudWatchLogManager(
                         response.rejectedLogEventsInfo?.tooNewLogEventStartIndex?.let {
                             acceptedIds = acceptedIds.slice(IntRange(0, it - 1))
                         }
-                        lastAttemptedIds = acceptedIds
                         // Nothing accepted (all too new): re-querying would return the same rows forever.
                         if (acceptedIds.isEmpty()) return@withContext
                         cloudWatchLoggingDatabase.bulkDelete(acceptedIds)
@@ -206,6 +234,7 @@ internal class CloudWatchLogManager(
                 isSyncInProgress.set(false)
             }
         }
+        return true
     }
 
     private suspend fun createLogStreamIfNotCreated(
@@ -213,13 +242,16 @@ internal class CloudWatchLogManager(
         groupName: String,
         client: CloudWatchLogsClient
     ) {
-        client.describeLogStreams(
-            DescribeLogStreamsRequest {
-                logGroupName = groupName
-                logStreamNamePrefix = logStream
-            }
-        ).apply {
-            if (this.logStreams == null || this.logStreams?.isEmpty() == true) {
+        // add() returns false if we've already ensured this stream this process; skip the describe call.
+        if (!ensuredStreams.add(logStream)) return
+        try {
+            val existing = client.describeLogStreams(
+                DescribeLogStreamsRequest {
+                    logGroupName = groupName
+                    logStreamNamePrefix = logStream
+                }
+            )
+            if (existing.logStreams.isNullOrEmpty()) {
                 client.createLogStream(
                     CreateLogStreamRequest {
                         logGroupName = groupName
@@ -227,6 +259,10 @@ internal class CloudWatchLogManager(
                     }
                 )
             }
+        } catch (e: Exception) {
+            // Don't cache a failed attempt — let a later batch retry the stream creation.
+            ensuredStreams.remove(logStream)
+            throw e
         }
     }
 

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/CloudWatchLogManager.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/CloudWatchLogManager.kt
@@ -28,6 +28,7 @@ import aws.sdk.kotlin.services.cloudwatchlogs.model.CreateLogStreamRequest
 import aws.sdk.kotlin.services.cloudwatchlogs.model.DescribeLogStreamsRequest
 import aws.sdk.kotlin.services.cloudwatchlogs.model.InputLogEvent
 import aws.sdk.kotlin.services.cloudwatchlogs.model.PutLogEventsRequest
+import aws.sdk.kotlin.services.cloudwatchlogs.model.ResourceNotFoundException
 import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.cloudwatch.db.CloudWatchDatabase
 import com.amplifyframework.cloudwatch.db.LogEvent
@@ -225,6 +226,12 @@ internal class CloudWatchLogManager(
             } catch (exception: CancellationException) {
                 throw exception
             } catch (exception: Exception) {
+                // The stream (or the whole group) may have been deleted server-side after we cached it.
+                // Drop the cache so the next flush re-runs describe/create and self-heals; clear() rather
+                // than one name since the group itself may have been recreated.
+                if (exception is ResourceNotFoundException) {
+                    ensuredStreams.clear()
+                }
                 onFlushLogFailure(null, exception)
                 if (isCacheFull()) {
                     cloudWatchLoggingDatabase.bulkDelete(lastAttemptedIds)

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/CloudWatchLoggingFilter.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/CloudWatchLoggingFilter.kt
@@ -45,6 +45,25 @@ internal class CloudWatchLoggingFilter(initialConstraints: LoggingConstraints) {
         return constraints.defaultLogLevel allows level
     }
 
+    /**
+     * Returns true if [level] could pass under *any* configured threshold (default, per-namespace, or
+     * per-user). Namespace-agnostic and deliberately permissive — [canLog] stays authoritative per
+     * message. Used by [AmplifyCloudWatchClient.isEnabledFor] so callers can skip materializing lazy
+     * log messages that no threshold would ever emit.
+     */
+    fun couldLog(level: LogLevel): Boolean {
+        val constraints = loggingConstraints
+        val thresholds = buildList {
+            add(constraints.defaultLogLevel)
+            addAll(constraints.namespaceLogLevel.values)
+            constraints.userLogLevel.values.forEach { userLevel ->
+                add(userLevel.defaultLogLevel)
+                addAll(userLevel.namespaceLogLevel.values)
+            }
+        }
+        return thresholds.any { it allows level }
+    }
+
     private fun Map<String, LogLevel>.matching(namespace: String): LogLevel? =
         entries.firstOrNull { it.key.equals(namespace, ignoreCase = true) }?.value
 }

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/CloudWatchLoggingFilter.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/CloudWatchLoggingFilter.kt
@@ -30,6 +30,15 @@ internal class CloudWatchLoggingFilter(initialConstraints: LoggingConstraints) {
 
     @Volatile
     var loggingConstraints: LoggingConstraints = initialConstraints
+        set(value) {
+            field = value
+            mostPermissiveThreshold = value.mostPermissive()
+        }
+
+    // Precomputed on every constraints change so couldLog (a hot path — called per sink per log
+    // statement) stays O(1) instead of rescanning every threshold on each call.
+    @Volatile
+    private var mostPermissiveThreshold: LogLevel = initialConstraints.mostPermissive()
 
     fun canLog(namespace: String, level: LogLevel, userIdentifier: String?): Boolean {
         val constraints = loggingConstraints
@@ -51,19 +60,19 @@ internal class CloudWatchLoggingFilter(initialConstraints: LoggingConstraints) {
      * message. Used by [AmplifyCloudWatchClient.isEnabledFor] so callers can skip materializing lazy
      * log messages that no threshold would ever emit.
      */
-    fun couldLog(level: LogLevel): Boolean {
-        val constraints = loggingConstraints
-        val thresholds = buildList {
-            add(constraints.defaultLogLevel)
-            addAll(constraints.namespaceLogLevel.values)
-            constraints.userLogLevel.values.forEach { userLevel ->
-                add(userLevel.defaultLogLevel)
-                addAll(userLevel.namespaceLogLevel.values)
-            }
-        }
-        return thresholds.any { it allows level }
-    }
+    fun couldLog(level: LogLevel): Boolean = mostPermissiveThreshold allows level
 
     private fun Map<String, LogLevel>.matching(namespace: String): LogLevel? =
         entries.firstOrNull { it.key.equals(namespace, ignoreCase = true) }?.value
+
+    // "any configured threshold allows level" == "the lowest (most permissive) threshold allows level",
+    // since allows is `this <= level`. LogLevel enum order runs Verbose (most permissive) .. None.
+    private fun LoggingConstraints.mostPermissive(): LogLevel = sequence {
+        yield(defaultLogLevel)
+        yieldAll(namespaceLogLevel.values)
+        userLogLevel.values.forEach {
+            yield(it.defaultLogLevel)
+            yieldAll(it.namespaceLogLevel.values)
+        }
+    }.min()
 }

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/FlushData.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/FlushData.kt
@@ -18,12 +18,15 @@ import com.amplifyframework.annotations.ExperimentalAmplifyApi
 import com.amplifyframework.foundation.result.Result
 
 /**
- * Data returned by a successful [AmplifyCloudWatchClient.flushLogs] call. It
- * currently carries no fields and exists so the operation can grow its result
- * shape without a breaking change.
+ * Data returned by a successful [AmplifyCloudWatchClient.flushLogs] call.
+ *
+ * @param flushed `true` if this call performed the flush; `false` if it was skipped because another
+ *   flush (an interval worker or a cache-full write) was already in progress. A caller that awaits
+ *   [AmplifyCloudWatchClient.flushLogs] before reading CloudWatch can use this to tell "flushed" from
+ *   "skipped".
  */
 @ExperimentalAmplifyApi
-class FlushData internal constructor()
+class FlushData internal constructor(val flushed: Boolean)
 
 /** Result of [AmplifyCloudWatchClient.flushLogs]. */
 @ExperimentalAmplifyApi

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/db/CloudWatchDatabase.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/db/CloudWatchDatabase.kt
@@ -40,7 +40,7 @@ class CloudWatchDatabase(
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     private val passphraseKey = "passphrase"
-    private val mb = 1024 * 1024
+    private val mb = 1024L * 1024
     private val amplifyKeyValueRepository: AmplifyKeyValueRepository by lazy {
         AmplifyKeyValueRepository(
             context,
@@ -88,7 +88,7 @@ class CloudWatchDatabase(
     fun isCacheFull(cacheSizeInMB: Int): Boolean {
         val path = context.getDatabasePath(databaseName)
         return if (path.exists()) {
-            path.length() >= cacheSizeInMB * mb
+            path.length() >= cacheSizeInMB.toLong() * mb
         } else {
             false
         }

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/worker/CloudWatchRouterWorker.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/worker/CloudWatchRouterWorker.kt
@@ -21,6 +21,7 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.google.common.util.concurrent.ListenableFuture
 import java.lang.IllegalStateException
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A [ListenableWorker] that WorkManager can instantiate with its default factory. It routes to a
@@ -40,15 +41,21 @@ internal class CloudWatchRouterWorker(appContext: Context, private val parameter
         internal const val WORKER_CLASS_NAME = "WORKER_CLASS_NAME"
         internal const val WORKER_ID = "WORKER_ID"
         internal const val WORKER_FACTORY_KEY = "AmplifyCloudWatchFactory"
+
+        // Registrations are written on whatever thread constructs a CloudWatchLogManager and read on a
+        // WorkManager background thread, so the map is concurrent and the flag is @Volatile.
+        @Volatile
         private var isWorkerFactoriesInitialized: Boolean = false
         val workerFactories = object : AbstractMutableMap<String, CloudWatchWorkerFactory>() {
 
-            private val backingWorkerMap = mutableMapOf<String, CloudWatchWorkerFactory>()
+            private val backingWorkerMap = ConcurrentHashMap<String, CloudWatchWorkerFactory>()
 
             override fun put(key: String, value: CloudWatchWorkerFactory): CloudWatchWorkerFactory? {
                 isWorkerFactoriesInitialized = true
                 return backingWorkerMap.put(key, value)
             }
+
+            override fun remove(key: String): CloudWatchWorkerFactory? = backingWorkerMap.remove(key)
 
             override val entries: MutableSet<MutableMap.MutableEntry<String, CloudWatchWorkerFactory>>
                 get() = backingWorkerMap.entries
@@ -70,8 +77,9 @@ internal class CloudWatchRouterWorker(appContext: Context, private val parameter
         } ?: run {
             // this is to prevent a race condition where workManager starts work before worker factory is initialized
             if (!isWorkerFactoriesInitialized) {
-                return CallbackToFutureAdapter.getFuture {
-                    Result.retry()
+                return CallbackToFutureAdapter.getFuture { completer ->
+                    completer.set(Result.retry())
+                    "CloudWatchRouterWorker.retry"
                 }
             } else {
                 throw IllegalStateException("Failed to find delegate for $workerClassName")

--- a/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/worker/CloudWatchRouterWorker.kt
+++ b/aws-cloudwatch/src/main/java/com/amplifyframework/cloudwatch/worker/CloudWatchRouterWorker.kt
@@ -20,7 +20,6 @@ import androidx.work.CoroutineWorker
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.google.common.util.concurrent.ListenableFuture
-import java.lang.IllegalStateException
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -82,7 +81,14 @@ internal class CloudWatchRouterWorker(appContext: Context, private val parameter
                     "CloudWatchRouterWorker.retry"
                 }
             } else {
-                throw IllegalStateException("Failed to find delegate for $workerClassName")
+                // No factory registered even though initialization has happened — the owning client was
+                // closed (dropping its registration) after WorkManager dequeued this job, or two clients
+                // shared a log group. Report a clean terminal failure rather than throwing an uncaught
+                // exception out of startWork().
+                return CallbackToFutureAdapter.getFuture { completer ->
+                    completer.set(Result.failure())
+                    "CloudWatchRouterWorker.noDelegate"
+                }
             }
         }
     }

--- a/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientOptionsTest.kt
+++ b/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientOptionsTest.kt
@@ -60,6 +60,18 @@ class AmplifyCloudWatchClientOptionsTest {
     }
 
     @Test
+    fun `build throws when localStoreMaxSizeInMB is not positive`() {
+        // A zero or negative value would make cacheSizeInMB * mb <= 0, so isCacheFull is always true
+        // and every write triggers a flush.
+        shouldThrow<IllegalArgumentException> {
+            AmplifyCloudWatchClientOptions.builder().logGroupName("/g").localStoreMaxSizeInMB(0).build()
+        }
+        shouldThrow<IllegalArgumentException> {
+            AmplifyCloudWatchClientOptions.builder().logGroupName("/g").localStoreMaxSizeInMB(-1).build()
+        }
+    }
+
+    @Test
     fun `dsl supports a custom flush strategy`() {
         val options = AmplifyCloudWatchClientOptions {
             logGroupName = "/g"

--- a/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientTest.kt
+++ b/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientTest.kt
@@ -28,6 +28,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -65,6 +66,57 @@ class AmplifyCloudWatchClientTest {
         client.isEnabledFor(LogLevel.Info) shouldBe false
         client.enable()
         client.isEnabledFor(LogLevel.Info) shouldBe true
+    }
+
+    @Test
+    fun `isEnabledFor is false for a level no configured threshold could emit`() = runTest {
+        // Default threshold Error: verbose/debug/info can never be emitted, so isEnabledFor must return
+        // false to spare the framework materializing lazy messages that would only be discarded.
+        val client = createClient(LoggingConstraints(defaultLogLevel = LogLevel.Error))
+
+        client.isEnabledFor(LogLevel.Verbose) shouldBe false
+        client.isEnabledFor(LogLevel.Info) shouldBe false
+        client.isEnabledFor(LogLevel.Error) shouldBe true
+    }
+
+    @Test
+    fun `isEnabledFor reflects the most permissive threshold across namespaces and users`() = runTest {
+        // A single verbose namespace override means verbose could be emitted somewhere.
+        val client = createClient(
+            LoggingConstraints(
+                defaultLogLevel = LogLevel.Error,
+                namespaceLogLevel = mapOf("Storage" to LogLevel.Verbose)
+            )
+        )
+
+        client.isEnabledFor(LogLevel.Verbose) shouldBe true
+    }
+
+    @Test
+    fun `disable applied after enable leaves the sync stopped`() = runTest {
+        val client = createClient()
+
+        client.enable()
+        client.disable()
+
+        // enable() applies synchronously (no deferred coroutine), so stopSync is the final effect and
+        // a quick enable to disable can't leave auto-flush running.
+        verifyOrder {
+            logManager.startSync() // construction
+            logManager.startSync() // enable()
+            logManager.stopSync() // disable()
+        }
+    }
+
+    @Test
+    fun `close tears down the manager, scope, and sdk client`() = runTest {
+        val client = createClient()
+
+        client.close()
+
+        verify(exactly = 1) { logManager.close() }
+        verify(exactly = 1) { sdkClient.close() }
+        client.isEnabledFor(LogLevel.Error) shouldBe false
     }
 
     @Test

--- a/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/CloudWatchLogManagerTest.kt
+++ b/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/CloudWatchLogManagerTest.kt
@@ -30,6 +30,7 @@ import aws.sdk.kotlin.services.cloudwatchlogs.model.LogStream
 import aws.sdk.kotlin.services.cloudwatchlogs.model.PutLogEventsRequest
 import aws.sdk.kotlin.services.cloudwatchlogs.model.PutLogEventsResponse
 import aws.sdk.kotlin.services.cloudwatchlogs.model.RejectedLogEventsInfo
+import aws.sdk.kotlin.services.cloudwatchlogs.model.ResourceNotFoundException
 import com.amplifyframework.annotations.InternalAmplifyApi
 import com.amplifyframework.cloudwatch.db.CloudWatchDatabase
 import com.amplifyframework.cloudwatch.db.LogEvent
@@ -340,6 +341,27 @@ internal class CloudWatchLogManagerTest {
         // Two batches share one stream name, so describeLogStreams is issued once, not per batch.
         coVerify(exactly = 1) { cloudWatchLogsClient.describeLogStreams(any()) }
         putRequests shouldHaveSize 2
+    }
+
+    @Test
+    fun `a ResourceNotFoundException clears the ensured-stream cache so the next flush re-describes`() = runTest {
+        coEvery { cloudWatchLogsClient.describeLogStreams(any()) } returns
+            DescribeLogStreamsResponse.invoke { logStreams = listOf(LogStream.invoke { logStreamName = "existing" }) }
+        coEvery { cloudWatchLogsClient.createLogStream(any()) } returns CreateLogStreamResponse.invoke { }
+        coJustRun { database.bulkDelete(any()) }
+
+        // First flush: the stream is deleted server-side, so putLogEvents fails with ResourceNotFound.
+        coEvery { database.queryAllEvents() } returns listOf(LogEvent(1L, "a", 1L))
+        coEvery { cloudWatchLogsClient.putLogEvents(any()) } throws
+            ResourceNotFoundException { message = "stream gone" }
+        shouldThrow<ResourceNotFoundException> { manager.syncLogEventsWithCloudwatch() }
+
+        // Second flush succeeds: because the cache was cleared, describeLogStreams runs again (self-heal).
+        coEvery { database.queryAllEvents() } returns listOf(LogEvent(2L, "b", 2L)) andThen emptyList()
+        coEvery { cloudWatchLogsClient.putLogEvents(any()) } returns PutLogEventsResponse.invoke { }
+        manager.syncLogEventsWithCloudwatch()
+
+        coVerify(exactly = 2) { cloudWatchLogsClient.describeLogStreams(any()) }
     }
 
     @Test

--- a/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/CloudWatchLogManagerTest.kt
+++ b/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/CloudWatchLogManagerTest.kt
@@ -280,6 +280,69 @@ internal class CloudWatchLogManagerTest {
     }
 
     @Test
+    fun `flush failure while cache is full drops the failed batch so the buffer can drain`() = runTest {
+        // The cache is full and CloudWatch rejects the batch. The recovery valve must drop the batch
+        // that failed; otherwise getNextBatch keeps re-picking the same rows and the buffer never drains.
+        every { database.isCacheFull(any()) } returns true
+        coEvery { database.queryAllEvents() } returns listOf(LogEvent(1L, "a", 1L), LogEvent(2L, "b", 2L))
+        coEvery { cloudWatchLogsClient.describeLogStreams(any()) } returns
+            DescribeLogStreamsResponse.invoke { logStreams = listOf(LogStream.invoke { logStreamName = "existing" }) }
+        coEvery { cloudWatchLogsClient.putLogEvents(any()) } throws RuntimeException("put failed")
+        coJustRun { database.bulkDelete(any()) }
+
+        shouldThrow<RuntimeException> { manager.syncLogEventsWithCloudwatch() }
+
+        coVerify(exactly = 1) { database.bulkDelete(listOf(1L, 2L)) }
+    }
+
+    @Test
+    fun `flush failure while cache is not full keeps the batch for retry`() = runTest {
+        every { database.isCacheFull(any()) } returns false
+        coEvery { database.queryAllEvents() } returns listOf(LogEvent(1L, "a", 1L))
+        coEvery { cloudWatchLogsClient.describeLogStreams(any()) } returns
+            DescribeLogStreamsResponse.invoke { logStreams = listOf(LogStream.invoke { logStreamName = "existing" }) }
+        coEvery { cloudWatchLogsClient.putLogEvents(any()) } throws RuntimeException("put failed")
+        coJustRun { database.bulkDelete(any()) }
+
+        shouldThrow<RuntimeException> { manager.syncLogEventsWithCloudwatch() }
+
+        // Nothing dropped: the entries stay buffered for the next flush.
+        coVerify(exactly = 0) { database.bulkDelete(any()) }
+    }
+
+    @Test
+    fun `a cache-full flush failure is reported only as a flush failure, not a write failure`() = runTest {
+        val event = CloudWatchLogEvent(1_000L, "Sample log")
+        every { database.isCacheFull(any()) } returns true
+        coEvery { database.saveLogEvent(event) } returns 1L
+        coEvery { database.queryAllEvents() } returns listOf(LogEvent(event.timestamp, event.message, 1L))
+        coEvery { cloudWatchLogsClient.describeLogStreams(any()) } returns
+            DescribeLogStreamsResponse.invoke { logStreams = listOf(LogStream.invoke { logStreamName = "existing" }) }
+        val error = RuntimeException("put failed")
+        coEvery { cloudWatchLogsClient.putLogEvents(any()) } throws error
+        coJustRun { database.bulkDelete(any()) }
+
+        manager.saveLogEvent(event)
+
+        // The event was persisted successfully, so the upload failure must not surface as a write failure.
+        writeFailures.shouldBeEmpty()
+        flushFailures shouldBe listOf(error)
+    }
+
+    @Test
+    fun `a multi-batch flush ensures each log stream only once`() = runTest {
+        val events = (1..10_001L).map { LogEvent(timestamp = it, message = "m", id = it) }
+        coEvery { database.queryAllEvents() } returns events andThen emptyList()
+        stubBatchCapture()
+
+        manager.syncLogEventsWithCloudwatch()
+
+        // Two batches share one stream name, so describeLogStreams is issued once, not per batch.
+        coVerify(exactly = 1) { cloudWatchLogsClient.describeLogStreams(any()) }
+        putRequests shouldHaveSize 2
+    }
+
+    @Test
     fun `stream name uses guest when no user identifier is set`() = runTest {
         coEvery { database.queryAllEvents() } returns listOf(LogEvent(1L, "hi", 1L)) andThen emptyList()
         stubSuccessfulUpload()

--- a/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/CloudWatchLoggingFilterTest.kt
+++ b/aws-cloudwatch/src/test/java/com/amplifyframework/cloudwatch/CloudWatchLoggingFilterTest.kt
@@ -144,4 +144,40 @@ class CloudWatchLoggingFilterTest {
 
         filter.canLog("Any", LogLevel.Info, null) shouldBe true
     }
+
+    @Test
+    fun `couldLog reflects the most permissive threshold across default, namespace, and user`() {
+        val filter = filter(
+            LoggingConstraints(
+                defaultLogLevel = LogLevel.Error,
+                namespaceLogLevel = mapOf("Storage" to LogLevel.Info),
+                userLogLevel = mapOf("user1" to UserLogLevel(namespaceLogLevel = mapOf("Auth" to LogLevel.Verbose)))
+            )
+        )
+
+        // Verbose is possible somewhere (user1/Auth), so it could log at every level down to Verbose.
+        filter.couldLog(LogLevel.Verbose) shouldBe true
+        filter.couldLog(LogLevel.Error) shouldBe true
+        // None is never a valid message level.
+        filter.couldLog(LogLevel.None) shouldBe false
+    }
+
+    @Test
+    fun `couldLog is false for levels below every threshold`() {
+        val filter = filter(LoggingConstraints(defaultLogLevel = LogLevel.Error))
+
+        filter.couldLog(LogLevel.Verbose) shouldBe false
+        filter.couldLog(LogLevel.Info) shouldBe false
+        filter.couldLog(LogLevel.Error) shouldBe true
+    }
+
+    @Test
+    fun `couldLog recomputes when loggingConstraints change`() {
+        val filter = filter(LoggingConstraints(defaultLogLevel = LogLevel.Error))
+        filter.couldLog(LogLevel.Info) shouldBe false
+
+        filter.loggingConstraints = LoggingConstraints(defaultLogLevel = LogLevel.Verbose)
+
+        filter.couldLog(LogLevel.Info) shouldBe true
+    }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

N/A

*Description of changes:*

Addresses review feedback on the standalone v3 CloudWatch client (`AmplifyCloudWatchClient`), covering a correctness regression, several robustness fixes, and a few smaller cleanups.

**Correctness**
- **Cache-full recovery no longer drops the failed batch (regression vs v2).** `lastAttemptedIds` was assigned *after* `putLogEvents` returned, so on failure the catch block's `bulkDelete` was a no-op — a full local store with a permanently-rejected batch would never drain. Now the batch ids are recorded *before* the call so the recovery valve drops the batch that actually failed (`CloudWatchLogManager`).
- **`isCacheFull` integer overflow.** `cacheSizeInMB * mb` overflowed `Int` (e.g. `Int.MIN_VALUE` at 2048 MB, `0` at 4096 MB), making `isCacheFull()` always true and flushing on every write. The multiplication is now done in `Long`, and `AmplifyCloudWatchClientOptions.build()` rejects a non-positive `localStoreMaxSizeInMB` (`CloudWatchDatabase`, `AmplifyCloudWatchClientOptions`).
- **`CloudWatchRouterWorker` retry future never completed.** The `CallbackToFutureAdapter` lambda returned `Result.retry()` as its debug tag but never called `completer.set(...)`, so the worker hung until timeout instead of rescheduling. It now delivers the result through the completer.

**Robustness / API**
- **`isEnabledFor` now honors the log level.** It previously ignored `level` and returned `isEnabled`, breaking the `LogSink` contract and defeating `AmplifyLogging`'s lazy-message evaluation framework-wide. It now returns `isEnabled && filter.couldLog(level)` — namespace-agnostic and conservative (never under-reporting), so per-namespace filtering in `emit` stays authoritative (`AmplifyCloudWatchClient`, `CloudWatchLoggingFilter.couldLog`).
- **`enable()`/`disable()` are now symmetric.** `enable()` deferred its state flip into `scope.launch { startSync() }` while `disable()` ran inline, so a quick `enable()` → `disable()` could leave auto-flush running. `startSync()` is now a plain (non-suspend) function called inline from both `enable()` and `init` (`AmplifyCloudWatchClient`, `CloudWatchLogManager`).
- **`flushLogs()` distinguishes "flushed" from "skipped".** When a sync was already in flight the guard returned immediately and `flushLogs()` still reported `Success`, so callers couldn't tell a real flush from a skipped one. `syncLogEventsWithCloudwatch()` now returns a `Boolean` surfaced as `FlushData.flushed` (`CloudWatchLogManager`, `FlushData`).
- **Thread-safe worker-factory registry + teardown.** `CloudWatchRouterWorker.workerFactories` is now backed by a `ConcurrentHashMap` with a `@Volatile` initialized flag (writes happen on the constructing thread, reads on a WorkManager thread), and gained a `remove` hook. An `@InternalAmplifyApi close()` on the client stops sync, drops the factory registration, cancels the scope, and closes the SDK client so a client no longer outlives its resources (`CloudWatchRouterWorker`, `CloudWatchLogManager.close`, `AmplifyCloudWatchClient.close`). `close()` is kept internal for now and can be promoted to public without a breaking change.

**Cleanups**
- **Store isolation token uses a truncated SHA-256** instead of `String.hashCode()` (32-bit, trivially collidable), making the "different log groups never share a store" guarantee structural rather than probabilistic (`AmplifyCloudWatchClient.storeToken`).
- **`describeLogStreams` is issued at most once per stream per process** instead of once per batch, halving the CloudWatch request count for large backlogs (`CloudWatchLogManager`).
- **A cache-full flush failure is no longer reported twice.** The `saveLogEvent` `try` is scoped to the DB write; the cache-full flush reports its own failure via `onFlushLogFailure` and its rethrow is swallowed, so an upload problem is no longer also surfaced as a `WriteLogFailure` for an event that was in fact persisted (`CloudWatchLogManager`).

*How did you test these changes?*

- Added unit tests for the cache-full flush-failure recovery, the "flush failure while cache is not full keeps the batch" path, single-report behavior, the single-`describeLogStreams` optimization, `isEnabledFor` under constraints, `enable()`/`disable()` ordering, `close()` teardown, and `localStoreMaxSizeInMB` validation.
- `./gradlew :aws-cloudwatch:testDebugUnitTest :aws-cloudwatch:ktlintCheck :aws-cloudwatch:apiCheck` — all pass.
- Ran the connected integration tests on an emulator against the provisioned CloudWatch backend — 10/10 pass.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
