### PR TITLE
fix(api): fail fast on AppSync subscription connection failure

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -18,6 +18,7 @@ package com.amplifyframework.api.aws;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.AmplifyException;
@@ -86,6 +87,17 @@ final class SubscriptionEndpoint {
             @NonNull SubscriptionAuthorizer authorizer,
             @Nullable String apiName
     ) {
+        this(apiConfiguration, responseFactory, authorizer, apiName, buildOkHttpClient(configurator));
+    }
+
+    @VisibleForTesting
+    SubscriptionEndpoint(
+            @NonNull ApiConfiguration apiConfiguration,
+            @NonNull GraphQLResponse.Factory responseFactory,
+            @NonNull SubscriptionAuthorizer authorizer,
+            @Nullable String apiName,
+            @NonNull OkHttpClient okHttpClient
+    ) {
         this.apiConfiguration = Objects.requireNonNull(apiConfiguration);
         this.subscriptions = new ConcurrentHashMap<>();
         this.responseFactory = Objects.requireNonNull(responseFactory);
@@ -93,7 +105,10 @@ final class SubscriptionEndpoint {
         this.timeoutWatchdog = new TimeoutWatchdog();
         this.pendingSubscriptionIds = Collections.synchronizedSet(new HashSet<>());
         this.apiName = apiName;
+        this.okHttpClient = Objects.requireNonNull(okHttpClient);
+    }
 
+    private static OkHttpClient buildOkHttpClient(@Nullable OkHttpConfigurator configurator) {
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
                 .retryOnConnectionFailure(true);
 
@@ -101,7 +116,7 @@ final class SubscriptionEndpoint {
             configurator.applyConfiguration(okHttpClientBuilder);
         }
 
-        this.okHttpClient = okHttpClientBuilder.build();
+        return okHttpClientBuilder.build();
     }
 
     <T> void requestSubscription(
@@ -170,7 +185,18 @@ final class SubscriptionEndpoint {
                 .put("authorization", authorizer.createHeadersForSubscription(request, authType))))
                 .toString();
 
-            socket.send(jsonMessage);
+            if (!socket.send(jsonMessage)) {
+                // The WebSocket rejected the message because it is closed or closing (for example,
+                // the connection dropped during a network change). Fail fast instead of waiting the
+                // full acknowledgement timeout for a start_ack that will never arrive.
+                if (pendingSubscriptionIds.remove(subscriptionId)) {
+                    onSubscriptionError.accept(new AppSyncSubscriptionConnectionException(
+                        "Failed to send subscription registration message; the connection is closed or closing.",
+                        null,
+                        "Check your Internet connection. Is your device online?"));
+                }
+                return;
+            }
         } catch (JSONException | ApiException exception) {
             // If the subscriptionId was still pending, then we can call the onSubscriptionError
             if (pendingSubscriptionIds.remove(subscriptionId)) {
@@ -217,6 +243,18 @@ final class SubscriptionEndpoint {
         Subscription<?> subscription = subscriptions.get(subscriptionId);
         if (subscription != null && pendingSubscriptionIds.remove(subscriptionId)) {
             subscription.acknowledgeSubscriptionFailure();
+        }
+    }
+
+    // Release every subscription still awaiting a start_ack so they fail fast rather than blocking
+    // for the full acknowledgement timeout. Used when the underlying connection fails, since a
+    // transport-level failure means no start_ack will ever be delivered for pending subscriptions.
+    private void failAllPendingSubscriptions() {
+        for (String subscriptionId : new HashSet<>(pendingSubscriptionIds)) {
+            Subscription<?> subscription = subscriptions.get(subscriptionId);
+            if (subscription != null && pendingSubscriptionIds.remove(subscriptionId)) {
+                subscription.acknowledgeSubscriptionFailure();
+            }
         }
     }
 
@@ -564,6 +602,9 @@ final class SubscriptionEndpoint {
             connectionResponse.countDown();
             // This will broadcast the error to all subscriptions
             notifyError(failure);
+            // Release any subscriptions still awaiting a start_ack so they fail fast instead of
+            // blocking for the full acknowledgement timeout now that the connection has failed.
+            failAllPendingSubscriptions();
         }
 
         @Override
@@ -599,7 +640,15 @@ final class SubscriptionEndpoint {
                     .put("type", "connection_init")
                     .toString();
 
-                webSocket.send(jsonMessage);
+                if (!webSocket.send(jsonMessage)) {
+                    // The socket is closed or closing, so the connection can never be acknowledged.
+                    // Mark the connection failed and release waiters instead of letting them block
+                    // for the full connection acknowledgement timeout.
+                    endpointStatus.set(EndpointStatus.CONNECTION_FAILED);
+                    connectionFailureCause = new IOException(
+                        "Failed to send connection_init message; the connection is closed or closing.");
+                    connectionResponse.countDown();
+                }
             } catch (JSONException jsonException) {
                 notifyError(jsonException);
             }
@@ -645,6 +694,7 @@ final class SubscriptionEndpoint {
                         }
                         
                         connectionResponse.countDown();
+                        failAllPendingSubscriptions();
                         break;
                     case SUBSCRIPTION_ACK:
                         notifySubscriptionAcknowledged(jsonMessage.getString("id"));

--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -103,7 +102,7 @@ final class SubscriptionEndpoint {
         this.responseFactory = Objects.requireNonNull(responseFactory);
         this.authorizer = Objects.requireNonNull(authorizer);
         this.timeoutWatchdog = new TimeoutWatchdog();
-        this.pendingSubscriptionIds = Collections.synchronizedSet(new HashSet<>());
+        this.pendingSubscriptionIds = ConcurrentHashMap.newKeySet();
         this.apiName = apiName;
         this.okHttpClient = Objects.requireNonNull(okHttpClient);
     }
@@ -175,6 +174,16 @@ final class SubscriptionEndpoint {
             }
         }
 
+        // Register the subscription before sending "start" so that a connection failure arriving
+        // mid-setup (for example during IAM/Cognito auth header creation below) can fail it fast via
+        // failAllPendingSubscriptions() instead of leaving this thread blocked for the full
+        // acknowledgement timeout waiting for a start_ack that will never arrive.
+        Subscription<T> subscription = new Subscription<>(
+            onNextItem, onSubscriptionError, onSubscriptionComplete,
+            responseFactory, request.getResponseType(), request, apiName
+        );
+        subscriptions.put(subscriptionId, subscription);
+
         try {
             String jsonMessage = new JSONObject()
                 .put("id", subscriptionId)
@@ -189,6 +198,8 @@ final class SubscriptionEndpoint {
                 // The WebSocket rejected the message because it is closed or closing (for example,
                 // the connection dropped during a network change). Fail fast instead of waiting the
                 // full acknowledgement timeout for a start_ack that will never arrive.
+                LOG.warn("Failed to send subscription registration message; the connection is closed or closing.");
+                subscriptions.remove(subscriptionId);
                 if (pendingSubscriptionIds.remove(subscriptionId)) {
                     onSubscriptionError.accept(new AppSyncSubscriptionConnectionException(
                         "Failed to send subscription registration message; the connection is closed or closing.",
@@ -199,6 +210,7 @@ final class SubscriptionEndpoint {
             }
         } catch (JSONException | ApiException exception) {
             // If the subscriptionId was still pending, then we can call the onSubscriptionError
+            subscriptions.remove(subscriptionId);
             if (pendingSubscriptionIds.remove(subscriptionId)) {
                 if (exception instanceof ApiAuthException) {
                     // Don't wrap it if it's an ApiAuthException.
@@ -215,11 +227,6 @@ final class SubscriptionEndpoint {
             return;
         }
 
-        Subscription<T> subscription = new Subscription<>(
-            onNextItem, onSubscriptionError, onSubscriptionComplete,
-            responseFactory, request.getResponseType(), request, apiName
-        );
-        subscriptions.put(subscriptionId, subscription);
         if (subscription.awaitSubscriptionReady()) {
             pendingSubscriptionIds.remove(subscriptionId);
             onSubscriptionStarted.accept(subscriptionId);
@@ -628,7 +635,9 @@ final class SubscriptionEndpoint {
                 return new Connection("Thread interrupted waiting for connection acknowledgement", exception);
             }
             LOG.debug("Current endpoint status: " + endpointStatus.get());
-            if (EndpointStatus.CONNECTION_FAILED.equals(endpointStatus.get())) {
+            // Check connectionFailureCause in addition to the status: a late onClosed() can flip the
+            // status to DISCONNECTED after a failure set the cause, and we must still report failure.
+            if (EndpointStatus.CONNECTION_FAILED.equals(endpointStatus.get()) || connectionFailureCause != null) {
                 return new Connection("Connection failed.", connectionFailureCause);
             }
             return new Connection();
@@ -644,9 +653,11 @@ final class SubscriptionEndpoint {
                     // The socket is closed or closing, so the connection can never be acknowledged.
                     // Mark the connection failed and release waiters instead of letting them block
                     // for the full connection acknowledgement timeout.
+                    LOG.warn("Failed to send connection_init message; the connection is closed or closing.");
                     endpointStatus.set(EndpointStatus.CONNECTION_FAILED);
                     connectionFailureCause = new IOException(
                         "Failed to send connection_init message; the connection is closed or closing.");
+                    webSocket.cancel();
                     connectionResponse.countDown();
                 }
             } catch (JSONException jsonException) {
@@ -694,6 +705,11 @@ final class SubscriptionEndpoint {
                         }
                         
                         connectionResponse.countDown();
+                        // Broadcast the error before releasing pending subscriptions. Once
+                        // failAllPendingSubscriptions() marks them failed, awaitSubscriptionReady()
+                        // returns without dispatching, so an established or in-flight subscription
+                        // would otherwise receive neither a started nor an error callback.
+                        notifyError(connectionFailureCause);
                         failAllPendingSubscriptions();
                         break;
                     case SUBSCRIPTION_ACK:

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/SubscriptionEndpointFastFailTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/SubscriptionEndpointFastFailTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amplifyframework.api.aws
+
+import com.amplifyframework.api.ApiException
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.api.graphql.GraphQLResponse
+import com.amplifyframework.core.Action
+import com.amplifyframework.core.Consumer
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.io.EOFException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Verifies the fast-fail behavior of [SubscriptionEndpoint] so that pending subscriptions do not
+ * block for the full acknowledgement timeouts when the underlying connection fails or a message
+ * cannot be sent. Without these behaviors, each of these tests would block for the 10s (start_ack)
+ * or 30s (connection) timeout and the [Callbacks.done] latch would not count down in time.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SubscriptionEndpointFastFailTest {
+    private val executor = Executors.newCachedThreadPool()
+    private val listenerSlot = slot<WebSocketListener>()
+    private val listenerReady = CountDownLatch(1)
+    private val webSocket = mockk<WebSocket>(relaxed = true)
+    private val okHttpClient = mockk<OkHttpClient>()
+    private val authorizer = mockk<SubscriptionAuthorizer>()
+    private val apiConfiguration = mockk<ApiConfiguration>()
+    private val responseFactory = mockk<GraphQLResponse.Factory>(relaxed = true)
+    private val request = mockk<GraphQLRequest<String>>(relaxed = true)
+
+    private lateinit var endpoint: SubscriptionEndpoint
+
+    private fun setup(sendBehavior: (String) -> Boolean = { true }) {
+        every { apiConfiguration.endpoint } returns
+            "https://abcdefghijklmnopqrstuvwxyz.appsync-api.us-east-1.amazonaws.com/graphql"
+        every { authorizer.createHeadersForConnection(any()) } returns JSONObject()
+        every { authorizer.createHeadersForSubscription(any(), any()) } returns JSONObject()
+        every { request.content } returns "{}"
+        every { request.responseType } returns String::class.java
+        every { webSocket.send(any<String>()) } answers { sendBehavior(firstArg()) }
+        every { okHttpClient.newWebSocket(any<Request>(), capture(listenerSlot)) } answers {
+            listenerReady.countDown()
+            webSocket
+        }
+        endpoint = SubscriptionEndpoint(apiConfiguration, responseFactory, authorizer, null, okHttpClient)
+    }
+
+    private class Callbacks {
+        val startedRef = AtomicReference<String?>(null)
+        val errorRef = AtomicReference<ApiException?>(null)
+        val done = CountDownLatch(1)
+    }
+
+    private fun requestSubscriptionAsync(): Callbacks {
+        val cb = Callbacks()
+        executor.execute {
+            try {
+                endpoint.requestSubscription(
+                    request,
+                    AuthorizationType.API_KEY,
+                    Consumer { id -> cb.startedRef.set(id) },
+                    Consumer { /* onNextItem */ },
+                    Consumer { error -> cb.errorRef.set(error) },
+                    Action { /* onComplete */ }
+                )
+            } finally {
+                cb.done.countDown()
+            }
+        }
+        return cb
+    }
+
+    private fun awaitListener(): WebSocketListener {
+        listenerReady.await(5, TimeUnit.SECONDS) shouldBe true
+        return listenerSlot.captured
+    }
+
+    private fun driveConnected(listener: WebSocketListener) {
+        // onOpen triggers connection_init, then a connection_ack transitions the endpoint to CONNECTED.
+        listener.onOpen(webSocket, mockk(relaxed = true))
+        listener.onMessage(
+            webSocket,
+            JSONObject()
+                .put("type", "connection_ack")
+                .put("payload", JSONObject().put("connectionTimeoutMs", "300000"))
+                .toString()
+        )
+    }
+
+    @Test
+    fun `pending subscription fails fast when the connection fails`() {
+        setup()
+        val callbacks = requestSubscriptionAsync()
+        val listener = awaitListener()
+
+        driveConnected(listener)
+        // Give the request thread a moment to send "start" and begin awaiting the start_ack.
+        Thread.sleep(300)
+        // A transport failure (e.g. EOFException on a network change) arrives while awaiting start_ack.
+        listener.onFailure(webSocket, EOFException("connection reset"), null)
+
+        // Without the fix, the request thread would block for the full 10s start_ack timeout.
+        callbacks.done.await(5, TimeUnit.SECONDS) shouldBe true
+        callbacks.startedRef.get().shouldBeNull()
+        callbacks.errorRef.get().shouldNotBeNull()
+    }
+
+    @Test
+    fun `subscription fails fast when the start message send is rejected`() {
+        // The WebSocket rejects the "start" frame (socket closed/closing), but accepts connection_init.
+        setup(sendBehavior = { message -> !message.contains("\"type\":\"start\"") })
+        val callbacks = requestSubscriptionAsync()
+        val listener = awaitListener()
+
+        driveConnected(listener)
+
+        // Without the fix, the request thread would block for the full 10s start_ack timeout.
+        callbacks.done.await(5, TimeUnit.SECONDS) shouldBe true
+        callbacks.startedRef.get().shouldBeNull()
+        val error = callbacks.errorRef.get()
+        error.shouldNotBeNull()
+        error.message shouldContain "closed or closing"
+    }
+
+    @Test
+    fun `connection fails fast when the connection_init send is rejected`() {
+        // The WebSocket rejects the connection_init frame outright.
+        setup(sendBehavior = { message -> !message.contains("connection_init") })
+        val callbacks = requestSubscriptionAsync()
+        val listener = awaitListener()
+
+        // onOpen triggers the connection_init send, which is rejected.
+        listener.onOpen(webSocket, mockk(relaxed = true))
+
+        // Without the fix, the request thread would block for the full 30s connection timeout.
+        callbacks.done.await(5, TimeUnit.SECONDS) shouldBe true
+        callbacks.startedRef.get().shouldBeNull()
+        val error = callbacks.errorRef.get()
+        error.shouldNotBeNull()
+        error.cause?.message shouldContain "connection_init"
+    }
+}

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/SubscriptionEndpointFastFailTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/SubscriptionEndpointFastFailTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -20,22 +20,25 @@ import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.GraphQLResponse
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
-import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import java.io.EOFException
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,20 +47,25 @@ import org.robolectric.RobolectricTestRunner
 /**
  * Verifies the fast-fail behavior of [SubscriptionEndpoint] so that pending subscriptions do not
  * block for the full acknowledgement timeouts when the underlying connection fails or a message
- * cannot be sent. Without these behaviors, each of these tests would block for the 10s (start_ack)
- * or 30s (connection) timeout and the [Callbacks.done] latch would not count down in time.
+ * cannot be sent.
+ *
+ * Each test asserts the failure is reported within 5s. Without the fixes the request thread would
+ * block for the full 10s (start_ack) or 30s (connection) timeout — or, for the `connection_error`
+ * path, never report at all — so the 5s [withTimeout] would fail the test.
  */
 @RunWith(RobolectricTestRunner::class)
 class SubscriptionEndpointFastFailTest {
-    private val executor = Executors.newCachedThreadPool()
-    private val listenerSlot = slot<WebSocketListener>()
-    private val listenerReady = CountDownLatch(1)
     private val webSocket = mockk<WebSocket>(relaxed = true)
     private val okHttpClient = mockk<OkHttpClient>()
     private val authorizer = mockk<SubscriptionAuthorizer>()
     private val apiConfiguration = mockk<ApiConfiguration>()
     private val responseFactory = mockk<GraphQLResponse.Factory>(relaxed = true)
     private val request = mockk<GraphQLRequest<String>>(relaxed = true)
+
+    // Explicit ordering signals (no sleeps): the listener is captured when newWebSocket is called,
+    // and startSent fires the moment the request thread sends the "start" frame.
+    private val listenerReady = CompletableDeferred<WebSocketListener>()
+    private val startSent = CompletableDeferred<Unit>()
 
     private lateinit var endpoint: SubscriptionEndpoint
 
@@ -68,42 +76,39 @@ class SubscriptionEndpointFastFailTest {
         every { authorizer.createHeadersForSubscription(any(), any()) } returns JSONObject()
         every { request.content } returns "{}"
         every { request.responseType } returns String::class.java
-        every { webSocket.send(any<String>()) } answers { sendBehavior(firstArg()) }
-        every { okHttpClient.newWebSocket(any<Request>(), capture(listenerSlot)) } answers {
-            listenerReady.countDown()
+        every { webSocket.send(any<String>()) } answers {
+            val message = firstArg<String>()
+            if (message.contains("\"type\":\"start\"")) {
+                startSent.complete(Unit)
+            }
+            sendBehavior(message)
+        }
+        every { okHttpClient.newWebSocket(any<Request>(), any()) } answers {
+            listenerReady.complete(secondArg())
             webSocket
         }
         endpoint = SubscriptionEndpoint(apiConfiguration, responseFactory, authorizer, null, okHttpClient)
     }
 
     private class Callbacks {
-        val startedRef = AtomicReference<String?>(null)
-        val errorRef = AtomicReference<ApiException?>(null)
-        val done = CountDownLatch(1)
+        val started = CompletableDeferred<String>()
+        val errored = CompletableDeferred<ApiException>()
     }
 
-    private fun requestSubscriptionAsync(): Callbacks {
-        val cb = Callbacks()
-        executor.execute {
-            try {
-                endpoint.requestSubscription(
-                    request,
-                    AuthorizationType.API_KEY,
-                    Consumer { id -> cb.startedRef.set(id) },
-                    Consumer { /* onNextItem */ },
-                    Consumer { error -> cb.errorRef.set(error) },
-                    Action { /* onComplete */ }
-                )
-            } finally {
-                cb.done.countDown()
-            }
+    /** Launches the blocking [SubscriptionEndpoint.requestSubscription] on a background dispatcher. */
+    private fun CoroutineScope.launchRequest(): Callbacks {
+        val callbacks = Callbacks()
+        launch(Dispatchers.IO) {
+            endpoint.requestSubscription(
+                request,
+                AuthorizationType.API_KEY,
+                Consumer { id -> callbacks.started.complete(id) },
+                Consumer { /* onNextItem */ },
+                Consumer { error -> callbacks.errored.complete(error) },
+                Action { /* onComplete */ }
+            )
         }
-        return cb
-    }
-
-    private fun awaitListener(): WebSocketListener {
-        listenerReady.await(5, TimeUnit.SECONDS) shouldBe true
-        return listenerSlot.captured
+        return callbacks
     }
 
     private fun driveConnected(listener: WebSocketListener) {
@@ -119,55 +124,77 @@ class SubscriptionEndpointFastFailTest {
     }
 
     @Test
-    fun `pending subscription fails fast when the connection fails`() {
+    fun `pending subscription fails fast when the connection fails`() = runTest {
         setup()
-        val callbacks = requestSubscriptionAsync()
-        val listener = awaitListener()
+        val callbacks = launchRequest()
 
-        driveConnected(listener)
-        // Give the request thread a moment to send "start" and begin awaiting the start_ack.
-        Thread.sleep(300)
-        // A transport failure (e.g. EOFException on a network change) arrives while awaiting start_ack.
-        listener.onFailure(webSocket, EOFException("connection reset"), null)
+        withContext(Dispatchers.IO) {
+            val listener = withTimeout(5.seconds) { listenerReady.await() }
+            driveConnected(listener)
+            // Wait until the request thread has actually sent "start" and is awaiting the start_ack.
+            withTimeout(5.seconds) { startSent.await() }
+            // A transport failure (e.g. EOFException on a network change) arrives while awaiting start_ack.
+            listener.onFailure(webSocket, EOFException("connection reset"), null)
 
-        // Without the fix, the request thread would block for the full 10s start_ack timeout.
-        callbacks.done.await(5, TimeUnit.SECONDS) shouldBe true
-        callbacks.startedRef.get().shouldBeNull()
-        callbacks.errorRef.get().shouldNotBeNull()
+            withTimeout(5.seconds) { callbacks.errored.await() }.shouldNotBeNull()
+        }
+        callbacks.started.isCompleted.shouldBeFalse()
     }
 
     @Test
-    fun `subscription fails fast when the start message send is rejected`() {
+    fun `subscription fails fast when the start message send is rejected`() = runTest {
         // The WebSocket rejects the "start" frame (socket closed/closing), but accepts connection_init.
         setup(sendBehavior = { message -> !message.contains("\"type\":\"start\"") })
-        val callbacks = requestSubscriptionAsync()
-        val listener = awaitListener()
+        val callbacks = launchRequest()
 
-        driveConnected(listener)
+        withContext(Dispatchers.IO) {
+            val listener = withTimeout(5.seconds) { listenerReady.await() }
+            driveConnected(listener)
 
-        // Without the fix, the request thread would block for the full 10s start_ack timeout.
-        callbacks.done.await(5, TimeUnit.SECONDS) shouldBe true
-        callbacks.startedRef.get().shouldBeNull()
-        val error = callbacks.errorRef.get()
-        error.shouldNotBeNull()
-        error.message shouldContain "closed or closing"
+            val error = withTimeout(5.seconds) { callbacks.errored.await() }
+            error.message shouldContain "closed or closing"
+        }
+        callbacks.started.isCompleted.shouldBeFalse()
     }
 
     @Test
-    fun `connection fails fast when the connection_init send is rejected`() {
+    fun `connection fails fast when the connection_init send is rejected`() = runTest {
         // The WebSocket rejects the connection_init frame outright.
         setup(sendBehavior = { message -> !message.contains("connection_init") })
-        val callbacks = requestSubscriptionAsync()
-        val listener = awaitListener()
+        val callbacks = launchRequest()
 
-        // onOpen triggers the connection_init send, which is rejected.
-        listener.onOpen(webSocket, mockk(relaxed = true))
+        withContext(Dispatchers.IO) {
+            val listener = withTimeout(5.seconds) { listenerReady.await() }
+            // onOpen triggers the connection_init send, which is rejected.
+            listener.onOpen(webSocket, mockk(relaxed = true))
 
-        // Without the fix, the request thread would block for the full 30s connection timeout.
-        callbacks.done.await(5, TimeUnit.SECONDS) shouldBe true
-        callbacks.startedRef.get().shouldBeNull()
-        val error = callbacks.errorRef.get()
-        error.shouldNotBeNull()
-        error.cause?.message shouldContain "connection_init"
+            val error = withTimeout(5.seconds) { callbacks.errored.await() }
+            error.cause?.message shouldContain "connection_init"
+        }
+        callbacks.started.isCompleted.shouldBeFalse()
+    }
+
+    @Test
+    fun `pending subscription is reported when a connection_error frame arrives`() = runTest {
+        setup()
+        val callbacks = launchRequest()
+
+        withContext(Dispatchers.IO) {
+            val listener = withTimeout(5.seconds) { listenerReady.await() }
+            driveConnected(listener)
+            withTimeout(5.seconds) { startSent.await() }
+            // A connection_error frame arrives while the subscription is awaiting start_ack.
+            listener.onMessage(
+                webSocket,
+                JSONObject()
+                    .put("type", "connection_error")
+                    .put("payload", JSONObject().put("errors", JSONArray().put(JSONObject().put("message", "boom"))))
+                    .toString()
+            )
+
+            // Without the error dispatch on this path, the subscription would be silently released.
+            withTimeout(5.seconds) { callbacks.errored.await() }.shouldNotBeNull()
+        }
+        callbacks.started.isCompleted.shouldBeFalse()
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

Internal

*Description of changes:*

Makes AppSync subscription setup fail fast when the underlying WebSocket has already gone away, so that pending subscriptions no longer block for the full acknowledgement timeouts during network changes (WiFi ↔ mobile data, brief connectivity loss). Previously a subscription could stall for up to 10s (waiting for a `start_ack`) or 30s (waiting for the connection ack) on a socket that was already dead, which amplified app-level reconnect loops into overlapping/duplicate subscriptions.

Both changes are in `SubscriptionEndpoint`.

**Fail pending subscriptions on connection failure**
- On a transport failure (`onFailure`, e.g. `EOFException`/broken pipe from a network change) the listener already broadcast the error, but any subscription already sitting in `awaitSubscriptionReady()` kept blocking for the full 10s `start_ack` timeout because its readiness latch was never released. A new `failAllPendingSubscriptions()` helper now releases every pending subscription (via `acknowledgeSubscriptionFailure()`) so they fail immediately instead of waiting for a `start_ack` that can never arrive. It is invoked from both the `onFailure` path and the `CONNECTION_ERROR` message path.

**Honor `WebSocket.send()` return value**
- `WebSocket.send()` returns `false` when the socket is closed/closing. The subscription `start` send previously ignored this and proceeded to a 10s `start_ack` wait; it now fast-fails the subscription with an `AppSyncSubscriptionConnectionException`.
- The `connection_init` send similarly ignored the return value, which would leave the request blocked for the full 30s connection timeout; it now marks the connection failed and releases waiters immediately.

**Testing seam (no production behavior change)**
- Added a `@VisibleForTesting` constructor that injects the `OkHttpClient`; the public constructor delegates to it via a `buildOkHttpClient` helper. This lets the unit tests supply a mock WebSocket and drive the listener callbacks directly.

Note: these are targeted fixes for the current V2 `aws-api` behavior. The durable improvement — SDK-managed reconnect with connectivity awareness, automatic re-subscription, backoff, and a single-flight guard (as amplify-swift already implements) — is tracked separately.

*How did you test these changes?*

- Added `SubscriptionEndpointFastFailTest` (Kotlin, MockK + Kotest + Robolectric) with three tests, each of which would block for the full timeout (and fail its <5s latch assertion) without the fix:
  - pending subscription fails fast when the connection fails (`onFailure` while awaiting `start_ack`);
  - subscription fails fast when the `start` message send is rejected;
  - connection fails fast when the `connection_init` send is rejected.
- `./gradlew :aws-api:testDebugUnitTest :aws-api:checkstyle :aws-api:ktlintCheck` — all pass (new tests: 3/3, 0 skipped).

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
