### PR TITLE
fix(api): keep org.json under R8 to prevent subscription connection acknowledgement timeout

### DIFF
--- a/aws-api/build.gradle.kts
+++ b/aws-api/build.gradle.kts
@@ -22,6 +22,9 @@ apply(from = rootProject.file("configuration/checkstyle.gradle"))
 
 android {
     namespace = "com.amplifyframework.api.aws"
+    defaultConfig {
+        consumerProguardFiles += file("consumer-rules.pro")
+    }
 }
 
 dependencies {

--- a/aws-api/consumer-rules.pro
+++ b/aws-api/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Keep org.json; R8 can obfuscate a dependency-bundled copy in release builds and break connection_ack parsing.
+-keep class org.json.** { *; }


### PR DESCRIPTION
## Description

On R8 release builds, GraphQL subscriptions fail with "Timed out waiting for connection acknowledgement". Amplify reads the AppSync `connection_ack` using `org.json`. When another dependency bundles its own `org.json` (Google IMA via mux-stats-sdk-media3), R8 renames those classes, so the ack is never read and the connection times out. Debug builds work because R8 is off. This ships a consumer ProGuard rule in `aws-api` that keeps `org.json`, so R8 leaves it alone. Same approach as `aws-auth-cognito`.

## Testing

- Reproduced e2e on an emulator: built an app with Amplify subscriptions + mux/IMA against a live AppSync backend. The minified release build hit the 30s timeout; the debug build worked.
- With the fix, the release build connected in ~2s and received subscription events.
- Confirmed the rule ships in `aws-api-release.aar` and reaches R8 in the app; `apiCheck`/`ktlintCheck` clean.
- No unit test: R8 bugs can't be reproduced in a JVM unit test, so the e2e repro is the proof.

Refs #2793
