### PR TITLE
chore: pass the mockk withArg capture block by name

### DIFF
--- a/aws-push-notifications-pinpoint-common/src/test/java/com/amplifyframework/pushnotifications/pinpoint/PushNotificationChannelsTest.kt
+++ b/aws-push-notifications-pinpoint-common/src/test/java/com/amplifyframework/pushnotifications/pinpoint/PushNotificationChannelsTest.kt
@@ -258,11 +258,11 @@ class PushNotificationChannelsTest {
 
     //region helpers
     private fun assertCreatedGroup(assertionBlock: MockKAssertScope.(NotificationChannelGroupCompat) -> Unit) = verify {
-        manager.createNotificationChannelGroup(withArg(assertionBlock))
+        manager.createNotificationChannelGroup(withArg(captureBlock = assertionBlock))
     }
 
     private fun assertCreatedChannel(assertionBlock: MockKAssertScope.(NotificationChannelCompat) -> Unit) = verify {
-        manager.createNotificationChannel(withArg(assertionBlock))
+        manager.createNotificationChannel(withArg(captureBlock = assertionBlock))
     }
     //endregion
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*

`PushNotificationChannelsTest` passes its assertion block to mockk's `withArg` positionally. mockk 1.14.9 added a defaulted `assertionErrorLogger: (AssertionError) -> Unit` parameter ahead of `captureBlock`, so a positional block now binds to the logger and the test source no longer compiles:

```
PushNotificationChannelsTest.kt:261:56 Argument type mismatch: actual type is
  'Function2<MockKAssertScope, NotificationChannelGroupCompat, Unit>',
  but 'Function1<AssertionError, Unit>' was expected.
```

Naming the argument compiles against both the currently pinned 1.14.5 (where the parameter is already called `captureBlock`) and 1.14.9+, so this unblocks the mockk bump in #3414 without tying the test to either version.

These are the only two positional call sites in the repo — the other 42 uses of `withArg`/`coWithArg` pass a trailing lambda and are unaffected.

*How did you test these changes?*

`./gradlew :aws-push-notifications-pinpoint-common:testDebugUnitTest --tests "com.amplifyframework.pushnotifications.pinpoint.PushNotificationChannelsTest"` passes with mockk 1.14.5, and also with 1.14.11 with the version catalog temporarily bumped locally. `./gradlew :aws-push-notifications-pinpoint-common:ktlintCheck` passes.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

No new tests: this is a compile-level fix to an existing test helper, and the existing `PushNotificationChannelsTest` cases cover it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.