### PR TITLE
fix(datastore): Use tryOnError in base sync to prevent UndeliverableException crash

### DIFF
--- a/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
+++ b/aws-datastore/src/main/java/com/amplifyframework/datastore/syncengine/SyncProcessor.java
@@ -353,9 +353,11 @@ final class SyncProcessor {
                                                     .collect(Collectors.toList());
                     String errors = String.join(",\n", errorStrings);
 
-                    emitter.onError(new DataStoreException.IrRecoverableException(
-                            "Received errors from AppSync: " + errors, "Report to AWS team."
-                    ));
+                    DataStoreException syncError = new DataStoreException.IrRecoverableException(
+                            "Received errors from AppSync: " + errors, "Report to AWS team.");
+                    if (!emitter.tryOnError(syncError)) {
+                        LOG.warn("Sync error emitted after the subscriber was disposed.", syncError);
+                    }
                 } else {
                     if (result.hasErrors()) {
                         LOG.warn(String.format("Both data and errors received on model sync: %s", result.getErrors()));
@@ -363,7 +365,11 @@ final class SyncProcessor {
 
                     emitter.onSuccess(result);
                 }
-            }, emitter::onError);
+            }, failure -> {
+                    if (!emitter.tryOnError(failure)) {
+                        LOG.warn("Sync failure emitted after the subscriber was disposed.", failure);
+                    }
+                });
             emitter.setDisposable(AmplifyDisposables.fromCancelable(cancelable));
         });
     }

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorDisposalTest.kt
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorDisposalTest.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.datastore.syncengine
+
+import androidx.test.core.app.ApplicationProvider
+import com.amplifyframework.api.graphql.GraphQLResponse
+import com.amplifyframework.api.graphql.PaginatedResult
+import com.amplifyframework.core.Consumer
+import com.amplifyframework.core.async.NoOpCancelable
+import com.amplifyframework.core.model.ModelProvider
+import com.amplifyframework.core.model.SchemaRegistry
+import com.amplifyframework.datastore.DataStoreConfiguration
+import com.amplifyframework.datastore.DataStoreConfigurationProvider
+import com.amplifyframework.datastore.DataStoreErrorHandler
+import com.amplifyframework.datastore.DataStoreException
+import com.amplifyframework.datastore.appsync.AppSync
+import com.amplifyframework.datastore.appsync.AppSyncMocking
+import com.amplifyframework.datastore.appsync.ModelWithMetadata
+import com.amplifyframework.datastore.storage.SynchronousStorageAdapter
+import com.amplifyframework.datastore.storage.sqlite.SQLiteStorageAdapter
+import com.amplifyframework.testmodels.commentsblog.AmplifyModelProvider
+import com.amplifyframework.testmodels.commentsblog.BlogOwner
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.mockk.mockk
+import io.reactivex.rxjava3.plugins.RxJavaPlugins
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.timeout
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression tests for the base-sync disposal race: when the subscriber is disposed while
+ * a sync network call is in flight, a late error must be delivered through emitter.tryOnError so it is
+ * dropped on the disposed emitter rather than crashing the app with an RxJava UndeliverableException.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SyncProcessorDisposalTest {
+    private val appSync = mock(AppSync::class.java) // using Mockito due to existing AppSyncMocking setup
+    private val errorHandler = mockk<DataStoreErrorHandler>(relaxed = true)
+
+    private lateinit var modelProvider: ModelProvider
+    private lateinit var storageAdapter: SynchronousStorageAdapter
+    private lateinit var syncProcessor: SyncProcessor
+
+    @Before
+    fun setup() {
+        modelProvider = AmplifyModelProvider.getInstance()
+        val schemaRegistry = SchemaRegistry.instance().apply {
+            clear()
+            register(modelProvider.models())
+        }
+
+        val configuration = DataStoreConfiguration.builder()
+            .errorHandler(errorHandler)
+            .syncInterval(1, TimeUnit.MINUTES)
+            .syncPageSize(1000)
+            .syncMaxRecords(10_000)
+            .syncMaxConcurrentModels(1)
+            .build()
+
+        val sqliteStorageAdapter = SQLiteStorageAdapter.forModels(schemaRegistry, modelProvider)
+        storageAdapter = SynchronousStorageAdapter.delegatingTo(sqliteStorageAdapter).apply {
+            initialize(ApplicationProvider.getApplicationContext(), configuration)
+        }
+
+        val configurationProvider = DataStoreConfigurationProvider { configuration }
+
+        syncProcessor = SyncProcessor.builder()
+            .modelProvider(modelProvider)
+            .schemaRegistry(schemaRegistry)
+            .syncTimeRegistry(SyncTimeRegistry(sqliteStorageAdapter))
+            .appSync(appSync)
+            .merger(
+                Merger(
+                    PersistentMutationOutbox(sqliteStorageAdapter),
+                    VersionRepository(sqliteStorageAdapter),
+                    sqliteStorageAdapter
+                )
+            )
+            .dataStoreConfigurationProvider(configurationProvider)
+            .queryPredicateProvider(
+                QueryPredicateProvider(configurationProvider).apply { resolvePredicates() }
+            )
+            .retryHandler(RetryHandler())
+            .isSyncRetryEnabled(false)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        storageAdapter.terminate()
+    }
+
+    @Test
+    fun `failure delivered after dispose does not throw UndeliverableException`() {
+        // Arrange: capture the failure callback without invoking it yet, keeping the sync in flight.
+        val capturedOnFailure = AtomicReference<Consumer<DataStoreException>>()
+        AppSyncMocking.sync(appSync)
+        doAnswer { invocation ->
+            capturedOnFailure.set(invocation.getArgument(2))
+            NoOpCancelable()
+        }.`when`(appSync).sync<BlogOwner>(any(), any(), any())
+
+        val undelivered = CopyOnWriteArrayList<Throwable>()
+        val previousHandler = RxJavaPlugins.getErrorHandler()
+        RxJavaPlugins.setErrorHandler { undelivered.add(it) }
+        try {
+            // Arrange: run the sync, wait for the callback, then dispose the subscriber.
+            val testObserver = syncProcessor.hydrate().test()
+            verify(appSync, timeout(TIMEOUT_MS).atLeastOnce()).sync<BlogOwner>(any(), any(), any())
+            val onFailure = capturedOnFailure.get().shouldNotBeNull()
+            testObserver.dispose()
+
+            // Act: deliver the failure to the now-disposed emitter.
+            onFailure.accept(DataStoreException("Sync failed after stop.", "Expected in this race."))
+
+            // Assert: no error reaches the global handler and the subscriber receives none.
+            undelivered.shouldBeEmpty()
+            testObserver.assertNoErrors()
+        } finally {
+            RxJavaPlugins.setErrorHandler(previousHandler)
+        }
+    }
+
+    @Test
+    fun `no-data response after dispose does not throw UndeliverableException`() {
+        // Arrange: capture the response callback without invoking it yet, keeping the sync in flight.
+        val capturedOnResponse =
+            AtomicReference<Consumer<GraphQLResponse<PaginatedResult<ModelWithMetadata<BlogOwner>>>>>()
+        AppSyncMocking.sync(appSync)
+        doAnswer { invocation ->
+            capturedOnResponse.set(invocation.getArgument(1))
+            NoOpCancelable()
+        }.`when`(appSync).sync<BlogOwner>(any(), any(), any())
+
+        val undelivered = CopyOnWriteArrayList<Throwable>()
+        val previousHandler = RxJavaPlugins.getErrorHandler()
+        RxJavaPlugins.setErrorHandler { undelivered.add(it) }
+        try {
+            // Arrange: run the sync, wait for the callback, then dispose the subscriber.
+            val testObserver = syncProcessor.hydrate().test()
+            verify(appSync, timeout(TIMEOUT_MS).atLeastOnce()).sync<BlogOwner>(any(), any(), any())
+            val onResponse = capturedOnResponse.get().shouldNotBeNull()
+            testObserver.dispose()
+
+            // Act: deliver a no-data (errors-only) response to the now-disposed emitter.
+            val noDataResponse = GraphQLResponse<PaginatedResult<ModelWithMetadata<BlogOwner>>>(
+                null,
+                listOf(GraphQLResponse.Error("Errors from AppSync after stop.", null, null, null))
+            )
+            onResponse.accept(noDataResponse)
+
+            // Assert: no error reaches the global handler and the subscriber receives none.
+            undelivered.shouldBeEmpty()
+            testObserver.assertNoErrors()
+        } finally {
+            RxJavaPlugins.setErrorHandler(previousHandler)
+        }
+    }
+
+    companion object {
+        private const val TIMEOUT_MS = 10_000L
+    }
+}

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -22,6 +22,8 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.PaginatedResult;
+import com.amplifyframework.core.Consumer;
+import com.amplifyframework.core.async.NoOpCancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchema;
@@ -79,12 +81,16 @@ import java.util.Random;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.exceptions.UndeliverableException;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.BLOGGER_ISLA;
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.BLOGGER_JAMESON;
@@ -92,10 +98,12 @@ import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstan
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.DRUM_POST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -881,6 +889,107 @@ public final class SyncProcessorTest {
             }
         }, 10000);
         verify(requestRetry, timeout(5000).times(1)).retry(any(), any());
+    }
+
+    /**
+     * Regression test: when the base-sync subscriber is disposed (for example, via DataStore.stop())
+     * while a sync network call is in flight, a subsequent failure callback must not crash the app with
+     * an RxJava UndeliverableException. The fix delivers the error via emitter.tryOnError, which no-ops
+     * on a disposed emitter instead of routing to the global RxJava error handler.
+     * @throws AmplifyException On failure to build the SyncProcessor.
+     * @throws InterruptedException If interrupted while awaiting the captured sync callback.
+     */
+    @Test
+    public void syncFailureAfterDisposeDoesNotThrowUndeliverable() throws AmplifyException, InterruptedException {
+        isSyncRetryEnabled = false;
+        initSyncProcessor(SYNC_MAX_RECORDS);
+
+        // Capture the AppSync failure consumer without invoking it, so the sync stays "in flight".
+        // AppSyncMocking wires up buildSyncRequest; we then override sync() to capture the failure callback.
+        final AtomicReference<Consumer<DataStoreException>> capturedOnFailure = new AtomicReference<>();
+        AppSyncMocking.sync(appSync);
+        doAnswer(invocation -> {
+            capturedOnFailure.set(invocation.getArgument(2));
+            return new NoOpCancelable();
+        }).when(appSync).sync(any(), any(), any());
+
+        // Record any error routed to RxJava's global "undeliverable" handler.
+        final List<Throwable> undelivered = new CopyOnWriteArrayList<>();
+        final io.reactivex.rxjava3.functions.Consumer<? super Throwable> previousHandler =
+                RxJavaPlugins.getErrorHandler();
+        RxJavaPlugins.setErrorHandler(undelivered::add);
+        try {
+            // Subscribe, then wait until the in-flight sync callback has been captured.
+            TestObserver<Void> testObserver = syncProcessor.hydrate().test();
+            verify(appSync, timeout(10_000).atLeastOnce()).sync(any(), any(), any());
+            assertNotNull("AppSync.sync was never invoked", capturedOnFailure.get());
+
+            // Dispose the subscriber (models the DataStore.stop() race), then deliver the failure.
+            testObserver.dispose();
+            capturedOnFailure.get().accept(
+                    new DataStoreException("Sync failed after stop.", "Expected in this race."));
+
+            // The failure must be swallowed by tryOnError, never surfaced as an UndeliverableException.
+            for (Throwable thrown : undelivered) {
+                assertFalse(
+                        "UndeliverableException leaked to the global handler: " + thrown,
+                        thrown instanceof UndeliverableException
+                            || thrown.getCause() instanceof UndeliverableException);
+            }
+        } finally {
+            RxJavaPlugins.setErrorHandler(previousHandler);
+        }
+    }
+
+    /**
+     * Companion to the failure-callback regression above, covering the success-callback error branch:
+     * when AppSync returns a no-data (errors-only) response after the subscriber has been disposed, the
+     * resulting error must be delivered via emitter.tryOnError and never surface as an RxJava
+     * UndeliverableException.
+     * @throws AmplifyException On failure to build the SyncProcessor.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void syncNoDataErrorAfterDisposeDoesNotThrowUndeliverable() throws AmplifyException {
+        isSyncRetryEnabled = false;
+        initSyncProcessor(SYNC_MAX_RECORDS);
+
+        // Capture the AppSync response consumer without invoking it, so the sync stays "in flight".
+        final AtomicReference<Consumer<GraphQLResponse<PaginatedResult<ModelWithMetadata<BlogOwner>>>>>
+                capturedOnResponse = new AtomicReference<>();
+        AppSyncMocking.sync(appSync);
+        doAnswer(invocation -> {
+            capturedOnResponse.set(invocation.getArgument(1));
+            return new NoOpCancelable();
+        }).when(appSync).sync(any(), any(), any());
+
+        // Record any error routed to RxJava's global "undeliverable" handler.
+        final List<Throwable> undelivered = new CopyOnWriteArrayList<>();
+        final io.reactivex.rxjava3.functions.Consumer<? super Throwable> previousHandler =
+                RxJavaPlugins.getErrorHandler();
+        RxJavaPlugins.setErrorHandler(undelivered::add);
+        try {
+            TestObserver<Void> testObserver = syncProcessor.hydrate().test();
+            verify(appSync, timeout(10_000).atLeastOnce()).sync(any(), any(), any());
+            assertNotNull("AppSync.sync was never invoked", capturedOnResponse.get());
+
+            // Dispose the subscriber, then deliver a no-data (errors-only) response.
+            testObserver.dispose();
+            GraphQLResponse<PaginatedResult<ModelWithMetadata<BlogOwner>>> noDataResponse =
+                    new GraphQLResponse<>(null, Arrays.asList(
+                            new GraphQLResponse.Error("Errors from AppSync after stop.", null, null, null)));
+            capturedOnResponse.get().accept(noDataResponse);
+
+            // The error must be swallowed by tryOnError, never surfaced as an UndeliverableException.
+            for (Throwable thrown : undelivered) {
+                assertFalse(
+                        "UndeliverableException leaked to the global handler: " + thrown,
+                        thrown instanceof UndeliverableException
+                            || thrown.getCause() instanceof UndeliverableException);
+            }
+        } finally {
+            RxJavaPlugins.setErrorHandler(previousHandler);
+        }
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -22,8 +22,6 @@ import com.amplifyframework.AmplifyException;
 import com.amplifyframework.api.graphql.GraphQLRequest;
 import com.amplifyframework.api.graphql.GraphQLResponse;
 import com.amplifyframework.api.graphql.PaginatedResult;
-import com.amplifyframework.core.Consumer;
-import com.amplifyframework.core.async.NoOpCancelable;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelProvider;
 import com.amplifyframework.core.model.ModelSchema;
@@ -81,15 +79,12 @@ import java.util.Random;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.BLOGGER_ISLA;
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.BLOGGER_JAMESON;
@@ -97,12 +92,10 @@ import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstan
 import static com.amplifyframework.datastore.appsync.TestModelWithMetadataInstances.DRUM_POST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -888,99 +881,6 @@ public final class SyncProcessorTest {
             }
         }, 10000);
         verify(requestRetry, timeout(5000).times(1)).retry(any(), any());
-    }
-
-    /**
-     * Regression test: when the base-sync subscriber is disposed (for example, via DataStore.stop())
-     * while a sync network call is in flight, a subsequent failure callback must not crash the app with
-     * an RxJava UndeliverableException. The fix delivers the error via emitter.tryOnError, which no-ops
-     * on a disposed emitter instead of routing to the global RxJava error handler.
-     * @throws AmplifyException On failure to build the SyncProcessor.
-     * @throws InterruptedException If interrupted while awaiting the captured sync callback.
-     */
-    @Test
-    public void syncFailureAfterDisposeDoesNotThrowUndeliverable() throws AmplifyException, InterruptedException {
-        isSyncRetryEnabled = false;
-        initSyncProcessor(SYNC_MAX_RECORDS);
-
-        // Capture the failure callback but never invoke it, so the sync stays in flight.
-        final AtomicReference<Consumer<DataStoreException>> capturedOnFailure = new AtomicReference<>();
-        AppSyncMocking.sync(appSync);
-        doAnswer(invocation -> {
-            capturedOnFailure.set(invocation.getArgument(2));
-            return new NoOpCancelable();
-        }).when(appSync).sync(any(), any(), any());
-
-        // Record errors routed to RxJava's global handler.
-        final List<Throwable> undelivered = new CopyOnWriteArrayList<>();
-        final io.reactivex.rxjava3.functions.Consumer<? super Throwable> previousHandler =
-                RxJavaPlugins.getErrorHandler();
-        RxJavaPlugins.setErrorHandler(undelivered::add);
-        try {
-            // Subscribe, then wait for the sync callback to be captured.
-            TestObserver<Void> testObserver = syncProcessor.hydrate().test();
-            verify(appSync, timeout(10_000).atLeastOnce()).sync(any(), any(), any());
-            assertNotNull("AppSync.sync was never invoked", capturedOnFailure.get());
-
-            // Dispose (models DataStore.stop()), then deliver the failure.
-            testObserver.dispose();
-            capturedOnFailure.get().accept(
-                    new DataStoreException("Sync failed after stop.", "Expected in this race."));
-
-            // tryOnError drops it on the disposed emitter.
-            assertTrue("Expected no undeliverable errors, but got: " + undelivered, undelivered.isEmpty());
-            // Contained: the disposed subscriber gets no error.
-            testObserver.assertNoErrors();
-        } finally {
-            RxJavaPlugins.setErrorHandler(previousHandler);
-        }
-    }
-
-    /**
-     * Companion to the failure-callback regression above, covering the success-callback error branch:
-     * when AppSync returns a no-data (errors-only) response after the subscriber has been disposed, the
-     * resulting error must be delivered via emitter.tryOnError and never surface as an RxJava
-     * UndeliverableException.
-     * @throws AmplifyException On failure to build the SyncProcessor.
-     */
-    @Test
-    public void syncNoDataErrorAfterDisposeDoesNotThrowUndeliverable() throws AmplifyException {
-        isSyncRetryEnabled = false;
-        initSyncProcessor(SYNC_MAX_RECORDS);
-
-        // Capture the response callback but never invoke it, so the sync stays in flight.
-        final AtomicReference<Consumer<GraphQLResponse<PaginatedResult<ModelWithMetadata<BlogOwner>>>>>
-                capturedOnResponse = new AtomicReference<>();
-        AppSyncMocking.sync(appSync);
-        doAnswer(invocation -> {
-            capturedOnResponse.set(invocation.getArgument(1));
-            return new NoOpCancelable();
-        }).when(appSync).sync(any(), any(), any());
-
-        // Record errors routed to RxJava's global handler.
-        final List<Throwable> undelivered = new CopyOnWriteArrayList<>();
-        final io.reactivex.rxjava3.functions.Consumer<? super Throwable> previousHandler =
-                RxJavaPlugins.getErrorHandler();
-        RxJavaPlugins.setErrorHandler(undelivered::add);
-        try {
-            TestObserver<Void> testObserver = syncProcessor.hydrate().test();
-            verify(appSync, timeout(10_000).atLeastOnce()).sync(any(), any(), any());
-            assertNotNull("AppSync.sync was never invoked", capturedOnResponse.get());
-
-            // Dispose, then deliver a no-data (errors-only) response.
-            testObserver.dispose();
-            GraphQLResponse<PaginatedResult<ModelWithMetadata<BlogOwner>>> noDataResponse =
-                    new GraphQLResponse<>(null, Arrays.asList(
-                            new GraphQLResponse.Error("Errors from AppSync after stop.", null, null, null)));
-            capturedOnResponse.get().accept(noDataResponse);
-
-            // tryOnError drops it on the disposed emitter.
-            assertTrue("Expected no undeliverable errors, but got: " + undelivered, undelivered.isEmpty());
-            // Contained: the disposed subscriber gets no error.
-            testObserver.assertNoErrors();
-        } finally {
-            RxJavaPlugins.setErrorHandler(previousHandler);
-        }
     }
 
     /**

--- a/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
+++ b/aws-datastore/src/test/java/com/amplifyframework/datastore/syncengine/SyncProcessorTest.java
@@ -88,7 +88,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.exceptions.UndeliverableException;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
@@ -904,8 +903,7 @@ public final class SyncProcessorTest {
         isSyncRetryEnabled = false;
         initSyncProcessor(SYNC_MAX_RECORDS);
 
-        // Capture the AppSync failure consumer without invoking it, so the sync stays "in flight".
-        // AppSyncMocking wires up buildSyncRequest; we then override sync() to capture the failure callback.
+        // Capture the failure callback but never invoke it, so the sync stays in flight.
         final AtomicReference<Consumer<DataStoreException>> capturedOnFailure = new AtomicReference<>();
         AppSyncMocking.sync(appSync);
         doAnswer(invocation -> {
@@ -913,29 +911,26 @@ public final class SyncProcessorTest {
             return new NoOpCancelable();
         }).when(appSync).sync(any(), any(), any());
 
-        // Record any error routed to RxJava's global "undeliverable" handler.
+        // Record errors routed to RxJava's global handler.
         final List<Throwable> undelivered = new CopyOnWriteArrayList<>();
         final io.reactivex.rxjava3.functions.Consumer<? super Throwable> previousHandler =
                 RxJavaPlugins.getErrorHandler();
         RxJavaPlugins.setErrorHandler(undelivered::add);
         try {
-            // Subscribe, then wait until the in-flight sync callback has been captured.
+            // Subscribe, then wait for the sync callback to be captured.
             TestObserver<Void> testObserver = syncProcessor.hydrate().test();
             verify(appSync, timeout(10_000).atLeastOnce()).sync(any(), any(), any());
             assertNotNull("AppSync.sync was never invoked", capturedOnFailure.get());
 
-            // Dispose the subscriber (models the DataStore.stop() race), then deliver the failure.
+            // Dispose (models DataStore.stop()), then deliver the failure.
             testObserver.dispose();
             capturedOnFailure.get().accept(
                     new DataStoreException("Sync failed after stop.", "Expected in this race."));
 
-            // The failure must be swallowed by tryOnError, never surfaced as an UndeliverableException.
-            for (Throwable thrown : undelivered) {
-                assertFalse(
-                        "UndeliverableException leaked to the global handler: " + thrown,
-                        thrown instanceof UndeliverableException
-                            || thrown.getCause() instanceof UndeliverableException);
-            }
+            // tryOnError drops it on the disposed emitter.
+            assertTrue("Expected no undeliverable errors, but got: " + undelivered, undelivered.isEmpty());
+            // Contained: the disposed subscriber gets no error.
+            testObserver.assertNoErrors();
         } finally {
             RxJavaPlugins.setErrorHandler(previousHandler);
         }
@@ -949,12 +944,11 @@ public final class SyncProcessorTest {
      * @throws AmplifyException On failure to build the SyncProcessor.
      */
     @Test
-    @SuppressWarnings("unchecked")
     public void syncNoDataErrorAfterDisposeDoesNotThrowUndeliverable() throws AmplifyException {
         isSyncRetryEnabled = false;
         initSyncProcessor(SYNC_MAX_RECORDS);
 
-        // Capture the AppSync response consumer without invoking it, so the sync stays "in flight".
+        // Capture the response callback but never invoke it, so the sync stays in flight.
         final AtomicReference<Consumer<GraphQLResponse<PaginatedResult<ModelWithMetadata<BlogOwner>>>>>
                 capturedOnResponse = new AtomicReference<>();
         AppSyncMocking.sync(appSync);
@@ -963,7 +957,7 @@ public final class SyncProcessorTest {
             return new NoOpCancelable();
         }).when(appSync).sync(any(), any(), any());
 
-        // Record any error routed to RxJava's global "undeliverable" handler.
+        // Record errors routed to RxJava's global handler.
         final List<Throwable> undelivered = new CopyOnWriteArrayList<>();
         final io.reactivex.rxjava3.functions.Consumer<? super Throwable> previousHandler =
                 RxJavaPlugins.getErrorHandler();
@@ -973,20 +967,17 @@ public final class SyncProcessorTest {
             verify(appSync, timeout(10_000).atLeastOnce()).sync(any(), any(), any());
             assertNotNull("AppSync.sync was never invoked", capturedOnResponse.get());
 
-            // Dispose the subscriber, then deliver a no-data (errors-only) response.
+            // Dispose, then deliver a no-data (errors-only) response.
             testObserver.dispose();
             GraphQLResponse<PaginatedResult<ModelWithMetadata<BlogOwner>>> noDataResponse =
                     new GraphQLResponse<>(null, Arrays.asList(
                             new GraphQLResponse.Error("Errors from AppSync after stop.", null, null, null)));
             capturedOnResponse.get().accept(noDataResponse);
 
-            // The error must be swallowed by tryOnError, never surfaced as an UndeliverableException.
-            for (Throwable thrown : undelivered) {
-                assertFalse(
-                        "UndeliverableException leaked to the global handler: " + thrown,
-                        thrown instanceof UndeliverableException
-                            || thrown.getCause() instanceof UndeliverableException);
-            }
+            // tryOnError drops it on the disposed emitter.
+            assertTrue("Expected no undeliverable errors, but got: " + undelivered, undelivered.isEmpty());
+            // Contained: the disposed subscriber gets no error.
+            testObserver.assertNoErrors();
         } finally {
             RxJavaPlugins.setErrorHandler(previousHandler);
         }


### PR DESCRIPTION
## Description

DataStore's base sync wraps the AppSync query in an RxJava `Single` in `SyncProcessor`. If sync is stopped while a request is still running, the OkHttp callback comes back after the subscriber is already disposed. The error is then delivered to a dead emitter, so RxJava reports it as an `UndeliverableException` and the app crashes. This is the crash seen across devices in Play logs, the same crash class as the earlier #2654 report.

`SyncProcessor` now emits these errors through `tryOnError` on both the failure and no-data paths. On a disposed emitter it is a no-op, so the error is logged rather than crashing the app, while active subscribers are unaffected. This follows the existing convention in `Orchestrator` and the rxbindings adapters.

## Testing

- Reproduced e2e on 2.21.0: started sync, dropped the network, and stopped DataStore mid-flight. The `UndeliverableException` appeared in logcat matching the reported stack.
- With the fix, re-ran the same race on API 28, 31, and 34 (~380 attempts): zero crashes, sync unaffected.
- Added unit tests for the failure and no-data branches. Each fails on the old code and passes with the fix. Unit tests, ktlint, checkstyle, and apiCheck all pass.

Refs #2898
