### PR TITLE
feat(api): add GraphQL subscriptions over a shared WebSocket

### DIFF
--- a/aws-appsync/api/aws-appsync.api
+++ b/aws-appsync/api/aws-appsync.api
@@ -164,6 +164,11 @@ public final class com/amazonaws/appsync/AppSyncInvalidConfigException : com/ama
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class com/amazonaws/appsync/AppSyncLimitExceededException : com/amazonaws/appsync/AppSyncSubscriptionException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class com/amazonaws/appsync/AppSyncNetworkException : com/amazonaws/appsync/AppSyncException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
@@ -21,9 +21,14 @@ import com.amplifyframework.foundation.result.Result
 import com.amplifyframework.foundation.result.getOrThrow
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 
@@ -54,6 +59,10 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
 
     private val closed = AtomicBoolean(false)
 
+    // close() is not suspend but the WebSocket teardown is, so it needs somewhere to run. Deliberately
+    // not cancelled: cancelling it would abort the very teardown it was created to perform.
+    private val teardownScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
     private val lazyHttpClient = lazy {
         OkHttpClient.Builder()
             .apply { configuration.httpClientConfigurator?.invoke(this) }
@@ -71,12 +80,38 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
         )
     }
 
+    private val webSocketClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .apply { configuration.webSocketClientConfigurator?.invoke(this) }
+            .build()
+    }
+
+    private val subscriber: AppSyncSubscriber by lazy {
+        val decorator = AppSyncRequestDecorator(configuration.region)
+        val realtimeUrl = AppSyncEndpointParser.realtimeUrl(configuration.endpoint).getOrThrow()
+
+        AppSyncSubscriber(
+            provider = AppSyncWebSocketProvider {
+                AppSyncWebSocket(
+                    realtimeUrl = realtimeUrl,
+                    httpEndpoint = configuration.endpoint,
+                    authorizer = configuration.authorization.defaultAuthorizer,
+                    decorator = decorator,
+                    client = webSocketClient
+                )
+            },
+            authorization = configuration.authorization,
+            decorator = decorator,
+            httpEndpoint = configuration.endpoint
+        )
+    }
+
     /**
      * Per-client connection state flow.
      * Emits [ConnectionState] changes for the shared WebSocket connection.
      */
     val events: SharedFlow<ConnectionState>
-        get() = TODO("Connection state will be implemented with subscriptions")
+        get() = subscriber.events
 
     /**
      * Execute a GraphQL query.
@@ -134,26 +169,40 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
      * @param request The GraphQL subscription request. Use model helpers or construct manually.
      * @return A cold [Flow] of [SubscriptionEvent].
      */
-    fun <T> subscribe(request: GraphQLRequest<T>): Flow<SubscriptionEvent<T>> =
-        TODO("Subscription implementation will be added in a follow-up PR")
+    fun <T> subscribe(request: GraphQLRequest<T>): Flow<SubscriptionEvent<T>> = flow {
+        // Checked at collection rather than call time, so a closed client fails the collector rather
+        // than throwing from a function that only builds a cold flow.
+        if (closed.get()) {
+            throw AppSyncValidationException(
+                message = "This client has been closed and cannot be reused.",
+                recoverySuggestion = "Create a new AmplifyAppSyncClient."
+            )
+        }
+        emitAll(subscriber.subscribe(request))
+    }
 
     /**
-     * Close the client, cancelling enqueued requests and releasing pooled connections.
-     * The client cannot be reused after closing.
+     * Close the client, cancelling enqueued requests, terminating active subscriptions and releasing
+     * pooled connections. The client cannot be reused after closing.
+     *
+     * Subscription teardown is asynchronous: this returns before the WebSocket has finished closing.
      *
      * A request that has already passed its own closed check can still be dispatched after this
      * returns, because closing does not lock the send path. Such a request completes normally rather
      * than being cancelled.
-     *
-     * TODO: terminate active subscriptions once subscriptions are supported.
      */
     fun close() {
         if (!closed.compareAndSet(false, true)) return
         // Nothing to release if no request was ever issued, and touching the client here would build
         // one — running the caller's configurator — purely to cancel an empty dispatcher.
-        if (!lazyHttpClient.isInitialized()) return
-        httpClient.dispatcher.cancelAll()
-        httpClient.connectionPool.evictAll()
+        if (lazyHttpClient.isInitialized()) {
+            httpClient.dispatcher.cancelAll()
+            httpClient.connectionPool.evictAll()
+        }
+        // The WebSocket teardown is suspending — it waits for closure to be observed so subscription
+        // flows complete normally rather than being cut off. close() is not suspend, so it is launched
+        // on a scope that deliberately outlives this call.
+        teardownScope.launch { subscriber.close() }
     }
 
     // ── Configuration ───────────────────────────────────────────────────

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
@@ -86,7 +86,7 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
             .build()
     }
 
-    private val subscriber: AppSyncSubscriber by lazy {
+    private val lazySubscriber = lazy {
         val decorator = AppSyncRequestDecorator(configuration.region)
         val realtimeUrl = AppSyncEndpointParser.realtimeUrl(configuration.endpoint).getOrThrow()
 
@@ -105,6 +105,8 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
             httpEndpoint = configuration.endpoint
         )
     }
+
+    private val subscriber: AppSyncSubscriber by lazySubscriber
 
     /**
      * Per-client connection state flow.
@@ -199,10 +201,16 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
             httpClient.dispatcher.cancelAll()
             httpClient.connectionPool.evictAll()
         }
-        // The WebSocket teardown is suspending — it waits for closure to be observed so subscription
-        // flows complete normally rather than being cut off. close() is not suspend, so it is launched
-        // on a scope that deliberately outlives this call.
-        teardownScope.launch { subscriber.close() }
+        // Same reasoning as the HTTP client: nothing to tear down if nothing ever subscribed, and
+        // touching the subscriber here would build it — resolving a realtime URL and standing up two
+        // scopes — only to cancel them. Resolving that URL can also fail, and it would fail on the
+        // teardown scope below, off the caller's thread, where nothing is watching.
+        if (lazySubscriber.isInitialized()) {
+            // The WebSocket teardown is suspending — it waits for closure to be observed so subscription
+            // flows complete normally rather than being cut off. close() is not suspend, so it is launched
+            // on a scope that deliberately outlives this call.
+            teardownScope.launch { subscriber.close() }
+        }
     }
 
     // ── Configuration ───────────────────────────────────────────────────

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
@@ -58,3 +58,17 @@ internal fun List<AppSyncWebSocketMessage.WireError>.hasSubscriptionLimitError()
     any { it.errorType == MAX_SUBSCRIPTIONS_REACHED }
 
 private const val MAX_SUBSCRIPTIONS_REACHED = "MaxSubscriptionsReachedError"
+
+/**
+ * Converts wire errors into the response type callers already handle, so an exception carrying them can
+ * be inspected the same way a query's errors are. The classification is preserved under `extensions`,
+ * which is where a GraphQL response carries it.
+ */
+internal fun List<AppSyncWebSocketMessage.WireError>.toGraphQLErrors(): List<GraphQLResponse.Error> = map {
+    GraphQLResponse.Error(
+        it.message,
+        null,
+        null,
+        it.errorType?.let { type -> mapOf("errorType" to type) } ?: emptyMap()
+    )
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.graphql.GraphQLResponse
+import com.amplifyframework.datastore.appsync.AppSyncExtensions
+
+/**
+ * Recognises the errors that mean "this identity was rejected", as opposed to errors that would recur
+ * with any identity. Only the former is worth retrying with a different auth mode.
+ *
+ * Both the HTTP and WebSocket paths need this, and both defer the classification to
+ * [AppSyncExtensions] so the client agrees with the API plugin on which error types count rather than
+ * maintaining its own list of magic strings.
+ */
+
+/**
+ * Whether any error on this response is an authorization failure.
+ *
+ * [AppSyncExtensions] reads `errorType` out of the map as a `String` without checking, so extensions
+ * whose `errorType` arrives as a JSON number make its constructor throw. That is server-controlled
+ * input, and one error object nobody can classify must not cost the caller the whole response, so a
+ * failure to classify counts as "not unauthorized" and the response is delivered with its errors intact.
+ */
+internal fun GraphQLResponse<*>.hasUnauthorizedError(): Boolean = errors.any { error ->
+    val extensions = error.extensions
+    !extensions.isNullOrEmpty() &&
+        runCatching { AppSyncExtensions(extensions).isUnauthorizedErrorType }.getOrDefault(false)
+}
+
+/** Whether any of these WebSocket errors is an authorization failure. */
+internal fun List<AppSyncWebSocketMessage.WireError>.hasUnauthorizedError(): Boolean = any { error ->
+    error.errorType?.let { AppSyncExtensions(it, null, null).isUnauthorizedErrorType } == true
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
@@ -44,3 +44,17 @@ internal fun GraphQLResponse<*>.hasUnauthorizedError(): Boolean = errors.any { e
 internal fun List<AppSyncWebSocketMessage.WireError>.hasUnauthorizedError(): Boolean = any { error ->
     error.errorType?.let { AppSyncExtensions(it, null, null).isUnauthorizedErrorType } == true
 }
+
+/**
+ * Whether any of these errors says the API's concurrent-subscription limit was reached.
+ *
+ * Checked against the wire string directly rather than through [AppSyncExtensions], whose error-type
+ * enum does not model this case.
+ *
+ * TODO: `LimitExceededError` is a sibling meaning a request-rate limit rather than a subscription
+ *  count. It needs different recovery advice, so it is not folded in here.
+ */
+internal fun List<AppSyncWebSocketMessage.WireError>.hasSubscriptionLimitError(): Boolean =
+    any { it.errorType == MAX_SUBSCRIPTIONS_REACHED }
+
+private const val MAX_SUBSCRIPTIONS_REACHED = "MaxSubscriptionsReachedError"

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
@@ -22,8 +22,7 @@ import com.amplifyframework.datastore.appsync.AppSyncExtensions
  * with any identity. Only the former is worth retrying with a different auth mode.
  *
  * Both the HTTP and WebSocket paths need this, and both defer the classification to
- * [AppSyncExtensions] so the client agrees with the API plugin on which error types count rather than
- * maintaining its own list of magic strings.
+ * [AppSyncExtensions] rather than maintaining a list of error-type strings here.
  */
 
 /**

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncClaimInjector.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncClaimInjector.kt
@@ -30,9 +30,8 @@ import com.amplifyframework.core.model.ModelOperation
  * Applies to subscriptions only. AppSync resolves the owner server-side for queries and mutations, so
  * they need nothing added.
  *
- * A private reimplementation of the plugin's `AuthRuleRequestDecorator`. It differs in one way worth
- * knowing: the plugin looks up a token from a registry of auth providers, whereas here the authorizer
- * already carries the token supplier, so the token is simply requested from it.
+ * The token is requested from the authorizer already in play for the attempt, so the claim always comes
+ * from the identity the subscription will actually be registered under.
  */
 internal class AppSyncClaimInjector {
 
@@ -66,7 +65,7 @@ internal class AppSyncClaimInjector {
                 rule.isOwnerReadRule() -> {
                     if (ownerRule != null) {
                         // AppSync generates a separate variable per owner rule, so there is no single
-                        // value to send. The plugin refuses this case too.
+                        // value to send.
                         throw AppSyncAuthorizationClaimException(
                             message = "The model has more than one owner @auth rule restricting reads, " +
                                 "so there is no single owner to send.",

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncClaimInjector.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncClaimInjector.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.aws.AppSyncGraphQLRequest
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.core.model.AuthRule
+import com.amplifyframework.core.model.AuthStrategy
+import com.amplifyframework.core.model.ModelOperation
+
+/**
+ * Adds the owner variable that owner-restricted subscriptions require.
+ *
+ * A model whose `@auth` rules restrict reads to an owner produces a subscription that AppSync expects
+ * to carry that owner as a variable. The value comes from a claim in the caller's own token, so only
+ * the client can supply it.
+ *
+ * Applies to subscriptions only. AppSync resolves the owner server-side for queries and mutations, so
+ * they need nothing added.
+ *
+ * A private reimplementation of the plugin's `AuthRuleRequestDecorator`. It differs in one way worth
+ * knowing: the plugin looks up a token from a registry of auth providers, whereas here the authorizer
+ * already carries the token supplier, so the token is simply requested from it.
+ */
+internal class AppSyncClaimInjector {
+
+    /**
+     * Returns [request] with the owner variable added, or unchanged when the rules do not call for one.
+     *
+     * Safe to call for any request: the rules decide. A request that is not an [AppSyncGraphQLRequest]
+     * carries no schema and is returned untouched.
+     *
+     * @param authMode The mode the subscription is being registered under. Which rules apply depends
+     *   on it — a rule that permits public reads under an API key means no owner is needed.
+     * @param authorizer The authorizer for [authMode], used to obtain the token the claims come from.
+     */
+    suspend fun <T> inject(
+        request: GraphQLRequest<T>,
+        authMode: AppSyncAuthMode,
+        authorizer: AppSyncClientAuthorizer
+    ): GraphQLRequest<T> {
+        val appSyncRequest = request as? AppSyncGraphQLRequest<T> ?: return request
+        val schema = appSyncRequest.modelSchema ?: return request
+
+        var ownerRule: AuthRule? = null
+        val groupsByClaim = mutableMapOf<String, MutableSet<String>>()
+
+        for (rule in schema.authRules) {
+            when {
+                // This rule already permits the read without an owner, so nothing needs adding and the
+                // remaining rules cannot change that.
+                rule.permitsPublicRead(authMode) -> return request
+
+                rule.isOwnerReadRule() -> {
+                    if (ownerRule != null) {
+                        // AppSync generates a separate variable per owner rule, so there is no single
+                        // value to send. The plugin refuses this case too.
+                        throw AppSyncAuthorizationClaimException(
+                            message = "The model has more than one owner @auth rule restricting reads, " +
+                                "so there is no single owner to send.",
+                            recoverySuggestion = "Restrict the model to one owner rule covering READ."
+                        )
+                    }
+                    ownerRule = rule
+                }
+
+                rule.isStaticGroupReadRule() ->
+                    groupsByClaim.getOrPut(rule.groupClaimOrDefault) { mutableSetOf() }
+                        .addAll(rule.groups)
+            }
+        }
+
+        val owner = ownerRule ?: return request
+
+        // Group membership takes precedence: a user who can already read via a group does not need the
+        // owner filter, and adding it would narrow what they receive.
+        val token = authorizer.tokenFor(authMode)
+        val payload = AppSyncJwt.payload(token)
+        if (groupsByClaim.any { (claim, permitted) ->
+                AppSyncJwt.groupsClaim(payload, claim).any(permitted::contains)
+            }
+        ) {
+            return request
+        }
+
+        val value = AppSyncJwt.stringClaim(payload, owner.identityClaimOrDefault)
+
+        return try {
+            appSyncRequest.newBuilder()
+                .variable(owner.ownerFieldOrDefault, "String!", value)
+                .build()
+        } catch (error: Exception) {
+            throw AppSyncValidationException(
+                message = "The owner variable could not be added to the subscription request.",
+                cause = error
+            )
+        }
+    }
+
+    /**
+     * Obtains the token whose claims identify the owner.
+     *
+     * Only User Pools and OIDC carry claims. An API key or IAM credential identifies no user, so an
+     * owner-restricted subscription cannot be authorized with one at all.
+     */
+    private suspend fun AppSyncClientAuthorizer.tokenFor(authMode: AppSyncAuthMode): String = when (this) {
+        is AppSyncClientAuthorizer.UserPools -> fetchToken.fetch("User Pools token")
+        is AppSyncClientAuthorizer.Oidc -> fetchToken.fetch("OIDC token")
+        else -> throw AppSyncProviderNotConfiguredException(
+            message = "The model restricts reads to an owner, which requires a token carrying claims, " +
+                "but the subscription is authorized with $authMode.",
+            recoverySuggestion = "Subscribe using Cognito User Pools or OpenID Connect."
+        )
+    }
+
+    /**
+     * Invokes a token supplier, translating any failure into a typed exception. A supplier is customer
+     * code and can throw anything; letting that escape untyped would stop the caller recognising it as
+     * an auth failure and trying another mode.
+     */
+    private suspend fun (suspend () -> String).fetch(description: String): String = try {
+        this()
+    } catch (error: Exception) {
+        throw AppSyncTokenFetchException(
+            message = "Fetching the $description failed.",
+            cause = error
+        )
+    }
+
+    private fun AuthRule.permitsPublicRead(authMode: AppSyncAuthMode): Boolean = authStrategy == AuthStrategy.PUBLIC &&
+        authProvider == AuthStrategy.Provider.API_KEY &&
+        authMode == AppSyncAuthMode.API_KEY &&
+        coversRead()
+
+    private fun AuthRule.isOwnerReadRule(): Boolean =
+        authStrategy == AuthStrategy.OWNER && operationsOrDefault.contains(ModelOperation.READ)
+
+    private fun AuthRule.isStaticGroupReadRule(): Boolean = authStrategy == AuthStrategy.GROUPS &&
+        groups.isNotEmpty() &&
+        operationsOrDefault.contains(ModelOperation.READ)
+
+    private fun AuthRule.coversRead(): Boolean =
+        operationsOrDefault.any { it == ModelOperation.LISTEN || it == ModelOperation.READ }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
@@ -55,6 +55,9 @@ internal object AppSyncEndpointParser {
 
     private const val API_LABEL = "appsync-api"
     private const val REALTIME_LABEL = "appsync-realtime-api"
+    private const val WSS_SCHEME = "wss://"
+    private const val DEFAULT_PATH = "/graphql"
+    private const val REALTIME_PATH_SUFFIX = "/realtime"
     private val REGION_REGEX = """^[a-z]{2,}(-[a-z]+)+-\d+$""".toRegex()
 
     /**
@@ -113,6 +116,38 @@ internal object AppSyncEndpointParser {
         )
     }
 
+    /**
+     * Derives the WebSocket URL that subscriptions connect to.
+     *
+     * Unlike [parse] this does **not** require a region, so it works for a custom domain — which
+     * carries no region in its host and therefore cannot be parsed at all. That matters because a
+     * custom-domain API is configured with an explicit region and must still be able to subscribe.
+     *
+     * The two domain shapes derive differently, which is why this cannot be one string substitution:
+     * - **Standard** (`{apiId}.appsync-api.{region}.{dnsSuffix}`) swaps the `appsync-api` label for
+     *   `appsync-realtime-api` and keeps the path.
+     * - **Custom** (anything else) keeps the host and appends `/realtime` to the path.
+     *
+     * @return the `wss://` URL, or a failure if no host could be read.
+     */
+    fun realtimeUrl(endpoint: String): Result<String, AppSyncEndpointResolutionException> {
+        val host = hostOf(endpoint)
+            ?: return failure("Could not read a host from the endpoint URL '$endpoint'.")
+        val path = pathOf(endpoint)
+
+        val labels = host.split('.')
+        val apiLabelIndex = labels.indexOf(API_LABEL)
+
+        // apiLabelIndex > 0 rather than >= 0: a bare `appsync-api.…` host with no API id is not a
+        // standard endpoint, and is treated as custom rather than silently mangled.
+        return if (apiLabelIndex > 0) {
+            val realtimeLabels = labels.toMutableList().also { it[apiLabelIndex] = REALTIME_LABEL }
+            Result.Success("$WSS_SCHEME${realtimeLabels.joinToString(".")}$path")
+        } else {
+            Result.Success("$WSS_SCHEME$host$path$REALTIME_PATH_SUFFIX")
+        }
+    }
+
     private fun hostOf(endpoint: String): String? {
         val withoutScheme = endpoint.substringAfter("://", missingDelimiterValue = endpoint)
         val host = withoutScheme
@@ -122,6 +157,17 @@ internal object AppSyncEndpointParser {
             .substringBefore(':') // strip any port
             .lowercase()
         return host.ifEmpty { null }
+    }
+
+    /**
+     * The path portion of the endpoint, defaulting to `/graphql`. Query and fragment are dropped —
+     * neither is meaningful on a WebSocket handshake URL.
+     */
+    private fun pathOf(endpoint: String): String {
+        val withoutScheme = endpoint.substringAfter("://", missingDelimiterValue = endpoint)
+        val authorityAndPath = withoutScheme.substringBefore('?').substringBefore('#')
+        val path = authorityAndPath.substringAfter('/', missingDelimiterValue = "")
+        return if (path.isEmpty()) DEFAULT_PATH else "/${path.trimEnd('/')}"
     }
 
     // Region labels are of the form {partition}-{area}-{number}, e.g. us-east-1, cn-north-1,

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncEndpointParser.kt
@@ -148,7 +148,12 @@ internal object AppSyncEndpointParser {
         }
     }
 
-    private fun hostOf(endpoint: String): String? {
+    /**
+     * The host portion of [endpoint], lowercased, or null if there is none.
+     *
+     * String surgery rather than a URL type, so it runs on a plain JVM as well as on a device.
+     */
+    fun hostOf(endpoint: String): String? {
         val withoutScheme = endpoint.substringAfter("://", missingDelimiterValue = endpoint)
         val host = withoutScheme
             .substringBefore('/')

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
@@ -250,6 +250,19 @@ class AppSyncTimeoutException(
     cause: Throwable? = null
 ) : AppSyncSubscriptionException(message, recoverySuggestion, cause)
 
+/**
+ * The API's maximum number of concurrent subscriptions was reached.
+ *
+ * Not resolved by re-subscribing or by using different credentials: the limit applies to the API, so
+ * something already open has to be released first.
+ */
+@ExperimentalAmplifyApi
+class AppSyncLimitExceededException(
+    message: String,
+    recoverySuggestion: String = "Close subscriptions that are no longer needed before opening more.",
+    cause: Throwable? = null
+) : AppSyncSubscriptionException(message, recoverySuggestion, cause)
+
 // ── Request ─────────────────────────────────────────────────────────────
 
 /** The request could not be built or was rejected before being sent. */

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -16,7 +16,6 @@ package com.amazonaws.appsync
 
 import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.GraphQLResponse
-import com.amplifyframework.datastore.appsync.AppSyncExtensions
 import com.amplifyframework.util.UserAgent
 import java.io.IOException
 import kotlin.coroutines.resume
@@ -96,7 +95,7 @@ internal class AppSyncHttpTransport(
             // not read with data for the rest of the selection set alongside an Unauthorized error, and
             // by then the operation has run — retrying would send a mutation a second time and apply it
             // twice. A response carrying data is therefore returned as it stands, errors included.
-            if (canFallBack && !response.hasData() && response.isUnauthorized()) {
+            if (canFallBack && !response.hasData() && response.hasUnauthorizedError()) {
                 lastAuthFailure = AppSyncGraphQLErrorException(
                     message = "Authorization failed with ${candidate.authMode}.",
                     errors = response.errors
@@ -122,21 +121,6 @@ internal class AppSyncHttpTransport(
             .build()
 
         return decorator.decorate(httpRequest, authorizer)
-    }
-
-    /**
-     * Whether the response carries an AppSync `Unauthorized` error. Defers to [AppSyncExtensions] for
-     * the classification rather than matching error-type strings here.
-     *
-     * [AppSyncExtensions] reads `errorType` as a `String` without checking, so extensions whose
-     * `errorType` arrives as a JSON number make its constructor throw. That is server-controlled input,
-     * and one error object nobody can classify must not cost the caller the whole response, so a failure
-     * to classify counts as "not unauthorized" and the response is delivered with its errors intact.
-     */
-    private fun GraphQLResponse<*>.isUnauthorized(): Boolean = errors.any { error ->
-        val extensions = error.extensions
-        !extensions.isNullOrEmpty() &&
-            runCatching { AppSyncExtensions(extensions).isUnauthorizedErrorType }.getOrDefault(false)
     }
 
     private fun exhausted(attempted: List<AppSyncAuthMode>, cause: AppSyncException?): AppSyncException {
@@ -205,7 +189,7 @@ internal class AppSyncHttpTransport(
         // rather than having to recognise a status code or an error string. Either signal is enough:
         // AppSync answers a rejected identity with a 401, and a rejected operation with an
         // Unauthorized error type that can arrive under any 4xx.
-        if (response.code == HTTP_UNAUTHORIZED || parsed?.isUnauthorized() == true) {
+        if (response.code == HTTP_UNAUTHORIZED || parsed?.hasUnauthorizedError() == true) {
             return AppSyncUnauthorizedException(
                 message = "The request was not authorized (HTTP status ${response.code})" +
                     (errors?.joinToString("; ") { it.message }?.let { ": $it" } ?: "."),

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncJwt.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncJwt.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import okio.ByteString.Companion.decodeBase64
+
+/**
+ * Reads claims out of a JWT payload.
+ *
+ * The signature is deliberately **not** verified. These claims are used only to populate a variable
+ * the service then authorizes for itself, so the token is being read for its content rather than
+ * trusted — AppSync validates it independently.
+ *
+ * A private reimplementation of the plugin's `CognitoJWTParser`, which decodes with
+ * `android.util.Base64`. This uses okio instead, which arrives with OkHttp and works on a plain JVM,
+ * so nothing here needs an Android runtime to be exercised.
+ */
+internal object AppSyncJwt {
+
+    private const val EXPECTED_PARTS = 3
+    private const val PAYLOAD_INDEX = 1
+
+    /**
+     * Decodes the payload of [token].
+     *
+     * @throws AppSyncTokenParsingException if the token is not a well-formed JWT.
+     */
+    fun payload(token: String): JsonObject {
+        val parts = token.split('.')
+        if (parts.size != EXPECTED_PARTS) {
+            throw AppSyncTokenParsingException(
+                message = "The token is not a JSON Web Token: expected $EXPECTED_PARTS " +
+                    "dot-separated parts but found ${parts.size}."
+            )
+        }
+
+        // JWT uses the base64url alphabet and omits padding; okio accepts both alphabets and tolerates
+        // the missing padding, so no pre-processing is needed.
+        val decoded = parts[PAYLOAD_INDEX].decodeBase64()?.utf8()
+            ?: throw AppSyncTokenParsingException(
+                message = "The token's payload is not valid base64."
+            )
+
+        return try {
+            JsonParser.parseString(decoded).asJsonObject
+        } catch (error: Exception) {
+            throw AppSyncTokenParsingException(
+                message = "The token's payload is not a JSON object.",
+                cause = error
+            )
+        }
+    }
+
+    /**
+     * Reads a string claim.
+     *
+     * @throws AppSyncAuthorizationClaimException if the claim is absent or is not a string. This is
+     *   distinct from a parsing failure: the token was readable, it simply does not carry what the
+     *   model's `@auth` rule requires.
+     */
+    fun stringClaim(payload: JsonObject, claim: String): String {
+        val value = payload.get(claim)?.takeIf { it.isJsonPrimitive }
+            ?: throw AppSyncAuthorizationClaimException(
+                message = "The token does not contain the '$claim' claim, which the model's @auth rule " +
+                    "requires to identify the owner."
+            )
+        return value.asString
+    }
+
+    /**
+     * Reads a claim holding a list of group names. Returns empty when the claim is absent, since a user
+     * simply belonging to no groups is normal rather than an error.
+     */
+    fun groupsClaim(payload: JsonObject, claim: String): List<String> {
+        val value = payload.get(claim) ?: return emptyList()
+        return when {
+            value.isJsonArray -> value.asJsonArray.mapNotNull { it.takeIf { e -> e.isJsonPrimitive }?.asString }
+            // A single group is sometimes emitted unwrapped.
+            value.isJsonPrimitive -> listOf(value.asString)
+            else -> emptyList()
+        }
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncJwt.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncJwt.kt
@@ -25,9 +25,8 @@ import okio.ByteString.Companion.decodeBase64
  * the service then authorizes for itself, so the token is being read for its content rather than
  * trusted — AppSync validates it independently.
  *
- * A private reimplementation of the plugin's `CognitoJWTParser`, which decodes with
- * `android.util.Base64`. This uses okio instead, which arrives with OkHttp and works on a plain JVM,
- * so nothing here needs an Android runtime to be exercised.
+ * Decodes with okio, which arrives alongside OkHttp and handles base64url and absent padding. Nothing
+ * here needs an Android runtime, so it can be exercised on a plain JVM.
  */
 internal object AppSyncJwt {
 

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
@@ -78,8 +78,8 @@ internal class AppSyncRequestDecorator(private val region: String) {
      * @param authorizer The authorizer to draw credentials from.
      * @param httpEndpoint The API's HTTP endpoint. SigV4 signs against this, not the `wss://` URL.
      * @param body The request document for a subscription, or null for the connection handshake.
-     *   Signing scope follows the plugin: a null body signs `{}` against `{endpoint}/connect`, and a
-     *   present body signs it against `{endpoint}`.
+     *   A null body signs `{}` against `{endpoint}/connect`; a present body is signed against
+     *   `{endpoint}` itself.
      */
     suspend fun authorizationHeaders(
         authorizer: AppSyncClientAuthorizer,
@@ -211,8 +211,8 @@ internal class AppSyncRequestDecorator(private val region: String) {
         const val DEFAULT_CONTENT_TYPE = "application/json"
         const val APPSYNC_SERVICE_NAME = "appsync"
 
-        // The WebSocket handshake and start messages are signed with these exact values, matching the
-        // plugin. The signature covers them, so they are not cosmetic.
+        // The WebSocket handshake and start messages are signed with these exact values. The signature
+        // covers them, so altering either would invalidate it.
         const val WEBSOCKET_ACCEPT = "application/json, text/javascript"
         const val WEBSOCKET_CONTENT_TYPE = "application/json; charset=UTF-8"
         const val CONNECT_PATH_SUFFIX = "/connect"

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
@@ -68,6 +68,49 @@ internal class AppSyncRequestDecorator(private val region: String) {
     private fun Request.withHeader(name: String, value: String) = newBuilder().header(name, value).build()
 
     /**
+     * Produces authorization as a **header map** rather than a decorated request.
+     *
+     * The WebSocket protocol needs this shape twice, and neither is an HTTP request the client sends:
+     * the handshake carries these headers on the upgrade request, and every `start` message embeds
+     * them in `payload.extensions.authorization`. AppSync authorizes each subscription separately from
+     * the connection, so the two differ in what gets signed.
+     *
+     * @param authorizer The authorizer to draw credentials from.
+     * @param httpEndpoint The API's HTTP endpoint. SigV4 signs against this, not the `wss://` URL.
+     * @param body The request document for a subscription, or null for the connection handshake.
+     *   Signing scope follows the plugin: a null body signs `{}` against `{endpoint}/connect`, and a
+     *   present body signs it against `{endpoint}`.
+     */
+    suspend fun authorizationHeaders(
+        authorizer: AppSyncClientAuthorizer,
+        httpEndpoint: String,
+        body: String? = null
+    ): Map<String, String> = when (authorizer) {
+        is AppSyncClientAuthorizer.ApiKey ->
+            mapOf(API_KEY_HEADER to authorizer.fetchApiKey.fetch("API key"))
+
+        is AppSyncClientAuthorizer.UserPools ->
+            mapOf(AUTHORIZATION_HEADER to authorizer.fetchToken.fetch("User Pools token"))
+
+        is AppSyncClientAuthorizer.Oidc ->
+            mapOf(AUTHORIZATION_HEADER to authorizer.fetchToken.fetch("OIDC token"))
+
+        is AppSyncClientAuthorizer.Lambda ->
+            mapOf(AUTHORIZATION_HEADER to authorizer.fetchToken.fetch("Lambda authorization token"))
+
+        is AppSyncClientAuthorizer.Iam -> {
+            val url = if (body == null) "$httpEndpoint$CONNECT_PATH_SUFFIX" else httpEndpoint
+            val signable = Request.Builder()
+                .url(url)
+                .header(ACCEPT_HEADER, WEBSOCKET_ACCEPT)
+                .header(CONTENT_TYPE_HEADER, WEBSOCKET_CONTENT_TYPE)
+                .post((body ?: EMPTY_BODY).toRequestBody(WEBSOCKET_CONTENT_TYPE.toMediaType()))
+                .build()
+            signable.signed(authorizer).headers.toMap()
+        }
+    }
+
+    /**
      * Invokes a credential supplier, translating any failure into a typed exception. A supplier is
      * customer code, so it can throw anything.
      *
@@ -163,7 +206,16 @@ internal class AppSyncRequestDecorator(private val region: String) {
         const val API_KEY_HEADER = "x-api-key"
         const val AUTHORIZATION_HEADER = "authorization"
         const val HOST_HEADER = "Host"
+        const val CONTENT_TYPE_HEADER = "content-type"
+        const val ACCEPT_HEADER = "accept"
         const val DEFAULT_CONTENT_TYPE = "application/json"
         const val APPSYNC_SERVICE_NAME = "appsync"
+
+        // The WebSocket handshake and start messages are signed with these exact values, matching the
+        // plugin. The signature covers them, so they are not cosmetic.
+        const val WEBSOCKET_ACCEPT = "application/json, text/javascript"
+        const val WEBSOCKET_CONTENT_TYPE = "application/json; charset=UTF-8"
+        const val CONNECT_PATH_SUFFIX = "/connect"
+        const val EMPTY_BODY = "{}"
     }
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRequestDecorator.kt
@@ -26,6 +26,10 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.net.url.Url
 import aws.smithy.kotlin.runtime.net.url.UrlEncoding
 import com.amplifyframework.foundation.credentials.toSmithyProvider
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import kotlinx.coroutines.CancellationException
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
@@ -75,28 +79,45 @@ internal class AppSyncRequestDecorator(private val region: String) {
      * them in `payload.extensions.authorization`. AppSync authorizes each subscription separately from
      * the connection, so the two differ in what gets signed.
      *
+     * Every mode must carry `host`, and API key must additionally carry `x-amz-date`; AppSync rejects
+     * a connection whose authorization object omits them with a routing error rather than an auth
+     * error. The SigV4 path already covers `host`, because the signature is computed over it.
+     *
      * @param authorizer The authorizer to draw credentials from.
-     * @param httpEndpoint The API's HTTP endpoint. SigV4 signs against this, not the `wss://` URL.
+     * @param httpEndpoint The API's HTTP endpoint. SigV4 signs against this, not the `wss://` URL, and
+     *   `host` is this endpoint's host rather than the realtime one's.
      * @param body The request document for a subscription, or null for the connection handshake.
      *   A null body signs `{}` against `{endpoint}/connect`; a present body is signed against
      *   `{endpoint}` itself.
+     * @throws AppSyncTokenFetchException if a token or API key supplier fails.
+     * @throws AppSyncSigningException if SigV4 signing fails.
+     * @throws AppSyncEndpointResolutionException if no host can be read from [httpEndpoint].
      */
     suspend fun authorizationHeaders(
         authorizer: AppSyncClientAuthorizer,
         httpEndpoint: String,
         body: String? = null
     ): Map<String, String> = when (authorizer) {
-        is AppSyncClientAuthorizer.ApiKey ->
-            mapOf(API_KEY_HEADER to authorizer.fetchApiKey.fetch("API key"))
+        is AppSyncClientAuthorizer.ApiKey -> mapOf(
+            HOST_KEY to httpEndpoint.host(),
+            AMZ_DATE_KEY to iso8601Now(),
+            API_KEY_HEADER to authorizer.fetchApiKey.fetch("API key")
+        )
 
-        is AppSyncClientAuthorizer.UserPools ->
-            mapOf(AUTHORIZATION_HEADER to authorizer.fetchToken.fetch("User Pools token"))
+        is AppSyncClientAuthorizer.UserPools -> mapOf(
+            HOST_KEY to httpEndpoint.host(),
+            AUTHORIZATION_KEY to authorizer.fetchToken.fetch("User Pools token")
+        )
 
-        is AppSyncClientAuthorizer.Oidc ->
-            mapOf(AUTHORIZATION_HEADER to authorizer.fetchToken.fetch("OIDC token"))
+        is AppSyncClientAuthorizer.Oidc -> mapOf(
+            HOST_KEY to httpEndpoint.host(),
+            AUTHORIZATION_KEY to authorizer.fetchToken.fetch("OIDC token")
+        )
 
-        is AppSyncClientAuthorizer.Lambda ->
-            mapOf(AUTHORIZATION_HEADER to authorizer.fetchToken.fetch("Lambda authorization token"))
+        is AppSyncClientAuthorizer.Lambda -> mapOf(
+            HOST_KEY to httpEndpoint.host(),
+            AUTHORIZATION_KEY to authorizer.fetchToken.fetch("Lambda authorization token")
+        )
 
         is AppSyncClientAuthorizer.Iam -> {
             val url = if (body == null) "$httpEndpoint$CONNECT_PATH_SUFFIX" else httpEndpoint
@@ -109,6 +130,14 @@ internal class AppSyncRequestDecorator(private val region: String) {
             signable.signed(authorizer).headers.toMap()
         }
     }
+
+    private fun String.host(): String = AppSyncEndpointParser.hostOf(this)
+        ?: throw AppSyncEndpointResolutionException(
+            message = "Could not read a host from the endpoint URL '$this'."
+        )
+
+    /** An ISO8601 basic-format UTC timestamp, the form AppSync expects for `x-amz-date`. */
+    private fun iso8601Now(): String = AMZ_DATE_FORMAT.format(Instant.now())
 
     /**
      * Invokes a credential supplier, translating any failure into a typed exception. A supplier is
@@ -210,6 +239,17 @@ internal class AppSyncRequestDecorator(private val region: String) {
         const val ACCEPT_HEADER = "accept"
         const val DEFAULT_CONTENT_TYPE = "application/json"
         const val APPSYNC_SERVICE_NAME = "appsync"
+
+        // Keys of the connection authorization object, not header names. That object reaches AppSync as
+        // JSON, where `Authorization` and `authorization` are two different keys — so this spelling is
+        // load-bearing, and cannot be shared with AUTHORIZATION_HEADER above, which names an HTTP
+        // header and is matched case-insensitively.
+        const val AUTHORIZATION_KEY = "Authorization"
+        const val HOST_KEY = "host"
+        const val AMZ_DATE_KEY = "x-amz-date"
+
+        val AMZ_DATE_FORMAT: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.US).withZone(ZoneOffset.UTC)
 
         // The WebSocket handshake and start messages are signed with these exact values. The signature
         // covers them, so altering either would invalidate it.

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.graphql.GraphQLRequest
+import java.util.UUID
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.launch
+
+/**
+ * Turns a GraphQL subscription request into a [Flow] of [SubscriptionEvent], multiplexed over the
+ * client's shared WebSocket.
+ *
+ * A private reimplementation of the plugin's `SubscriptionOperation` and the registry inside
+ * `SubscriptionEndpoint`. Because the socket exposes one flow of messages, a subscription is a
+ * *filter* over it keyed by subscription id rather than an entry in a callback registry.
+ *
+ * @param provider Supplies the shared connection, opening it on first subscribe.
+ * @param authorization The client's authorizer configuration.
+ * @param decorator Produces the per-subscription authorization headers.
+ * @param httpEndpoint The HTTP endpoint. SigV4 signs the `start` message against it.
+ * @param authModeResolver Chooses the auth mode, honouring `@auth` rules and per-request overrides.
+ */
+internal class AppSyncSubscriber(
+    private val provider: AppSyncWebSocketProvider,
+    private val authorization: AppSyncAuthorization,
+    private val decorator: AppSyncRequestDecorator,
+    private val httpEndpoint: String,
+    private val authModeResolver: AppSyncAuthModeResolver = AppSyncAuthModeResolver(authorization),
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    private val connectionEvents = MutableSharedFlow<ConnectionState>(replay = 1)
+    private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
+
+    /** Connection state for the shared socket. Replays the latest so a late observer is not blind. */
+    val events: SharedFlow<ConnectionState> = connectionEvents.asSharedFlow()
+
+    /**
+     * A cold flow for one subscription. Nothing happens until it is collected; cancelling the
+     * collector sends `stop` and releases the subscription.
+     *
+     * Lifecycle and terminality:
+     * - `Connecting` → `Connected` → `Data`*, then normal completion or a terminal throw.
+     * - Registration failures and connection failures are **terminal**.
+     * - GraphQL errors carried *inside* a data message are **not** terminal — they are delivered on
+     *   the response, because the service considered the message deliverable.
+     * - A data message that fails to deserialize is **not** terminal either; it is dropped and the
+     *   stream continues. Losing one message is better than tearing down a working subscription.
+     * - `complete` from the service, and a clean socket close, both end the flow normally.
+     */
+    fun <T> subscribe(request: GraphQLRequest<T>): Flow<SubscriptionEvent<T>> = flow {
+        emit(SubscriptionEvent.Connecting)
+
+        val socket = connectedSocket()
+        val id = UUID.randomUUID().toString()
+        val start = startMessage(id, request)
+
+        emitAll(
+            socket.messages
+                // onStart runs once this collector is subscribed. Sending `start` any earlier would
+                // race the reply: the socket's flow has no replay, so a fast start_ack would be lost
+                // and the subscription would appear to hang.
+                .onStart { socket.send(start) }
+                .onCompletion { socket.send(AppSyncWebSocketMessage.Stop(id)) }
+                .transformWhile { message -> handle(message, id, request) }
+        )
+    }
+
+    private suspend fun <T> startMessage(id: String, request: GraphQLRequest<T>): AppSyncWebSocketMessage.Start {
+        val authMode = authModeResolver.resolve(request).first()
+        val authorizer = authorization.authorizerFor(authMode)
+            ?: throw AppSyncProviderNotConfiguredException(
+                message = "No authorizer is configured for auth mode $authMode."
+            )
+
+        return AppSyncWebSocketMessage.Start(
+            id = id,
+            query = request.content,
+            // A non-null body signs against the plain endpoint, which is what AppSync expects for an
+            // individual subscription as opposed to the connection.
+            authorizationHeaders = decorator.authorizationHeaders(authorizer, httpEndpoint, request.content)
+        )
+    }
+
+    /**
+     * Decides what one inbound message means for this subscription.
+     *
+     * @return true to keep the flow open, false to complete it normally. Throws to terminate it.
+     */
+    private suspend fun <T> kotlinx.coroutines.flow.FlowCollector<SubscriptionEvent<T>>.handle(
+        message: AppSyncWebSocketMessage.Inbound,
+        id: String,
+        request: GraphQLRequest<T>
+    ): Boolean = when (message) {
+        is AppSyncWebSocketMessage.StartAck -> {
+            if (message.id == id) emit(SubscriptionEvent.Connected)
+            true
+        }
+
+        is AppSyncWebSocketMessage.Data -> {
+            if (message.id == id) {
+                // Deserialization failure is deliberately swallowed: it is non-terminal, so one
+                // unreadable message must not end a healthy subscription.
+                runCatching { AppSyncResponseDeserializer.deserialize(request, message.payload) }
+                    .getOrNull()
+                    ?.let { emit(SubscriptionEvent.Data(it)) }
+            }
+            true
+        }
+
+        is AppSyncWebSocketMessage.Complete -> message.id != id
+
+        is AppSyncWebSocketMessage.Error -> {
+            // A null id is a connection-level error, which is terminal for every subscription on it.
+            if (message.id == id || message.id == null) {
+                throw AppSyncGraphQLErrorException(
+                    message = "The subscription failed: " +
+                        message.errors.joinToString("; ").ifEmpty { "no reason given" },
+                    errors = emptyList()
+                )
+            }
+            true
+        }
+
+        is AppSyncWebSocketMessage.ConnectionError -> throw AppSyncConnectionException(
+            message = "The subscription connection failed: " +
+                message.errors.joinToString("; ").ifEmpty { "no reason given" }
+        )
+
+        // A cause means the connection died; no cause means close() was called, which ends
+        // subscription streams normally rather than throwing.
+        is AppSyncWebSocketMessage.Closed -> message.cause?.let { throw it } ?: false
+
+        // Keep-alives, unknown frames, and anything addressed to another subscription.
+        is AppSyncWebSocketMessage.ConnectionAck,
+        is AppSyncWebSocketMessage.KeepAlive,
+        is AppSyncWebSocketMessage.Unknown -> true
+    }
+
+    /**
+     * Returns the shared socket, emitting connection state around the attempt.
+     */
+    private suspend fun connectedSocket(): AppSyncWebSocket {
+        provider.existing?.let { return it }
+
+        connectionEvents.emit(ConnectionState.Connecting)
+        val socket = try {
+            provider.connection()
+        } catch (error: Throwable) {
+            connectionEvents.emit(ConnectionState.Disconnected(AppSyncException.from(error)))
+            throw error
+        }
+        connectionEvents.emit(ConnectionState.Connected)
+        watchForDisconnect(socket)
+        return socket
+    }
+
+    /**
+     * Reports an unexpected disconnect on [events].
+     *
+     * One watcher per connection, not per subscription: every subscriber sees the same `Closed`
+     * message, so emitting from the per-subscription path would report the same disconnect N times.
+     */
+    private fun watchForDisconnect(socket: AppSyncWebSocket) {
+        scope.launch {
+            // Already gone — the Closed message has been and passed, so there is nothing left to await.
+            if (socket.isClosed) {
+                connectionEvents.emit(ConnectionState.Disconnected(null))
+                return@launch
+            }
+            val closed = socket.messages.first { it is AppSyncWebSocketMessage.Closed }
+            connectionEvents.emit(
+                ConnectionState.Disconnected((closed as AppSyncWebSocketMessage.Closed).cause)
+            )
+        }
+    }
+
+    /** Closes the shared connection and reports a clean disconnect. */
+    suspend fun close() {
+        provider.close()
+        connectionEvents.emit(ConnectionState.Disconnected(null))
+        scope.cancel()
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -53,6 +53,7 @@ internal class AppSyncSubscriber(
     private val decorator: AppSyncRequestDecorator,
     private val httpEndpoint: String,
     private val authModeResolver: AppSyncAuthModeResolver = AppSyncAuthModeResolver(authorization),
+    private val claimInjector: AppSyncClaimInjector = AppSyncClaimInjector(),
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     private val connectionEvents = MutableSharedFlow<ConnectionState>(replay = 1)
@@ -134,20 +135,23 @@ internal class AppSyncSubscriber(
                 // spent, and reusing it would conflate the two attempts' replies.
                 id = UUID.randomUUID().toString()
                 try {
+                    // Owner-restricted models need the owner sent as a variable, and which rules apply
+                    // depends on the mode, so this is resolved per attempt rather than once.
+                    val decorated = claimInjector.inject(request, mode, authorizer)
                     socket.send(
                         AppSyncWebSocketMessage.Start(
                             id = id,
-                            query = request.content,
+                            query = decorated.content,
                             authorizationHeaders = decorator.authorizationHeaders(
                                 authorizer,
                                 httpEndpoint,
-                                request.content
+                                decorated.content
                             )
                         )
                     )
                     return
                 } catch (error: AppSyncAuthException) {
-                    // Credentials for this mode could not be obtained; another may still work.
+                    // Credentials or claims for this mode could not be obtained; another may still work.
                     failures += error
                 }
             }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -16,22 +16,27 @@ package com.amazonaws.appsync
 
 import com.amplifyframework.api.graphql.GraphQLRequest
 import java.util.UUID
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 
 /**
  * Turns a GraphQL subscription request into a [Flow] of [SubscriptionEvent], multiplexed over the
@@ -54,6 +59,7 @@ internal class AppSyncSubscriber(
     private val httpEndpoint: String,
     private val authModeResolver: AppSyncAuthModeResolver = AppSyncAuthModeResolver(authorization),
     private val claimInjector: AppSyncClaimInjector = AppSyncClaimInjector(),
+    private val registrationTimeout: Duration = DEFAULT_REGISTRATION_TIMEOUT,
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     private val connectionEvents = MutableSharedFlow<ConnectionState>(replay = 1)
@@ -75,21 +81,40 @@ internal class AppSyncSubscriber(
      *   stream continues. Losing one message is better than tearing down a working subscription.
      * - `complete` from the service, and a clean socket close, both end the flow normally.
      */
-    fun <T> subscribe(request: GraphQLRequest<T>): Flow<SubscriptionEvent<T>> = flow {
-        emit(SubscriptionEvent.Connecting)
+    fun <T> subscribe(request: GraphQLRequest<T>): Flow<SubscriptionEvent<T>> = channelFlow {
+        send(SubscriptionEvent.Connecting)
 
         val socket = connectedSocket()
         val registration = Registration(request, authModeResolver.resolve(request))
 
-        emitAll(
+        // Bounds the wait for the service to acknowledge. Without it a subscription whose start message
+        // is never answered stays on Connecting indefinitely: no further frames arrive, so nothing in
+        // the message pipeline can notice the silence.
+        val acknowledgement = launch {
+            try {
+                withTimeout(registrationTimeout) { registration.acknowledged.await() }
+            } catch (timeout: TimeoutCancellationException) {
+                close(
+                    AppSyncTimeoutException(
+                        message = "AppSync did not acknowledge the subscription within " +
+                            "${registrationTimeout.inWholeSeconds}s.",
+                        cause = timeout
+                    )
+                )
+            }
+        }
+
+        try {
             socket.messages
-                // onStart runs once this collector is subscribed. Sending `start` any earlier would
-                // race the reply: the socket's flow has no replay, so a fast start_ack would be lost
-                // and the subscription would appear to hang.
+                // Sending `start` any earlier would race the reply: the socket's flow has no replay, so
+                // a fast start_ack would be lost and the subscription would appear to hang.
                 .onStart { registration.register(socket) }
                 .onCompletion { socket.send(AppSyncWebSocketMessage.Stop(registration.id)) }
                 .transformWhile { message -> handle(message, registration, socket, request) }
-        )
+                .collect { send(it) }
+        } finally {
+            acknowledgement.cancel()
+        }
     }
 
     /**
@@ -106,6 +131,9 @@ internal class AppSyncSubscriber(
         private val authModes = candidates.map { it.authMode }
         private var index = -1
         private val failures = mutableListOf<AppSyncException>()
+
+        /** Completes once the service acknowledges the current attempt. */
+        val acknowledged = CompletableDeferred<Unit>()
 
         /** The id of the current attempt. Changes on every retry. */
         var id: String = UUID.randomUUID().toString()
@@ -138,7 +166,7 @@ internal class AppSyncSubscriber(
                     // Owner-restricted models need the owner sent as a variable, and which rules apply
                     // depends on the mode, so this is resolved per attempt rather than once.
                     val decorated = claimInjector.inject(request, mode, authorizer)
-                    socket.send(
+                    val sent = socket.send(
                         AppSyncWebSocketMessage.Start(
                             id = id,
                             query = decorated.content,
@@ -149,6 +177,15 @@ internal class AppSyncSubscriber(
                             )
                         )
                     )
+                    // A send that did not land means the socket died between being handed out and being
+                    // written to. No reply will ever arrive, so failing now beats waiting forever.
+                    // isClosed is checked after the send because a send can succeed into a socket that
+                    // closes immediately afterwards.
+                    if (!sent || socket.isClosed) {
+                        throw AppSyncConnectionException(
+                            message = "The connection closed before the subscription could be registered."
+                        )
+                    }
                     return
                 } catch (error: AppSyncAuthException) {
                     // Credentials or claims for this mode could not be obtained; another may still work.
@@ -180,14 +217,17 @@ internal class AppSyncSubscriber(
      *
      * @return true to keep the flow open, false to complete it normally. Throws to terminate it.
      */
-    private suspend fun <T> kotlinx.coroutines.flow.FlowCollector<SubscriptionEvent<T>>.handle(
+    private suspend fun <T> FlowCollector<SubscriptionEvent<T>>.handle(
         message: AppSyncWebSocketMessage.Inbound,
         registration: Registration,
         socket: AppSyncWebSocket,
         request: GraphQLRequest<T>
     ): Boolean = when (message) {
         is AppSyncWebSocketMessage.StartAck -> {
-            if (message.id == registration.id) emit(SubscriptionEvent.Connected)
+            if (message.id == registration.id) {
+                registration.acknowledged.complete(Unit)
+                emit(SubscriptionEvent.Connected)
+            }
             true
         }
 
@@ -238,11 +278,17 @@ internal class AppSyncSubscriber(
                     // Every eligible mode has now been rejected.
                     rejectedIdentity && registration.hasFallback -> throw registration.exhausted()
                     // Either there was never a fallback, or the failure is not about identity at all —
-                    // retrying would fail the same way and hide the reason. Report what the service said.
+                    // retrying would fail the same way and hide the reason.
+                    //
+                    // Reported as a response failure rather than a subscription failure, unlike the
+                    // connection_error case below. The distinction is the origin: this is the service
+                    // answering the subscription's own document with GraphQL errors, whereas a
+                    // connection_error means the transport itself was refused. A caller that wants to
+                    // treat any subscription death alike should catch AppSyncException.
                     else -> throw AppSyncGraphQLErrorException(
                         message = "The subscription failed: " +
                             message.errors.joinToString("; ") { it.message }.ifEmpty { "no reason given" },
-                        errors = emptyList()
+                        errors = message.errors.toGraphQLErrors()
                     )
                 }
             } else {
@@ -274,6 +320,10 @@ internal class AppSyncSubscriber(
         connectionEvents.emit(ConnectionState.Connecting)
         val socket = try {
             provider.connection()
+        } catch (cancellation: CancellationException) {
+            // Nothing was disconnected — the caller went away. Reporting a disconnect here would tell
+            // every events observer about a connection failure that did not happen.
+            throw cancellation
         } catch (error: Throwable) {
             connectionEvents.emit(ConnectionState.Disconnected(AppSyncException.from(error)))
             throw error
@@ -286,21 +336,22 @@ internal class AppSyncSubscriber(
     /**
      * Reports an unexpected disconnect on [events].
      *
-     * One watcher per connection, not per subscription: every subscriber sees the same `Closed`
-     * message, so emitting from the per-subscription path would report the same disconnect N times.
+     * One watcher per connection, not per subscription: every subscriber sees the same closure, so
+     * emitting from the per-subscription path would report the same disconnect N times.
+     *
+     * Awaits the socket's settled terminal state rather than a message, so a socket that dies between
+     * being handed out and this watcher starting is still reported — with a message it would be missed
+     * and [events] would claim the connection is alive.
      */
     private fun watchForDisconnect(socket: AppSyncWebSocket) {
         scope.launch {
-            // Already gone — the Closed message has been and passed, so there is nothing left to await.
-            if (socket.isClosed) {
-                connectionEvents.emit(ConnectionState.Disconnected(null))
-                return@launch
-            }
-            val closed = socket.messages.first { it is AppSyncWebSocketMessage.Closed }
-            connectionEvents.emit(
-                ConnectionState.Disconnected((closed as AppSyncWebSocketMessage.Closed).cause)
-            )
+            connectionEvents.emit(ConnectionState.Disconnected(socket.closure.await()))
         }
+    }
+
+    private companion object {
+        // Matches the plugin's subscription acknowledgement bound.
+        val DEFAULT_REGISTRATION_TIMEOUT = 10.seconds
     }
 
     /** Closes the shared connection and reports a clean disconnect. */

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -42,9 +42,8 @@ import kotlinx.coroutines.withTimeout
  * Turns a GraphQL subscription request into a [Flow] of [SubscriptionEvent], multiplexed over the
  * client's shared WebSocket.
  *
- * A private reimplementation of the plugin's `SubscriptionOperation` and the registry inside
- * `SubscriptionEndpoint`. Because the socket exposes one flow of messages, a subscription is a
- * *filter* over it keyed by subscription id rather than an entry in a callback registry.
+ * Because the socket exposes one flow of messages, a subscription is a *filter* over that flow keyed by
+ * subscription id rather than an entry in a callback registry.
  *
  * @param provider Supplies the shared connection, opening it on first subscribe.
  * @param authorization The client's authorizer configuration.
@@ -350,7 +349,7 @@ internal class AppSyncSubscriber(
     }
 
     private companion object {
-        // Matches the plugin's subscription acknowledgement bound.
+        // Without a bound, a subscription the service never acknowledges sits on Connecting forever.
         val DEFAULT_REGISTRATION_TIMEOUT = 10.seconds
     }
 

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -224,6 +224,12 @@ internal class AppSyncSubscriber(
             if (message.id == registration.id || message.id == null) {
                 val rejectedIdentity = message.errors.hasUnauthorizedError()
                 when {
+                    // Checked before the auth retry: the limit belongs to the API, not the identity, so
+                    // trying another auth mode would consume attempts and fail the same way.
+                    message.errors.hasSubscriptionLimitError() -> throw AppSyncLimitExceededException(
+                        message = "The API's concurrent subscription limit was reached: " +
+                            message.errors.joinToString("; ") { it.message }.ifEmpty { "no reason given" }
+                    )
                     // The identity was rejected; a different auth mode may be accepted.
                     rejectedIdentity && registration.canRetry -> {
                         registration.register(socket)

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -78,34 +78,97 @@ internal class AppSyncSubscriber(
         emit(SubscriptionEvent.Connecting)
 
         val socket = connectedSocket()
-        val id = UUID.randomUUID().toString()
-        val start = startMessage(id, request)
+        val registration = Registration(request, authModeResolver.resolve(request))
 
         emitAll(
             socket.messages
                 // onStart runs once this collector is subscribed. Sending `start` any earlier would
                 // race the reply: the socket's flow has no replay, so a fast start_ack would be lost
                 // and the subscription would appear to hang.
-                .onStart { socket.send(start) }
-                .onCompletion { socket.send(AppSyncWebSocketMessage.Stop(id)) }
-                .transformWhile { message -> handle(message, id, request) }
+                .onStart { registration.register(socket) }
+                .onCompletion { socket.send(AppSyncWebSocketMessage.Stop(registration.id)) }
+                .transformWhile { message -> handle(message, registration, socket, request) }
         )
     }
 
-    private suspend fun <T> startMessage(id: String, request: GraphQLRequest<T>): AppSyncWebSocketMessage.Start {
-        val authMode = authModeResolver.resolve(request).first()
-        val authorizer = authorization.authorizerFor(authMode)
-            ?: throw AppSyncProviderNotConfiguredException(
-                message = "No authorizer is configured for auth mode $authMode."
-            )
+    /**
+     * Tracks which auth mode a subscription is currently registered under, and moves to the next one
+     * when the service rejects the identity.
+     *
+     * Registration is retried rather than the whole subscription because the connection is shared and
+     * already established — only the `start` message needs replaying, under a fresh id.
+     */
+    private inner class Registration(
+        private val request: GraphQLRequest<*>,
+        private val candidates: List<AppSyncAuthCandidate>
+    ) {
+        private val authModes = candidates.map { it.authMode }
+        private var index = -1
+        private val failures = mutableListOf<AppSyncException>()
 
-        return AppSyncWebSocketMessage.Start(
-            id = id,
-            query = request.content,
-            // A non-null body signs against the plain endpoint, which is what AppSync expects for an
-            // individual subscription as opposed to the connection.
-            authorizationHeaders = decorator.authorizationHeaders(authorizer, httpEndpoint, request.content)
-        )
+        /** The id of the current attempt. Changes on every retry. */
+        var id: String = UUID.randomUUID().toString()
+            private set
+
+        /** The mode the current attempt used, for reporting. */
+        val attemptedModes: List<AppSyncAuthMode>
+            get() = authModes.take(index + 1)
+
+        val canRetry: Boolean
+            get() = index < candidates.lastIndex
+
+        /** Whether there was ever more than one mode to try. */
+        val hasFallback: Boolean
+            get() = candidates.size > 1
+
+        /**
+         * Sends `start` under the next auth mode, skipping modes whose credentials cannot be obtained.
+         *
+         * @throws AppSyncException if no remaining mode can produce a usable `start` message.
+         */
+        suspend fun register(socket: AppSyncWebSocket) {
+            while (index < candidates.lastIndex) {
+                index++
+                val (mode, authorizer) = candidates[index]
+                // A fresh id per attempt: the previous one was rejected, so the service considers it
+                // spent, and reusing it would conflate the two attempts' replies.
+                id = UUID.randomUUID().toString()
+                try {
+                    socket.send(
+                        AppSyncWebSocketMessage.Start(
+                            id = id,
+                            query = request.content,
+                            authorizationHeaders = decorator.authorizationHeaders(
+                                authorizer,
+                                httpEndpoint,
+                                request.content
+                            )
+                        )
+                    )
+                    return
+                } catch (error: AppSyncAuthException) {
+                    // Credentials for this mode could not be obtained; another may still work.
+                    failures += error
+                }
+            }
+            throw exhausted()
+        }
+
+        /** The failure to report once no mode is left to try. */
+        fun exhausted(): AppSyncException {
+            // With a single candidate there is nothing to exhaust, so the real failure is more useful.
+            if (authModes.size <= 1) {
+                return failures.lastOrNull() ?: AppSyncProviderNotConfiguredException(
+                    message = "No auth mode was available to authorize the subscription."
+                )
+            }
+            return AppSyncAuthExhaustedException(
+                message = "The subscription failed with every eligible auth mode: " +
+                    authModes.joinToString() + ".",
+                attemptedAuthModes = authModes,
+                cause = failures.lastOrNull()
+            )
+        }
     }
 
     /**
@@ -115,42 +178,71 @@ internal class AppSyncSubscriber(
      */
     private suspend fun <T> kotlinx.coroutines.flow.FlowCollector<SubscriptionEvent<T>>.handle(
         message: AppSyncWebSocketMessage.Inbound,
-        id: String,
+        registration: Registration,
+        socket: AppSyncWebSocket,
         request: GraphQLRequest<T>
     ): Boolean = when (message) {
         is AppSyncWebSocketMessage.StartAck -> {
-            if (message.id == id) emit(SubscriptionEvent.Connected)
+            if (message.id == registration.id) emit(SubscriptionEvent.Connected)
             true
         }
 
         is AppSyncWebSocketMessage.Data -> {
-            if (message.id == id) {
+            if (message.id == registration.id) {
                 // Deserialization failure is deliberately swallowed: it is non-terminal, so one
                 // unreadable message must not end a healthy subscription.
-                runCatching { AppSyncResponseDeserializer.deserialize(request, message.payload) }
-                    .getOrNull()
-                    ?.let { emit(SubscriptionEvent.Data(it)) }
+                val response = runCatching {
+                    AppSyncResponseDeserializer.deserialize(request, message.payload)
+                }.getOrNull()
+
+                when {
+                    response == null -> true
+                    // AppSync can reject the identity in a data message rather than an error frame, so
+                    // this is a retry trigger too, not just something to hand to the consumer.
+                    response.hasUnauthorizedError() && registration.canRetry -> {
+                        registration.register(socket)
+                        true
+                    }
+                    else -> {
+                        emit(SubscriptionEvent.Data(response))
+                        true
+                    }
+                }
+            } else {
+                true
             }
-            true
         }
 
-        is AppSyncWebSocketMessage.Complete -> message.id != id
+        is AppSyncWebSocketMessage.Complete -> message.id != registration.id
 
         is AppSyncWebSocketMessage.Error -> {
-            // A null id is a connection-level error, which is terminal for every subscription on it.
-            if (message.id == id || message.id == null) {
-                throw AppSyncGraphQLErrorException(
-                    message = "The subscription failed: " +
-                        message.errors.joinToString("; ").ifEmpty { "no reason given" },
-                    errors = emptyList()
-                )
+            // A null id is a connection-level error, which applies to every subscription on it.
+            if (message.id == registration.id || message.id == null) {
+                val rejectedIdentity = message.errors.hasUnauthorizedError()
+                when {
+                    // The identity was rejected; a different auth mode may be accepted.
+                    rejectedIdentity && registration.canRetry -> {
+                        registration.register(socket)
+                        true
+                    }
+                    // Every eligible mode has now been rejected.
+                    rejectedIdentity && registration.hasFallback -> throw registration.exhausted()
+                    // Either there was never a fallback, or the failure is not about identity at all —
+                    // retrying would fail the same way and hide the reason. Report what the service said.
+                    else -> throw AppSyncGraphQLErrorException(
+                        message = "The subscription failed: " +
+                            message.errors.joinToString("; ") { it.message }.ifEmpty { "no reason given" },
+                        errors = emptyList()
+                    )
+                }
+            } else {
+                true
             }
-            true
         }
 
         is AppSyncWebSocketMessage.ConnectionError -> throw AppSyncConnectionException(
             message = "The subscription connection failed: " +
-                message.errors.joinToString("; ").ifEmpty { "no reason given" }
+                message.errors.joinToString("; ") { it.message }.ifEmpty { "no reason given" }
         )
 
         // A cause means the connection died; no cause means close() was called, which ends

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
@@ -48,9 +48,8 @@ import okhttp3.WebSocketListener
 /**
  * One AppSync realtime WebSocket connection, shared by every subscription on a client.
  *
- * A private reimplementation of the plugin's `SubscriptionEndpoint`, which is 720 lines of Java built
- * around locks, latches and callbacks. This exposes a single [messages] flow instead and lets callers
- * filter it, which is what makes per-subscription multiplexing a `filter` rather than a registry.
+ * Exposes a single [messages] flow rather than a callback registry, which is what lets every
+ * subscription multiplex over one connection by filtering that flow.
  *
  * Deliberately has no reconnection logic: a dead connection surfaces as a terminal error and the
  * consumer re-subscribes.
@@ -302,7 +301,8 @@ internal class AppSyncWebSocket(
         const val USER_AGENT_HEADER = "User-Agent"
         const val NORMAL_CLOSURE = 1000
 
-        // Matches the plugin's connection acknowledgement bound.
+        // An upgraded socket carries no read timeout of its own, so a server that accepts the upgrade
+        // and then says nothing would leave connect() suspended indefinitely.
         val DEFAULT_HANDSHAKE_TIMEOUT = 30.seconds
     }
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
@@ -16,12 +16,16 @@ package com.amazonaws.appsync
 
 import com.amplifyframework.util.UserAgent
 import java.io.IOException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
@@ -31,7 +35,10 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -73,8 +80,15 @@ internal class AppSyncWebSocket(
     val messages = messageFlow.asSharedFlow()
 
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
+
+    @Volatile
     private var socket: WebSocket? = null
+
+    @Volatile
     private var watchdog: Job? = null
+
+    @Volatile
+    private var watchdogTimeoutMs: Long = 0
 
     @Volatile
     var isClosed = false
@@ -85,12 +99,28 @@ internal class AppSyncWebSocket(
     private var pendingCloseCause: AppSyncException? = null
 
     /**
+     * Completes when the socket dies, carrying the reason or null for a clean close.
+     *
+     * Waiting on this rather than on a [AppSyncWebSocketMessage.Closed] message removes a race: the
+     * message flow has no replay, so anyone who subscribes after closure has already been emitted would
+     * wait forever. This is settled state, so it can be awaited at any point and still be observed.
+     */
+    private val terminated = CompletableDeferred<AppSyncException?>()
+    private val disconnectMutex = Mutex()
+
+    /** Completes when the socket dies. See [terminated]. */
+    val closure: Deferred<AppSyncException?> get() = terminated
+
+    /**
      * Opens the socket and completes the AppSync handshake.
      *
+     * @param handshakeTimeout How long to wait for the service to acknowledge. Bounding this matters
+     *   because OkHttp leaves an upgraded WebSocket with no read timeout, so a server that completes
+     *   the upgrade and then goes silent would otherwise suspend this call indefinitely.
      * @throws AppSyncConnectionException if the connection is refused or closes during the handshake.
-     * @throws AppSyncTimeoutException if no acknowledgement arrives.
+     * @throws AppSyncTimeoutException if the service does not acknowledge within [handshakeTimeout].
      */
-    suspend fun connect(): Unit = coroutineScope {
+    suspend fun connect(handshakeTimeout: Duration = DEFAULT_HANDSHAKE_TIMEOUT): Unit = coroutineScope {
         // Collection has to be running before the socket opens, or a fast connection_ack lands before
         // anyone is listening and the await below waits forever. The shared flow has no replay.
         val listening = CompletableDeferred<Unit>()
@@ -106,13 +136,24 @@ internal class AppSyncWebSocket(
 
         socket = client.newWebSocket(request, this@AppSyncWebSocket)
 
-        when (val result = handshake.await()) {
+        val result = try {
+            withTimeout(handshakeTimeout) { handshake.await() }
+        } catch (timeout: TimeoutCancellationException) {
+            teardown()
+            throw AppSyncTimeoutException(
+                message = "AppSync did not acknowledge the subscription connection within " +
+                    "${handshakeTimeout.inWholeSeconds}s.",
+                cause = timeout
+            )
+        }
+
+        when (result) {
             is AppSyncWebSocketMessage.ConnectionAck -> resetWatchdog(result.connectionTimeoutMs)
             is AppSyncWebSocketMessage.ConnectionError -> {
                 teardown()
                 throw AppSyncConnectionException(
                     message = "AppSync refused the subscription connection: " +
-                        result.errors.joinToString("; ").ifEmpty { "no reason given" }
+                        result.errors.joinToString("; ") { it.message }.ifEmpty { "no reason given" }
                 )
             }
             is AppSyncWebSocketMessage.Closed -> {
@@ -137,23 +178,23 @@ internal class AppSyncWebSocket(
 
     /**
      * Closes the socket and waits for closure to be observed, so a caller can rely on the connection
-     * being gone once this returns. Idempotent.
+     * being gone once this returns. Idempotent, including under concurrent callers.
      *
      * @param cause Why it is being closed, or null for a clean shutdown.
      */
     suspend fun disconnect(cause: AppSyncException? = null): Unit = withContext(ioDispatcher) {
-        if (isClosed) return@withContext
-        pendingCloseCause = cause
-
-        val listening = CompletableDeferred<Unit>()
-        val closed = async { awaitClosed { listening.complete(Unit) } }
-        listening.await()
-
-        socket?.close(NORMAL_CLOSURE, "Client closed the connection") ?: run {
-            // Never opened, so no close frame will come back — synthesize one.
-            handleClosed()
+        // Serialized so two concurrent callers cannot both pass the isClosed check, leaving the second
+        // awaiting a closure notification that has already been delivered.
+        disconnectMutex.withLock {
+            if (!isClosed) {
+                pendingCloseCause = cause
+                socket?.close(NORMAL_CLOSURE, "Client closed the connection")
+                    // Never opened, so no close frame will come back — synthesize one.
+                    ?: handleClosed()
+            }
         }
-        closed.await()
+        // Settled state rather than a message, so this is safe however late it is awaited.
+        terminated.await()
         scope.cancel()
     }
 
@@ -209,10 +250,6 @@ internal class AppSyncWebSocket(
                 it is AppSyncWebSocketMessage.Closed
         }
 
-    private suspend fun awaitClosed(onListening: () -> Unit) = messages
-        .onStart { onListening() }
-        .first { it is AppSyncWebSocketMessage.Closed }
-
     /**
      * AppSync closes an idle connection without warning, so the absence of traffic for longer than the
      * timeout it advertised is treated as a dead connection rather than waiting on a socket that will
@@ -238,20 +275,25 @@ internal class AppSyncWebSocket(
         }
     }
 
-    @Volatile
-    private var watchdogTimeoutMs: Long = 0
-
+    /**
+     * Every closure path funnels through here, so this is where the socket's resources are released and
+     * its terminal state is published.
+     */
     private fun handleClosed() {
         if (isClosed) return
         isClosed = true
         watchdog?.cancel()
-        messageFlow.tryEmit(AppSyncWebSocketMessage.Closed(pendingCloseCause))
+        val cause = pendingCloseCause
+        messageFlow.tryEmit(AppSyncWebSocketMessage.Closed(cause))
+        terminated.complete(cause)
+        // The scope's lifetime is the socket's. Cancelling here rather than only in disconnect() covers
+        // a socket that dies on its own, which is the common case.
+        scope.cancel()
     }
 
     private fun teardown() {
         socket?.cancel()
         handleClosed()
-        scope.cancel()
     }
 
     private companion object {
@@ -259,5 +301,8 @@ internal class AppSyncWebSocket(
         const val GRAPHQL_WS_SUBPROTOCOL = "graphql-ws"
         const val USER_AGENT_HEADER = "User-Agent"
         const val NORMAL_CLOSURE = 1000
+
+        // Matches the plugin's connection acknowledgement bound.
+        val DEFAULT_HANDSHAKE_TIMEOUT = 30.seconds
     }
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.util.UserAgent
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+
+/**
+ * One AppSync realtime WebSocket connection, shared by every subscription on a client.
+ *
+ * A private reimplementation of the plugin's `SubscriptionEndpoint`, which is 720 lines of Java built
+ * around locks, latches and callbacks. This exposes a single [messages] flow instead and lets callers
+ * filter it, which is what makes per-subscription multiplexing a `filter` rather than a registry.
+ *
+ * Deliberately has no reconnection logic: a dead connection surfaces as a terminal error and the
+ * consumer re-subscribes.
+ *
+ * @param realtimeUrl The `wss://` URL, from [AppSyncEndpointParser.realtimeUrl].
+ * @param httpEndpoint The HTTP endpoint, needed because SigV4 signs against it rather than the socket.
+ * @param authorizer Supplies the connection's credentials.
+ * @param decorator Produces the authorization headers.
+ * @param client The OkHttp client to open the socket with.
+ */
+internal class AppSyncWebSocket(
+    private val realtimeUrl: String,
+    private val httpEndpoint: String,
+    private val authorizer: AppSyncClientAuthorizer,
+    private val decorator: AppSyncRequestDecorator,
+    private val client: OkHttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : WebSocketListener() {
+
+    // extraBufferCapacity keeps tryEmit from ever dropping a frame: emission happens on OkHttp's
+    // callback thread, which cannot suspend to wait for a slow collector.
+    private val messageFlow = MutableSharedFlow<AppSyncWebSocketMessage.Inbound>(
+        extraBufferCapacity = Int.MAX_VALUE
+    )
+
+    /** Every inbound message, including the synthetic [AppSyncWebSocketMessage.Closed]. */
+    val messages = messageFlow.asSharedFlow()
+
+    private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private var socket: WebSocket? = null
+    private var watchdog: Job? = null
+
+    @Volatile
+    var isClosed = false
+        private set
+
+    /** Set before the socket is torn down so the emitted [AppSyncWebSocketMessage.Closed] can explain why. */
+    @Volatile
+    private var pendingCloseCause: AppSyncException? = null
+
+    /**
+     * Opens the socket and completes the AppSync handshake.
+     *
+     * @throws AppSyncConnectionException if the connection is refused or closes during the handshake.
+     * @throws AppSyncTimeoutException if no acknowledgement arrives.
+     */
+    suspend fun connect(): Unit = coroutineScope {
+        // Collection has to be running before the socket opens, or a fast connection_ack lands before
+        // anyone is listening and the await below waits forever. The shared flow has no replay.
+        val listening = CompletableDeferred<Unit>()
+        val handshake = async { awaitHandshake { listening.complete(Unit) } }
+        listening.await()
+
+        val request = try {
+            buildConnectRequest()
+        } catch (error: AppSyncException) {
+            handshake.cancel()
+            throw error
+        }
+
+        socket = client.newWebSocket(request, this@AppSyncWebSocket)
+
+        when (val result = handshake.await()) {
+            is AppSyncWebSocketMessage.ConnectionAck -> resetWatchdog(result.connectionTimeoutMs)
+            is AppSyncWebSocketMessage.ConnectionError -> {
+                teardown()
+                throw AppSyncConnectionException(
+                    message = "AppSync refused the subscription connection: " +
+                        result.errors.joinToString("; ").ifEmpty { "no reason given" }
+                )
+            }
+            is AppSyncWebSocketMessage.Closed -> {
+                teardown()
+                throw result.cause ?: AppSyncConnectionException(
+                    message = "The subscription connection closed during the handshake."
+                )
+            }
+            else -> {
+                teardown()
+                throw AppSyncConnectionException(message = "Unexpected handshake reply: $result.")
+            }
+        }
+    }
+
+    /**
+     * Sends a message.
+     *
+     * @return false if the socket is not open or its send queue rejected the message.
+     */
+    fun send(message: AppSyncWebSocketMessage.Outbound): Boolean = socket?.send(message.toJson()) ?: false
+
+    /**
+     * Closes the socket and waits for closure to be observed, so a caller can rely on the connection
+     * being gone once this returns. Idempotent.
+     *
+     * @param cause Why it is being closed, or null for a clean shutdown.
+     */
+    suspend fun disconnect(cause: AppSyncException? = null): Unit = withContext(ioDispatcher) {
+        if (isClosed) return@withContext
+        pendingCloseCause = cause
+
+        val listening = CompletableDeferred<Unit>()
+        val closed = async { awaitClosed { listening.complete(Unit) } }
+        listening.await()
+
+        socket?.close(NORMAL_CLOSURE, "Client closed the connection") ?: run {
+            // Never opened, so no close frame will come back — synthesize one.
+            handleClosed()
+        }
+        closed.await()
+        scope.cancel()
+    }
+
+    // ── WebSocketListener ───────────────────────────────────────────────
+
+    override fun onOpen(webSocket: WebSocket, response: Response) {
+        // AppSync expects connection_init immediately; the ack is what makes the socket usable.
+        webSocket.send(AppSyncWebSocketMessage.ConnectionInit.toJson())
+    }
+
+    override fun onMessage(webSocket: WebSocket, text: String) {
+        // Any frame proves the connection is alive, including a keep-alive.
+        restartWatchdog()
+        messageFlow.tryEmit(AppSyncWebSocketMessage.parse(text))
+    }
+
+    override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+        // onClosed is not called after a failure, so this has to close things out itself.
+        if (pendingCloseCause == null) {
+            pendingCloseCause = when (t) {
+                is IOException -> AppSyncConnectionException(
+                    message = t.message ?: "The subscription connection failed.",
+                    cause = t
+                )
+                else -> AppSyncException.from(t)
+            }
+        }
+        handleClosed()
+    }
+
+    override fun onClosed(webSocket: WebSocket, code: Int, reason: String) = handleClosed()
+
+    // ── Internals ───────────────────────────────────────────────────────
+
+    private suspend fun buildConnectRequest(): Request {
+        // body = null signs the handshake against {endpoint}/connect, which is what AppSync expects
+        // for the connection as opposed to an individual subscription.
+        val authHeaders = decorator.authorizationHeaders(authorizer, httpEndpoint, body = null)
+
+        return Request.Builder()
+            .url(realtimeUrl)
+            .addHeader(SUBPROTOCOL_HEADER, GRAPHQL_WS_SUBPROTOCOL)
+            .header(USER_AGENT_HEADER, UserAgent.string())
+            .apply { authHeaders.forEach { (name, value) -> header(name, value) } }
+            .build()
+    }
+
+    private suspend fun awaitHandshake(onListening: () -> Unit) = messages
+        .onStart { onListening() }
+        .first {
+            it is AppSyncWebSocketMessage.ConnectionAck ||
+                it is AppSyncWebSocketMessage.ConnectionError ||
+                it is AppSyncWebSocketMessage.Closed
+        }
+
+    private suspend fun awaitClosed(onListening: () -> Unit) = messages
+        .onStart { onListening() }
+        .first { it is AppSyncWebSocketMessage.Closed }
+
+    /**
+     * AppSync closes an idle connection without warning, so the absence of traffic for longer than the
+     * timeout it advertised is treated as a dead connection rather than waiting on a socket that will
+     * never answer.
+     */
+    private fun resetWatchdog(timeoutMs: Long) {
+        watchdogTimeoutMs = timeoutMs
+        restartWatchdog()
+    }
+
+    private fun restartWatchdog() {
+        val timeout = watchdogTimeoutMs
+        if (timeout <= 0) return
+        watchdog?.cancel()
+        watchdog = scope.launch {
+            delay(timeout)
+            pendingCloseCause = AppSyncTimeoutException(
+                message = "No traffic on the subscription connection for ${timeout}ms."
+            )
+            // cancel(), not close(): a timed-out socket is not expected to complete a closing handshake.
+            socket?.cancel()
+            handleClosed()
+        }
+    }
+
+    @Volatile
+    private var watchdogTimeoutMs: Long = 0
+
+    private fun handleClosed() {
+        if (isClosed) return
+        isClosed = true
+        watchdog?.cancel()
+        messageFlow.tryEmit(AppSyncWebSocketMessage.Closed(pendingCloseCause))
+    }
+
+    private fun teardown() {
+        socket?.cancel()
+        handleClosed()
+        scope.cancel()
+    }
+
+    private companion object {
+        const val SUBPROTOCOL_HEADER = "Sec-WebSocket-Protocol"
+        const val GRAPHQL_WS_SUBPROTOCOL = "graphql-ws"
+        const val USER_AGENT_HEADER = "User-Agent"
+        const val NORMAL_CLOSURE = 1000
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+
+/**
+ * Messages of AppSync's `graphql-ws` subscription protocol.
+ *
+ * A private reimplementation of the plugin's `SubscriptionMessageType` plus its ad-hoc `JSONObject`
+ * construction, modelled as a sealed hierarchy so the receive side is exhaustive and an unrecognised
+ * message cannot be silently mistaken for a known one.
+ *
+ * Only the wire shapes the client actually uses are modelled. `connection_terminate` is absent
+ * because the client closes the socket rather than negotiating termination.
+ */
+internal sealed interface AppSyncWebSocketMessage {
+
+    /** Messages the client sends. */
+    sealed interface Outbound : AppSyncWebSocketMessage {
+        fun toJson(): String
+    }
+
+    /** Opens the connection. Sent immediately on socket open. */
+    data object ConnectionInit : Outbound {
+        override fun toJson() = """{"type":"$TYPE_CONNECTION_INIT"}"""
+    }
+
+    /**
+     * Registers one subscription.
+     *
+     * @param id Correlates every later message for this subscription.
+     * @param query The serialized GraphQL request, as `GraphQLRequest.content` produces it.
+     * @param authorizationHeaders The same headers an equivalent HTTP request would carry. AppSync
+     *   authorizes each subscription separately from the connection, so these are per-message.
+     */
+    data class Start(
+        val id: String,
+        val query: String,
+        val authorizationHeaders: Map<String, String>
+    ) : Outbound {
+        override fun toJson(): String {
+            val authorization = JsonObject().apply {
+                authorizationHeaders.forEach { (name, value) -> addProperty(name, value) }
+            }
+            val extensions = JsonObject().apply { add("authorization", authorization) }
+            val payload = JsonObject().apply {
+                addProperty("data", query)
+                add("extensions", extensions)
+            }
+            return JsonObject().apply {
+                addProperty("id", id)
+                addProperty("type", TYPE_START)
+                add("payload", payload)
+            }.toString()
+        }
+    }
+
+    /** Unregisters one subscription. Sent on flow cancellation. */
+    data class Stop(val id: String) : Outbound {
+        override fun toJson() = """{"id":"$id","type":"$TYPE_STOP"}"""
+    }
+
+    /** Messages the service sends. */
+    sealed interface Inbound : AppSyncWebSocketMessage
+
+    /**
+     * The connection is established.
+     *
+     * @param connectionTimeoutMs How long the service will hold the connection without traffic. The
+     *   client resets its keep-alive watchdog to this.
+     */
+    data class ConnectionAck(val connectionTimeoutMs: Long) : Inbound
+
+    /** The connection was rejected. Terminal for every subscription on it. */
+    data class ConnectionError(val errors: List<String>) : Inbound
+
+    /** Keep-alive. Carries no data; its only purpose is resetting the watchdog. */
+    data object KeepAlive : Inbound
+
+    /** One subscription was registered successfully. */
+    data class StartAck(val id: String) : Inbound
+
+    /** A data message for one subscription. [payload] is the raw GraphQL response JSON. */
+    data class Data(val id: String, val payload: String) : Inbound
+
+    /** One subscription failed. Terminal for that subscription only. */
+    data class Error(val id: String?, val errors: List<String>) : Inbound
+
+    /** One subscription ended normally, at the service's initiative. */
+    data class Complete(val id: String) : Inbound
+
+    /**
+     * A message this client does not model. Kept rather than dropped so an unexpected wire change is
+     * visible in logs instead of looking like silence.
+     */
+    data class Unknown(val type: String?, val raw: String) : Inbound
+
+    /**
+     * The socket closed. **Synthetic** — never parsed from a frame; [AppSyncWebSocket] emits it so
+     * that closure arrives on the same flow as everything else. Without it, a caller awaiting a
+     * specific reply would hang when the socket dies instead of failing.
+     *
+     * @param cause Why it closed, or null for a clean client-initiated close.
+     */
+    data class Closed(val cause: AppSyncException?) : Inbound
+
+    companion object {
+        const val TYPE_CONNECTION_INIT = "connection_init"
+        const val TYPE_START = "start"
+        const val TYPE_STOP = "stop"
+
+        private const val TYPE_CONNECTION_ACK = "connection_ack"
+        private const val TYPE_CONNECTION_ERROR = "connection_error"
+        private const val TYPE_KEEP_ALIVE = "ka"
+        private const val TYPE_START_ACK = "start_ack"
+        private const val TYPE_DATA = "data"
+        private const val TYPE_ERROR = "error"
+        private const val TYPE_COMPLETE = "complete"
+
+        private const val DEFAULT_CONNECTION_TIMEOUT_MS = 300_000L
+
+        /**
+         * Parses an inbound frame. Never throws: a frame that cannot be understood becomes [Unknown],
+         * because one malformed message must not take down a connection carrying other healthy
+         * subscriptions.
+         */
+        fun parse(text: String): Inbound = try {
+            val root = JsonParser.parseString(text).asJsonObject
+            val type = root.get("type")?.takeIf { !it.isJsonNull }?.asString
+            val id = root.get("id")?.takeIf { !it.isJsonNull }?.asString
+
+            when (type) {
+                TYPE_CONNECTION_ACK -> ConnectionAck(
+                    connectionTimeoutMs = root.getAsJsonObject("payload")
+                        ?.get("connectionTimeoutMs")?.takeIf { it.isJsonPrimitive }?.asLong
+                        ?: DEFAULT_CONNECTION_TIMEOUT_MS
+                )
+                TYPE_CONNECTION_ERROR -> ConnectionError(root.errorMessages())
+                TYPE_KEEP_ALIVE -> KeepAlive
+                TYPE_START_ACK -> id?.let { StartAck(it) } ?: Unknown(type, text)
+                // The payload is passed through as raw JSON rather than deserialized here: only the
+                // subscriber knows the request's response type.
+                TYPE_DATA -> id?.let { Data(it, root.get("payload")?.toString() ?: "") }
+                    ?: Unknown(type, text)
+                TYPE_ERROR -> Error(id, root.errorMessages())
+                TYPE_COMPLETE -> id?.let { Complete(it) } ?: Unknown(type, text)
+                else -> Unknown(type, text)
+            }
+        } catch (error: Exception) {
+            Unknown(type = null, raw = text)
+        }
+
+        /**
+         * AppSync puts errors in `payload.errors` on a connection error and in `payload.errors` or a
+         * top-level `errors` on a subscription error, so both shapes are read.
+         */
+        private fun JsonObject.errorMessages(): List<String> {
+            val errors = getAsJsonObject("payload")?.getAsJsonArray("errors")
+                ?: getAsJsonArray("errors")
+                ?: return emptyList()
+
+            return errors.mapNotNull { element ->
+                when {
+                    element.isJsonPrimitive -> element.asString
+                    element.isJsonObject ->
+                        element.asJsonObject
+                            .get("message")?.takeIf { it.isJsonPrimitive }?.asString
+                            ?: element.toString()
+                    else -> null
+                }
+            }
+        }
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
@@ -20,9 +20,8 @@ import com.google.gson.JsonParser
 /**
  * Messages of AppSync's `graphql-ws` subscription protocol.
  *
- * A private reimplementation of the plugin's `SubscriptionMessageType` plus its ad-hoc `JSONObject`
- * construction, modelled as a sealed hierarchy so the receive side is exhaustive and an unrecognised
- * message cannot be silently mistaken for a known one.
+ * Modelled as a sealed hierarchy so the receive side is exhaustive and an unrecognised message cannot
+ * be silently mistaken for a known one.
  *
  * Only the wire shapes the client actually uses are modelled. `connection_terminate` is absent
  * because the client closes the socket rather than negotiating termination.

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
@@ -86,7 +86,7 @@ internal sealed interface AppSyncWebSocketMessage {
     data class ConnectionAck(val connectionTimeoutMs: Long) : Inbound
 
     /** The connection was rejected. Terminal for every subscription on it. */
-    data class ConnectionError(val errors: List<String>) : Inbound
+    data class ConnectionError(val errors: List<WireError>) : Inbound
 
     /** Keep-alive. Carries no data; its only purpose is resetting the watchdog. */
     data object KeepAlive : Inbound
@@ -98,7 +98,17 @@ internal sealed interface AppSyncWebSocketMessage {
     data class Data(val id: String, val payload: String) : Inbound
 
     /** One subscription failed. Terminal for that subscription only. */
-    data class Error(val id: String?, val errors: List<String>) : Inbound
+    data class Error(val id: String?, val errors: List<WireError>) : Inbound
+
+    /**
+     * One error from the service.
+     *
+     * @param message The human-readable reason.
+     * @param errorType The service's error classification, from the error's `extensions.errorType`.
+     *   Null when the service did not supply one. This is what distinguishes an authorization failure
+     *   — which another auth mode might satisfy — from a failure that would recur regardless.
+     */
+    data class WireError(val message: String, val errorType: String?)
 
     /** One subscription ended normally, at the service's initiative. */
     data class Complete(val id: String) : Inbound
@@ -168,18 +178,23 @@ internal sealed interface AppSyncWebSocketMessage {
          * AppSync puts errors in `payload.errors` on a connection error and in `payload.errors` or a
          * top-level `errors` on a subscription error, so both shapes are read.
          */
-        private fun JsonObject.errorMessages(): List<String> {
+        private fun JsonObject.errorMessages(): List<WireError> {
             val errors = getAsJsonObject("payload")?.getAsJsonArray("errors")
                 ?: getAsJsonArray("errors")
                 ?: return emptyList()
 
             return errors.mapNotNull { element ->
                 when {
-                    element.isJsonPrimitive -> element.asString
-                    element.isJsonObject ->
-                        element.asJsonObject
-                            .get("message")?.takeIf { it.isJsonPrimitive }?.asString
-                            ?: element.toString()
+                    element.isJsonPrimitive -> WireError(element.asString, errorType = null)
+                    element.isJsonObject -> {
+                        val obj = element.asJsonObject
+                        WireError(
+                            message = obj.get("message")?.takeIf { it.isJsonPrimitive }?.asString
+                                ?: obj.toString(),
+                            errorType = obj.getAsJsonObject("extensions")
+                                ?.get("errorType")?.takeIf { it.isJsonPrimitive }?.asString
+                        )
+                    }
                     else -> null
                 }
             }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
@@ -191,8 +191,12 @@ internal sealed interface AppSyncWebSocketMessage {
                         WireError(
                             message = obj.get("message")?.takeIf { it.isJsonPrimitive }?.asString
                                 ?: obj.toString(),
-                            errorType = obj.getAsJsonObject("extensions")
-                                ?.get("errorType")?.takeIf { it.isJsonPrimitive }?.asString
+                            // Read both locations. A subscription error frame carries a GraphQL response
+                            // shape, which nests the classification under extensions; connection-level
+                            // frames put it directly on the error object.
+                            errorType = obj.get("errorType")?.takeIf { it.isJsonPrimitive }?.asString
+                                ?: obj.getAsJsonObject("extensions")
+                                    ?.get("errorType")?.takeIf { it.isJsonPrimitive }?.asString
                         )
                     }
                     else -> null

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
@@ -71,7 +71,11 @@ internal sealed interface AppSyncWebSocketMessage {
 
     /** Unregisters one subscription. Sent on flow cancellation. */
     data class Stop(val id: String) : Outbound {
-        override fun toJson() = """{"id":"$id","type":"$TYPE_STOP"}"""
+        // Built rather than interpolated, so an id containing a quote cannot produce invalid JSON.
+        override fun toJson() = JsonObject().apply {
+            addProperty("id", id)
+            addProperty("type", TYPE_STOP)
+        }.toString()
     }
 
     /** Messages the service sends. */
@@ -114,8 +118,11 @@ internal sealed interface AppSyncWebSocketMessage {
     data class Complete(val id: String) : Inbound
 
     /**
-     * A message this client does not model. Kept rather than dropped so an unexpected wire change is
-     * visible in logs instead of looking like silence.
+     * A message this client does not model. Modelled explicitly rather than discarded during parsing so
+     * that an unexpected wire change is a value a caller can match on.
+     *
+     * TODO: log these — nothing in this module logs today, so an unknown frame currently passes
+     *  unnoticed.
      */
     data class Unknown(val type: String?, val raw: String) : Inbound
 

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketProvider.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketProvider.kt
@@ -14,9 +14,13 @@
  */
 package com.amazonaws.appsync
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -38,11 +42,18 @@ import kotlinx.coroutines.sync.withLock
  * @param connectionFactory Creates a socket. Injectable so tests need no real endpoint.
  */
 internal class AppSyncWebSocketProvider(
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val connectionFactory: () -> AppSyncWebSocket
 ) {
     private val mutex = Mutex()
     private var connected: AppSyncWebSocket? = null
     private var inProgress: Deferred<Result<AppSyncWebSocket>>? = null
+
+    // The attempt is launched here rather than in the calling coroutine. Scoping it to the caller would
+    // make the shared Deferred a child of whichever caller happened to arrive first, so that caller
+    // being cancelled — a screen closing, a take(1) completing — would cancel the connection out from
+    // under everyone who joined it.
+    private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
 
     /** The live socket, or null if none has been established. Never opens one. */
     val existing: AppSyncWebSocket?
@@ -53,22 +64,22 @@ internal class AppSyncWebSocketProvider(
      *
      * @throws AppSyncException if the connection attempt fails. The failure is not cached.
      */
-    suspend fun connection(): AppSyncWebSocket = coroutineScope {
+    suspend fun connection(): AppSyncWebSocket {
         // Fast path: a live connection needs no lock contention.
-        existing?.let { return@coroutineScope it }
+        existing?.let { return it }
 
         // Join an attempt already running, without holding the lock while it completes — otherwise a
         // slow connect would serialize every waiting subscriber behind the mutex.
         inProgress?.takeUnless { it.isCompleted }?.let {
-            return@coroutineScope it.await().getOrElse { error -> throw error }
+            return it.await().getOrElse { error -> throw error }
         }
 
         val attempt = mutex.withLock {
             // Re-check under the lock: another coroutine may have finished between the checks above
             // and acquiring it. Without this, both would start an attempt.
-            existing?.let { return@coroutineScope it }
+            existing?.let { return it }
             inProgress?.takeUnless { it.isCompleted }
-                ?: async { attemptConnection() }.also { inProgress = it }
+                ?: scope.async { attemptConnection() }.also { inProgress = it }
         }
 
         val result = attempt.await()
@@ -78,7 +89,7 @@ internal class AppSyncWebSocketProvider(
             result.getOrNull()?.let { connected = it }
         }
 
-        result.getOrElse { error -> throw error }
+        return result.getOrElse { error -> throw error }
     }
 
     /**
@@ -94,6 +105,7 @@ internal class AppSyncWebSocketProvider(
             }
         }
         socket?.disconnect(cause)
+        scope.cancel()
     }
 
     private suspend fun attemptConnection(): Result<AppSyncWebSocket> = try {

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketProvider.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketProvider.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Hands out the client's single shared WebSocket, opening it on first use.
+ *
+ * The connection is lazy: a client that never subscribes never opens a socket. It is shared because
+ * AppSync multiplexes every subscription over one connection, so opening one per subscription would
+ * both waste connections and hit the API's connection limit sooner.
+ *
+ * Concurrency is the whole point of this class. Two coroutines calling `subscribe()` at the same
+ * moment must not open two sockets, and a caller arriving while a connection is still being
+ * established must wait for that attempt rather than starting a second one.
+ *
+ * A failed attempt is **not** cached: the next caller retries. A closed connection is discarded and
+ * replaced, which is what lets a client recover after `MaxSubscriptionsReached` or an idle timeout
+ * without the caller managing connection state.
+ *
+ * @param connectionFactory Creates a socket. Injectable so tests need no real endpoint.
+ */
+internal class AppSyncWebSocketProvider(
+    private val connectionFactory: () -> AppSyncWebSocket
+) {
+    private val mutex = Mutex()
+    private var connected: AppSyncWebSocket? = null
+    private var inProgress: Deferred<Result<AppSyncWebSocket>>? = null
+
+    /** The live socket, or null if none has been established. Never opens one. */
+    val existing: AppSyncWebSocket?
+        get() = connected?.takeUnless { it.isClosed }
+
+    /**
+     * Returns the shared socket, connecting if necessary.
+     *
+     * @throws AppSyncException if the connection attempt fails. The failure is not cached.
+     */
+    suspend fun connection(): AppSyncWebSocket = coroutineScope {
+        // Fast path: a live connection needs no lock contention.
+        existing?.let { return@coroutineScope it }
+
+        // Join an attempt already running, without holding the lock while it completes — otherwise a
+        // slow connect would serialize every waiting subscriber behind the mutex.
+        inProgress?.takeUnless { it.isCompleted }?.let {
+            return@coroutineScope it.await().getOrElse { error -> throw error }
+        }
+
+        val attempt = mutex.withLock {
+            // Re-check under the lock: another coroutine may have finished between the checks above
+            // and acquiring it. Without this, both would start an attempt.
+            existing?.let { return@coroutineScope it }
+            inProgress?.takeUnless { it.isCompleted }
+                ?: async { attemptConnection() }.also { inProgress = it }
+        }
+
+        val result = attempt.await()
+
+        mutex.withLock {
+            if (inProgress === attempt) inProgress = null
+            result.getOrNull()?.let { connected = it }
+        }
+
+        result.getOrElse { error -> throw error }
+    }
+
+    /**
+     * Closes the shared socket, if there is one, and forgets it.
+     *
+     * @param cause Why it is being closed, or null for a clean shutdown.
+     */
+    suspend fun close(cause: AppSyncException? = null) {
+        val socket = mutex.withLock {
+            connected.also {
+                connected = null
+                inProgress = null
+            }
+        }
+        socket?.disconnect(cause)
+    }
+
+    private suspend fun attemptConnection(): Result<AppSyncWebSocket> = try {
+        Result.success(connectionFactory().also { it.connect() })
+    } catch (error: Exception) {
+        // Surfaced as a typed failure so every caller joined to this attempt sees the same reason.
+        Result.failure(AppSyncException.from(error))
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -37,6 +37,7 @@ import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -340,6 +341,34 @@ class AmplifyAppSyncClientTest {
         inFlight.isCancelled shouldBe true
         // Cancellation must not be mistaken for a failure worth attempting under another auth mode.
         server.requestCount shouldBe 1
+    }
+
+    // ── Subscriptions ───────────────────────────────────────────────────
+
+    @Test
+    fun `subscribe on a closed client fails the collector`() = runTest {
+        // Deliberately a different mechanism from query/mutate: subscribe returns a cold flow, so the
+        // check belongs at collection rather than at the call that merely builds it.
+        val client = client()
+        client.close()
+
+        val error = runCatching { client.subscribe(request()).first() }.exceptionOrNull()
+
+        error.shouldBeInstanceOf<AppSyncValidationException>()
+        error.message shouldContain "closed"
+    }
+
+    @Test
+    fun `the websocket client configurator is applied`() = runTest {
+        // This PR makes the WebSocket configurator live for the first time; without a test, passing
+        // httpClientConfigurator here by mistake would go unnoticed.
+        var configured = false
+        val client = client { webSocketClientConfigurator = { configured = true } }
+
+        // The connection attempt fails against a server that will not upgrade; touching it is enough.
+        runCatching { client.subscribe(request()).first() }
+
+        configured shouldBe true
     }
 
     // ── Configuration ───────────────────────────────────────────────────

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -36,6 +36,7 @@ import io.mockk.mockk
 import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
@@ -43,6 +44,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.RecordedRequest
@@ -374,6 +376,37 @@ class AmplifyAppSyncClientTest {
     }
 
     @Test
+    fun `close on a client that never subscribed does not build the subscriber`() = runBlocking<Unit> {
+        // Mirrors the http client guard. Building the subscriber resolves a realtime URL, and an endpoint
+        // with no host cannot produce one — so if close() touches it, getOrThrow fails on the teardown
+        // scope: a different thread, no handler, nothing watching. Caught here through the default
+        // uncaught-exception handler, which is where such a failure actually lands.
+        val uncaught = CompletableDeferred<Throwable>()
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, error -> uncaught.complete(error) }
+
+        try {
+            val client = AmplifyAppSyncClient(
+                AmplifyAppSyncClient.Configuration {
+                    // An explicit region means build() never parses the endpoint, so an unusable one
+                    // reaches the client intact.
+                    endpoint = ""
+                    region = "us-east-1"
+                    authorization = AppSyncAuthorization.Single(AppSyncClientAuthorizer.ApiKey("da2-fakekey"))
+                }
+            )
+
+            client.close()
+
+            // A launch on Dispatchers.IO runs in milliseconds, so this is generous. Kept short because
+            // it is the wait for something that must never arrive, and every run pays it in full.
+            withTimeoutOrNull(NOTHING_LAUNCHED_TIMEOUT) { uncaught.await() }.shouldBeNull()
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previous)
+        }
+    }
+
+    @Test
     fun `close tears down the shared connection through the subscriber`() = runBlocking<Unit> {
         // The one link in the teardown chain nothing else pins. What subscriber.close() does is covered
         // in AppSyncSubscriberTest; that close() actually reaches it is not, and the call is launched on
@@ -699,5 +732,8 @@ class AmplifyAppSyncClientTest {
 
         // Bounds the wait for close()'s asynchronous teardown, so a broken chain fails rather than hangs.
         val TEARDOWN_TIMEOUT = 5.seconds
+
+        // Bounds a wait for work that must never be launched at all.
+        val NOTHING_LAUNCHED_TIMEOUT = 1.seconds
     }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -35,12 +35,14 @@ import io.mockk.every
 import io.mockk.mockk
 import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.RecordedRequest
@@ -371,6 +373,32 @@ class AmplifyAppSyncClientTest {
         configured shouldBe true
     }
 
+    @Test
+    fun `close tears down the shared connection through the subscriber`() = runBlocking<Unit> {
+        // The one link in the teardown chain nothing else pins. What subscriber.close() does is covered
+        // in AppSyncSubscriberTest; that close() actually reaches it is not, and the call is launched on
+        // a scope that outlives close() rather than awaited — so dropping the launch would leak the
+        // WebSocket with every other test still green.
+        //
+        // Observed through events rather than through a live subscription: server-to-client frames do not
+        // arrive over MockWebServer (see AppSyncWebSocketTest), so a real subscription could not reach
+        // Connected here to be torn down. The clean Disconnected only exists because subscriber.close() ran.
+        //
+        // Real dispatchers, so this cannot be runTest: the teardown runs on Dispatchers.IO and a virtual
+        // clock would not wait for it.
+        val client = client()
+        // Read before closing so the subscriber already exists, making this a teardown of a live one
+        // rather than one built for the sole purpose of closing it.
+        val events = client.events
+
+        client.close()
+
+        val state = withTimeout(TEARDOWN_TIMEOUT) { events.first { it is ConnectionState.Disconnected } }
+
+        // A null cause is the client closing deliberately, not the connection dying under it.
+        (state as ConnectionState.Disconnected).cause.shouldBeNull()
+    }
+
     // ── Configuration ───────────────────────────────────────────────────
 
     @Test
@@ -668,5 +696,8 @@ class AmplifyAppSyncClientTest {
 
     private companion object {
         const val REQUEST_TIMEOUT_SECONDS = 5L
+
+        // Bounds the wait for close()'s asynchronous teardown, so a broken chain fails rather than hangs.
+        val TEARDOWN_TIMEOUT = 5.seconds
     }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncClaimInjectorTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncClaimInjectorTest.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.aws.AppSyncGraphQLRequest
+import com.amplifyframework.api.aws.GsonVariablesSerializer
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.api.graphql.SimpleGraphQLRequest
+import com.amplifyframework.core.model.AuthRule
+import com.amplifyframework.core.model.AuthStrategy
+import com.amplifyframework.core.model.ModelOperation
+import com.amplifyframework.core.model.ModelSchema
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.Test
+
+/**
+ * Tests [AppSyncClaimInjector].
+ *
+ * The rule logic decides whether a subscription gets an owner variable at all, and getting it wrong is
+ * silent in both directions: injecting when unnecessary narrows what a subscriber receives, while
+ * failing to inject makes AppSync reject the subscription. Each branch has a test.
+ */
+class AppSyncClaimInjectorTest {
+
+    private val injector = AppSyncClaimInjector()
+    private val variableSlot = slot<String>()
+    private val valueSlot = slot<Any>()
+
+    private val userPools = AppSyncClientAuthorizer.UserPools { jwt(mapOf("username" to "alice")) }
+
+    // ── When no owner variable is needed ────────────────────────────────
+
+    @Test
+    fun `a raw request is returned untouched, having no schema to inspect`() = runTest {
+        val raw: GraphQLRequest<String> = SimpleGraphQLRequest(
+            "subscription { onCreateTodo { id } }",
+            emptyMap(),
+            String::class.java,
+            GsonVariablesSerializer()
+        )
+
+        injector.inject(raw, AppSyncAuthMode.USER_POOLS, userPools) shouldBe raw
+    }
+
+    @Test
+    fun `a model with no owner rule is returned untouched`() = runTest {
+        val request = requestWith(privateRule())
+
+        injector.inject(request, AppSyncAuthMode.USER_POOLS, userPools) shouldBe request
+        verify(exactly = 0) { request.newBuilder() }
+    }
+
+    @Test
+    fun `a public read rule under an api key needs no owner`() = runTest {
+        // The rule already permits the read, so adding an owner filter would narrow it for no reason.
+        val request = requestWith(publicRule(), ownerRule())
+
+        injector.inject(request, AppSyncAuthMode.API_KEY, AppSyncClientAuthorizer.ApiKey("da2-fake")) shouldBe
+            request
+    }
+
+    @Test
+    fun `a public read rule does not apply when subscribing with a different mode`() = runTest {
+        // The public rule only excuses the owner when the request is actually using the API key.
+        val request = requestWith(publicRule(), ownerRule())
+
+        injector.inject(request, AppSyncAuthMode.USER_POOLS, userPools)
+
+        variableSlot.captured shouldBe "owner"
+    }
+
+    @Test
+    fun `group membership takes precedence over the owner filter`() = runTest {
+        // A user who can already read via a group should receive everything that group can see.
+        val inGroup = AppSyncClientAuthorizer.UserPools {
+            jwt(mapOf("username" to "alice", "cognito:groups" to listOf("Admins")))
+        }
+        val request = requestWith(ownerRule(), groupRule("Admins"))
+
+        injector.inject(request, AppSyncAuthMode.USER_POOLS, inGroup) shouldBe request
+    }
+
+    @Test
+    fun `a user outside every read-restricting group still gets the owner filter`() = runTest {
+        val notInGroup = AppSyncClientAuthorizer.UserPools {
+            jwt(mapOf("username" to "alice", "cognito:groups" to listOf("Readers")))
+        }
+        val request = requestWith(ownerRule(), groupRule("Admins"))
+
+        injector.inject(request, AppSyncAuthMode.USER_POOLS, notInGroup)
+
+        variableSlot.captured shouldBe "owner"
+    }
+
+    // ── When it is needed ───────────────────────────────────────────────
+
+    @Test
+    fun `the owner variable is added from the identity claim`() = runTest {
+        val request = requestWith(ownerRule())
+
+        injector.inject(request, AppSyncAuthMode.USER_POOLS, userPools)
+
+        variableSlot.captured shouldBe "owner"
+        valueSlot.captured shouldBe "alice"
+    }
+
+    @Test
+    fun `a custom owner field and identity claim are honoured`() = runTest {
+        val custom = AppSyncClientAuthorizer.UserPools { jwt(mapOf("email" to "alice@example.com")) }
+        val request = requestWith(ownerRule(ownerField = "editor", identityClaim = "email"))
+
+        injector.inject(request, AppSyncAuthMode.USER_POOLS, custom)
+
+        variableSlot.captured shouldBe "editor"
+        valueSlot.captured shouldBe "alice@example.com"
+    }
+
+    @Test
+    fun `an OIDC token is read the same way`() = runTest {
+        val oidc = AppSyncClientAuthorizer.Oidc { jwt(mapOf("username" to "bob")) }
+        val request = requestWith(ownerRule())
+
+        injector.inject(request, AppSyncAuthMode.OIDC, oidc)
+
+        valueSlot.captured shouldBe "bob"
+    }
+
+    @Test
+    fun `an identity claim of cognito colon username reads the username claim`() = runTest {
+        // AuthRule maps that value to "username" for backwards compatibility with an older CLI, so a
+        // token carrying "username" satisfies a rule that names "cognito:username".
+        val request = requestWith(ownerRule(identityClaim = "cognito:username"))
+
+        injector.inject(request, AppSyncAuthMode.USER_POOLS, userPools)
+
+        valueSlot.captured shouldBe "alice"
+    }
+
+    // ── Failures ────────────────────────────────────────────────────────
+
+    @Test
+    fun `an auth mode with no claims cannot satisfy an owner rule`() = runTest {
+        // An API key identifies no user, so there is no owner to send.
+        val error = shouldThrow<AppSyncProviderNotConfiguredException> {
+            injector.inject(requestWith(ownerRule()), AppSyncAuthMode.API_KEY, AppSyncClientAuthorizer.ApiKey("k"))
+        }
+
+        error.message shouldContain "API_KEY"
+    }
+
+    @Test
+    fun `a missing identity claim is an authorization claim failure, not a parsing failure`() = runTest {
+        // The token was readable; it just does not carry what the rule requires.
+        val noClaim = AppSyncClientAuthorizer.UserPools { jwt(mapOf("sub" to "123")) }
+
+        shouldThrow<AppSyncAuthorizationClaimException> {
+            injector.inject(requestWith(ownerRule()), AppSyncAuthMode.USER_POOLS, noClaim)
+        }.message shouldContain "username"
+    }
+
+    @Test
+    fun `a malformed token is a parsing failure`() = runTest {
+        val bad = AppSyncClientAuthorizer.UserPools { "not-a-jwt" }
+
+        shouldThrow<AppSyncTokenParsingException> {
+            injector.inject(requestWith(ownerRule()), AppSyncAuthMode.USER_POOLS, bad)
+        }
+    }
+
+    @Test
+    fun `more than one owner read rule is refused rather than guessed at`() = runTest {
+        // AppSync generates a variable per owner rule, so there is no single value to send.
+        val request = requestWith(ownerRule(), ownerRule(ownerField = "editor"))
+
+        shouldThrow<AppSyncAuthorizationClaimException> {
+            injector.inject(request, AppSyncAuthMode.USER_POOLS, userPools)
+        }.message shouldContain "more than one owner"
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    /** An unsigned JWT whose payload carries [claims]. The signature is never checked. */
+    private fun jwt(claims: Map<String, Any>): String {
+        val payload = buildString {
+            append("{")
+            append(
+                claims.entries.joinToString(",") { (key, value) ->
+                    val rendered = when (value) {
+                        is List<*> -> value.joinToString(",", "[", "]") { "\"$it\"" }
+                        else -> "\"$value\""
+                    }
+                    "\"$key\":$rendered"
+                }
+            )
+            append("}")
+        }
+        val encoded = payload.encodeUtf8().base64Url().trimEnd('=')
+        return "header.$encoded.signature"
+    }
+
+    private fun requestWith(vararg rules: AuthRule): AppSyncGraphQLRequest<String> {
+        val rebuilt: AppSyncGraphQLRequest<String> = mockk(relaxed = true)
+        val builder: AppSyncGraphQLRequest.Builder = mockk(relaxed = true)
+        every { builder.variable(capture(variableSlot), any(), capture(valueSlot)) } returns builder
+        every { builder.build<String>() } returns rebuilt
+
+        return mockk {
+            every { content } returns """{"query":"subscription { onCreateTodo { id } }"}"""
+            every { modelSchema } returns ModelSchema.builder()
+                .name("Todo")
+                .authRules(rules.toList())
+                .build()
+            every { newBuilder() } returns builder
+        }
+    }
+
+    private fun ownerRule(ownerField: String = "owner", identityClaim: String = "username") = AuthRule.builder()
+        .authStrategy(AuthStrategy.OWNER)
+        .authProvider(AuthStrategy.OWNER.defaultAuthProvider)
+        .identityClaim(identityClaim)
+        .ownerField(ownerField)
+        .operations(listOf(ModelOperation.READ))
+        .build()
+
+    private fun groupRule(vararg groups: String) = AuthRule.builder()
+        .authStrategy(AuthStrategy.GROUPS)
+        .authProvider(AuthStrategy.GROUPS.defaultAuthProvider)
+        .identityClaim("cognito:groups")
+        .groups(groups.toList())
+        .operations(listOf(ModelOperation.READ))
+        .build()
+
+    private fun publicRule() = AuthRule.builder()
+        .authStrategy(AuthStrategy.PUBLIC)
+        .authProvider(AuthStrategy.Provider.API_KEY)
+        .operations(listOf(ModelOperation.READ))
+        .build()
+
+    private fun privateRule() = AuthRule.builder()
+        .authStrategy(AuthStrategy.PRIVATE)
+        .authProvider(AuthStrategy.Provider.IAM)
+        .operations(listOf(ModelOperation.READ))
+        .build()
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
@@ -182,6 +182,15 @@ class AppSyncEndpointParserTest {
     }
 
     @Test
+    fun `a standard host with a trailing slash still swaps the label`() {
+        // The plugin classifies this as a custom domain, because its standard-endpoint pattern requires
+        // a path of exactly "/graphql" — so it would append /realtime to the standard host instead.
+        // Recognising it as standard is the intended behaviour here.
+        realtimeUrl("https://abc123.appsync-api.us-east-1.amazonaws.com/graphql/") shouldBe
+            "wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql"
+    }
+
+    @Test
     fun `a trailing slash does not produce a doubled separator`() {
         realtimeUrl("https://api.example.com/graphql/") shouldBe "wss://api.example.com/graphql/realtime"
     }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
@@ -130,4 +130,65 @@ class AppSyncEndpointParserTest {
         AppSyncEndpointParser.parse("")
             .shouldBeInstanceOf<Result.Failure<AppSyncEndpointResolutionException>>()
     }
+
+    // ── Realtime URL derivation ─────────────────────────────────────────
+
+    private fun realtimeUrl(endpoint: String) = (AppSyncEndpointParser.realtimeUrl(endpoint) as Result.Success).data
+
+    @Test
+    fun `a standard endpoint swaps the api label and keeps the path`() {
+        realtimeUrl("https://abc123.appsync-api.us-east-1.amazonaws.com/graphql") shouldBe
+            "wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql"
+    }
+
+    @Test
+    fun `a china endpoint keeps its com-cn suffix in the realtime url`() {
+        // The reason this is a parser and not a string replace: a swap that assumed .amazonaws.com
+        // produces a realtime host that does not resolve here.
+        realtimeUrl("https://abc123.appsync-api.cn-north-1.amazonaws.com.cn/graphql") shouldBe
+            "wss://abc123.appsync-realtime-api.cn-north-1.amazonaws.com.cn/graphql"
+    }
+
+    @Test
+    fun `a govcloud endpoint derives its realtime url`() {
+        realtimeUrl("https://abc123.appsync-api.us-gov-west-1.amazonaws.com/graphql") shouldBe
+            "wss://abc123.appsync-realtime-api.us-gov-west-1.amazonaws.com/graphql"
+    }
+
+    @Test
+    fun `a custom domain appends realtime to the path instead of swapping a label`() {
+        // A custom domain has no appsync-api label to swap, so its realtime endpoint is a subpath.
+        // This is why realtimeUrl is separate from parse: parse cannot handle a custom domain at all,
+        // having no region to find, but subscriptions still have to work on one.
+        realtimeUrl("https://api.example.com/graphql") shouldBe "wss://api.example.com/graphql/realtime"
+    }
+
+    @Test
+    fun `a custom domain with a nested path preserves it`() {
+        realtimeUrl("https://api.example.com/v2/graphql") shouldBe
+            "wss://api.example.com/v2/graphql/realtime"
+    }
+
+    @Test
+    fun `an endpoint with no path defaults to graphql`() {
+        realtimeUrl("https://abc123.appsync-api.us-east-1.amazonaws.com") shouldBe
+            "wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql"
+    }
+
+    @Test
+    fun `a query string and fragment are dropped from the realtime url`() {
+        realtimeUrl("https://abc123.appsync-api.eu-west-2.amazonaws.com/graphql?trace=1#frag") shouldBe
+            "wss://abc123.appsync-realtime-api.eu-west-2.amazonaws.com/graphql"
+    }
+
+    @Test
+    fun `a trailing slash does not produce a doubled separator`() {
+        realtimeUrl("https://api.example.com/graphql/") shouldBe "wss://api.example.com/graphql/realtime"
+    }
+
+    @Test
+    fun `an empty endpoint has no realtime url`() {
+        AppSyncEndpointParser.realtimeUrl("")
+            .shouldBeInstanceOf<Result.Failure<AppSyncEndpointResolutionException>>()
+    }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncEndpointParserTest.kt
@@ -183,9 +183,8 @@ class AppSyncEndpointParserTest {
 
     @Test
     fun `a standard host with a trailing slash still swaps the label`() {
-        // The plugin classifies this as a custom domain, because its standard-endpoint pattern requires
-        // a path of exactly "/graphql" — so it would append /realtime to the standard host instead.
-        // Recognising it as standard is the intended behaviour here.
+        // A trailing slash must not defeat standard-host recognition: the label swap is decided by the
+        // host, so the path plays no part in the classification.
         realtimeUrl("https://abc123.appsync-api.us-east-1.amazonaws.com/graphql/") shouldBe
             "wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql"
     }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncExceptionTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncExceptionTest.kt
@@ -78,6 +78,7 @@ class AppSyncExceptionTest {
     fun `subscription leaves are catchable as one group`() {
         AppSyncConnectionException("a").shouldBeInstanceOf<AppSyncSubscriptionException>()
         AppSyncTimeoutException("b").shouldBeInstanceOf<AppSyncSubscriptionException>()
+        AppSyncLimitExceededException("c").shouldBeInstanceOf<AppSyncSubscriptionException>()
     }
 
     @Test
@@ -119,12 +120,13 @@ class AppSyncExceptionTest {
             AppSyncGraphQLErrorException("a", emptyList()),
             AppSyncConnectionException("a"),
             AppSyncTimeoutException("a"),
+            AppSyncLimitExceededException("a"),
             AppSyncValidationException("a"),
             AppSyncNetworkException("a"),
             AppSyncUnknownException("a")
         )
 
-        leaves.size shouldBe 15
+        leaves.size shouldBe 16
         leaves.forEach { it.recoverySuggestion.shouldNotBeBlank() }
     }
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncRequestDecoratorTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncRequestDecoratorTest.kt
@@ -17,11 +17,22 @@ package com.amazonaws.appsync
 import com.amplifyframework.foundation.credentials.AwsCredentials
 import com.amplifyframework.foundation.credentials.AwsCredentialsProvider
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.maps.shouldNotContainKey
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldMatch
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldStartWith
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.math.abs
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.coroutines.TimeoutCancellationException
@@ -182,6 +193,140 @@ class AppSyncRequestDecoratorTest {
         decorated.signature() shouldContain "/cn-north-1/appsync/aws4_request"
     }
 
+    // ── Connection authorization object ─────────────────────────────────
+    //
+    // These key sets are what AppSync validates the realtime connection against. They are JSON keys,
+    // not HTTP header names, so casing is significant and each mode's set is asserted exactly — a
+    // missing `host` or a lowercased `Authorization` is accepted by the client and rejected by the
+    // service as a routing error, with nothing in the failure naming the field at fault.
+
+    @Test
+    fun `api key connection authorization carries host, date and the key`() = runTest {
+        val auth = decorator.authorizationHeaders(
+            AppSyncClientAuthorizer.ApiKey("da2-fakekey"),
+            HTTP_ENDPOINT
+        )
+
+        auth.keys shouldContainExactly setOf("host", "x-amz-date", "x-api-key")
+        auth["host"] shouldBe ENDPOINT_HOST
+        auth["x-api-key"] shouldBe "da2-fakekey"
+    }
+
+    @Test
+    fun `user pools connection authorization carries host and a capitalized Authorization`() = runTest {
+        val auth = decorator.authorizationHeaders(
+            AppSyncClientAuthorizer.UserPools { "user-pools-token" },
+            HTTP_ENDPOINT
+        )
+
+        auth.keys shouldContainExactly setOf("host", "Authorization")
+        auth["host"] shouldBe ENDPOINT_HOST
+        auth["Authorization"] shouldBe "user-pools-token"
+    }
+
+    @Test
+    fun `oidc connection authorization carries host and a capitalized Authorization`() = runTest {
+        val auth = decorator.authorizationHeaders(
+            AppSyncClientAuthorizer.Oidc { "oidc-token" },
+            HTTP_ENDPOINT
+        )
+
+        auth.keys shouldContainExactly setOf("host", "Authorization")
+        auth["host"] shouldBe ENDPOINT_HOST
+        auth["Authorization"] shouldBe "oidc-token"
+    }
+
+    @Test
+    fun `lambda connection authorization carries host and a capitalized Authorization`() = runTest {
+        val auth = decorator.authorizationHeaders(
+            AppSyncClientAuthorizer.Lambda { "lambda-token" },
+            HTTP_ENDPOINT
+        )
+
+        auth.keys shouldContainExactly setOf("host", "Authorization")
+        auth["host"] shouldBe ENDPOINT_HOST
+        auth["Authorization"] shouldBe "lambda-token"
+    }
+
+    @Test
+    fun `iam connection authorization carries host among the signed headers`() = runTest {
+        val auth = decorator.authorizationHeaders(iamAuthorizer(), HTTP_ENDPOINT)
+
+        // Signing produces the key set, so it is asserted by containment rather than exactly.
+        auth["host"] shouldBe ENDPOINT_HOST
+        auth["authorization"].shouldNotBeNull() shouldStartWith "AWS4-HMAC-SHA256"
+        auth["x-amz-date"].shouldNotBeNull()
+    }
+
+    @Test
+    fun `only api key carries a date in the connection authorization`() = runTest {
+        // x-amz-date is part of what API key authorization is validated against. The token modes are
+        // not dated, and sending one would be rejected.
+        decorator.authorizationHeaders(AppSyncClientAuthorizer.ApiKey("da2-fakekey"), HTTP_ENDPOINT)
+            .shouldContainKey("x-amz-date")
+
+        decorator.authorizationHeaders(AppSyncClientAuthorizer.UserPools { "t" }, HTTP_ENDPOINT)
+            .shouldNotContainKey("x-amz-date")
+        decorator.authorizationHeaders(AppSyncClientAuthorizer.Oidc { "t" }, HTTP_ENDPOINT)
+            .shouldNotContainKey("x-amz-date")
+        decorator.authorizationHeaders(AppSyncClientAuthorizer.Lambda { "t" }, HTTP_ENDPOINT)
+            .shouldNotContainKey("x-amz-date")
+    }
+
+    @Test
+    fun `the api key date is an iso8601 basic format utc timestamp`() = runTest {
+        val date = decorator.authorizationHeaders(
+            AppSyncClientAuthorizer.ApiKey("da2-fakekey"),
+            HTTP_ENDPOINT
+        )["x-amz-date"].shouldNotBeNull()
+
+        date shouldMatch Regex("""\d{8}T\d{6}Z""")
+        // Parses back as UTC, so a non-UTC default zone cannot make the timestamp claim a Z it is not.
+        val parsed = LocalDateTime
+            .parse(date, DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.US))
+            .toInstant(ZoneOffset.UTC)
+        abs(parsed.toEpochMilli() - System.currentTimeMillis()) shouldBeLessThan CLOCK_SKEW_MILLIS
+    }
+
+    @Test
+    fun `host is the http endpoint's host, not the realtime host`() = runTest {
+        val auth = decorator.authorizationHeaders(
+            AppSyncClientAuthorizer.UserPools { "token" },
+            HTTP_ENDPOINT
+        )
+
+        auth["host"] shouldBe "abc123.appsync-api.us-east-1.amazonaws.com"
+        auth["host"]!! shouldNotContain "realtime"
+    }
+
+    @Test
+    fun `host keeps the china dns suffix`() = runTest {
+        decorator.authorizationHeaders(
+            AppSyncClientAuthorizer.ApiKey("da2-fakekey"),
+            "https://abc123.appsync-api.cn-north-1.amazonaws.com.cn/graphql"
+        )["host"] shouldBe "abc123.appsync-api.cn-north-1.amazonaws.com.cn"
+    }
+
+    @Test
+    fun `an endpoint with no host is reported as a configuration failure`() = runTest {
+        // Reported here rather than sent on, because the service's rejection of a hostless
+        // authorization object names no field and reads as a routing error.
+        shouldThrow<AppSyncEndpointResolutionException> {
+            decorator.authorizationHeaders(AppSyncClientAuthorizer.ApiKey("da2-fakekey"), "")
+        }
+    }
+
+    @Test
+    fun `a subscription body does not change the non-iam key sets`() = runTest {
+        // Only the SigV4 path varies with the body; the token modes are the same either way.
+        val body = """{"query":"subscription { onCreateTodo { id } }"}"""
+
+        decorator.authorizationHeaders(AppSyncClientAuthorizer.ApiKey("da2-fakekey"), HTTP_ENDPOINT, body)
+            .keys shouldContainExactly setOf("host", "x-amz-date", "x-api-key")
+        decorator.authorizationHeaders(AppSyncClientAuthorizer.UserPools { "t" }, HTTP_ENDPOINT, body)
+            .keys shouldContainExactly setOf("host", "Authorization")
+    }
+
     // ── Supplier failures ───────────────────────────────────────────────
 
     @Test
@@ -272,5 +417,8 @@ class AppSyncRequestDecoratorTest {
     private companion object {
         val JSON = "application/json".toMediaType()
         const val CANCELLATION_TIMEOUT_MILLIS = 1_000L
+        const val HTTP_ENDPOINT = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql"
+        const val ENDPOINT_HOST = "abc123.appsync-api.us-east-1.amazonaws.com"
+        const val CLOCK_SKEW_MILLIS = 60_000L
     }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -494,6 +494,45 @@ class AppSyncSubscriberTest {
         }
     }
 
+    @Test
+    fun `a subscription limit error is terminal and is not retried`() = runTest {
+        // The limit belongs to the API, not the identity, so another auth mode would fail the same way.
+        val subscriber = subscriber(multiAuth())
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val firstId = startedId
+
+            messages.emit(
+                AppSyncWebSocketMessage.Error(
+                    firstId,
+                    listOf(wireError("Max number of 100 subscriptions reached", "MaxSubscriptionsReachedError"))
+                )
+            )
+
+            awaitError().shouldBeInstanceOf<AppSyncLimitExceededException>()
+                .message shouldContain "100 subscriptions"
+        }
+    }
+
+    @Test
+    fun `a subscription limit error wins over an unauthorized error in the same frame`() = runTest {
+        val subscriber = subscriber(multiAuth())
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(
+                AppSyncWebSocketMessage.Error(
+                    startedId,
+                    listOf(unauthorized(), wireError("limit", "MaxSubscriptionsReachedError"))
+                )
+            )
+
+            awaitError().shouldBeInstanceOf<AppSyncLimitExceededException>()
+        }
+    }
+
     // ── Connection state ────────────────────────────────────────────────
 
     @Test

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -31,6 +31,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -60,19 +61,26 @@ class AppSyncSubscriberTest {
     private val messages = MutableSharedFlow<AppSyncWebSocketMessage.Inbound>(extraBufferCapacity = 64)
     private val sentSlot = slot<AppSyncWebSocketMessage.Outbound>()
 
+    /** The socket's settled terminal state. Completing it is how these tests simulate the socket dying. */
+    private val terminated = CompletableDeferred<AppSyncException?>()
+
     private val socket: AppSyncWebSocket = mockk(relaxed = true) {
         every { this@mockk.messages } returns this@AppSyncSubscriberTest.messages
         every { isClosed } returns false
         every { send(capture(sentSlot)) } returns true
+        every { closure } returns terminated
     }
 
     private fun subscriber(
         authorization: AppSyncAuthorization = AppSyncAuthorization.Single(
             AppSyncClientAuthorizer.ApiKey("da2-fakekey")
         ),
+        // Deliberately NOT linked to runTest's scheduler: leaving it unadvanced keeps the subscriber's
+        // disconnect watcher from running, which is what lets the tests below assert expectNoEvents().
+        // The disconnect test opts into a linked dispatcher precisely to make the watcher run.
         ioDispatcher: CoroutineDispatcher = StandardTestDispatcher()
     ) = AppSyncSubscriber(
-        provider = AppSyncWebSocketProvider { socket },
+        provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) { socket },
         authorization = authorization,
         decorator = AppSyncRequestDecorator("us-east-1"),
         httpEndpoint = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql",
@@ -281,8 +289,11 @@ class AppSyncSubscriberTest {
 
             messages.emit(AppSyncWebSocketMessage.Error(id, listOf(wireError("Validation failed"))))
 
-            awaitError().shouldBeInstanceOf<AppSyncGraphQLErrorException>()
-                .message shouldContain "Validation failed"
+            val error = awaitError().shouldBeInstanceOf<AppSyncGraphQLErrorException>()
+            error.message shouldContain "Validation failed"
+            // The parsed errors are carried on the exception, so its own recovery suggestion —
+            // "inspect the errors list" — is actually actionable.
+            error.errors.single().message shouldBe "Validation failed"
         }
     }
 
@@ -554,7 +565,9 @@ class AppSyncSubscriberTest {
     @Test
     fun `events reports a Disconnected with the cause when connecting fails`() = runTest {
         val failing = AppSyncSubscriber(
-            provider = AppSyncWebSocketProvider { throw AppSyncConnectionException("refused") },
+            provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) {
+                throw AppSyncConnectionException("refused")
+            },
             authorization = AppSyncAuthorization.Single(AppSyncClientAuthorizer.ApiKey("da2-fakekey")),
             decorator = AppSyncRequestDecorator("us-east-1"),
             httpEndpoint = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql"
@@ -580,6 +593,7 @@ class AppSyncSubscriberTest {
         subscriber.events.test {
             subscriber.subscribe(request()).test {
                 awaitItem() shouldBe SubscriptionEvent.Connecting
+                terminated.complete(AppSyncTimeoutException("idle"))
                 messages.emit(AppSyncWebSocketMessage.Closed(AppSyncTimeoutException("idle")))
                 awaitError()
             }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -15,10 +15,16 @@
 package com.amazonaws.appsync
 
 import app.cash.turbine.test
+import com.amplifyframework.api.aws.AppSyncGraphQLRequest
 import com.amplifyframework.api.aws.GsonVariablesSerializer
 import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.SimpleGraphQLRequest
+import com.amplifyframework.core.model.AuthRule
+import com.amplifyframework.core.model.AuthStrategy
+import com.amplifyframework.core.model.ModelOperation
+import com.amplifyframework.core.model.ModelSchema
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
@@ -81,6 +87,54 @@ class AppSyncSubscriberTest {
 
     private val startedId: String
         get() = (sentSlot.captured as AppSyncWebSocketMessage.Start).id
+
+    /** Auth rules are irrelevant here — a Multi with two authorizers is enough to have a fallback. */
+    private fun multiAuth() = AppSyncAuthorization.Multi(
+        defaultAuthMode = AppSyncAuthMode.USER_POOLS,
+        authorizers = listOf(
+            AppSyncClientAuthorizer.UserPools { "user-pools-token" },
+            AppSyncClientAuthorizer.ApiKey("da2-fakekey")
+        )
+    )
+
+    /**
+     * A request carrying model metadata, so auth-rule resolution yields more than one candidate mode.
+     * A raw request has no schema and therefore resolves to the default alone, which is why retry does
+     * not engage for one.
+     *
+     * Mocked rather than built because a real [AppSyncGraphQLRequest] also runs selection-set
+     * generation, which needs a code-generated model class.
+     */
+    private fun modelRequest(): AppSyncGraphQLRequest<String> {
+        val ownerRule = AuthRule.builder()
+            .authStrategy(AuthStrategy.OWNER)
+            .authProvider(AuthStrategy.OWNER.defaultAuthProvider)
+            .identityClaim("cognito:username")
+            .ownerField("owner")
+            .operations(listOf(ModelOperation.READ))
+            .build()
+        val publicRule = AuthRule.builder()
+            .authStrategy(AuthStrategy.PUBLIC)
+            .authProvider(AuthStrategy.Provider.API_KEY)
+            .operations(listOf(ModelOperation.READ))
+            .build()
+
+        return mockk {
+            every { content } returns """{"query":"subscription { onCreateTodo { id name } }"}"""
+            every { responseType } returns String::class.java
+            every { modelSchema } returns ModelSchema.builder()
+                .name("Todo")
+                .authRules(listOf(ownerRule, publicRule))
+                .build()
+            every { authRuleOperation } returns ModelOperation.READ
+            every { authorizationType } returns null
+        }
+    }
+
+    private fun wireError(message: String, errorType: String? = null) =
+        AppSyncWebSocketMessage.WireError(message, errorType)
+
+    private fun unauthorized() = wireError("Not Authorized to access onCreateTodo", "Unauthorized")
 
     // ── Lifecycle ───────────────────────────────────────────────────────
 
@@ -215,7 +269,7 @@ class AppSyncSubscriberTest {
             awaitItem() shouldBe SubscriptionEvent.Connecting
             val id = startedId
 
-            messages.emit(AppSyncWebSocketMessage.Error(id, listOf("Validation failed")))
+            messages.emit(AppSyncWebSocketMessage.Error(id, listOf(wireError("Validation failed"))))
 
             awaitError().shouldBeInstanceOf<AppSyncGraphQLErrorException>()
                 .message shouldContain "Validation failed"
@@ -227,7 +281,7 @@ class AppSyncSubscriberTest {
         subscriber().subscribe(request()).test {
             awaitItem() shouldBe SubscriptionEvent.Connecting
 
-            messages.emit(AppSyncWebSocketMessage.Error(null, listOf("connection died")))
+            messages.emit(AppSyncWebSocketMessage.Error(null, listOf(wireError("connection died"))))
 
             awaitError().shouldBeInstanceOf<AppSyncGraphQLErrorException>()
         }
@@ -238,7 +292,7 @@ class AppSyncSubscriberTest {
         subscriber().subscribe(request()).test {
             awaitItem() shouldBe SubscriptionEvent.Connecting
 
-            messages.emit(AppSyncWebSocketMessage.ConnectionError(listOf("Unauthorized")))
+            messages.emit(AppSyncWebSocketMessage.ConnectionError(listOf(wireError("Unauthorized"))))
 
             awaitError().shouldBeInstanceOf<AppSyncConnectionException>()
                 .message shouldContain "Unauthorized"
@@ -307,6 +361,126 @@ class AppSyncSubscriberTest {
             awaitItem() shouldBe SubscriptionEvent.Connected
 
             cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Multi-auth retry ────────────────────────────────────────────────
+
+    @Test
+    fun `an unauthorized error frame re-registers under the next auth mode`() = runTest {
+        val subscriber = subscriber(multiAuth())
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val firstId = startedId
+            (sentSlot.captured as AppSyncWebSocketMessage.Start)
+                .authorizationHeaders["authorization"] shouldBe "user-pools-token"
+
+            messages.emit(AppSyncWebSocketMessage.Error(firstId, listOf(unauthorized())))
+
+            // Re-registered under a new id and a different identity, without ending the stream.
+            val retry = sentSlot.captured.shouldBeInstanceOf<AppSyncWebSocketMessage.Start>()
+            retry.id shouldNotBe firstId
+            retry.authorizationHeaders["x-api-key"] shouldBe "da2-fakekey"
+            expectNoEvents()
+
+            messages.emit(AppSyncWebSocketMessage.StartAck(retry.id))
+            awaitItem() shouldBe SubscriptionEvent.Connected
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `an unauthorized data message also triggers a retry`() = runTest {
+        // AppSync can reject the identity in a data message rather than an error frame.
+        val subscriber = subscriber(multiAuth())
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val firstId = startedId
+
+            messages.emit(
+                AppSyncWebSocketMessage.Data(
+                    firstId,
+                    """{"errors":[{"message":"Not Authorized","extensions":{"errorType":"Unauthorized"}}]}"""
+                )
+            )
+
+            // Retried rather than handed to the consumer.
+            expectNoEvents()
+            (sentSlot.captured as AppSyncWebSocketMessage.Start).id shouldNotBe firstId
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `exhausting every auth mode reports which were attempted`() = runTest {
+        val subscriber = subscriber(multiAuth())
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(AppSyncWebSocketMessage.Error(startedId, listOf(unauthorized())))
+            messages.emit(AppSyncWebSocketMessage.Error(startedId, listOf(unauthorized())))
+
+            val error = awaitError().shouldBeInstanceOf<AppSyncAuthExhaustedException>()
+            error.attemptedAuthModes shouldBe listOf(AppSyncAuthMode.USER_POOLS, AppSyncAuthMode.API_KEY)
+        }
+    }
+
+    @Test
+    fun `a non-auth error is terminal even when other auth modes remain`() = runTest {
+        // Retrying a validation failure would fail identically under a different identity and hide the
+        // real reason behind an exhaustion error.
+        val subscriber = subscriber(multiAuth())
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(
+                AppSyncWebSocketMessage.Error(startedId, listOf(wireError("Validation failed")))
+            )
+
+            awaitError().shouldBeInstanceOf<AppSyncGraphQLErrorException>()
+        }
+    }
+
+    @Test
+    fun `a mode whose credentials cannot be obtained is skipped`() = runTest {
+        val subscriber = subscriber(
+            AppSyncAuthorization.Multi(
+                defaultAuthMode = AppSyncAuthMode.API_KEY,
+                authorizers = listOf(
+                    AppSyncClientAuthorizer.UserPools { error("session expired") },
+                    AppSyncClientAuthorizer.ApiKey("da2-fakekey")
+                )
+            )
+        )
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            // The first mode never produced a start message; the second did.
+            (sentSlot.captured as AppSyncWebSocketMessage.Start)
+                .authorizationHeaders["x-api-key"] shouldBe "da2-fakekey"
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `single auth does not retry, and surfaces the rejection reason directly`() = runTest {
+        // With one candidate there is nothing to exhaust, so reporting "auth exhausted" would hide what
+        // the service actually said.
+        subscriber().subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(AppSyncWebSocketMessage.Error(startedId, listOf(unauthorized())))
+
+            awaitError().shouldBeInstanceOf<AppSyncGraphQLErrorException>()
+                .message shouldContain "Not Authorized"
         }
     }
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import app.cash.turbine.test
+import com.amplifyframework.api.aws.GsonVariablesSerializer
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.api.graphql.SimpleGraphQLRequest
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests [AppSyncSubscriber] — the subscription lifecycle and, mostly, its terminality rules.
+ *
+ * The distinction between terminal and non-terminal is easy to implement backwards, so each side has a
+ * test: a GraphQL error carried *inside* a data message is **not** terminal (the service considered the
+ * message deliverable), while a subscription `error` frame **is**. Likewise a socket close with a cause
+ * throws but a clean close completes normally.
+ *
+ * The socket is mocked and its message flow driven directly, which is how the rest of the repo tests
+ * WebSocket behaviour.
+ *
+ * Robolectric is required because `GraphQLRequest.getContent()` uses `android.text.TextUtils`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppSyncSubscriberTest {
+
+    private val messages = MutableSharedFlow<AppSyncWebSocketMessage.Inbound>(extraBufferCapacity = 64)
+    private val sentSlot = slot<AppSyncWebSocketMessage.Outbound>()
+
+    private val socket: AppSyncWebSocket = mockk(relaxed = true) {
+        every { this@mockk.messages } returns this@AppSyncSubscriberTest.messages
+        every { isClosed } returns false
+        every { send(capture(sentSlot)) } returns true
+    }
+
+    private fun subscriber(
+        authorization: AppSyncAuthorization = AppSyncAuthorization.Single(
+            AppSyncClientAuthorizer.ApiKey("da2-fakekey")
+        ),
+        ioDispatcher: CoroutineDispatcher = StandardTestDispatcher()
+    ) = AppSyncSubscriber(
+        provider = AppSyncWebSocketProvider { socket },
+        authorization = authorization,
+        decorator = AppSyncRequestDecorator("us-east-1"),
+        httpEndpoint = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql",
+        ioDispatcher = ioDispatcher
+    )
+
+    private fun request(): GraphQLRequest<String> = SimpleGraphQLRequest(
+        "subscription { onCreateTodo { id name } }",
+        emptyMap(),
+        String::class.java,
+        GsonVariablesSerializer()
+    )
+
+    private val startedId: String
+        get() = (sentSlot.captured as AppSyncWebSocketMessage.Start).id
+
+    // ── Lifecycle ───────────────────────────────────────────────────────
+
+    @Test
+    fun `emits Connecting then Connected then Data`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            val id = startedId
+            messages.emit(AppSyncWebSocketMessage.StartAck(id))
+            awaitItem() shouldBe SubscriptionEvent.Connected
+
+            messages.emit(AppSyncWebSocketMessage.Data(id, """{"data":"hello"}"""))
+            val data = awaitItem().shouldBeInstanceOf<SubscriptionEvent.Data<String>>()
+            data.response.data shouldBe "hello"
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `nothing is sent until the flow is collected`() {
+        subscriber().subscribe(request())
+
+        verify(exactly = 0) { socket.send(any()) }
+    }
+
+    @Test
+    fun `the start message carries the document and its auth headers`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            val start = sentSlot.captured.shouldBeInstanceOf<AppSyncWebSocketMessage.Start>()
+            start.query shouldContain "onCreateTodo"
+            start.authorizationHeaders["x-api-key"] shouldBe "da2-fakekey"
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `cancelling the collector sends stop`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify { socket.send(match { it is AppSyncWebSocketMessage.Stop }) }
+    }
+
+    @Test
+    fun `messages addressed to another subscription are ignored`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(AppSyncWebSocketMessage.StartAck("someone-else"))
+            messages.emit(AppSyncWebSocketMessage.Data("someone-else", """{"data":"theirs"}"""))
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `keep-alives and unknown frames do not disturb the stream`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val id = startedId
+
+            messages.emit(AppSyncWebSocketMessage.KeepAlive)
+            messages.emit(AppSyncWebSocketMessage.Unknown("something_new", "{}"))
+            expectNoEvents()
+
+            messages.emit(AppSyncWebSocketMessage.StartAck(id))
+            awaitItem() shouldBe SubscriptionEvent.Connected
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Non-terminal cases ──────────────────────────────────────────────
+
+    @Test
+    fun `graphql errors inside a data message are delivered, not terminal`() = runTest {
+        // The service considered the message deliverable, so the consumer gets the data and the errors
+        // and the subscription stays open.
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val id = startedId
+
+            messages.emit(
+                AppSyncWebSocketMessage.Data(
+                    id,
+                    """{"data":"partial","errors":[{"message":"Unauthorized on field secret"}]}"""
+                )
+            )
+
+            val data = awaitItem().shouldBeInstanceOf<SubscriptionEvent.Data<String>>()
+            data.response.data shouldBe "partial"
+            data.response.errors.size shouldBe 1
+
+            // Still open: another message arrives afterwards.
+            messages.emit(AppSyncWebSocketMessage.Data(id, """{"data":"next"}"""))
+            awaitItem().shouldBeInstanceOf<SubscriptionEvent.Data<String>>()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `an undeserializable data message is dropped and the stream continues`() = runTest {
+        // Losing one message is better than tearing down a working subscription.
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val id = startedId
+
+            messages.emit(AppSyncWebSocketMessage.Data(id, "{not json"))
+            expectNoEvents()
+
+            messages.emit(AppSyncWebSocketMessage.Data(id, """{"data":"recovered"}"""))
+            awaitItem().shouldBeInstanceOf<SubscriptionEvent.Data<String>>()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Terminal cases ──────────────────────────────────────────────────
+
+    @Test
+    fun `an error frame for this subscription is terminal`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val id = startedId
+
+            messages.emit(AppSyncWebSocketMessage.Error(id, listOf("Validation failed")))
+
+            awaitError().shouldBeInstanceOf<AppSyncGraphQLErrorException>()
+                .message shouldContain "Validation failed"
+        }
+    }
+
+    @Test
+    fun `a connection-level error with no id is terminal for this subscription`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(AppSyncWebSocketMessage.Error(null, listOf("connection died")))
+
+            awaitError().shouldBeInstanceOf<AppSyncGraphQLErrorException>()
+        }
+    }
+
+    @Test
+    fun `a connection_error is terminal`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(AppSyncWebSocketMessage.ConnectionError(listOf("Unauthorized")))
+
+            awaitError().shouldBeInstanceOf<AppSyncConnectionException>()
+                .message shouldContain "Unauthorized"
+        }
+    }
+
+    @Test
+    fun `a socket close with a cause is terminal`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(AppSyncWebSocketMessage.Closed(AppSyncTimeoutException("idle")))
+
+            awaitError().shouldBeInstanceOf<AppSyncTimeoutException>()
+        }
+    }
+
+    @Test
+    fun `a failing authorizer makes the subscription terminal`() = runTest {
+        val failing = subscriber(
+            AppSyncAuthorization.Single(AppSyncClientAuthorizer.UserPools { error("expired") })
+        )
+
+        failing.subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            awaitError().shouldBeInstanceOf<AppSyncTokenFetchException>()
+        }
+    }
+
+    // ── Normal completion ───────────────────────────────────────────────
+
+    @Test
+    fun `a complete frame ends the flow normally`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val id = startedId
+
+            messages.emit(AppSyncWebSocketMessage.Complete(id))
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `a clean socket close ends the flow normally rather than throwing`() = runTest {
+        // This is what makes close() a graceful shutdown: a null cause means the client asked for it.
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(AppSyncWebSocketMessage.Closed(cause = null))
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `a complete for another subscription does not end this one`() = runTest {
+        subscriber().subscribe(request()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val id = startedId
+
+            messages.emit(AppSyncWebSocketMessage.Complete("someone-else"))
+            expectNoEvents()
+
+            messages.emit(AppSyncWebSocketMessage.StartAck(id))
+            awaitItem() shouldBe SubscriptionEvent.Connected
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Connection state ────────────────────────────────────────────────
+
+    @Test
+    fun `events reports Connecting then Connected around the first subscribe`() = runTest {
+        val subscriber = subscriber()
+
+        subscriber.events.test {
+            subscriber.subscribe(request()).test {
+                awaitItem() shouldBe SubscriptionEvent.Connecting
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            awaitItem() shouldBe ConnectionState.Connecting
+            awaitItem() shouldBe ConnectionState.Connected
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `events reports a Disconnected with the cause when connecting fails`() = runTest {
+        val failing = AppSyncSubscriber(
+            provider = AppSyncWebSocketProvider { throw AppSyncConnectionException("refused") },
+            authorization = AppSyncAuthorization.Single(AppSyncClientAuthorizer.ApiKey("da2-fakekey")),
+            decorator = AppSyncRequestDecorator("us-east-1"),
+            httpEndpoint = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql"
+        )
+
+        failing.events.test {
+            failing.subscribe(request()).test {
+                awaitItem() shouldBe SubscriptionEvent.Connecting
+                awaitError()
+            }
+
+            awaitItem() shouldBe ConnectionState.Connecting
+            val disconnected = awaitItem().shouldBeInstanceOf<ConnectionState.Disconnected>()
+            disconnected.cause.shouldBeInstanceOf<AppSyncConnectionException>()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `events reports a Disconnected with the cause when the connection dies unexpectedly`() = runTest {
+        val subscriber = subscriber(ioDispatcher = UnconfinedTestDispatcher(testScheduler))
+
+        subscriber.events.test {
+            subscriber.subscribe(request()).test {
+                awaitItem() shouldBe SubscriptionEvent.Connecting
+                messages.emit(AppSyncWebSocketMessage.Closed(AppSyncTimeoutException("idle")))
+                awaitError()
+            }
+
+            awaitItem() shouldBe ConnectionState.Connecting
+            awaitItem() shouldBe ConnectionState.Connected
+            val disconnected = awaitItem().shouldBeInstanceOf<ConnectionState.Disconnected>()
+            disconnected.cause.shouldBeInstanceOf<AppSyncTimeoutException>()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `close reports a clean Disconnected with no cause`() = runTest {
+        val subscriber = subscriber()
+
+        subscriber.events.test {
+            subscriber.close()
+
+            awaitItem() shouldBe ConnectionState.Disconnected(null)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `events replays the latest state to a late observer`() = runTest {
+        val subscriber = subscriber()
+        subscriber.close()
+
+        // A consumer that starts observing after the fact should still learn the current state.
+        subscriber.events.test {
+            awaitItem() shouldBe ConnectionState.Disconnected(null)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import okio.ByteString.Companion.encodeUtf8
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -92,7 +93,7 @@ class AppSyncSubscriberTest {
     private fun multiAuth() = AppSyncAuthorization.Multi(
         defaultAuthMode = AppSyncAuthMode.USER_POOLS,
         authorizers = listOf(
-            AppSyncClientAuthorizer.UserPools { "user-pools-token" },
+            AppSyncClientAuthorizer.UserPools { OWNER_JWT },
             AppSyncClientAuthorizer.ApiKey("da2-fakekey")
         )
     )
@@ -128,6 +129,15 @@ class AppSyncSubscriberTest {
                 .build()
             every { authRuleOperation } returns ModelOperation.READ
             every { authorizationType } returns null
+            // The owner rule means claim injection rebuilds the request; the rebuilt one only needs to
+            // answer content.
+            every { newBuilder() } returns mockk(relaxed = true) {
+                every { variable(any(), any(), any()) } returns this
+                every { build<String>() } returns mockk(relaxed = true) {
+                    every { content } returns
+                        """{"query":"subscription { onCreateTodo { id name } }","variables":{"owner":"alice"}}"""
+                }
+            }
         }
     }
 
@@ -374,7 +384,7 @@ class AppSyncSubscriberTest {
             awaitItem() shouldBe SubscriptionEvent.Connecting
             val firstId = startedId
             (sentSlot.captured as AppSyncWebSocketMessage.Start)
-                .authorizationHeaders["authorization"] shouldBe "user-pools-token"
+                .authorizationHeaders["authorization"] shouldBe OWNER_JWT
 
             messages.emit(AppSyncWebSocketMessage.Error(firstId, listOf(unauthorized())))
 
@@ -565,5 +575,15 @@ class AppSyncSubscriberTest {
             awaitItem() shouldBe ConnectionState.Disconnected(null)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    private companion object {
+        /**
+         * Unsigned JWT carrying `username`, which is what an owner rule's identity claim resolves to.
+         * The model request below carries an owner rule, so claim injection reads this token; a token
+         * that is not a JWT would make the mode be skipped rather than tried.
+         */
+        val OWNER_JWT = "header." +
+            """{"username":"alice"}""".encodeUtf8().base64Url().trimEnd('=') + ".signature"
     }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -395,7 +395,7 @@ class AppSyncSubscriberTest {
             awaitItem() shouldBe SubscriptionEvent.Connecting
             val firstId = startedId
             (sentSlot.captured as AppSyncWebSocketMessage.Start)
-                .authorizationHeaders["authorization"] shouldBe OWNER_JWT
+                .authorizationHeaders["Authorization"] shouldBe OWNER_JWT
 
             messages.emit(AppSyncWebSocketMessage.Error(firstId, listOf(unauthorized())))
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketMessageTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketMessageTest.kt
@@ -138,7 +138,7 @@ class AppSyncWebSocketMessageTest {
         )
 
         message.shouldBeInstanceOf<AppSyncWebSocketMessage.ConnectionError>()
-        message.errors shouldContainExactly listOf("Unauthorized")
+        message.errors.map { it.message } shouldContainExactly listOf("Unauthorized")
     }
 
     @Test
@@ -150,7 +150,7 @@ class AppSyncWebSocketMessageTest {
 
         message.shouldBeInstanceOf<AppSyncWebSocketMessage.Error>()
         message.id shouldBe "sub-1"
-        message.errors shouldContainExactly listOf("MaxSubscriptionsReachedError")
+        message.errors.map { it.message } shouldContainExactly listOf("MaxSubscriptionsReachedError")
     }
 
     @Test
@@ -160,7 +160,9 @@ class AppSyncWebSocketMessageTest {
         )
 
         message.shouldBeInstanceOf<AppSyncWebSocketMessage.Error>()
-        message.errors shouldContainExactly listOf("something broke")
+        message.errors.map { it.message } shouldContainExactly listOf("something broke")
+        // A bare string carries no classification, so the error type is unknown rather than assumed.
+        message.errors.single().errorType shouldBe null
     }
 
     @Test

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketMessageTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketMessageTest.kt
@@ -173,6 +173,29 @@ class AppSyncWebSocketMessageTest {
         message.id shouldBe null
     }
 
+    @Test
+    fun `an errorType on the error object itself is read`() {
+        // The realtime protocol puts the classification directly on the error, not under extensions.
+        val message = AppSyncWebSocketMessage.parse(
+            """{"type":"error","id":"sub-1","payload":{"errors":[
+               {"errorType":"MaxSubscriptionsReachedError","message":"limit reached"}]}}"""
+        )
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.Error>()
+        message.errors.single().errorType shouldBe "MaxSubscriptionsReachedError"
+    }
+
+    @Test
+    fun `an errorType under extensions is still read`() {
+        val message = AppSyncWebSocketMessage.parse(
+            """{"type":"error","id":"sub-1","payload":{"errors":[
+               {"message":"nope","extensions":{"errorType":"Unauthorized"}}]}}"""
+        )
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.Error>()
+        message.errors.single().errorType shouldBe "Unauthorized"
+    }
+
     // ── Robustness: nothing may throw ───────────────────────────────────
 
     @Test

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketMessageTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketMessageTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.google.gson.JsonParser
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+
+/**
+ * Tests [AppSyncWebSocketMessage] — the `graphql-ws` wire format.
+ *
+ * The parsing side is the substance: a subscription connection is shared, so one malformed frame must
+ * not be able to take down the other subscriptions riding on it. Every unparseable input is expected
+ * to become [AppSyncWebSocketMessage.Unknown] rather than throw.
+ */
+class AppSyncWebSocketMessageTest {
+
+    // ── Outbound ────────────────────────────────────────────────────────
+
+    @Test
+    fun `connection init has just a type`() {
+        val json = JsonParser.parseString(AppSyncWebSocketMessage.ConnectionInit.toJson()).asJsonObject
+
+        json.get("type").asString shouldBe "connection_init"
+    }
+
+    @Test
+    fun `start carries the document and its auth headers under payload extensions`() {
+        val message = AppSyncWebSocketMessage.Start(
+            id = "sub-1",
+            query = """{"query":"subscription { onCreateTodo { id } }"}""",
+            authorizationHeaders = mapOf("x-api-key" to "da2-fakekey", "host" to "example.com")
+        )
+
+        val json = JsonParser.parseString(message.toJson()).asJsonObject
+
+        json.get("id").asString shouldBe "sub-1"
+        json.get("type").asString shouldBe "start"
+        val payload = json.getAsJsonObject("payload")
+        payload.get("data").asString shouldContain "onCreateTodo"
+        val authorization = payload.getAsJsonObject("extensions").getAsJsonObject("authorization")
+        authorization.get("x-api-key").asString shouldBe "da2-fakekey"
+        authorization.get("host").asString shouldBe "example.com"
+    }
+
+    @Test
+    fun `start with no auth headers still produces a valid authorization object`() {
+        val message = AppSyncWebSocketMessage.Start("sub-1", "{}", emptyMap())
+
+        val payload = JsonParser.parseString(message.toJson()).asJsonObject.getAsJsonObject("payload")
+
+        payload.getAsJsonObject("extensions").getAsJsonObject("authorization").size() shouldBe 0
+    }
+
+    @Test
+    fun `stop carries the id being cancelled`() {
+        val json = JsonParser.parseString(AppSyncWebSocketMessage.Stop("sub-7").toJson()).asJsonObject
+
+        json.get("id").asString shouldBe "sub-7"
+        json.get("type").asString shouldBe "stop"
+    }
+
+    // ── Inbound ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `parses connection_ack and its timeout`() {
+        val message = AppSyncWebSocketMessage.parse(
+            """{"type":"connection_ack","payload":{"connectionTimeoutMs":300000}}"""
+        )
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.ConnectionAck>()
+        message.connectionTimeoutMs shouldBe 300_000L
+    }
+
+    @Test
+    fun `connection_ack without a timeout falls back to a default rather than failing`() {
+        val message = AppSyncWebSocketMessage.parse("""{"type":"connection_ack"}""")
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.ConnectionAck>()
+        message.connectionTimeoutMs shouldBe 300_000L
+    }
+
+    @Test
+    fun `parses keep-alive`() {
+        AppSyncWebSocketMessage.parse("""{"type":"ka"}""")
+            .shouldBeInstanceOf<AppSyncWebSocketMessage.KeepAlive>()
+    }
+
+    @Test
+    fun `parses start_ack with its id`() {
+        val message = AppSyncWebSocketMessage.parse("""{"type":"start_ack","id":"sub-1"}""")
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.StartAck>()
+        message.id shouldBe "sub-1"
+    }
+
+    @Test
+    fun `parses data and passes the payload through as raw json`() {
+        // The payload is not deserialized here: only the subscriber knows the response type.
+        val message = AppSyncWebSocketMessage.parse(
+            """{"type":"data","id":"sub-1","payload":{"data":{"onCreateTodo":{"id":"1"}}}}"""
+        )
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.Data>()
+        message.id shouldBe "sub-1"
+        message.payload shouldContain "onCreateTodo"
+    }
+
+    @Test
+    fun `parses complete`() {
+        val message = AppSyncWebSocketMessage.parse("""{"type":"complete","id":"sub-1"}""")
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.Complete>()
+        message.id shouldBe "sub-1"
+    }
+
+    // ── Error shapes ────────────────────────────────────────────────────
+
+    @Test
+    fun `parses connection_error messages from payload errors`() {
+        val message = AppSyncWebSocketMessage.parse(
+            """{"type":"connection_error","payload":{"errors":[{"message":"Unauthorized"}]}}"""
+        )
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.ConnectionError>()
+        message.errors shouldContainExactly listOf("Unauthorized")
+    }
+
+    @Test
+    fun `parses subscription error from a top-level errors array too`() {
+        // AppSync uses both shapes depending on the failure, so both are read.
+        val message = AppSyncWebSocketMessage.parse(
+            """{"type":"error","id":"sub-1","errors":[{"message":"MaxSubscriptionsReachedError"}]}"""
+        )
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.Error>()
+        message.id shouldBe "sub-1"
+        message.errors shouldContainExactly listOf("MaxSubscriptionsReachedError")
+    }
+
+    @Test
+    fun `parses errors given as bare strings`() {
+        val message = AppSyncWebSocketMessage.parse(
+            """{"type":"error","id":"sub-1","payload":{"errors":["something broke"]}}"""
+        )
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.Error>()
+        message.errors shouldContainExactly listOf("something broke")
+    }
+
+    @Test
+    fun `an error with no id is still an Error, since a connection-level error has none`() {
+        val message = AppSyncWebSocketMessage.parse("""{"type":"error","payload":{"errors":[]}}""")
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.Error>()
+        message.id shouldBe null
+    }
+
+    // ── Robustness: nothing may throw ───────────────────────────────────
+
+    @Test
+    fun `an unrecognised type becomes Unknown rather than throwing`() {
+        val message = AppSyncWebSocketMessage.parse("""{"type":"something_new","id":"x"}""")
+
+        message.shouldBeInstanceOf<AppSyncWebSocketMessage.Unknown>()
+        message.type shouldBe "something_new"
+    }
+
+    @Test
+    fun `malformed json becomes Unknown rather than throwing`() {
+        // One bad frame must not take down a shared connection carrying healthy subscriptions.
+        listOf("", "not json", "{", "[]", """{"type":}""").forEach { bad ->
+            AppSyncWebSocketMessage.parse(bad)
+                .shouldBeInstanceOf<AppSyncWebSocketMessage.Unknown>()
+        }
+    }
+
+    @Test
+    fun `a message whose type requires an id but has none becomes Unknown`() {
+        // Without an id these cannot be routed to a subscriber, so they must not masquerade as valid.
+        listOf("start_ack", "data", "complete").forEach { type ->
+            AppSyncWebSocketMessage.parse("""{"type":"$type"}""")
+                .shouldBeInstanceOf<AppSyncWebSocketMessage.Unknown>()
+        }
+    }
+
+    @Test
+    fun `a null type becomes Unknown`() {
+        AppSyncWebSocketMessage.parse("""{"type":null}""")
+            .shouldBeInstanceOf<AppSyncWebSocketMessage.Unknown>()
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketProviderTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketProviderTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Tests [AppSyncWebSocketProvider] — the lazy shared connection.
+ *
+ * The connection count is what these assert. AppSync multiplexes every subscription over one socket,
+ * so opening a second one is a real defect: it wastes a connection and reaches the API's connection
+ * limit sooner. The concurrent case is the one worth having, because a naive
+ * check-then-open has a window where two subscribers both see "no connection" and both open.
+ */
+class AppSyncWebSocketProviderTest {
+
+    private val connectionsOpened = AtomicInteger(0)
+
+    private fun liveSocket(): AppSyncWebSocket = mockk(relaxed = true) {
+        every { isClosed } returns false
+        coEvery { connect() } returns Unit
+    }
+
+    private fun provider(factory: () -> AppSyncWebSocket = { liveSocket() }) = AppSyncWebSocketProvider {
+        connectionsOpened.incrementAndGet()
+        factory()
+    }
+
+    // ── Laziness and sharing ────────────────────────────────────────────
+
+    @Test
+    fun `no connection is opened until one is asked for`() {
+        provider()
+
+        connectionsOpened.get() shouldBe 0
+    }
+
+    @Test
+    fun `existing does not open a connection`() {
+        provider().existing.shouldBeNull()
+
+        connectionsOpened.get() shouldBe 0
+    }
+
+    @Test
+    fun `the first request opens a connection`() = runTest {
+        val provider = provider()
+
+        provider.connection()
+
+        connectionsOpened.get() shouldBe 1
+    }
+
+    @Test
+    fun `a second request reuses the same connection`() = runTest {
+        val provider = provider()
+
+        val first = provider.connection()
+        val second = provider.connection()
+
+        first shouldBe second
+        connectionsOpened.get() shouldBe 1
+    }
+
+    @Test
+    fun `concurrent requests share one connection`() = runTest {
+        // The case a naive check-then-open gets wrong: several subscribers arriving before the first
+        // attempt completes must join it rather than each starting their own. The delay is inside
+        // connect() so the attempt is genuinely in flight while the others arrive.
+        val provider = provider {
+            mockk(relaxed = true) {
+                every { isClosed } returns false
+                coEvery { connect() } coAnswers { delay(50) }
+            }
+        }
+
+        val sockets = (1..8).map { async { provider.connection() } }.awaitAll()
+
+        connectionsOpened.get() shouldBe 1
+        sockets.distinct().size shouldBe 1
+    }
+
+    // ── Failure is not cached ───────────────────────────────────────────
+
+    @Test
+    fun `a failed attempt is not cached, so the next caller retries`() = runTest {
+        var attempts = 0
+        val provider = AppSyncWebSocketProvider {
+            attempts++
+            if (attempts == 1) throw AppSyncConnectionException("refused") else liveSocket()
+        }
+
+        shouldThrow<AppSyncConnectionException> { provider.connection() }
+        provider.connection()
+
+        attempts shouldBe 2
+    }
+
+    @Test
+    fun `a connection failure surfaces as a typed AppSyncException`() = runTest {
+        val provider = AppSyncWebSocketProvider { throw IllegalStateException("boom") }
+
+        shouldThrow<AppSyncException> { provider.connection() }
+            .shouldBeInstanceOf<AppSyncUnknownException>()
+    }
+
+    @Test
+    fun `every caller joined to a failed attempt sees the failure`() = runTest {
+        val provider = AppSyncWebSocketProvider {
+            throw AppSyncConnectionException("refused")
+        }
+
+        val results = (1..4).map {
+            async { runCatching { provider.connection() } }
+        }.awaitAll()
+
+        results.forEach { it.isFailure shouldBe true }
+    }
+
+    // ── Replacing a dead connection ─────────────────────────────────────
+
+    @Test
+    fun `a closed connection is replaced rather than handed out`() = runTest {
+        val closed: AppSyncWebSocket = mockk(relaxed = true) { every { isClosed } returns true }
+        var handedOut = 0
+        val provider = AppSyncWebSocketProvider {
+            handedOut++
+            if (handedOut == 1) closed else liveSocket()
+        }
+
+        val first = provider.connection()
+        val second = provider.connection()
+
+        // This is what lets a client recover from an idle timeout without managing state itself.
+        first shouldBe closed
+        (second === closed) shouldBe false
+        handedOut shouldBe 2
+    }
+
+    @Test
+    fun `existing reports null once the connection has closed`() = runTest {
+        val socket: AppSyncWebSocket = mockk(relaxed = true) { every { isClosed } returns true }
+        val provider = AppSyncWebSocketProvider { socket }
+
+        provider.connection()
+
+        provider.existing.shouldBeNull()
+    }
+
+    // ── close() ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `close disconnects the shared socket`() = runTest {
+        val socket = liveSocket()
+        val provider = AppSyncWebSocketProvider { socket }
+        provider.connection()
+
+        provider.close()
+
+        coVerify(exactly = 1) { socket.disconnect(null) }
+    }
+
+    @Test
+    fun `close passes the cause through`() = runTest {
+        val socket = liveSocket()
+        val cause = AppSyncTimeoutException("idle")
+        val provider = AppSyncWebSocketProvider { socket }
+        provider.connection()
+
+        provider.close(cause)
+
+        coVerify(exactly = 1) { socket.disconnect(cause) }
+    }
+
+    @Test
+    fun `close on a provider that never connected does nothing`() = runTest {
+        provider().close()
+
+        connectionsOpened.get() shouldBe 0
+    }
+
+    @Test
+    fun `a request after close opens a fresh connection`() = runTest {
+        val provider = provider()
+        provider.connection()
+
+        provider.close()
+        provider.connection()
+
+        connectionsOpened.get() shouldBe 2
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketProviderTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketProviderTest.kt
@@ -23,9 +23,13 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -43,7 +47,7 @@ class AppSyncWebSocketProviderTest {
 
     private fun liveSocket(): AppSyncWebSocket = mockk(relaxed = true) {
         every { isClosed } returns false
-        coEvery { connect() } returns Unit
+        coEvery { connect(any()) } returns Unit
     }
 
     private fun provider(factory: () -> AppSyncWebSocket = { liveSocket() }) = AppSyncWebSocketProvider {
@@ -95,7 +99,7 @@ class AppSyncWebSocketProviderTest {
         val provider = provider {
             mockk(relaxed = true) {
                 every { isClosed } returns false
-                coEvery { connect() } coAnswers { delay(50) }
+                coEvery { connect(any()) } coAnswers { delay(50) }
             }
         }
 
@@ -105,12 +109,37 @@ class AppSyncWebSocketProviderTest {
         sockets.distinct().size shouldBe 1
     }
 
+    @Test
+    fun `cancelling the first caller does not cancel the attempt others joined`() = runTest {
+        // The attempt belongs to the provider, not to whichever caller happened to arrive first. If it
+        // were scoped to the caller, that caller going away — a screen closing, a take(1) completing —
+        // would cancel the connection out from under everyone waiting on it.
+        val gate = CompletableDeferred<Unit>()
+        val provider = provider {
+            mockk(relaxed = true) {
+                every { isClosed } returns false
+                coEvery { connect(any()) } coAnswers { gate.await() }
+            }
+        }
+
+        val first = launch { provider.connection() }
+        val second = async { provider.connection() }
+        runCurrent()
+
+        first.cancel()
+        gate.complete(Unit)
+
+        // The joiner still gets its connection.
+        second.await()
+        connectionsOpened.get() shouldBe 1
+    }
+
     // ── Failure is not cached ───────────────────────────────────────────
 
     @Test
     fun `a failed attempt is not cached, so the next caller retries`() = runTest {
         var attempts = 0
-        val provider = AppSyncWebSocketProvider {
+        val provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) {
             attempts++
             if (attempts == 1) throw AppSyncConnectionException("refused") else liveSocket()
         }
@@ -123,7 +152,7 @@ class AppSyncWebSocketProviderTest {
 
     @Test
     fun `a connection failure surfaces as a typed AppSyncException`() = runTest {
-        val provider = AppSyncWebSocketProvider { throw IllegalStateException("boom") }
+        val provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) { throw IllegalStateException("boom") }
 
         shouldThrow<AppSyncException> { provider.connection() }
             .shouldBeInstanceOf<AppSyncUnknownException>()
@@ -131,7 +160,7 @@ class AppSyncWebSocketProviderTest {
 
     @Test
     fun `every caller joined to a failed attempt sees the failure`() = runTest {
-        val provider = AppSyncWebSocketProvider {
+        val provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) {
             throw AppSyncConnectionException("refused")
         }
 
@@ -148,7 +177,7 @@ class AppSyncWebSocketProviderTest {
     fun `a closed connection is replaced rather than handed out`() = runTest {
         val closed: AppSyncWebSocket = mockk(relaxed = true) { every { isClosed } returns true }
         var handedOut = 0
-        val provider = AppSyncWebSocketProvider {
+        val provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) {
             handedOut++
             if (handedOut == 1) closed else liveSocket()
         }
@@ -165,7 +194,7 @@ class AppSyncWebSocketProviderTest {
     @Test
     fun `existing reports null once the connection has closed`() = runTest {
         val socket: AppSyncWebSocket = mockk(relaxed = true) { every { isClosed } returns true }
-        val provider = AppSyncWebSocketProvider { socket }
+        val provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) { socket }
 
         provider.connection()
 
@@ -177,7 +206,7 @@ class AppSyncWebSocketProviderTest {
     @Test
     fun `close disconnects the shared socket`() = runTest {
         val socket = liveSocket()
-        val provider = AppSyncWebSocketProvider { socket }
+        val provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) { socket }
         provider.connection()
 
         provider.close()
@@ -189,7 +218,7 @@ class AppSyncWebSocketProviderTest {
     fun `close passes the cause through`() = runTest {
         val socket = liveSocket()
         val cause = AppSyncTimeoutException("idle")
-        val provider = AppSyncWebSocketProvider { socket }
+        val provider = AppSyncWebSocketProvider(UnconfinedTestDispatcher()) { socket }
         provider.connection()
 
         provider.close(cause)
@@ -205,13 +234,15 @@ class AppSyncWebSocketProviderTest {
     }
 
     @Test
-    fun `a request after close opens a fresh connection`() = runTest {
+    fun `close ends the provider, since the client that owns it cannot be reused`() = runTest {
+        // close() cancels the scope the shared attempt runs in, so the provider is single-use. That
+        // matches the client's own contract, which states it cannot be reused after closing.
         val provider = provider()
         provider.connection()
 
         provider.close()
-        provider.connection()
 
-        connectionsOpened.get() shouldBe 2
+        shouldThrow<Exception> { provider.connection() }
+        connectionsOpened.get() shouldBe 1
     }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketTest.kt
@@ -23,6 +23,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -129,6 +130,23 @@ class AppSyncWebSocketTest {
         scriptServer(KEEP_ALIVE, ACK)
 
         webSocket().connect()
+    }
+
+    @Test
+    fun `a silent server times the handshake out rather than hanging`() = runTest {
+        // OkHttp leaves an upgraded WebSocket with no read timeout, so without this bound a server that
+        // completes the 101 and then says nothing would suspend connect() forever — and every later
+        // subscriber would join the same hung attempt.
+        every { client.newWebSocket(any(), any()) } answers {
+            secondArg<WebSocketListener>().onOpen(rawSocket, mockk(relaxed = true))
+            rawSocket
+        }
+
+        val error = shouldThrow<AppSyncTimeoutException> {
+            webSocket().connect(handshakeTimeout = 5.seconds)
+        }
+
+        error.message shouldContain "5s"
     }
 
     // ── Handshake failures ──────────────────────────────────────────────

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncWebSocketTest.kt
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import app.cash.turbine.test
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests [AppSyncWebSocket] by driving its [WebSocketListener] callbacks directly against a mocked
+ * OkHttp socket.
+ *
+ * This is the pattern the rest of the repo uses for WebSocket unit tests — `EventsWebSocketTest` mocks
+ * `OkHttpClient` and `WebSocket` outright, and `LivenessWebSocketTest`'s server-side listener is
+ * entirely empty because it invokes the client listener itself. Neither relies on MockWebServer
+ * delivering server-to-client frames; I tried that first and the frames never arrive (the upgrade
+ * succeeds with a 101, then the connection resets). Real-socket behaviour is covered by instrumented
+ * tests instead.
+ *
+ * The handshake ordering is what these mostly pin. `connection_ack` is delivered *synchronously* from
+ * inside `newWebSocket`, i.e. before the caller reaches its `await` — a harsher ordering than a real
+ * server produces, and exactly the race that loses the ack if collection has not already started.
+ *
+ * Robolectric is required because the handshake sets a User-Agent, and building one reads
+ * `android.os.Build`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppSyncWebSocketTest {
+
+    private val client = mockk<OkHttpClient>()
+    private val rawSocket = mockk<WebSocket>(relaxed = true)
+    private val requestSlot = slot<Request>()
+
+    /**
+     * Makes `newWebSocket` play a scripted exchange the moment the socket is created: `onOpen`,
+     * then each frame in [frames].
+     */
+    private fun scriptServer(vararg frames: String) {
+        every { client.newWebSocket(capture(requestSlot), any()) } answers {
+            val listener = secondArg<WebSocketListener>()
+            listener.onOpen(rawSocket, mockk(relaxed = true))
+            frames.forEach { listener.onMessage(rawSocket, it) }
+            rawSocket
+        }
+    }
+
+    private fun webSocket(authorizer: AppSyncClientAuthorizer = AppSyncClientAuthorizer.ApiKey("da2-fakekey")) =
+        AppSyncWebSocket(
+            realtimeUrl = "wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+            httpEndpoint = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql",
+            authorizer = authorizer,
+            decorator = AppSyncRequestDecorator("us-east-1"),
+            client = client
+        )
+
+    // ── Handshake ───────────────────────────────────────────────────────
+
+    @Test
+    fun `connect completes once the service acknowledges`() = runTest {
+        scriptServer(ACK)
+
+        val socket = webSocket()
+        socket.connect()
+
+        socket.isClosed shouldBe false
+    }
+
+    @Test
+    fun `an ack delivered before the caller awaits is not missed`() = runTest {
+        // The ordering bug this guards: the shared flow has no replay, so if collection has not begun
+        // before the socket opens, a synchronous ack is lost and connect() hangs forever.
+        scriptServer(ACK)
+
+        webSocket().connect()
+    }
+
+    @Test
+    fun `connection_init is sent unprompted on open`() = runTest {
+        scriptServer(ACK)
+
+        webSocket().connect()
+
+        verify { rawSocket.send(match<String> { it.contains("connection_init") }) }
+    }
+
+    @Test
+    fun `the upgrade request carries the subprotocol, user agent and auth headers`() = runTest {
+        scriptServer(ACK)
+
+        webSocket().connect()
+
+        val request = requestSlot.captured
+        request.header("Sec-WebSocket-Protocol") shouldBe "graphql-ws"
+        request.header("x-api-key") shouldBe "da2-fakekey"
+        request.header("User-Agent").isNullOrBlank() shouldBe false
+        request.url.toString() shouldContain "appsync-realtime-api"
+    }
+
+    @Test
+    fun `a keep-alive before the ack does not satisfy the handshake`() = runTest {
+        // A ka proves liveness but not readiness; only the ack means the connection can carry
+        // subscriptions.
+        scriptServer(KEEP_ALIVE, ACK)
+
+        webSocket().connect()
+    }
+
+    // ── Handshake failures ──────────────────────────────────────────────
+
+    @Test
+    fun `a connection_error fails the connect with the service reason`() = runTest {
+        scriptServer("""{"type":"connection_error","payload":{"errors":[{"message":"Unauthorized"}]}}""")
+
+        val error = shouldThrow<AppSyncConnectionException> { webSocket().connect() }
+
+        error.message shouldContain "Unauthorized"
+    }
+
+    @Test
+    fun `a connection_error with no reason still fails cleanly`() = runTest {
+        scriptServer("""{"type":"connection_error"}""")
+
+        shouldThrow<AppSyncConnectionException> { webSocket().connect() }
+            .message shouldContain "no reason given"
+    }
+
+    @Test
+    fun `a socket closing during the handshake fails the connect rather than hanging`() = runTest {
+        every { client.newWebSocket(any(), any()) } answers {
+            val listener = secondArg<WebSocketListener>()
+            listener.onOpen(rawSocket, mockk(relaxed = true))
+            listener.onClosed(rawSocket, 1000, "server went away")
+            rawSocket
+        }
+
+        shouldThrow<AppSyncConnectionException> { webSocket().connect() }
+    }
+
+    @Test
+    fun `a socket failure during the handshake surfaces the cause`() = runTest {
+        val cause = java.io.IOException("connection reset")
+        every { client.newWebSocket(any(), any()) } answers {
+            val listener = secondArg<WebSocketListener>()
+            listener.onFailure(rawSocket, cause, null)
+            rawSocket
+        }
+
+        val error = shouldThrow<AppSyncConnectionException> { webSocket().connect() }
+
+        error.cause shouldBe cause
+    }
+
+    @Test
+    fun `a failing authorizer fails the connect before any socket is opened`() = runTest {
+        shouldThrow<AppSyncTokenFetchException> {
+            webSocket(AppSyncClientAuthorizer.UserPools { error("session expired") }).connect()
+        }
+
+        verify(exactly = 0) { client.newWebSocket(any(), any()) }
+    }
+
+    // ── Message routing ─────────────────────────────────────────────────
+
+    @Test
+    fun `inbound frames reach the messages flow`() = runTest {
+        scriptServer(ACK)
+        val socket = webSocket()
+        socket.connect()
+
+        // Turbine subscribes before the block runs. A plain `async { first { } }` does not start until
+        // a suspension point, so the frame below would be emitted into a flow with no subscriber and
+        // lost — the same no-replay race the handshake has to defend against.
+        socket.messages.test {
+            socket.onMessage(rawSocket, """{"type":"data","id":"sub-1","payload":{"data":{"x":1}}}""")
+
+            val data = awaitItem().shouldBeInstanceOf<AppSyncWebSocketMessage.Data>()
+            data.id shouldBe "sub-1"
+            data.payload shouldContain "\"x\""
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a malformed frame becomes Unknown and leaves the connection open`() = runTest {
+        scriptServer(ACK)
+        val socket = webSocket()
+        socket.connect()
+
+        socket.messages.test {
+            socket.onMessage(rawSocket, "{not json")
+
+            awaitItem().shouldBeInstanceOf<AppSyncWebSocketMessage.Unknown>()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // The point: one bad frame must not take down the subscriptions sharing this socket.
+        socket.isClosed shouldBe false
+    }
+
+    @Test
+    fun `send serializes the message onto the socket`() = runTest {
+        scriptServer(ACK)
+        val socket = webSocket()
+        socket.connect()
+
+        socket.send(AppSyncWebSocketMessage.Stop("sub-9"))
+
+        verify { rawSocket.send(match<String> { it.contains("\"stop\"") && it.contains("sub-9") }) }
+    }
+
+    @Test
+    fun `send returns false before the socket is open`() {
+        webSocket().send(AppSyncWebSocketMessage.Stop("sub-1")) shouldBe false
+    }
+
+    // ── Closure ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `a failure after connect closes the socket and emits Closed with the cause`() = runTest {
+        scriptServer(ACK)
+        val socket = webSocket()
+        socket.connect()
+
+        socket.messages.test {
+            socket.onFailure(rawSocket, java.io.IOException("dropped"), null)
+
+            val message = awaitItem().shouldBeInstanceOf<AppSyncWebSocketMessage.Closed>()
+            message.cause.shouldBeInstanceOf<AppSyncConnectionException>()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        socket.isClosed shouldBe true
+    }
+
+    @Test
+    fun `a clean close emits Closed with no cause`() = runTest {
+        scriptServer(ACK)
+        val socket = webSocket()
+        socket.connect()
+
+        socket.messages.test {
+            socket.onClosed(rawSocket, 1000, "done")
+
+            awaitItem().shouldBeInstanceOf<AppSyncWebSocketMessage.Closed>().cause shouldBe null
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `closure is reported once, not per callback`() = runTest {
+        // OkHttp can deliver onFailure and onClosed for the same death; subscribers must not see two.
+        scriptServer(ACK)
+        val socket = webSocket()
+        socket.connect()
+
+        socket.onClosed(rawSocket, 1000, "first")
+        socket.onClosed(rawSocket, 1000, "second")
+        socket.onFailure(rawSocket, java.io.IOException("also this"), null)
+
+        socket.isClosed shouldBe true
+    }
+
+    @Test
+    fun `disconnect closes the socket`() = runTest {
+        scriptServer(ACK)
+        // close() on the mock does not call back, so the listener is driven directly, mirroring how
+        // LivenessWebSocketTest does it.
+        val socket = webSocket()
+        socket.connect()
+        every { rawSocket.close(any(), any()) } answers {
+            socket.onClosed(rawSocket, firstArg(), secondArg() ?: "")
+            true
+        }
+
+        socket.disconnect()
+
+        socket.isClosed shouldBe true
+        verify { rawSocket.close(1000, any()) }
+    }
+
+    @Test
+    fun `disconnect on a socket that never connected returns rather than hanging`() = runTest {
+        webSocket().disconnect()
+    }
+
+    private companion object {
+        const val ACK = """{"type":"connection_ack","payload":{"connectionTimeoutMs":300000}}"""
+        const val KEEP_ALIVE = """{"type":"ka"}"""
+    }
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

n/a

*Description of changes:*

Implements `subscribe()`, the connection-state flow and `close()`. Every remaining `TODO()` in the module is gone, so the client surface is complete.

**Four commits, reviewable in order** — each is self-contained:

| Commit | What |
|---|---|
| `9947129` | Subscriptions over a shared WebSocket |
| `dcc2ac0` | Retry a subscription with the next eligible auth mode |
| `ff132cc` | Send the owner claim for owner-restricted subscriptions |
| `d030ff4` | Report the API's concurrent subscription limit |

The only public API change across all four is `AppSyncLimitExceededException` (+5 lines in the dump). Everything else is `internal`, and `subscribe()` / `events` / `close()` already existed as signatures.

---

### 1. Subscriptions over a shared WebSocket

The plugin's `SubscriptionEndpoint` is 720 lines of Java built around locks, latches and a callback registry. This exposes a single `messages` flow instead, which is what lets a subscription be a **filter keyed by id** rather than a registry entry.

Two details are load-bearing rather than stylistic:

- **`connect()` starts collecting before opening the socket.** The flow has no replay, so open-then-listen loses a fast `connection_ack` and waits forever. A test delivers the ack *synchronously* from inside `newWebSocket` — harsher than a real server — to pin exactly that. `subscribe()` sends `start` from `onStart` for the same reason.
- **`onFailure` also closes out**, because OkHttp does not call `onClosed` after a failure. Without it a dead socket never reports closure and every subscriber hangs.

`AppSyncWebSocketProvider` opens on first use and shares one connection, since AppSync multiplexes every subscription over one socket. A mutex plus a shared `Deferred` means concurrent first-subscribers join a single attempt; a naive check-then-open has a window where each sees "no connection" and each opens one. A failed attempt is not cached and a closed connection is replaced, which is what lets a client recover from an idle timeout without the caller managing connection state.

**Terminality is asymmetric and easy to implement backwards, so each row has a test:**

| | Behaviour |
|---|---|
| Not terminal | GraphQL errors carried *inside* a data message — delivered on the response, since the service considered the message deliverable |
| Not terminal | A data message that fails to deserialize — dropped, stream continues. Losing one message beats ending a working subscription |
| Terminal | An `error` frame for this id; an `error` with **no** id (connection-level); `connection_error`; a socket close **with** a cause |
| Normal completion | A `complete` frame; a socket close with **no** cause — which is what makes `close()` graceful rather than an error for every subscriber |

Also in this commit: `realtimeUrl()` on the endpoint parser, deliberately separate from `parse()`. `parse()` needs a region in the host so it cannot handle a custom domain at all — but a custom-domain API is configured with an explicit region and must still be able to subscribe. A standard host swaps the `appsync-api` label; a custom one appends `/realtime` to the path.

### 2. Multi-auth retry

Brings subscriptions in line with the HTTP path. Registration is retried under a fresh id rather than the whole subscription: the connection is already established, so only `start` needs replaying.

Two triggers, matching the plugin: an `error` frame carrying an unauthorized error type, **and** a `data` message carrying one — AppSync can reject an identity in a data message rather than an error frame, and that response was previously handed straight to the consumer.

A mode whose credentials cannot be obtained is skipped rather than failing the subscription. Non-auth errors stay terminal even when modes remain, since retrying a validation failure would fail identically and hide the reason.

**Retry only engages for a request carrying a model schema.** A raw request has no `@auth` rules to inspect, so it resolves to the default mode alone and there is nothing to fall back to — same as the HTTP path.

This also fixed a real defect: with a *single* candidate mode the code reported `AppSyncProviderNotConfiguredException` — "no auth mode was available" — for what was actually the service rejecting the one identity you have. It now reports what the service said.

### 3. Owner claim injection

A model whose `@auth` rules restrict reads to an owner produces a subscription AppSync expects to carry that owner as a variable. The value comes from a claim in the caller's token, so only the client can supply it, and without it the service rejects the subscription. Subscriptions only — AppSync resolves the owner server-side for queries and mutations.

The rule logic is worth reviewing because getting it wrong is silent **in both directions**: injecting unnecessarily narrows what a subscriber receives, while failing to inject makes the subscription fail. Each branch is tested — a public-read rule excuses the owner but only when the subscription actually uses the API key; group membership takes precedence, because a user who can already read via a group would receive less with an owner filter; more than one owner read rule is refused rather than guessed at, since AppSync generates a variable per rule.

This gives `AppSyncTokenParsingException` and `AppSyncAuthorizationClaimException` their first throw sites, and they are deliberately distinct: an unreadable token is a parsing failure, a readable token missing the required claim is a claim failure. Conflating them points a caller at the wrong problem.

Claims are read **without verifying the signature** — the token is read for its content rather than trusted, since the claim populates a variable AppSync then authorizes for itself. Decoding uses okio rather than `android.util.Base64`, so this needs no Android runtime to exercise.

### 4. Concurrent subscription limit

Recognises `MaxSubscriptionsReachedError` as `AppSyncLimitExceededException`, reintroducing the type that #3412 removed for having no throw site. It has one now, and its recovery suggestion says to close existing subscriptions, because neither re-subscribing nor different credentials will help.

Checked **before** the auth retry — the limit belongs to the API, not the identity, so another auth mode would consume attempts and fail identically. Terminal, with a test for a frame carrying both a limit error and an unauthorized error.

**This commit also fixes error classification more broadly.** Errors on the wire carry their type in two places depending on the frame: a subscription `error` frame has a GraphQL response shape, nesting it under `extensions`, while connection-level frames put it directly on the error object. Only `extensions` was being read, so a top-level `errorType` was silently dropped — which affected the unauthorized detection from commit 2, not just this. Both locations are now read, with a test for each.

`LimitExceededError` is a sibling meaning a *request-rate* limit rather than a subscription count. It needs different recovery advice, so it is deliberately not folded in.

*How did you test these changes?*

**199 unit tests, all passing.** Also green with `--rerun-tasks`: `apiCheck`, `ktlintCheck`, `compileReleaseKotlin`, `licensee`.

| Class | Tests |
|---|---|
| `AppSyncSubscriberTest` | 29 |
| `AmplifyAppSyncClientTest` | 25 |
| `AppSyncEndpointParserTest` | 21 |
| `AppSyncWebSocketMessageTest` | 20 |
| `AppSyncWebSocketTest` | 19 |
| `AppSyncExceptionTest` | 16 |
| `AppSyncResponseDeserializerTest` | 15 |
| `AppSyncClaimInjectorTest` | 14 |
| `AppSyncRequestDecoratorTest` | 14 |
| `AppSyncWebSocketProviderTest` | 14 |
| `AppSyncAuthModeResolverTest` | 12 |

**On test approach, since it is unusual:** WebSocket behaviour is tested by driving the `WebSocketListener` callbacks directly against a mocked OkHttp socket, not through `MockWebServer`. That matches the rest of the repo — `EventsWebSocketTest` mocks `OkHttpClient` and `WebSocket` outright, and `LivenessWebSocketTest`'s server-side listener is *entirely empty* because it invokes the client listener itself. I tried `MockWebServer`'s `withWebSocketUpgrade` first and server-to-client frames never arrive: the upgrade succeeds with a 101, then the connection resets.

### One known gap

**No instrumented coverage of the real socket**, for the reason above — it needs a device or emulator test. Everything else in the protocol and flow layers is covered by unit tests.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests — needed for real-socket coverage; see the known gap above
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
