### PR TITLE
chore: upgrade MockWebServer to 5.4.0 and migrate off the removed package

### DIFF
--- a/appsync/aws-sdk-appsync-events/src/test/java/com/amazonaws/sdk/appsync/events/EventsRestClientTest.kt
+++ b/appsync/aws-sdk-appsync-events/src/test/java/com/amazonaws/sdk/appsync/events/EventsRestClientTest.kt
@@ -29,14 +29,14 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
-import mockwebserver3.SocketPolicy
+import mockwebserver3.SocketEffect
 import okio.Buffer
 import org.junit.After
-import org.junit.Before
 import org.junit.Test
 
 class EventsRestClientTest {
-    private val mockWebServer = MockWebServer()
+    // Server must be started before url() is called in the interceptor initializer below
+    private val mockWebServer = MockWebServer().apply { start() }
     private val expectedEndpoint = "https://abc.appsync-api.us-east-1.amazonaws.com/event"
     private val expectedHost = "abc.appsync-api.us-east-1.amazonaws.com"
     private val expectedStandardHeaders = mapOf(
@@ -58,14 +58,9 @@ class EventsRestClientTest {
         )
     )
 
-    @Before
-    fun setUp() {
-        mockWebServer.start()
-    }
-
     @After
     fun tearDown() {
-        mockWebServer.shutdown()
+        mockWebServer.close()
     }
 
     @Test
@@ -78,9 +73,10 @@ class EventsRestClientTest {
             .bufferedReader()
             .readText()
         mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .code(200)
+                .body(responseBody)
+                .build()
         )
 
         // WHEN
@@ -122,10 +118,11 @@ class EventsRestClientTest {
             .readText()
 
         mockWebServer.enqueue(
-            MockResponse()
-                .setSocketPolicy(SocketPolicy.DISCONNECT_AT_START)
-                .setResponseCode(200)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .onRequestStart(SocketEffect.CloseSocket())
+                .code(200)
+                .body(responseBody)
+                .build()
         )
 
         val response = client.publish(expectedChannel, JsonPrimitive(1))
@@ -160,9 +157,10 @@ class EventsRestClientTest {
             .readText()
 
         mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(400)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .code(400)
+                .body(responseBody)
+                .build()
         )
 
         val response = client.publish(expectedChannel, JsonPrimitive(1))
@@ -199,9 +197,10 @@ class EventsRestClientTest {
         val responseBody = "uh-oh"
 
         mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(400)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .code(400)
+                .body(responseBody)
+                .build()
         )
 
         val response = client.publish(expectedChannel, JsonPrimitive(1))
@@ -241,9 +240,10 @@ class EventsRestClientTest {
             .bufferedReader()
             .readText()
         mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .code(200)
+                .body(responseBody)
+                .build()
         )
 
         // WHEN
@@ -284,9 +284,10 @@ class EventsRestClientTest {
             .bufferedReader()
             .readText()
         mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .code(200)
+                .body(responseBody)
+                .build()
         )
 
         // WHEN
@@ -327,9 +328,10 @@ class EventsRestClientTest {
             .bufferedReader()
             .readText()
         mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .code(200)
+                .body(responseBody)
+                .build()
         )
 
         // WHEN
@@ -368,9 +370,10 @@ class EventsRestClientTest {
             .bufferedReader()
             .readText()
         mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .code(200)
+                .body(responseBody)
+                .build()
         )
 
         // WHEN
@@ -411,9 +414,10 @@ class EventsRestClientTest {
             .bufferedReader()
             .readText()
         mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(responseBody)
+            MockResponse.Builder()
+                .code(200)
+                .body(responseBody)
+                .build()
         )
 
         // WHEN

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginTest.java
@@ -53,14 +53,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.StreamSupport;
 
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -129,11 +129,11 @@ public final class AWSApiPluginTest {
 
     /**
      * Stop the {@link MockWebServer} that was started in {@link #setup()}.
-     * @throws IOException On failure to shutdown the MockWebServer
+     * @throws IOException On failure to close the MockWebServer
      */
     @After
     public void cleanup() throws IOException {
-        webServer.shutdown();
+        webServer.close();
     }
 
     /**
@@ -163,7 +163,7 @@ public final class AWSApiPluginTest {
         String expectedBody = new JSONObject()
             .put("key", "value")
             .toString();
-        webServer.enqueue(new MockResponse().setBody(expectedBody));
+        webServer.enqueue(new MockResponse.Builder().body(expectedBody).build());
 
         // Make a request using the client from the escape hatch
         Request request = new Request.Builder().url(baseUrl).build();
@@ -183,8 +183,9 @@ public final class AWSApiPluginTest {
      */
     @Test
     public void graphQlQueryRendersValidResponse() throws ApiException {
-        webServer.enqueue(new MockResponse()
-            .setBody(Resources.readAsString("blog-owners-query-results.json")));
+        webServer.enqueue(new MockResponse.Builder()
+            .body(Resources.readAsString("blog-owners-query-results.json"))
+            .build());
 
         GraphQLResponse<PaginatedResult<BlogOwner>> actualResponse =
             Await.<GraphQLResponse<PaginatedResult<BlogOwner>>, ApiException>result(((onResult, onError) ->
@@ -207,8 +208,9 @@ public final class AWSApiPluginTest {
      */
     @Test
     public void graphQlPaginatedQueryRendersExpectedResponse() throws ApiException {
-        webServer.enqueue(new MockResponse()
-                .setBody(Resources.readAsString("blog-owners-query-results.json")));
+        webServer.enqueue(new MockResponse.Builder()
+                .body(Resources.readAsString("blog-owners-query-results.json"))
+                .build());
 
         GraphQLResponse<PaginatedResult<BlogOwner>> actualResponse =
                 Await.<GraphQLResponse<PaginatedResult<BlogOwner>>, ApiException>result(((onResult, onError) ->
@@ -235,7 +237,7 @@ public final class AWSApiPluginTest {
     @Test
     public void graphQlMutationWithClientErrorResponseCodeShouldNotCallOnResponse() throws InterruptedException {
         final int CLIENT_ERROR_CODE = 400;
-        webServer.enqueue(new MockResponse().setResponseCode(CLIENT_ERROR_CODE));
+        webServer.enqueue(new MockResponse.Builder().code(CLIENT_ERROR_CODE).build());
 
         final CountDownLatch latch = new CountDownLatch(2);
         final AtomicReference<Throwable> unexpectedErrorContainer = new AtomicReference<>();
@@ -315,8 +317,9 @@ public final class AWSApiPluginTest {
     public void headerInterceptorsAreConfigured() throws ApiException, InterruptedException {
         // Arrange some response. This isn't the point of the test,
         // but it keeps the mock web server from freezing up.
-        webServer.enqueue(new MockResponse()
-            .setBody(Resources.readAsString("blog-owners-query-results.json")));
+        webServer.enqueue(new MockResponse.Builder()
+            .body(Resources.readAsString("blog-owners-query-results.json"))
+            .build());
 
         // Fire off a request
         Await.<GraphQLResponse<PaginatedResult<BlogOwner>>, ApiException>result((onResult, onError) ->
@@ -325,7 +328,7 @@ public final class AWSApiPluginTest {
 
         RecordedRequest recordedRequest = webServer.takeRequest(5, TimeUnit.MILLISECONDS);
         assertNotNull(recordedRequest);
-        assertEquals("specialValue", recordedRequest.getHeader("specialKey"));
+        assertEquals("specialValue", recordedRequest.getHeaders().get("specialKey"));
     }
 
     /**
@@ -336,8 +339,9 @@ public final class AWSApiPluginTest {
      */
     @Test
     public void requestUsesCognitoForAuth() throws AmplifyException, InterruptedException {
-        webServer.enqueue(new MockResponse()
-                              .setBody(Resources.readAsString("blog-owners-query-results.json")));
+        webServer.enqueue(new MockResponse.Builder()
+                              .body(Resources.readAsString("blog-owners-query-results.json"))
+                              .build());
 
         AppSyncGraphQLRequest<PaginatedResult<BlogOwner>> appSyncGraphQLRequest =
             createQueryRequestWithAuthMode(BlogOwner.class, AuthorizationType.AMAZON_COGNITO_USER_POOLS);
@@ -348,9 +352,9 @@ public final class AWSApiPluginTest {
             );
 
         RecordedRequest recordedRequest = webServer.takeRequest();
-        assertNull(recordedRequest.getHeader("x-api-key"));
-        assertNotNull(recordedRequest.getHeader("authorization"));
-        assertEquals("FAKE_TOKEN", recordedRequest.getHeader("authorization"));
+        assertNull(recordedRequest.getHeaders().get("x-api-key"));
+        assertNotNull(recordedRequest.getHeaders().get("authorization"));
+        assertEquals("FAKE_TOKEN", recordedRequest.getHeaders().get("authorization"));
         assertEquals(
             Arrays.asList("Curly", "Moe", "Larry"),
             StreamSupport.stream(actualResponse.getData().spliterator(), false)
@@ -366,8 +370,9 @@ public final class AWSApiPluginTest {
      */
     @Test
     public void requestUsesIamForAuth() throws AmplifyException, InterruptedException {
-        webServer.enqueue(new MockResponse()
-                              .setBody(Resources.readAsString("blog-owners-query-results.json")));
+        webServer.enqueue(new MockResponse.Builder()
+                              .body(Resources.readAsString("blog-owners-query-results.json"))
+                              .build());
 
         AppSyncGraphQLRequest<PaginatedResult<BlogOwner>> appSyncGraphQLRequest =
             createQueryRequestWithAuthMode(BlogOwner.class, AuthorizationType.AWS_IAM);
@@ -378,9 +383,9 @@ public final class AWSApiPluginTest {
             );
 
         RecordedRequest recordedRequest = webServer.takeRequest();
-        assertNull(recordedRequest.getHeader("x-api-key"));
-        assertNotNull(recordedRequest.getHeader("authorization"));
-        assertTrue(recordedRequest.getHeader("authorization").startsWith("AWS4-HMAC-SHA256"));
+        assertNull(recordedRequest.getHeaders().get("x-api-key"));
+        assertNotNull(recordedRequest.getHeaders().get("authorization"));
+        assertTrue(recordedRequest.getHeaders().get("authorization").startsWith("AWS4-HMAC-SHA256"));
         assertEquals(
             Arrays.asList("Curly", "Moe", "Larry"),
             StreamSupport.stream(actualResponse.getData().spliterator(), false)

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginUserAgentTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AWSApiPluginUserAgentTest.java
@@ -33,8 +33,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
@@ -85,7 +85,7 @@ public final class AWSApiPluginUserAgentTest {
      */
     @After
     public void tearDown() throws IOException {
-        server.shutdown();
+        server.close();
     }
 
     /**
@@ -115,7 +115,7 @@ public final class AWSApiPluginUserAgentTest {
         // Wait for server to receive the request and return user agent
         RecordedRequest request = server.takeRequest(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertNotNull(request);
-        return request.getHeader("User-Agent");
+        return request.getHeaders().get("User-Agent");
     }
 
     private String getEndpoint() {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncErrorPropagationTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/AppSyncErrorPropagationTest.kt
@@ -24,9 +24,9 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.io.IOException
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
 import okhttp3.HttpUrl
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.After
@@ -75,12 +75,12 @@ class AppSyncErrorPropagationTest {
 
     /**
      * Stop the [MockWebServer] that was started in [setup].
-     * @throws IOException On failure to shutdown the MockWebServer
+     * @throws IOException On failure to close the MockWebServer
      */
     @After
     @Throws(IOException::class)
     fun cleanup() {
-        webServer.shutdown()
+        webServer.close()
     }
 
     /**
@@ -100,9 +100,10 @@ class AppSyncErrorPropagationTest {
         """.trimIndent()
 
         webServer.enqueue(
-            MockResponse()
-                .setResponseCode(401)
-                .setBody(errorResponse)
+            MockResponse.Builder()
+                .code(401)
+                .body(errorResponse)
+                .build()
         )
 
         // Act - execute query and capture error
@@ -134,9 +135,10 @@ class AppSyncErrorPropagationTest {
         val invalidJson = "not valid json at all"
 
         webServer.enqueue(
-            MockResponse()
-                .setResponseCode(400)
-                .setBody(invalidJson)
+            MockResponse.Builder()
+                .code(400)
+                .body(invalidJson)
+                .build()
         )
 
         // Act

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/auth/OwnerBasedAuthTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/auth/OwnerBasedAuthTest.java
@@ -51,8 +51,8 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 
+import mockwebserver3.MockWebServer;
 import okhttp3.HttpUrl;
-import okhttp3.mockwebserver.MockWebServer;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -92,11 +92,11 @@ public final class OwnerBasedAuthTest {
 
     /**
      * Stop the {@link MockWebServer} that was started in {@link #setup()}.
-     * @throws IOException On failure to shutdown the MockWebServer
+     * @throws IOException On failure to close the MockWebServer
      */
     @After
     public void cleanup() throws IOException {
-        webServer.shutdown();
+        webServer.close();
     }
 
     private void configurePlugin() throws ApiException {

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/operation/AWSRestOperationTest.java
@@ -34,10 +34,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
@@ -65,15 +65,16 @@ public final class AWSRestOperationTest {
         server.start(8080);
         baseUrl = server.url("/");
 
-        MockResponse response = new MockResponse()
-            .setResponseCode(200)
-            .setBody(new JSONObject()
+        MockResponse response = new MockResponse.Builder()
+            .code(200)
+            .body(new JSONObject()
                 .put("message", "thanks!")
                 .toString()
             )
             .addHeader("foo", "bar")
             .addHeader("foo", "baz")
-            .addHeader("qux", "quux");
+            .addHeader("qux", "quux")
+            .build();
         server.enqueue(response);
 
         client = new OkHttpClient();
@@ -81,11 +82,11 @@ public final class AWSRestOperationTest {
 
     /**
      * Stop the {@link MockWebServer} that was started in {@link #setup()}.
-     * @throws IOException On failure to shutdown the MockWebServer
+     * @throws IOException On failure to close the MockWebServer
      */
     @After
     public void cleanup() throws IOException {
-        server.shutdown();
+        server.close();
     }
 
     /**

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestQuerySemicolonEncodingTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/utils/RestQuerySemicolonEncodingTest.kt
@@ -23,10 +23,10 @@ import com.amplifyframework.api.rest.RestResponse
 import com.amplifyframework.testutils.Await
 import io.kotest.matchers.shouldBe
 import java.io.IOException
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -53,18 +53,18 @@ class RestQuerySemicolonEncodingTest {
         server = MockWebServer()
         server.start()
         baseUrl = server.url("/")
-        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        server.enqueue(MockResponse.Builder().code(200).body("{}").build())
         client = OkHttpClient()
     }
 
     /**
-     * Shuts down the mock web server.
-     * @throws IOException On failure to shut down the server
+     * Closes the mock web server.
+     * @throws IOException On failure to close the server
      */
     @After
     @Throws(IOException::class)
     fun cleanup() {
-        server.shutdown()
+        server.close()
     }
 
     @Test
@@ -93,6 +93,6 @@ class RestQuerySemicolonEncodingTest {
         Await.result<RestResponse, ApiException> { onResult, onError ->
             AWSRestOperation(request, baseUrl.toUrl().toString(), client, onResult, onError).start()
         }
-        server.takeRequest().path shouldBe "/path?filter=X%3BY"
+        server.takeRequest().target shouldBe "/path?filter=X%3BY"
     }
 }

--- a/aws-connect/src/test/java/com/amplifyframework/connect/internal/ConnectServiceTest.kt
+++ b/aws-connect/src/test/java/com/amplifyframework/connect/internal/ConnectServiceTest.kt
@@ -59,54 +59,54 @@ class ConnectServiceTest {
 
     @After
     fun teardown() {
-        server.shutdown()
+        server.close()
     }
 
     @Test
     fun `identifyUser sends POST to identify-user with SigV4`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        server.enqueue(MockResponse.Builder().code(200).body("{}").build())
 
         service.identifyUser(testCredentials, """{"userProfile":{"name":"Alice"}}""")
 
         val request = server.takeRequest()
         request.method shouldBe "POST"
-        request.path shouldBe "/identify-user"
-        request.getHeader("Authorization")!! shouldContain "AWS4-HMAC-SHA256"
-        request.getHeader("X-Amz-Security-Token") shouldBe "session"
-        request.body.readUtf8() shouldBe """{"userProfile":{"name":"Alice"}}"""
+        request.target shouldBe "/identify-user"
+        request.headers["Authorization"]!! shouldContain "AWS4-HMAC-SHA256"
+        request.headers["X-Amz-Security-Token"] shouldBe "session"
+        request.body!!.utf8() shouldBe """{"userProfile":{"name":"Alice"}}"""
     }
 
     @Test
     fun `registerDevice sends POST to register-device with SigV4`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        server.enqueue(MockResponse.Builder().code(200).body("{}").build())
 
         service.registerDevice(testCredentials, """{"device":{"token":"t","deviceId":"d"}}""")
 
         val request = server.takeRequest()
         request.method shouldBe "POST"
-        request.path shouldBe "/register-device"
-        request.getHeader("Authorization")!! shouldContain "AWS4-HMAC-SHA256"
+        request.target shouldBe "/register-device"
+        request.headers["Authorization"]!! shouldContain "AWS4-HMAC-SHA256"
     }
 
     @Test
     fun `removeDevice sends POST to remove-device with SigV4`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        server.enqueue(MockResponse.Builder().code(200).body("{}").build())
 
         service.removeDevice(testCredentials, """{"deviceId":"d"}""")
 
         val request = server.takeRequest()
         request.method shouldBe "POST"
-        request.path shouldBe "/remove-device"
-        request.getHeader("Authorization")!! shouldContain "AWS4-HMAC-SHA256"
+        request.target shouldBe "/remove-device"
+        request.headers["Authorization"]!! shouldContain "AWS4-HMAC-SHA256"
     }
 
     @Test
     fun `requests carry the Amplify connect user agent`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        server.enqueue(MockResponse.Builder().code(200).body("{}").build())
 
         service.identifyUser(testCredentials, "{}")
 
-        val userAgent = server.takeRequest().getHeader("User-Agent")!!
+        val userAgent = server.takeRequest().headers["User-Agent"]!!
         userAgent shouldContain "md/amplify-connect#"
         userAgent shouldContain "lib/amplify-android#"
     }
@@ -142,7 +142,7 @@ class ConnectServiceTest {
 
     @Test
     fun `maps 429 to ThrottlingException`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(429).setBody("{}"))
+        server.enqueue(MockResponse.Builder().code(429).body("{}").build())
 
         shouldThrow<ConnectThrottlingException> {
             service.identifyUser(testCredentials, "{}")
@@ -151,7 +151,7 @@ class ConnectServiceTest {
 
     @Test
     fun `maps 401 to AccessDeniedException`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(401).setBody("{}"))
+        server.enqueue(MockResponse.Builder().code(401).body("{}").build())
 
         shouldThrow<ConnectAccessDeniedException> {
             service.identifyUser(testCredentials, "{}")
@@ -160,7 +160,7 @@ class ConnectServiceTest {
 
     @Test
     fun `maps 403 to AccessDeniedException`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(403).setBody("{}"))
+        server.enqueue(MockResponse.Builder().code(403).body("{}").build())
 
         shouldThrow<ConnectAccessDeniedException> {
             service.identifyUser(testCredentials, "{}")
@@ -170,7 +170,7 @@ class ConnectServiceTest {
     @Test
     fun `maps 400 to ValidationException with detail`() = runTest {
         server.enqueue(
-            MockResponse().setResponseCode(400).setBody("""{"error":"Bad input"}""")
+            MockResponse.Builder().code(400).body("""{"error":"Bad input"}""").build()
         )
 
         val ex = shouldThrow<ConnectValidationException> {
@@ -182,7 +182,7 @@ class ConnectServiceTest {
     @Test
     fun `maps 500 to ServiceException`() = runTest {
         server.enqueue(
-            MockResponse().setResponseCode(500).setBody("""{"message":"Internal"}""")
+            MockResponse.Builder().code(500).body("""{"message":"Internal"}""").build()
         )
 
         val ex = shouldThrow<ConnectServiceException> {
@@ -193,7 +193,7 @@ class ConnectServiceTest {
 
     @Test
     fun `network failure throws ConnectNetworkException`() = runTest {
-        server.shutdown()
+        server.close()
         val brokenService = ConnectService(
             endpoint = "http://localhost:1",
             region = "us-east-1"

--- a/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
+++ b/aws-predictions/src/test/java/com/amplifyframework/predictions/aws/http/LivenessWebSocketTest.kt
@@ -117,11 +117,13 @@ internal class LivenessWebSocketTest {
     fun setUp() {
         Dispatchers.setMain(Dispatchers.Unconfined)
         server = MockWebServer()
+        // url() no longer starts the server implicitly, so it must be started before it can be addressed
+        server.start()
     }
 
     @After
     fun shutDown() {
-        server.shutdown()
+        server.close()
         Dispatchers.resetMain()
     }
 
@@ -272,8 +274,7 @@ internal class LivenessWebSocketTest {
         )
         livenessWebSocket.webSocketListener = latchingListener
 
-        server.enqueue(MockResponse().withWebSocketUpgrade(ServerWebSocketListener()))
-        server.start()
+        server.enqueue(MockResponse.Builder().webSocketUpgrade(ServerWebSocketListener()).build())
         livenessWebSocket.start()
 
         openLatch.await(3, TimeUnit.SECONDS)
@@ -696,8 +697,7 @@ internal class LivenessWebSocketTest {
         )
         livenessWebSocket.webSocketListener = latchingListener
 
-        server.enqueue(MockResponse().withWebSocketUpgrade(ServerWebSocketListener()))
-        server.start()
+        server.enqueue(MockResponse.Builder().webSocketUpgrade(ServerWebSocketListener()).build())
 
         livenessWebSocket.webSocketError = PredictionsException(
             "invalid signature",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,6 @@ material = "1.8.0"
 mockito = "3.9.0"
 mockito-inline = "3.11.2"
 mockk = "1.14.5"
-mockwebserver = "5.0.0-alpha.11"
 navigation = "2.3.4"
 oauth2 = "0.26.0"
 okhttp = "5.4.0"
@@ -146,7 +145,7 @@ test-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockit
 test-mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito-inline" }
 test-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 test-mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
-test-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
+test-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver3", version.ref = "okhttp" }
 test-robolectric = { module = "org.robolectric:robolectric", version.ref="robolectric" }
 test-totp = { module = "dev.robinohs:totp-kt", version.ref="totp" }
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine"}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-requests) guidelines

### Why

MockWebServer had its own version pin at `5.0.0-alpha.11` while OkHttp moved to `5.4.0`. The two are published from the same release, so a separate pin only creates the opportunity for them to drift — and they had.

The alpha's WebSocket support reaches into `okhttp3.internal.ws.RealWebSocket$Streams`, which no longer exists, so serving a WebSocket upgrade fails at `start()` with a `NoClassDefFoundError` on an Android runtime. That is how this surfaced: it makes instrumented coverage of any WebSocket client impossible. JVM unit tests were unaffected, which is why it went unnoticed.

### What changed

**The separate version pin is gone.** The library entry now takes `version.ref = "okhttp"`, so the two cannot diverge again. This is the actual fix — the version bump alone would leave the same trap set for the next OkHttp upgrade.

**The coordinate moves from `com.squareup.okhttp3:mockwebserver` to `:mockwebserver3`.** The former still ships in 5.4.0, but only as a compatibility shim: 13 classes holding the deprecated `okhttp3.mockwebserver` package and delegating to `mockwebserver3`. Worth dropping now that nothing needs the old package.

That is what requires the test migration — the deprecated package is no longer on the classpath:

- `MockResponse` is immutable in 5.x, so every construction moves to its `Builder` (`setResponseCode` → `code`, `setBody` → `body`, `withWebSocketUpgrade` → `webSocketUpgrade`).
- `RecordedRequest` changed: `getHeader(name)` → `headers[name]`, `getPath()` → `target`, and `body` is a nullable `ByteString` rather than a `Buffer`.
- `server.shutdown()` → `server.close()`.

Two behaviour changes broke tests until handled, and are worth knowing if you maintain tests here:

- **`url()` no longer starts the server implicitly.** Tests calling it from a field initializer, or relying on lazy startup, need an explicit `start()`. That alone accounted for every failure in `aws-predictions` and in the Events REST tests.
- **The `SocketPolicy` enum is replaced by `SocketEffect`**, applied at a named point in the exchange. The single `DISCONNECT_AT_START` usage becomes `onRequestStart(SocketEffect.CloseSocket())`, which preserves its meaning: accept the connection, then kill the socket before replying. `ShutdownConnection` would be a graceful FIN and `Stall` would turn a disconnect test into a write-timeout test, so neither is equivalent.

### Testing

419 tests across `aws-api` (214), `aws-connect` (49), `aws-predictions` (78) and `aws-sdk-appsync-events` (78) — 0 failures. `ktlintCheck` and `checkstyle` pass.

Every declared test still runs: per-class counts were compared against the `@Test` counts at `HEAD` to confirm nothing was silently dropped, and no assertion was weakened to accommodate the new API. Verified that only `mockwebserver3` resolves on the test classpath, so nothing still reaches the shim.

### Noted, not fixed here

`LivenessWebSocketTest.web socket detects clock skew from server response` waits out its full 3s timeout both before and after this change — its `CountDownLatch(2)` never reaches zero, and it passes only because `webSocket` was already assigned by an earlier manually-invoked `onOpen`. Pre-existing and unrelated to this migration, but it does not currently assert what its name suggests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
