### PR TITLE
fix(api): Parse subscription connection_ack and data payloads independent of org.json impl

### DIFF
--- a/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
+++ b/aws-api/src/main/java/com/amplifyframework/api/aws/SubscriptionEndpoint.java
@@ -681,9 +681,9 @@ final class SubscriptionEndpoint {
                                     "WebSocket closed due to timeout."
                             );
                         },
-                            Integer.parseInt(
-                                jsonMessage.getJSONObject("payload").getString("connectionTimeoutMs")
-                            )
+                            // getInt coerces in both the platform and reference org.json; getString throws
+                            // on a JSON number under the reference impl a dependency may bundle.
+                            jsonMessage.getJSONObject("payload").getInt("connectionTimeoutMs")
                         );
                         endpointStatus.set(EndpointStatus.CONNECTED);
                         connectionResponse.countDown();
@@ -723,10 +723,16 @@ final class SubscriptionEndpoint {
                         break;
                     case SUBSCRIPTION_ERROR:
                         notifySubscriptionFailure(jsonMessage.getString("id"));
-                        notifySubscriptionData(jsonMessage.getString("id"), jsonMessage.getString("payload"));
+                        notifySubscriptionData(
+                            jsonMessage.getString("id"),
+                            jsonMessage.getJSONObject("payload").toString()
+                        );
                         break;
                     case SUBSCRIPTION_DATA:
-                        notifySubscriptionData(jsonMessage.getString("id"), jsonMessage.getString("payload"));
+                        notifySubscriptionData(
+                            jsonMessage.getString("id"),
+                            jsonMessage.getJSONObject("payload").toString()
+                        );
                         break;
                     default:
                         notifyError(new AppSyncUnknownException(

--- a/aws-api/src/test/java/com/amplifyframework/api/aws/SubscriptionEndpointFastFailTest.kt
+++ b/aws-api/src/test/java/com/amplifyframework/api/aws/SubscriptionEndpointFastFailTest.kt
@@ -22,6 +22,7 @@ import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
@@ -59,13 +60,16 @@ class SubscriptionEndpointFastFailTest {
     private val okHttpClient = mockk<OkHttpClient>()
     private val authorizer = mockk<SubscriptionAuthorizer>()
     private val apiConfiguration = mockk<ApiConfiguration>()
-    private val responseFactory = mockk<GraphQLResponse.Factory>(relaxed = true)
+    private val responseFactory: GraphQLResponse.Factory = GsonGraphQLResponseFactory()
     private val request = mockk<GraphQLRequest<String>>(relaxed = true)
 
     // Explicit ordering signals (no sleeps): the listener is captured when newWebSocket is called,
     // and startSent fires the moment the request thread sends the "start" frame.
     private val listenerReady = CompletableDeferred<WebSocketListener>()
     private val startSent = CompletableDeferred<Unit>()
+
+    // The subscription id carried on the "start" frame, so a test can reply with a matching "start_ack".
+    private val startId = CompletableDeferred<String>()
 
     private lateinit var endpoint: SubscriptionEndpoint
 
@@ -80,6 +84,9 @@ class SubscriptionEndpointFastFailTest {
             val message = firstArg<String>()
             if (message.contains("\"type\":\"start\"")) {
                 startSent.complete(Unit)
+                if (!startId.isCompleted) {
+                    startId.complete(JSONObject(message).getString("id"))
+                }
             }
             sendBehavior(message)
         }
@@ -93,6 +100,7 @@ class SubscriptionEndpointFastFailTest {
     private class Callbacks {
         val started = CompletableDeferred<String>()
         val errored = CompletableDeferred<ApiException>()
+        val nextItem = CompletableDeferred<Unit>()
     }
 
     /** Launches the blocking [SubscriptionEndpoint.requestSubscription] on a background dispatcher. */
@@ -103,7 +111,7 @@ class SubscriptionEndpointFastFailTest {
                 request,
                 AuthorizationType.API_KEY,
                 Consumer { id -> callbacks.started.complete(id) },
-                Consumer { /* onNextItem */ },
+                Consumer { callbacks.nextItem.complete(Unit) },
                 Consumer { error -> callbacks.errored.complete(error) },
                 Action { /* onComplete */ }
             )
@@ -118,9 +126,95 @@ class SubscriptionEndpointFastFailTest {
             webSocket,
             JSONObject()
                 .put("type", "connection_ack")
-                .put("payload", JSONObject().put("connectionTimeoutMs", "300000"))
+                .put("payload", JSONObject().put("connectionTimeoutMs", 300000))
                 .toString()
         )
+    }
+
+    @Test
+    fun `subscription data frame with an object payload is delivered`() = runTest {
+        // A SUBSCRIPTION_DATA frame carries "payload" as a JSON object; the endpoint must extract it
+        // without getString, which throws on an object under the reference org.json.
+        setup()
+        val callbacks = launchRequest()
+
+        withContext(Dispatchers.IO) {
+            val listener = withTimeout(5.seconds) { listenerReady.await() }
+            driveConnected(listener)
+            withTimeout(5.seconds) { startSent.await() }
+            val id = withTimeout(5.seconds) { startId.await() }
+            listener.onMessage(webSocket, JSONObject().put("type", "start_ack").put("id", id).toString())
+            withTimeout(5.seconds) { callbacks.started.await() }
+
+            // A data frame whose payload is an object (the real AppSync shape).
+            listener.onMessage(
+                webSocket,
+                JSONObject()
+                    .put("type", "data")
+                    .put("id", id)
+                    .put(
+                        "payload",
+                        JSONObject().put("data", JSONObject().put("onCreateTodo", JSONObject().put("id", "1")))
+                    )
+                    .toString()
+            )
+
+            withTimeout(5.seconds) { callbacks.nextItem.await() }.shouldNotBeNull()
+        }
+        callbacks.errored.isCompleted.shouldBeFalse()
+    }
+
+    @Test
+    fun `subscription error frame with an object payload is delivered`() = runTest {
+        // A SUBSCRIPTION_ERROR frame also carries "payload" as a JSON object and takes the same
+        // getJSONObject path as a data frame.
+        setup()
+        val callbacks = launchRequest()
+
+        withContext(Dispatchers.IO) {
+            val listener = withTimeout(5.seconds) { listenerReady.await() }
+            driveConnected(listener)
+            withTimeout(5.seconds) { startSent.await() }
+            val id = withTimeout(5.seconds) { startId.await() }
+            listener.onMessage(webSocket, JSONObject().put("type", "start_ack").put("id", id).toString())
+            withTimeout(5.seconds) { callbacks.started.await() }
+
+            listener.onMessage(
+                webSocket,
+                JSONObject()
+                    .put("type", "error")
+                    .put("id", id)
+                    .put("payload", JSONObject().put("errors", JSONArray().put(JSONObject().put("message", "boom"))))
+                    .toString()
+            )
+
+            withTimeout(5.seconds) { callbacks.nextItem.await() }.shouldNotBeNull()
+        }
+    }
+
+    @Test
+    fun `subscription starts when connection_ack carries a numeric connectionTimeoutMs`() = runTest {
+        // Real AppSync sends connectionTimeoutMs as a JSON number (see websocket-connection_ack.json).
+        // The endpoint must parse it (getInt) and reach CONNECTED so the subscription can start; a
+        // getString-based parse throws on a number under the reference org.json.
+        setup()
+        val callbacks = launchRequest()
+
+        withContext(Dispatchers.IO) {
+            val listener = withTimeout(5.seconds) { listenerReady.await() }
+            driveConnected(listener)
+            withTimeout(5.seconds) { startSent.await() }
+            val id = withTimeout(5.seconds) { startId.await() }
+
+            // Server acknowledges the subscription start; this only happens if the ack parsed cleanly.
+            listener.onMessage(
+                webSocket,
+                JSONObject().put("type", "start_ack").put("id", id).toString()
+            )
+
+            withTimeout(5.seconds) { callbacks.started.await() } shouldBe id
+        }
+        callbacks.errored.isCompleted.shouldBeFalse()
     }
 
     @Test


### PR DESCRIPTION
## Description

On R8 release builds, GraphQL subscriptions time out on the connection ack, and those that connect fail to deliver events. `SubscriptionEndpoint` reads `connectionTimeoutMs` and the data/error `payload` with `getString`, but those values are a JSON number and a JSON object. Android's built-in `org.json` coerces them, while the stricter reference `org.json` that a dependency like Google IMA bundles throws. Under R8 the stricter one can win, so the ack never parses and events fail to deserialize.

The fix reads each value as its real type: `getInt` for `connectionTimeoutMs` and `getJSONObject("payload").toString()` for the payloads, which both implementations handle the same way.

## Testing

- Reproduced on an emulator against a live AppSync backend using a minified release build that also depends on mux/IMA. Subscribing reproduced the 30s timeout reported in the issue.
- After the fix, the same release build connected within a few seconds, and a create mutation delivered the subscription event e2e.
- Added unit tests covering a numeric ack and object payloads on the data and error frames (`SubscriptionEndpointFastFailTest`). Unit tests, ktlint, and the API compatibility check all pass.
- This cannot be covered by a JVM unit test because the test environment uses the lenient `org.json`, so the e2e run serves as the regression proof.

Follow-up to #3423 (reviewer request)

Refs #2793
