### PR TITLE
fix(api): classify rate limiting, and log what the AppSync client drops silently

### DIFF
--- a/aws-appsync/api/aws-appsync.api
+++ b/aws-appsync/api/aws-appsync.api
@@ -164,11 +164,6 @@ public final class com/amazonaws/appsync/AppSyncInvalidConfigException : com/ama
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/amazonaws/appsync/AppSyncLimitExceededException : com/amazonaws/appsync/AppSyncSubscriptionException {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
 public final class com/amazonaws/appsync/AppSyncNetworkException : com/amazonaws/appsync/AppSyncException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -202,6 +197,11 @@ public final class com/amazonaws/appsync/AppSyncSigningException : com/amazonaws
 public abstract class com/amazonaws/appsync/AppSyncSubscriptionException : com/amazonaws/appsync/AppSyncException {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/amazonaws/appsync/AppSyncSubscriptionLimitExceededException : com/amazonaws/appsync/AppSyncSubscriptionException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/amazonaws/appsync/AppSyncTimeoutException : com/amazonaws/appsync/AppSyncSubscriptionException {

--- a/aws-appsync/api/aws-appsync.api
+++ b/aws-appsync/api/aws-appsync.api
@@ -179,6 +179,11 @@ public final class com/amazonaws/appsync/AppSyncProviderNotConfiguredException :
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class com/amazonaws/appsync/AppSyncRateLimitExceededException : com/amazonaws/appsync/AppSyncException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public abstract class com/amazonaws/appsync/AppSyncRequestException : com/amazonaws/appsync/AppSyncException {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/aws-appsync/build.gradle.kts
+++ b/aws-appsync/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
     testImplementation(libs.bundles.test.unit)
     testImplementation(libs.bundles.test.unit.android)
+    testImplementation(libs.test.kotlin.reflection)
     testImplementation(libs.test.mockwebserver)
     testImplementation(project(":testutils"))
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
@@ -21,8 +21,9 @@ import com.amplifyframework.datastore.appsync.AppSyncExtensions
  * Recognises the errors that mean "this identity was rejected", as opposed to errors that would recur
  * with any identity. Only the former is worth retrying with a different auth mode.
  *
- * Both the HTTP and WebSocket paths need this, and both defer the classification to
- * [AppSyncExtensions] rather than maintaining a list of error-type strings here.
+ * Both the HTTP and WebSocket paths need this. Authorization failures defer to [AppSyncExtensions],
+ * which already knows which types mean "rejected identity". The two limit checks below cannot: its
+ * error-type enum does not model either of them, so they match the wire string directly.
  */
 
 /**
@@ -61,6 +62,9 @@ internal fun List<AppSyncWebSocketMessage.WireError>.hasSubscriptionLimitError()
  *
  * A cap on how fast requests may arrive, not on how many subscriptions may be open, so the remedy is to
  * back off rather than to release anything.
+ *
+ * Matched against the wire string for the same reason as [hasSubscriptionLimitError]: [AppSyncExtensions]
+ * does not model this error type either.
  */
 internal fun List<AppSyncWebSocketMessage.WireError>.hasRateLimitError(): Boolean =
     any { it.errorType == LIMIT_EXCEEDED }
@@ -83,6 +87,6 @@ internal fun List<AppSyncWebSocketMessage.WireError>.toGraphQLErrors(): List<Gra
         it.message,
         null,
         null,
-        it.errorType?.let { type -> mapOf("errorType" to type) } ?: emptyMap()
+        it.errorType?.let { type -> mapOf(ERROR_TYPE_KEY to type) } ?: emptyMap()
     )
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncAuthErrors.kt
@@ -50,13 +50,28 @@ internal fun List<AppSyncWebSocketMessage.WireError>.hasUnauthorizedError(): Boo
  * Checked against the wire string directly rather than through [AppSyncExtensions], whose error-type
  * enum does not model this case.
  *
- * TODO: `LimitExceededError` is a sibling meaning a request-rate limit rather than a subscription
- *  count. It needs different recovery advice, so it is not folded in here.
+ * Deliberately narrower than [hasRateLimitError]: the two limits are released by different actions, so
+ * they must not be folded together.
  */
 internal fun List<AppSyncWebSocketMessage.WireError>.hasSubscriptionLimitError(): Boolean =
     any { it.errorType == MAX_SUBSCRIPTIONS_REACHED }
 
+/**
+ * Whether any of these errors says the API's request rate limit was exceeded.
+ *
+ * A cap on how fast requests may arrive, not on how many subscriptions may be open, so the remedy is to
+ * back off rather than to release anything.
+ */
+internal fun List<AppSyncWebSocketMessage.WireError>.hasRateLimitError(): Boolean =
+    any { it.errorType == LIMIT_EXCEEDED }
+
+/** Whether any error on this response says the API's request rate limit was exceeded. */
+internal fun GraphQLResponse<*>.hasRateLimitError(): Boolean =
+    errors.any { it.extensions?.get(ERROR_TYPE_KEY) == LIMIT_EXCEEDED }
+
 private const val MAX_SUBSCRIPTIONS_REACHED = "MaxSubscriptionsReachedError"
+private const val LIMIT_EXCEEDED = "LimitExceededError"
+private const val ERROR_TYPE_KEY = "errorType"
 
 /**
  * Converts wire errors into the response type callers already handle, so an exception carrying them can

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
@@ -283,6 +283,22 @@ class AppSyncValidationException(
 
 // ── Ungrouped leaves ────────────────────────────────────────────────────
 
+/**
+ * The API's request rate limit was exceeded.
+ *
+ * Ungrouped for the same reason [AppSyncNetworkException] is: nothing about the request is wrong and
+ * no credential will change the outcome. The same request is likely to succeed once the rate falls.
+ *
+ * Distinct from [AppSyncLimitExceededException], which is the cap on how many subscriptions may be
+ * open at once — that one is released by closing a subscription, this one by slowing down.
+ */
+@ExperimentalAmplifyApi
+class AppSyncRateLimitExceededException(
+    message: String,
+    recoverySuggestion: String = "Retry with exponential backoff, and reduce the rate of requests.",
+    cause: Throwable? = null
+) : AppSyncException(message, recoverySuggestion, cause)
+
 /** The request could not reach the service. */
 @ExperimentalAmplifyApi
 class AppSyncNetworkException(

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncException.kt
@@ -39,7 +39,8 @@ import java.io.IOException
  *
  * The groups are [AppSyncAuthException], [AppSyncConfigurationException],
  * [AppSyncResponseException], [AppSyncSubscriptionException] and [AppSyncRequestException].
- * [AppSyncNetworkException] and [AppSyncUnknownException] are leaves directly under this base.
+ * [AppSyncNetworkException], [AppSyncRateLimitExceededException] and [AppSyncUnknownException] are
+ * leaves directly under this base.
  *
  * @param message Error message describing what went wrong
  * @param recoverySuggestion Suggested action to resolve the error
@@ -257,7 +258,7 @@ class AppSyncTimeoutException(
  * something already open has to be released first.
  */
 @ExperimentalAmplifyApi
-class AppSyncLimitExceededException(
+class AppSyncSubscriptionLimitExceededException(
     message: String,
     recoverySuggestion: String = "Close subscriptions that are no longer needed before opening more.",
     cause: Throwable? = null
@@ -289,8 +290,8 @@ class AppSyncValidationException(
  * Ungrouped for the same reason [AppSyncNetworkException] is: nothing about the request is wrong and
  * no credential will change the outcome. The same request is likely to succeed once the rate falls.
  *
- * Distinct from [AppSyncLimitExceededException], which is the cap on how many subscriptions may be
- * open at once — that one is released by closing a subscription, this one by slowing down.
+ * Only raised for a rejected request. A throttle reported on a successful response is delivered as an
+ * error on that response, as any other GraphQL error is.
  */
 @ExperimentalAmplifyApi
 class AppSyncRateLimitExceededException(

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -189,6 +189,15 @@ internal class AppSyncHttpTransport(
         // rather than having to recognise a status code or an error string. Either signal is enough:
         // AppSync answers a rejected identity with a 401, and a rejected operation with an
         // Unauthorized error type that can arrive under any 4xx.
+        // A throttle is not a defect in the request, so it must not arrive as one — the advice to check
+        // the document and variables would send a caller to correct something that is already correct.
+        if (response.code == HTTP_TOO_MANY_REQUESTS || parsed?.hasRateLimitError() == true) {
+            return AppSyncRateLimitExceededException(
+                message = "The request was throttled (HTTP status ${response.code})" +
+                    (errors?.joinToString("; ") { it.message }?.let { ": $it" } ?: ".")
+            )
+        }
+
         if (response.code == HTTP_UNAUTHORIZED || parsed?.hasUnauthorizedError() == true) {
             return AppSyncUnauthorizedException(
                 message = "The request was not authorized (HTTP status ${response.code})" +
@@ -244,6 +253,7 @@ internal class AppSyncHttpTransport(
         const val USER_AGENT_HEADER = "User-Agent"
         val CLIENT_ERROR_CODES = 400..499
         const val HTTP_UNAUTHORIZED = 401
+        const val HTTP_TOO_MANY_REQUESTS = 429
         const val SERVER_ERROR_MIN = 500
 
         // Internal error, bad gateway, service unavailable and gateway timeout. Each can clear without

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -185,10 +185,6 @@ internal class AppSyncHttpTransport(
         val parsed = runCatching { AppSyncResponseDeserializer.deserialize(request, body) }.getOrNull()
         val errors = parsed?.errors?.takeIf { it.isNotEmpty() }
 
-        // Reported as an auth failure so a caller can match the whole category to re-authenticate,
-        // rather than having to recognise a status code or an error string. Either signal is enough:
-        // AppSync answers a rejected identity with a 401, and a rejected operation with an
-        // Unauthorized error type that can arrive under any 4xx.
         // A throttle is not a defect in the request, so it must not arrive as one — the advice to check
         // the document and variables would send a caller to correct something that is already correct.
         if (response.code == HTTP_TOO_MANY_REQUESTS || parsed?.hasRateLimitError() == true) {
@@ -198,6 +194,10 @@ internal class AppSyncHttpTransport(
             )
         }
 
+        // Reported as an auth failure so a caller can match the whole category to re-authenticate,
+        // rather than having to recognise a status code or an error string. Either signal is enough:
+        // AppSync answers a rejected identity with a 401, and a rejected operation with an
+        // Unauthorized error type that can arrive under any 4xx.
         if (response.code == HTTP_UNAUTHORIZED || parsed?.hasUnauthorizedError() == true) {
             return AppSyncUnauthorizedException(
                 message = "The request was not authorized (HTTP status ${response.code})" +

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -237,17 +237,17 @@ internal class AppSyncSubscriber(
             if (message.id == registration.id) {
                 // Deserialization failure is deliberately swallowed: it is non-terminal, so one
                 // unreadable message must not end a healthy subscription.
-                val failure = runCatching {
+                val deserialization = runCatching {
                     AppSyncResponseDeserializer.deserialize(request, message.payload)
                 }
-                val response = failure.getOrNull()
+                val response = deserialization.getOrNull()
 
                 when {
                     response == null -> {
                         // Logged because it is the only trace this message existed: the subscription
                         // continues and the consumer is told nothing, so without this a message lost to
                         // a schema mismatch looks exactly like one the service never sent.
-                        logger.warn(failure.exceptionOrNull()) {
+                        logger.warn(deserialization.exceptionOrNull()) {
                             "Dropping a subscription message that could not be deserialized."
                         }
                         true
@@ -277,7 +277,7 @@ internal class AppSyncSubscriber(
                 when {
                     // Checked before the auth retry: the limit belongs to the API, not the identity, so
                     // trying another auth mode would consume attempts and fail the same way.
-                    message.errors.hasSubscriptionLimitError() -> throw AppSyncLimitExceededException(
+                    message.errors.hasSubscriptionLimitError() -> throw AppSyncSubscriptionLimitExceededException(
                         message = "The API's concurrent subscription limit was reached: " +
                             message.errors.joinToString("; ") { it.message }.ifEmpty { "no reason given" }
                     )
@@ -322,16 +322,11 @@ internal class AppSyncSubscriber(
         // subscription streams normally rather than throwing.
         is AppSyncWebSocketMessage.Closed -> message.cause?.let { throw it } ?: false
 
-        // Expected traffic that this subscription has nothing to do.
+        // Expected traffic that this subscription has nothing to do with. An unrecognized frame is
+        // logged by the socket, which sees it once, rather than here, which sees it per subscription.
         is AppSyncWebSocketMessage.ConnectionAck,
-        is AppSyncWebSocketMessage.KeepAlive -> true
-
-        // Logged, unlike the two above, because an unmodelled frame means the wire carried something
-        // this client does not understand — worth a trace, where a keep-alive would only be noise.
-        is AppSyncWebSocketMessage.Unknown -> {
-            logger.debug { "Ignoring an unrecognized message of type ${message.type}." }
-            true
-        }
+        is AppSyncWebSocketMessage.KeepAlive,
+        is AppSyncWebSocketMessage.Unknown -> true
     }
 
     /**

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -269,6 +269,12 @@ internal class AppSyncSubscriber(
                         message = "The API's concurrent subscription limit was reached: " +
                             message.errors.joinToString("; ") { it.message }.ifEmpty { "no reason given" }
                     )
+                    // Also checked before the auth retry, and for the same reason: a rate limit belongs
+                    // to the API rather than to the identity.
+                    message.errors.hasRateLimitError() -> throw AppSyncRateLimitExceededException(
+                        message = "The API's request rate limit was exceeded: " +
+                            message.errors.joinToString("; ") { it.message }.ifEmpty { "no reason given" }
+                    )
                     // The identity was rejected; a different auth mode may be accepted.
                     rejectedIdentity && registration.canRetry -> {
                         registration.register(socket)

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -15,6 +15,7 @@
 package com.amazonaws.appsync
 
 import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.foundation.logging.AmplifyLogging
 import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -61,6 +62,8 @@ internal class AppSyncSubscriber(
     private val registrationTimeout: Duration = DEFAULT_REGISTRATION_TIMEOUT,
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
+
+    private val logger = AmplifyLogging.logger<AppSyncSubscriber>()
     private val connectionEvents = MutableSharedFlow<ConnectionState>(replay = 1)
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
 
@@ -234,12 +237,21 @@ internal class AppSyncSubscriber(
             if (message.id == registration.id) {
                 // Deserialization failure is deliberately swallowed: it is non-terminal, so one
                 // unreadable message must not end a healthy subscription.
-                val response = runCatching {
+                val failure = runCatching {
                     AppSyncResponseDeserializer.deserialize(request, message.payload)
-                }.getOrNull()
+                }
+                val response = failure.getOrNull()
 
                 when {
-                    response == null -> true
+                    response == null -> {
+                        // Logged because it is the only trace this message existed: the subscription
+                        // continues and the consumer is told nothing, so without this a message lost to
+                        // a schema mismatch looks exactly like one the service never sent.
+                        logger.warn(failure.exceptionOrNull()) {
+                            "Dropping a subscription message that could not be deserialized."
+                        }
+                        true
+                    }
                     // AppSync can reject the identity in a data message rather than an error frame, so
                     // this is a retry trigger too, not just something to hand to the consumer.
                     response.hasUnauthorizedError() && registration.canRetry -> {
@@ -310,10 +322,16 @@ internal class AppSyncSubscriber(
         // subscription streams normally rather than throwing.
         is AppSyncWebSocketMessage.Closed -> message.cause?.let { throw it } ?: false
 
-        // Keep-alives, unknown frames, and anything addressed to another subscription.
+        // Expected traffic that this subscription has nothing to do.
         is AppSyncWebSocketMessage.ConnectionAck,
-        is AppSyncWebSocketMessage.KeepAlive,
-        is AppSyncWebSocketMessage.Unknown -> true
+        is AppSyncWebSocketMessage.KeepAlive -> true
+
+        // Logged, unlike the two above, because an unmodelled frame means the wire carried something
+        // this client does not understand — worth a trace, where a keep-alive would only be noise.
+        is AppSyncWebSocketMessage.Unknown -> {
+            logger.debug { "Ignoring an unrecognized message of type ${message.type}." }
+            true
+        }
     }
 
     /**

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
@@ -81,6 +81,8 @@ internal class AppSyncWebSocket(
 
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
 
+    private val logger = AmplifyLogging.logger<AppSyncWebSocket>()
+
     @Volatile
     private var socket: WebSocket? = null
 
@@ -89,8 +91,6 @@ internal class AppSyncWebSocket(
 
     @Volatile
     private var watchdogTimeoutMs: Long = 0
-
-    private val logger = AmplifyLogging.logger<AppSyncWebSocket>()
 
     @Volatile
     var isClosed = false
@@ -210,13 +210,23 @@ internal class AppSyncWebSocket(
     override fun onMessage(webSocket: WebSocket, text: String) {
         // Any frame proves the connection is alive, including a keep-alive.
         restartWatchdog()
-        messageFlow.tryEmit(AppSyncWebSocketMessage.parse(text))
+        val message = AppSyncWebSocketMessage.parse(text)
+        // Logged here rather than where the message is handled, because this is the one place each frame
+        // arrives exactly once. A subscriber sees every frame on the shared flow, so logging downstream
+        // would repeat the same unmodelled frame once per open subscription.
+        if (message is AppSyncWebSocketMessage.Unknown) {
+            logger.debug { "Ignoring an unrecognized message: $text" }
+        }
+        messageFlow.tryEmit(message)
     }
 
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-        logger.warn(t) { "The subscription connection failed." }
         // onClosed is not called after a failure, so this has to close things out itself.
         if (pendingCloseCause == null) {
+            // Logged inside this branch, not above it: a deliberate teardown cancels the socket, which
+            // OkHttp reports here too. A cause is already set in that case, and it names the real reason
+            // — warning unconditionally would contradict it with the cancellation we caused ourselves.
+            logger.warn(t) { "The subscription connection failed." }
             pendingCloseCause = when (t) {
                 is IOException -> AppSyncConnectionException(
                     message = t.message ?: "The subscription connection failed.",

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocket.kt
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.appsync
 
+import com.amplifyframework.foundation.logging.AmplifyLogging
 import com.amplifyframework.util.UserAgent
 import java.io.IOException
 import kotlin.time.Duration
@@ -88,6 +89,8 @@ internal class AppSyncWebSocket(
 
     @Volatile
     private var watchdogTimeoutMs: Long = 0
+
+    private val logger = AmplifyLogging.logger<AppSyncWebSocket>()
 
     @Volatile
     var isClosed = false
@@ -211,6 +214,7 @@ internal class AppSyncWebSocket(
     }
 
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+        logger.warn(t) { "The subscription connection failed." }
         // onClosed is not called after a failure, so this has to close things out itself.
         if (pendingCloseCause == null) {
             pendingCloseCause = when (t) {
@@ -265,6 +269,9 @@ internal class AppSyncWebSocket(
         watchdog?.cancel()
         watchdog = scope.launch {
             delay(timeout)
+            logger.warn {
+                "Closing the subscription connection: no traffic for ${timeout}ms."
+            }
             pendingCloseCause = AppSyncTimeoutException(
                 message = "No traffic on the subscription connection for ${timeout}ms."
             )

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncWebSocketMessage.kt
@@ -118,10 +118,8 @@ internal sealed interface AppSyncWebSocketMessage {
 
     /**
      * A message this client does not model. Modelled explicitly rather than discarded during parsing so
-     * that an unexpected wire change is a value a caller can match on.
-     *
-     * TODO: log these — nothing in this module logs today, so an unknown frame currently passes
-     *  unnoticed.
+     * that an unexpected wire change is a value a caller can match on, and is logged by whichever
+     * component receives it — parsing stays a pure function.
      */
     data class Unknown(val type: String?, val raw: String) : Inbound
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -215,6 +215,8 @@ class AmplifyAppSyncClientTest {
 
         client().query(request()).shouldBeFailure().error
             .shouldBeInstanceOf<AppSyncRateLimitExceededException>()
+            // The service's own reason reaches the message; the 429 case above has no body to carry one.
+            .message shouldContain "Rate exceeded"
     }
 
     @Test

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AmplifyAppSyncClientTest.kt
@@ -193,6 +193,31 @@ class AmplifyAppSyncClientTest {
     }
 
     @Test
+    fun `a 429 is a rate limit, not a request problem`() = runTest {
+        // A throttle used to arrive as a validation failure, whose advice is to correct the request —
+        // misleading, because the request is fine and only its timing is not.
+        server.enqueue(jsonResponse("Too Many Requests", code = 429))
+
+        val error = client().query(request()).shouldBeFailure().error
+
+        error.shouldBeInstanceOf<AppSyncRateLimitExceededException>()
+        error.recoverySuggestion shouldContain "backoff"
+    }
+
+    @Test
+    fun `a LimitExceededError type under another status is still a rate limit`() = runTest {
+        server.enqueue(
+            jsonResponse(
+                """{"errors":[{"message":"Rate exceeded","extensions":{"errorType":"LimitExceededError"}}]}""",
+                code = HttpURLConnection.HTTP_BAD_REQUEST
+            )
+        )
+
+        client().query(request()).shouldBeFailure().error
+            .shouldBeInstanceOf<AppSyncRateLimitExceededException>()
+    }
+
+    @Test
     fun `an Unauthorized error type under a non-401 status is still an auth failure`() = runTest {
         // The error type is the authoritative signal; AppSync does not always pair it with a 401.
         server.enqueue(

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncExceptionTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncExceptionTest.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.string.shouldNotBeBlank
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.io.IOException
 import java.net.SocketTimeoutException
+import kotlin.reflect.KClass
 import org.junit.Test
 
 /**
@@ -78,7 +79,7 @@ class AppSyncExceptionTest {
     fun `subscription leaves are catchable as one group`() {
         AppSyncConnectionException("a").shouldBeInstanceOf<AppSyncSubscriptionException>()
         AppSyncTimeoutException("b").shouldBeInstanceOf<AppSyncSubscriptionException>()
-        AppSyncLimitExceededException("c").shouldBeInstanceOf<AppSyncSubscriptionException>()
+        AppSyncSubscriptionLimitExceededException("c").shouldBeInstanceOf<AppSyncSubscriptionException>()
     }
 
     @Test
@@ -87,14 +88,14 @@ class AppSyncExceptionTest {
     }
 
     @Test
-    fun `network and unknown are leaves directly under the base, in no group`() {
-        // Guards the hierarchy shape: these two deliberately have no intermediate group, so a `when`
-        // over
+    fun `network, rate limit and unknown are leaves directly under the base, in no group`() {
+        // Guards the hierarchy shape: these deliberately have no intermediate group, so a `when` over
         // the groups must still handle them.
         val network: AppSyncException = AppSyncNetworkException("a")
-        val unknown: AppSyncException = AppSyncUnknownException("b")
+        val rateLimit: AppSyncException = AppSyncRateLimitExceededException("b")
+        val unknown: AppSyncException = AppSyncUnknownException("c")
 
-        listOf(network, unknown).forEach {
+        listOf(network, rateLimit, unknown).forEach {
             (it is AppSyncAuthException) shouldBe false
             (it is AppSyncConfigurationException) shouldBe false
             (it is AppSyncResponseException) shouldBe false
@@ -113,6 +114,7 @@ class AppSyncExceptionTest {
             AppSyncSigningException("a"),
             AppSyncTokenParsingException("a"),
             AppSyncAuthorizationClaimException("a"),
+            AppSyncUnauthorizedException("a"),
             AppSyncAuthExhaustedException("a", emptyList()),
             AppSyncInvalidConfigException("a"),
             AppSyncEndpointResolutionException("a"),
@@ -120,14 +122,25 @@ class AppSyncExceptionTest {
             AppSyncGraphQLErrorException("a", emptyList()),
             AppSyncConnectionException("a"),
             AppSyncTimeoutException("a"),
-            AppSyncLimitExceededException("a"),
+            AppSyncSubscriptionLimitExceededException("a"),
             AppSyncValidationException("a"),
             AppSyncNetworkException("a"),
+            AppSyncRateLimitExceededException("a"),
             AppSyncUnknownException("a")
         )
 
-        leaves.size shouldBe 16
+        // Compared against the hierarchy rather than against a count. A `size shouldBe n` assertion
+        // counts the list directly below it, so it can never fail when a leaf is added — which is the
+        // one thing it exists to catch, and it did not: AppSyncUnauthorizedException was absent from
+        // this list while the count still passed.
+        leaves.map { it::class.simpleName }.toSet() shouldBe AppSyncException::class.leafNames()
         leaves.forEach { it.recoverySuggestion.shouldNotBeBlank() }
+    }
+
+    /** Every concrete type reachable through the sealed hierarchy, by simple name. */
+    private fun KClass<*>.leafNames(): Set<String> = when {
+        sealedSubclasses.isEmpty() -> setOfNotNull(simpleName)
+        else -> sealedSubclasses.flatMap { it.leafNames() }.toSet()
     }
 
     @Test

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -521,30 +521,53 @@ class AppSyncSubscriberTest {
                 )
             )
 
-            awaitError().shouldBeInstanceOf<AppSyncLimitExceededException>()
+            awaitError().shouldBeInstanceOf<AppSyncSubscriptionLimitExceededException>()
                 .message shouldContain "100 subscriptions"
         }
     }
 
     @Test
-    fun `a rate limit error is terminal and distinct from the subscription limit`() = runTest {
-        // Both are "limit" errors, but they are released by different actions — backing off versus
-        // closing a subscription — so they must not collapse into one type.
+    fun `a rate limit error wins over an unauthorized error in the same frame`() = runTest {
+        // Carries both so the precedence is actually exercised: with a rate-limit error alone the
+        // auth-retry branch is not a candidate at all, and this would pass wherever the check sat.
+        // A rate limit belongs to the API, so retrying under another identity only wastes an attempt.
         val subscriber = subscriber(multiAuth())
 
         subscriber.subscribe(modelRequest()).test {
             awaitItem() shouldBe SubscriptionEvent.Connecting
-            val firstId = startedId
 
             messages.emit(
                 AppSyncWebSocketMessage.Error(
-                    firstId,
-                    listOf(wireError("Rate exceeded", "LimitExceededError"))
+                    startedId,
+                    listOf(unauthorized(), wireError("Rate exceeded", "LimitExceededError"))
                 )
             )
 
             awaitError().shouldBeInstanceOf<AppSyncRateLimitExceededException>()
                 .message shouldContain "Rate exceeded"
+        }
+    }
+
+    @Test
+    fun `the subscription limit wins over a rate limit in the same frame`() = runTest {
+        // The two are separate types precisely because the remedies differ, so which one a frame
+        // carrying both resolves to is a decision worth pinning rather than leaving to branch order.
+        val subscriber = subscriber(multiAuth())
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+
+            messages.emit(
+                AppSyncWebSocketMessage.Error(
+                    startedId,
+                    listOf(
+                        wireError("Rate exceeded", "LimitExceededError"),
+                        wireError("limit", "MaxSubscriptionsReachedError")
+                    )
+                )
+            )
+
+            awaitError().shouldBeInstanceOf<AppSyncSubscriptionLimitExceededException>()
         }
     }
 
@@ -562,7 +585,7 @@ class AppSyncSubscriberTest {
                 )
             )
 
-            awaitError().shouldBeInstanceOf<AppSyncLimitExceededException>()
+            awaitError().shouldBeInstanceOf<AppSyncSubscriptionLimitExceededException>()
         }
     }
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -527,6 +527,28 @@ class AppSyncSubscriberTest {
     }
 
     @Test
+    fun `a rate limit error is terminal and distinct from the subscription limit`() = runTest {
+        // Both are "limit" errors, but they are released by different actions — backing off versus
+        // closing a subscription — so they must not collapse into one type.
+        val subscriber = subscriber(multiAuth())
+
+        subscriber.subscribe(modelRequest()).test {
+            awaitItem() shouldBe SubscriptionEvent.Connecting
+            val firstId = startedId
+
+            messages.emit(
+                AppSyncWebSocketMessage.Error(
+                    firstId,
+                    listOf(wireError("Rate exceeded", "LimitExceededError"))
+                )
+            )
+
+            awaitError().shouldBeInstanceOf<AppSyncRateLimitExceededException>()
+                .message shouldContain "Rate exceeded"
+        }
+    }
+
+    @Test
     fun `a subscription limit error wins over an unauthorized error in the same frame`() = runTest {
         val subscriber = subscriber(multiAuth())
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-requests) guidelines

### Description

**A throttled request was reported as a request defect.** Any 4xx that was not an auth rejection became `AppSyncValidationException`, whose advice is to correct the request — which sends a caller to fix a document and variables that are already correct, when the only thing wrong was the timing. `AppSyncRateLimitExceededException` is now raised for a 429 and for any 4xx carrying a `LimitExceededError` type, since the service does not always pair the two. The subscription path recognises it as well, beside the concurrent-subscription check and before the auth retry — a rate limit belongs to the API, not the identity, so another auth mode would consume an attempt and fail identically.

It is kept deliberately distinct from `AppSyncLimitExceededException`, the cap on how many subscriptions may be open at once. The two read alike but are released by different actions — backing off versus closing something already open — so collapsing them would give one of the two the wrong advice.

**Nothing in the module logged**, so three paths that deliberately continue rather than fail left no trace. The significant one is a subscription message that cannot be deserialized: it is dropped by design, but the consumer is told nothing, so a message lost to a schema mismatch is indistinguishable from one the service never sent. That now warns. An unrecognized frame logs at debug — keep-alives and acks deliberately do not, since they shared a branch with the unknown case and logging all three would bury the one that matters. The socket also warns when the watchdog closes a connection for silence and when OkHttp reports a failure; both end every subscription on that connection and neither previously said why.

Loggers are created internally per class, so there is no public API and no configuration for this. A customer enables output by registering a sink during application startup.

### Not included

The third TODO, registering deserializers for lazily-loaded model lists and pages, is left in place. It reads like an adapter registration but the counterpart is a family of types plus a way to issue follow-up queries on demand, which needs the client itself — registering adapters without that would produce values that deserialize and then fail on access. It belongs with the rest of the lazy-loading work rather than here.

### Testing

220 unit tests, 0 failures. `apiCheck`, `ktlintCheck`, `compileReleaseKotlin` and `licensee` all pass. `apiDump` regenerated: the only public change is `AppSyncRateLimitExceededException`.

New coverage: a 429, a `LimitExceededError` type under a different status, and a subscription error frame carrying it.

The logging is not unit tested, deliberately. Sinks are process-global, a logger captures the sink set when it is constructed, and foundation keeps sink removal internal to itself — so a test registering a fake sink could not remove it afterwards and would collect output from every other test in the module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
