### PR TITLE
feat(api): lazy loading for related models

### DIFF
--- a/aws-appsync/build.gradle.kts
+++ b/aws-appsync/build.gradle.kts
@@ -40,4 +40,5 @@ dependencies {
     testImplementation(libs.test.kotlin.reflection)
     testImplementation(libs.test.mockwebserver)
     testImplementation(project(":testutils"))
+    testImplementation(project(":testmodels"))
 }

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AmplifyAppSyncClient.kt
@@ -71,12 +71,39 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
 
     private val httpClient: OkHttpClient by lazyHttpClient
 
+    /**
+     * Issues the follow-up request a lazily-loaded relationship needs, by going back through this
+     * client's own send path so the request is authorized and retried exactly as any other is.
+     *
+     * Handed to [appSyncGson] during construction but only invoked once a relationship is loaded, which
+     * is what allows the two to reference each other.
+     */
+    private val modelLoader = object : AppSyncModelLoader {
+        override suspend fun <M> load(request: GraphQLRequest<M>): M? {
+            val response = send(request).getOrThrow()
+            // Errors with no data mean the relationship could not be read, so they must not reach the
+            // caller as an absent relationship.
+            if (response.data == null && response.hasErrors()) {
+                throw AppSyncGraphQLErrorException(
+                    message = "Loading a relationship failed with GraphQL errors.",
+                    errors = response.errors
+                )
+            }
+            return response.data
+        }
+    }
+
+    private val appSyncGson by lazy { AppSyncGson(modelLoader) }
+
+    private val deserializer: AppSyncResponseDeserializer by lazy { AppSyncResponseDeserializer(appSyncGson.gson) }
+
     private val transport: AppSyncHttpTransport by lazy {
         AppSyncHttpTransport(
             endpoint = configuration.endpoint,
             client = httpClient,
             authorization = configuration.authorization,
-            decorator = AppSyncRequestDecorator(configuration.region)
+            decorator = AppSyncRequestDecorator(configuration.region),
+            deserializer = deserializer
         )
     }
 
@@ -102,7 +129,8 @@ class AmplifyAppSyncClient(val configuration: Configuration) {
             },
             authorization = configuration.authorization,
             decorator = decorator,
-            httpEndpoint = configuration.endpoint
+            httpEndpoint = configuration.endpoint,
+            deserializer = deserializer
         )
     }
 

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
@@ -53,6 +53,9 @@ internal class AppSyncGson(
                 AppSyncModelListDeserializer.register(it)
                 AppSyncModelPageDeserializer.register(it)
                 AppSyncModelReferenceDeserializer.register(it, loader, schemaRegistry)
+                // Registered after the adapters above so that it wraps whichever of them reads a model:
+                // they do the reading, and this fills in the relationship fields they left null.
+                AppSyncRelationshipTypeAdapterFactory.register(it, loader, schemaRegistry)
             }
             // A mutation that clears a field needs an explicit `"field": null` in the payload, because
             // AppSync reads an absent field as "leave unchanged" rather than "set to null".

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
@@ -30,7 +30,8 @@ import com.google.gson.GsonBuilder
  * Private to the client rather than shared, so neither the adapter set nor the null handling below can
  * be altered from outside.
  *
- * TODO: register deserializers for lazily-loaded model lists and pages, which this set does not cover.
+ * Related lists and pages that arrive in full are covered. TODO: a lazily-loaded ModelReference still
+ * is not — it needs a way to issue the follow-up query, which this instance has no handle on.
  */
 internal object AppSyncGson {
 
@@ -44,6 +45,8 @@ internal object AppSyncGson {
                 ModelWithMetadataAdapter.register(it)
                 SerializedModelAdapter.register(it)
                 SerializedCustomTypeAdapter.register(it)
+                AppSyncModelListDeserializer.register(it)
+                AppSyncModelPageDeserializer.register(it)
             }
             // A mutation that clears a field needs an explicit `"field": null` in the payload, because
             // AppSync reads an absent field as "leave unchanged" rather than "set to null".

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncGson.kt
@@ -28,14 +28,19 @@ import com.google.gson.GsonBuilder
  * The Gson instance the client serializes requests and deserializes responses with.
  *
  * Private to the client rather than shared, so neither the adapter set nor the null handling below can
- * be altered from outside.
+ * be altered from outside. One instance per client, because a lazily-loaded relationship needs to issue
+ * its own request and so the adapters have to carry that client's [AppSyncModelLoader].
  *
- * Related lists and pages that arrive in full are covered. TODO: a lazily-loaded ModelReference still
- * is not — it needs a way to issue the follow-up query, which this instance has no handle on.
+ * [gson] is built on first use, which is what lets a client hand in a loader that routes back through
+ * the client itself: the loader is captured while the client is still being constructed, but is not
+ * invoked until a relationship is actually loaded.
  */
-internal object AppSyncGson {
+internal class AppSyncGson(
+    private val loader: AppSyncModelLoader,
+    private val schemaRegistry: AppSyncSchemaRegistry = AppSyncSchemaRegistry()
+) {
 
-    val instance: Gson by lazy {
+    val gson: Gson by lazy {
         GsonBuilder()
             .also {
                 GsonTemporalAdapters.register(it)
@@ -47,6 +52,7 @@ internal object AppSyncGson {
                 SerializedCustomTypeAdapter.register(it)
                 AppSyncModelListDeserializer.register(it)
                 AppSyncModelPageDeserializer.register(it)
+                AppSyncModelReferenceDeserializer.register(it, loader, schemaRegistry)
             }
             // A mutation that clears a field needs an explicit `"field": null` in the payload, because
             // AppSync reads an absent field as "leave unchanged" rather than "set to null".

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncHttpTransport.kt
@@ -45,6 +45,7 @@ internal class AppSyncHttpTransport(
     private val client: OkHttpClient,
     private val authorization: AppSyncAuthorization,
     private val decorator: AppSyncRequestDecorator,
+    private val deserializer: AppSyncResponseDeserializer,
     private val authModeResolver: AppSyncAuthModeResolver = AppSyncAuthModeResolver(authorization)
 ) {
 
@@ -178,11 +179,11 @@ internal class AppSyncHttpTransport(
             )
         }
 
-        return AppSyncResponseDeserializer.deserialize(request, body)
+        return deserializer.deserialize(request, body)
     }
 
     private fun <T> clientError(request: GraphQLRequest<T>, response: Response, body: String?): AppSyncException {
-        val parsed = runCatching { AppSyncResponseDeserializer.deserialize(request, body) }.getOrNull()
+        val parsed = runCatching { deserializer.deserialize(request, body) }.getOrNull()
         val errors = parsed?.errors?.takeIf { it.isNotEmpty() }
 
         // A throttle is not a defect in the request, so it must not arrive as one — the advice to check

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncLazyDeserializers.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncLazyDeserializers.kt
@@ -14,16 +14,90 @@
  */
 package com.amazonaws.appsync
 
+import com.amplifyframework.core.model.LoadedModelReferenceImpl
 import com.amplifyframework.core.model.Model
 import com.amplifyframework.core.model.ModelList
 import com.amplifyframework.core.model.ModelPage
+import com.amplifyframework.core.model.ModelReference
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
+
+/**
+ * Deserializes a related model, which may or may not have arrived with the response.
+ *
+ * A selection set that requested the related model's fields yields a
+ * [com.amplifyframework.core.model.LoadedModelReference] holding it. One that requested only its
+ * primary key yields a reference that fetches the model when it is first accessed.
+ *
+ * A relationship the parent does not have is never seen here: a JSON null becomes a null field before
+ * a deserializer is consulted.
+ */
+internal class AppSyncModelReferenceDeserializer<M : Model>(
+    private val loader: AppSyncModelLoader,
+    private val schemaRegistry: AppSyncSchemaRegistry
+) : JsonDeserializer<ModelReference<M>> {
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): ModelReference<M> {
+        val parameterized = typeOfT as? ParameterizedType
+            ?: throw AppSyncDeserializationException(
+                message = "A related model was requested as ${typeOfT.typeName}, which carries no model type.",
+                recoverySuggestion = "Request the relationship as ModelReference<T> so the model type is known."
+            )
+
+        @Suppress("UNCHECKED_CAST")
+        val modelClass = parameterized.actualTypeArguments.first() as Class<M>
+        val jsonObject = json.asJsonObjectOrThrow()
+        val keyFields = schemaRegistry.schemaFor(modelClass).primaryIndexFields
+
+        // More fields than the key means the selection set asked for the model itself, so it is already
+        // here and there is nothing to defer. A failure to read it is not fatal: the key is still
+        // present, so the model can be fetched instead.
+        if (jsonObject.size() > keyFields.size) {
+            runCatching { context.deserialize<M>(json, modelClass) }
+                .onSuccess { return LoadedModelReferenceImpl(it) }
+        }
+
+        return AppSyncLazyModelReference(modelClass, jsonObject.keyValues(keyFields), loader)
+    }
+
+    /**
+     * Reads the primary key values, which are what identify the model in the follow-up query.
+     *
+     * A key that is incomplete identifies nothing, so it is reported as no key at all — the reference
+     * then resolves to null rather than issuing a request that cannot succeed.
+     */
+    private fun JsonObject.keyValues(keyFields: List<String>): Map<String, Any> {
+        val values = keyFields.mapNotNull { field ->
+            (get(field) as? JsonPrimitive)?.let { field to it.keyValue() }
+        }.toMap()
+        return if (values.size == keyFields.size) values else emptyMap()
+    }
+
+    /**
+     * Unwraps a key so it travels as the type the model declares. The value becomes a query variable,
+     * and the JSON wrapper would not serialize as the scalar the variable's type requires.
+     */
+    private fun JsonPrimitive.keyValue(): Any = when {
+        isBoolean -> asBoolean
+        isNumber -> asNumber
+        else -> asString
+    }
+
+    companion object {
+        fun register(builder: GsonBuilder, loader: AppSyncModelLoader, schemaRegistry: AppSyncSchemaRegistry) {
+            builder.registerTypeAdapter(
+                ModelReference::class.java,
+                AppSyncModelReferenceDeserializer<Model>(loader, schemaRegistry)
+            )
+        }
+    }
+}
 
 /**
  * Deserializes a related list that arrived in full, as `{"items": [...]}`.
@@ -96,7 +170,7 @@ private fun deserializeNextToken(json: JsonElement): AppSyncPaginationToken? =
 
 private fun JsonElement.asJsonObjectOrThrow(): JsonObject = this as? JsonObject
     ?: throw AppSyncDeserializationException(
-        message = "A related list was expected to be a JSON object, but was ${this::class.simpleName}."
+        message = "A relationship was expected to be a JSON object, but was ${this::class.simpleName}."
     )
 
 private const val ITEMS_KEY = "items"

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncLazyDeserializers.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncLazyDeserializers.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelList
+import com.amplifyframework.core.model.ModelPage
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+/**
+ * Deserializes a related list that arrived in full, as `{"items": [...]}`.
+ *
+ * Produces a [com.amplifyframework.core.model.LoadedModelList], never a lazy one: everything the
+ * caller asked for is already in the payload, so there is nothing to defer.
+ */
+internal class AppSyncModelListDeserializer<M : Model> : JsonDeserializer<ModelList<M>> {
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext) =
+        AppSyncLoadedModelList(deserializeItems<M>(json, typeOfT, context))
+
+    companion object {
+        fun register(builder: GsonBuilder) {
+            builder.registerTypeAdapter(ModelList::class.java, AppSyncModelListDeserializer<Model>())
+        }
+    }
+}
+
+/**
+ * Deserializes one page of a paginated list, as `{"items": [...], "nextToken": "..."}`.
+ */
+internal class AppSyncModelPageDeserializer<M : Model> : JsonDeserializer<ModelPage<M>> {
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext) = AppSyncModelPage(
+        items = deserializeItems<M>(json, typeOfT, context),
+        nextToken = deserializeNextToken(json)
+    )
+
+    companion object {
+        fun register(builder: GsonBuilder) {
+            // A hierarchy adapter, unlike the list above: a response type may be a subtype of ModelPage,
+            // and an exact-type adapter would not be consulted for one.
+            builder.registerTypeHierarchyAdapter(ModelPage::class.java, AppSyncModelPageDeserializer<Model>())
+        }
+    }
+}
+
+/**
+ * Reads the `items` array, deserializing each entry as the list's element type.
+ *
+ * The element type comes from the requested type's parameter, so the caller's `ModelList<Todo>` is what
+ * decides how each item is read.
+ */
+private fun <M : Model> deserializeItems(
+    json: JsonElement,
+    typeOfT: Type,
+    context: JsonDeserializationContext
+): List<M> {
+    val parameterized = typeOfT as? ParameterizedType
+        ?: throw AppSyncDeserializationException(
+            message = "A related list was requested as ${typeOfT.typeName}, which carries no element type.",
+            recoverySuggestion = "Request the list as ModelList<T> or ModelPage<T> so the item type is known."
+        )
+    val elementType = parameterized.actualTypeArguments.first()
+
+    val items = json.asJsonObjectOrThrow().get(ITEMS_KEY)
+        ?.takeIf { it.isJsonArray }
+        ?: throw AppSyncDeserializationException(
+            message = "A related list was expected to carry an \"$ITEMS_KEY\" array, but did not.",
+            recoverySuggestion = "Verify the selection set requests the list's items."
+        )
+
+    return items.asJsonArray.map { context.deserialize(it.asJsonObject, elementType) }
+}
+
+/** Reads `nextToken`, absent when the page is the last one. */
+private fun deserializeNextToken(json: JsonElement): AppSyncPaginationToken? =
+    json.asJsonObjectOrThrow().get(NEXT_TOKEN_KEY)
+        ?.takeIf { it.isJsonPrimitive }
+        ?.let { AppSyncPaginationToken(it.asString) }
+
+private fun JsonElement.asJsonObjectOrThrow(): JsonObject = this as? JsonObject
+    ?: throw AppSyncDeserializationException(
+        message = "A related list was expected to be a JSON object, but was ${this::class.simpleName}."
+    )
+
+private const val ITEMS_KEY = "items"
+private const val NEXT_TOKEN_KEY = "nextToken"

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncLazyModelTypes.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncLazyModelTypes.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.api.aws.AppSyncGraphQLRequestFactory
+import com.amplifyframework.api.graphql.GraphQLRequest
+import com.amplifyframework.core.Consumer
+import com.amplifyframework.core.NullableConsumer
+import com.amplifyframework.core.model.LazyModelList
+import com.amplifyframework.core.model.LazyModelReference
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelPage
+import com.amplifyframework.core.model.PaginationToken
+import com.amplifyframework.core.model.query.predicate.QueryField
+import com.amplifyframework.core.model.query.predicate.QueryPredicate
+import com.amplifyframework.core.model.query.predicate.QueryPredicates
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A related model that was not included in the response, fetched on first access and then cached.
+ *
+ * The related model is identified by [keyMap], the primary key values that the parent's response
+ * carried in place of the model itself. An empty [keyMap] means the parent had no related model at
+ * all: such a reference resolves to null without ever issuing a request.
+ *
+ * Both `fetchModel` overloads report failure as [AmplifyException] whose `cause` is always an
+ * [AppSyncException], so a caller that wants the typed error can match on it:
+ *
+ * ```kotlin
+ * val blog = try {
+ *     post.blog.fetchModel()
+ * } catch (e: AmplifyException) {
+ *     when (e.cause) {
+ *         is AppSyncNetworkException -> retryLater()
+ *         else -> report(e)
+ *     }
+ * }
+ * ```
+ */
+internal class AppSyncLazyModelReference<M : Model>(
+    private val modelClass: Class<M>,
+    private val keyMap: Map<String, Any>,
+    private val loader: AppSyncModelLoader,
+    private val callbackScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+) : LazyModelReference<M> {
+
+    // Wrapped rather than held bare, because a loaded value may itself be null: a bare null could not
+    // be told apart from "nothing has been loaded yet", and would be re-fetched on every access.
+    private val cached = AtomicReference<Cached<M>?>(null)
+    private val mutex = Mutex()
+
+    init {
+        if (keyMap.isEmpty()) {
+            cached.set(Cached(null))
+        }
+    }
+
+    override fun getIdentifier(): Map<String, Any> = keyMap
+
+    override suspend fun fetchModel(): M? {
+        val hit = cached.get()
+        if (hit != null) return hit.value
+        return load()
+    }
+
+    override fun fetchModel(onSuccess: NullableConsumer<M?>, onError: Consumer<AmplifyException>) {
+        val hit = cached.get()
+        if (hit != null) {
+            // Returning here is what keeps onSuccess to a single call: falling through would deliver
+            // the cached value and then deliver it again from the coroutine below.
+            onSuccess.accept(hit.value)
+            return
+        }
+        callbackScope.launch {
+            try {
+                onSuccess.accept(fetchModel())
+            } catch (error: AmplifyException) {
+                onError.accept(error)
+            }
+        }
+    }
+
+    /**
+     * Fetches under a lock, so concurrent callers issue one request between them rather than one each.
+     * The cache is re-read inside the lock: by the time a queued caller acquires it the value is
+     * usually already there.
+     */
+    private suspend fun load(): M? = mutex.withLock {
+        cached.get()?.let { return it.value }
+
+        val value = try {
+            val request: GraphQLRequest<M> = AppSyncGraphQLRequestFactory.buildQueryFromKeyMap(modelClass, keyMap)
+            loader.load(request)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Exception) {
+            throw lazyLoadFailure("Could not load the related ${modelClass.simpleName}.", error)
+        }
+
+        cached.set(Cached(value))
+        value
+    }
+
+    /** Distinguishes a loaded null from an absent value. */
+    private class Cached<M : Model>(val value: M?)
+}
+
+/**
+ * A related list that was not included in the response, fetched a page at a time.
+ *
+ * Unlike a single reference, pages are not cached: each `fetchPage` issues a request, because the
+ * caller controls which page it asks for.
+ *
+ * Every `fetchPage` overload reports failure as [AmplifyException] whose `cause` is always an
+ * [AppSyncException], so a caller that wants the typed error can match on it.
+ */
+// TODO: nothing constructs this yet. A response leaves a lazy list field null, so filling it in
+//  needs a post-deserialization pass that derives the foreign-key map from the child schema's
+//  associations. Until that exists this type is reachable only from tests.
+internal class AppSyncLazyModelList<out M : Model>(
+    private val modelClass: Class<M>,
+    keyMap: Map<String, Any>,
+    private val loader: AppSyncModelLoader,
+    private val callbackScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+) : LazyModelList<M> {
+
+    // The parent's key values are the filter for the child query: they name the foreign key fields on
+    // the child that point back at the parent.
+    private val predicate: QueryPredicate = keyMap.entries.fold(QueryPredicates.all()) { predicate, (field, value) ->
+        predicate.and(QueryField.field(modelClass.simpleName, field).eq(value))
+    }
+
+    override suspend fun fetchPage(paginationToken: PaginationToken?): ModelPage<M> {
+        val page = try {
+            val request: GraphQLRequest<ModelPage<M>> = AppSyncGraphQLRequestFactory.buildModelPageQuery(
+                modelClass,
+                predicate,
+                AppSyncModelPage::class.java,
+                (paginationToken as? AppSyncPaginationToken)?.nextToken
+            )
+            loader.load(request)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Exception) {
+            throw lazyLoadFailure("Could not load a page of related ${modelClass.simpleName}.", error)
+        }
+
+        return page ?: throw lazyLoadFailure(
+            "Could not load a page of related ${modelClass.simpleName}.",
+            AppSyncUnknownException(
+                message = "The response carried no page of results.",
+                recoverySuggestion = "Verify the API returns a list for this relationship."
+            )
+        )
+    }
+
+    override fun fetchPage(onSuccess: Consumer<ModelPage<@UnsafeVariance M>>, onError: Consumer<AmplifyException>) =
+        fetchPage(null, onSuccess, onError)
+
+    override fun fetchPage(
+        paginationToken: PaginationToken?,
+        onSuccess: Consumer<ModelPage<@UnsafeVariance M>>,
+        onError: Consumer<AmplifyException>
+    ) {
+        callbackScope.launch {
+            try {
+                onSuccess.accept(fetchPage(paginationToken))
+            } catch (error: AmplifyException) {
+                onError.accept(error)
+            }
+        }
+    }
+}
+
+/**
+ * Wraps a failure so it can be thrown from a lazy load.
+ *
+ * The two hierarchies involved are unrelated classes that happen to share a name, and the lazy
+ * interfaces declare the one in `com.amplifyframework`. Throwing the client's own exception directly
+ * would be an undeclared checked exception that a Java caller's `catch (AmplifyException)` could not
+ * catch, so it travels as the cause instead, with its recovery suggestion carried across.
+ */
+private fun lazyLoadFailure(message: String, error: Throwable): AmplifyException {
+    val cause = AppSyncException.from(error)
+    return AmplifyException(message, cause, cause.recoverySuggestion)
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncLazyModelTypes.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncLazyModelTypes.kt
@@ -133,9 +133,6 @@ internal class AppSyncLazyModelReference<M : Model>(
  * Every `fetchPage` overload reports failure as [AmplifyException] whose `cause` is always an
  * [AppSyncException], so a caller that wants the typed error can match on it.
  */
-// TODO: nothing constructs this yet. A response leaves a lazy list field null, so filling it in
-//  needs a post-deserialization pass that derives the foreign-key map from the child schema's
-//  associations. Until that exists this type is reachable only from tests.
 internal class AppSyncLazyModelList<out M : Model>(
     private val modelClass: Class<M>,
     keyMap: Map<String, Any>,

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncModelListTypes.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncModelListTypes.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.LoadedModelList
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelPage
+import com.amplifyframework.core.model.PaginationToken
+
+/**
+ * A list of models that arrived complete in a response, so there is nothing left to fetch.
+ */
+internal class AppSyncLoadedModelList<out M : Model>(override val items: List<M>) : LoadedModelList<M>
+
+/**
+ * One page of models, and the token for the next page when the service reported one.
+ *
+ * [ModelPage.hasNextPage] is derived from [nextToken], so a null token is what tells a caller the
+ * pagination is finished.
+ */
+internal class AppSyncModelPage<out M : Model>(
+    override val items: List<M>,
+    override val nextToken: AppSyncPaginationToken?
+) : ModelPage<M>
+
+/**
+ * An opaque cursor into a paginated result.
+ *
+ * [PaginationToken] carries no members: the value is meaningful only to AppSync, and a caller is
+ * expected to hand it back rather than interpret it.
+ */
+internal class AppSyncPaginationToken(val nextToken: String) : PaginationToken

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncModelLoader.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncModelLoader.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.graphql.GraphQLRequest
+
+/**
+ * Issues the follow-up request a lazily-loaded relationship needs.
+ *
+ * A deserialized lazy reference has to be able to query, but it is produced by a Gson instance that is
+ * built while the client is still being constructed. This one-method seam is what keeps the two apart:
+ * the client supplies an implementation that routes back through its own send path, and nothing in the
+ * deserialization layer holds a client.
+ *
+ * Implementations report failure by throwing [AppSyncException].
+ */
+internal interface AppSyncModelLoader {
+    suspend fun <M> load(request: GraphQLRequest<M>): M?
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncModelProviderLocator.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncModelProviderLocator.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.ModelProvider
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Modifier
+
+/**
+ * Finds the code-generated [ModelProvider] on the class path.
+ *
+ * Codegen emits the provider at a fixed fully-qualified name with a static `getInstance()`. None of
+ * that is verifiable at compile time — the provider lives in the consuming application, not here — so
+ * it is resolved reflectively and every way that can fail is reported as a configuration error the
+ * caller can act on.
+ */
+internal object AppSyncModelProviderLocator {
+
+    private const val DEFAULT_CLASS_NAME = "com.amplifyframework.datastore.generated.model.AmplifyModelProvider"
+    private const val ACCESSOR_NAME = "getInstance"
+
+    fun locate(className: String = DEFAULT_CLASS_NAME): ModelProvider {
+        val providerClass = try {
+            Class.forName(className)
+        } catch (error: ClassNotFoundException) {
+            throw AppSyncInvalidConfigException(
+                message = "Could not find the code-generated model provider $className.",
+                recoverySuggestion = "Verify that codegen has run and that $className is compiled into the app.",
+                cause = error
+            )
+        }
+
+        if (!ModelProvider::class.java.isAssignableFrom(providerClass)) {
+            throw AppSyncInvalidConfigException(
+                message = "Found $className, but it does not implement ${ModelProvider::class.java.name}.",
+                recoverySuggestion = "Verify that $className has not been modified since it was generated."
+            )
+        }
+
+        val accessor = try {
+            providerClass.getDeclaredMethod(ACCESSOR_NAME)
+        } catch (error: NoSuchMethodException) {
+            throw AppSyncInvalidConfigException(
+                message = "Found the model provider $className, but it has no $ACCESSOR_NAME() method.",
+                recoverySuggestion = "Verify that $className has not been modified since it was generated.",
+                cause = error
+            )
+        }
+
+        // Invoked with a null receiver below, so a non-static accessor would fail as an unhelpful
+        // NullPointerException rather than as the configuration problem it is.
+        if (!Modifier.isStatic(accessor.modifiers)) {
+            throw AppSyncInvalidConfigException(
+                message = "The $ACCESSOR_NAME() method on $className is not static.",
+                recoverySuggestion = "Verify that $className has not been modified since it was generated."
+            )
+        }
+
+        val provider = try {
+            accessor.invoke(null)
+        } catch (error: IllegalAccessException) {
+            throw AppSyncInvalidConfigException(
+                message = "The $ACCESSOR_NAME() method on $className is not accessible.",
+                recoverySuggestion = "Verify that $className has not been modified since it was generated.",
+                cause = error
+            )
+        } catch (error: InvocationTargetException) {
+            throw AppSyncUnknownException(
+                message = "Calling $ACCESSOR_NAME() on $className threw ${error.targetException}.",
+                cause = error.targetException ?: error
+            )
+        }
+
+        return provider as? ModelProvider ?: throw AppSyncInvalidConfigException(
+            message = "The $ACCESSOR_NAME() method on $className returned no model provider.",
+            recoverySuggestion = "Verify that $className has not been modified since it was generated."
+        )
+    }
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRelationshipTypeAdapterFactory.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncRelationshipTypeAdapterFactory.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.LoadedModelReferenceImpl
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelField
+import com.amplifyframework.core.model.ModelIdentifier
+import com.amplifyframework.core.model.ModelSchema
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.TypeAdapter
+import com.google.gson.TypeAdapterFactory
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import java.lang.reflect.Field
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Fills in the relationship fields a response did not carry.
+ *
+ * A relationship the selection set did not ask for is absent from the payload, so the model arrives with
+ * that field null. What the absence means depends on the relationship:
+ *
+ *  - a related model came with no key to fetch it by, so there is nothing to defer: the field becomes a
+ *    reference that is already loaded, holding null.
+ *  - a related list is found by the parent's own key, which the response does carry, so the field becomes
+ *    a list that fetches its pages when the caller asks for one.
+ *
+ * A field the response did populate holds what the caller asked for, and is left alone.
+ *
+ * The adapter that would otherwise have read the type is wrapped rather than replaced: the delegate does
+ * all of the reading, and only the fields it left null are filled in afterwards.
+ */
+internal class AppSyncRelationshipTypeAdapterFactory(
+    private val loader: AppSyncModelLoader,
+    private val schemaRegistry: AppSyncSchemaRegistry
+) : TypeAdapterFactory {
+
+    // Derived once per class rather than once per instance: a response carrying a list of models would
+    // otherwise reflect over the same class for every item in it.
+    private val schemas = ConcurrentHashMap<Class<out Model>, ModelSchema>()
+
+    override fun <T> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T> {
+        val delegate = gson.getDelegateAdapter(this, type)
+
+        return object : TypeAdapter<T>() {
+            override fun write(out: JsonWriter, value: T) = delegate.write(out, value)
+
+            override fun read(reader: JsonReader): T {
+                val value = delegate.read(reader)
+                // This is consulted for every type the client reads, so anything that is not a model is
+                // handed straight back without a schema being looked at at all.
+                (value as? Model)?.let { fillAbsentRelationships(it) }
+                return value
+            }
+        }
+    }
+
+    private fun fillAbsentRelationships(parent: Model) {
+        val schema = schemaOrNull(parent.javaClass) ?: return
+
+        schema.fields.values.forEach { field ->
+            when {
+                field.isModelReference -> parent.fillIfAbsent(field.name) { LoadedModelReferenceImpl<Model>() }
+                field.isModelList -> parent.fillIfAbsent(field.name) { lazyListFor(parent, field) }
+            }
+        }
+    }
+
+    /**
+     * Builds the list that fetches the related models on demand.
+     *
+     * The query is filtered by the foreign key fields on the child that point back at the parent, which
+     * the child's association to the parent names. Those names line up positionally with the parent's
+     * identifying values: one for a single primary key, and the partition key followed by the sort keys
+     * for a composite one.
+     *
+     * Null when the list cannot be identified, which leaves the field null.
+     */
+    private fun lazyListFor(parent: Model, field: ModelField): AppSyncLazyModelList<Model>? {
+        val childSchema = schemaRegistry.schemaFor(field.targetType)
+        val targetNames = childSchema.associations.values
+            // TODO: this picks arbitrarily when a child declares two associations back to the same parent
+            //  type, so one of the two lists would be keyed wrongly. The parent field's own association
+            //  names the child field via associatedName, which resolves it exactly; needs a fixture with
+            //  two such associations to test.
+            .firstOrNull { it.associatedType == parent.modelName }
+            ?.targetNames
+            ?.toList()
+            .orEmpty()
+
+        if (targetNames.isEmpty()) {
+            throw AppSyncInvalidConfigException(
+                message = "${field.targetType} declares no relationship back to ${parent.modelName}, so the " +
+                    "related ${field.name} cannot be identified.",
+                recoverySuggestion = "Regenerate the models so that ${field.targetType} and " +
+                    "${parent.modelName} describe the same relationship."
+            )
+        }
+
+        // Nothing to filter the child query by, and an unfiltered query would answer with every child
+        // rather than this parent's. The field is left null instead, so the absence stays visible.
+        val identifiers = parent.identifyingValuesOrNull() ?: return null
+
+        if (targetNames.size > identifiers.size) {
+            throw AppSyncInvalidConfigException(
+                message = "${field.targetType} points back at ${parent.modelName} through ${targetNames.size} " +
+                    "fields, but ${parent.modelName} is identified by ${identifiers.size}.",
+                recoverySuggestion = "Regenerate the models so that ${field.targetType} and " +
+                    "${parent.modelName} describe the same primary key."
+            )
+        }
+
+        return AppSyncLazyModelList(childSchema.modelClass, targetNames.zip(identifiers).toMap(), loader)
+    }
+
+    /**
+     * A type whose schema cannot be derived carries no relationship metadata to act on, so it is handed
+     * back as it was read rather than failing a response that is otherwise complete.
+     */
+    private fun schemaOrNull(modelClass: Class<out Model>): ModelSchema? = schemas[modelClass]
+        ?: runCatching { ModelSchema.fromModelClass(modelClass) }
+            .getOrNull()
+            ?.also { schemas[modelClass] = it }
+
+    companion object {
+        fun register(builder: GsonBuilder, loader: AppSyncModelLoader, schemaRegistry: AppSyncSchemaRegistry) {
+            builder.registerTypeAdapterFactory(AppSyncRelationshipTypeAdapterFactory(loader, schemaRegistry))
+        }
+    }
+}
+
+/** Writes [newValue] to the named field when it is null, and leaves it alone when it is not. */
+private fun Model.fillIfAbsent(name: String, newValue: () -> Any?) {
+    val field = javaClass.relationshipField(name) ?: return
+    if (field.get(this) != null) return
+    newValue()?.let { field.set(this, it) }
+}
+
+/**
+ * Finds the field a schema entry names, searching up the hierarchy the schema itself was derived from. A
+ * name with no field behind it is skipped, since there is nothing to write to.
+ */
+private fun Class<*>.relationshipField(name: String): Field? = generateSequence(this) { it.superclass }
+    .flatMap { it.declaredFields.asSequence() }
+    .firstOrNull { it.name == name }
+    ?.apply { isAccessible = true }
+
+/**
+ * The values that identify this model, in the order a composite key declares them: the partition key
+ * first, then the sort keys.
+ *
+ * Null when a value is missing, which is what a response that did not select the primary key leaves
+ * behind. Reading the key is guarded because a model missing it reports that by failing rather than by
+ * answering with null.
+ */
+private fun Model.identifyingValuesOrNull(): List<Any>? {
+    val identifier = runCatching { resolveIdentifier() }.getOrNull() ?: return null
+    val values = when (identifier) {
+        is ModelIdentifier<*> -> listOf(identifier.key()) + identifier.sortedKeys()
+        else -> listOf(identifier.toString())
+    }
+    return if (values.any { it == null }) null else values.filterNotNull()
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncResponseDeserializer.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncResponseDeserializer.kt
@@ -19,6 +19,7 @@ import com.amplifyframework.api.graphql.GraphQLRequest
 import com.amplifyframework.api.graphql.GraphQLResponse
 import com.amplifyframework.api.graphql.PaginatedResult
 import com.amplifyframework.util.TypeMaker
+import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
@@ -30,13 +31,12 @@ import java.lang.reflect.Type
 /**
  * Turns an AppSync JSON response body into a typed [GraphQLResponse].
  *
- * Reports failure as an [AppSyncDeserializationException]. Lazily-loaded model lists and pages are not
- * covered.
+ * Reports failure as an [AppSyncDeserializationException].
+ *
+ * Holds the client's [Gson] rather than a shared one, because the adapters that deserialize a lazily
+ * loaded relationship have to be able to issue a request through that client.
  */
-internal object AppSyncResponseDeserializer {
-
-    private const val ITEMS_KEY = "items"
-    private const val NEXT_TOKEN_KEY = "nextToken"
+internal class AppSyncResponseDeserializer(private val gson: Gson) {
 
     /**
      * Deserializes [responseJson] into a [GraphQLResponse] of the request's response type.
@@ -56,7 +56,7 @@ internal object AppSyncResponseDeserializer {
         val responseType = TypeMaker.getParameterizedType(GraphQLResponse::class.java, request.responseType)
 
         return try {
-            AppSyncGson.instance.newBuilder()
+            gson.newBuilder()
                 .registerTypeHierarchyAdapter(Iterable::class.java, IterableDeserializer(request))
                 .create()
                 .fromJson(responseJson, responseType)
@@ -130,3 +130,6 @@ internal object AppSyncResponseDeserializer {
         }
     }
 }
+
+private const val ITEMS_KEY = "items"
+private const val NEXT_TOKEN_KEY = "nextToken"

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSchemaRegistry.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSchemaRegistry.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelProvider
+import com.amplifyframework.core.model.ModelSchema
+
+/**
+ * Looks up the schema for a model type, which is what supplies the primary key field names a lazy
+ * reference needs in order to build its own query.
+ *
+ * The schemas are resolved on first lookup, not at construction, so a consumer whose responses carry
+ * no lazily-loaded relationships never triggers the reflective search for the code-generated provider.
+ */
+internal class AppSyncSchemaRegistry(
+    private val modelProvider: () -> ModelProvider = { AppSyncModelProviderLocator.locate() }
+) {
+    private val schemas: Map<String, ModelSchema> by lazy { modelProvider().modelSchemas() }
+
+    fun <M : Model> schemaFor(modelClass: Class<M>): ModelSchema = schemaFor(modelClass.simpleName)
+
+    fun schemaFor(modelName: String): ModelSchema = schemas[modelName] ?: throw AppSyncInvalidConfigException(
+        message = "No schema for the model type $modelName.",
+        recoverySuggestion = "Regenerate the models and verify $modelName is listed in AmplifyModelProvider."
+    )
+}

--- a/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
+++ b/aws-appsync/src/main/java/com/amazonaws/appsync/AppSyncSubscriber.kt
@@ -57,6 +57,7 @@ internal class AppSyncSubscriber(
     private val authorization: AppSyncAuthorization,
     private val decorator: AppSyncRequestDecorator,
     private val httpEndpoint: String,
+    private val deserializer: AppSyncResponseDeserializer,
     private val authModeResolver: AppSyncAuthModeResolver = AppSyncAuthModeResolver(authorization),
     private val claimInjector: AppSyncClaimInjector = AppSyncClaimInjector(),
     private val registrationTimeout: Duration = DEFAULT_REGISTRATION_TIMEOUT,
@@ -238,7 +239,7 @@ internal class AppSyncSubscriber(
                 // Deserialization failure is deliberately swallowed: it is non-terminal, so one
                 // unreadable message must not end a healthy subscription.
                 val deserialization = runCatching {
-                    AppSyncResponseDeserializer.deserialize(request, message.payload)
+                    deserializer.deserialize(request, message.payload)
                 }
                 val response = deserialization.getOrNull()
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncGsonTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncGsonTest.kt
@@ -24,9 +24,11 @@ import org.junit.Test
  */
 class AppSyncGsonTest {
 
+    private val gson = AppSyncGson(RecordingModelLoader()).gson
+
     @Test
     fun `nulls are serialized rather than omitted`() {
-        val json = AppSyncGson.instance.toJson(mapOf("name" to null, "id" to "1"))
+        val json = gson.toJson(mapOf("name" to null, "id" to "1"))
 
         // A mutation that clears a field needs the explicit null: an absent field means "leave
         // unchanged" to AppSync, which is a different request.
@@ -37,6 +39,6 @@ class AppSyncGsonTest {
     fun `temporal adapters are registered`() {
         val date = Temporal.Date("2026-01-02")
 
-        AppSyncGson.instance.toJson(date) shouldBe """"2026-01-02""""
+        gson.toJson(date) shouldBe """"2026-01-02""""
     }
 }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncLazyModelListTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncLazyModelListTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.core.model.ModelPage
+import com.amplifyframework.testmodels.lazy.Blog
+import com.amplifyframework.testmodels.lazy.Post
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests a related list that is fetched a page at a time.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppSyncLazyModelListTest {
+
+    // The foreign key on Post that points back at its Blog, which is what the parent's response carries.
+    private val keyMap = mapOf("blogPostsId" to "b1")
+
+    private val posts = listOf(
+        Post.builder().name("first").blog(Blog.justId("b1")).build(),
+        Post.builder().name("second").blog(Blog.justId("b1")).build()
+    )
+
+    private fun pageLoader(page: ModelPage<Post>?) = RecordingModelLoader { page }
+
+    @Test
+    fun `fetching builds a list query filtered by the parent's key`() = runTest {
+        val loader = pageLoader(AppSyncModelPage(posts, null))
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, loader)
+
+        val page = list.fetchPage()
+
+        page.items shouldContainExactly posts
+        page.hasNextPage shouldBe false
+        val request = loader.requests.single()
+        request.query shouldContain "listPosts"
+        request.variables["filter"].toString() shouldContain "blogPostsId"
+    }
+
+    @Test
+    fun `a page carries the token for the next one`() = runTest {
+        val loader = pageLoader(AppSyncModelPage(posts, AppSyncPaginationToken("cursor-abc")))
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, loader)
+
+        val page = list.fetchPage()
+
+        page.hasNextPage shouldBe true
+        page.nextToken.shouldBeInstanceOf<AppSyncPaginationToken>().nextToken shouldBe "cursor-abc"
+    }
+
+    @Test
+    fun `a supplied token is sent as the cursor for the requested page`() = runTest {
+        val loader = pageLoader(AppSyncModelPage(posts, null))
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, loader)
+
+        list.fetchPage(AppSyncPaginationToken("cursor-abc"))
+
+        loader.requests.single().variables["nextToken"] shouldBe "cursor-abc"
+    }
+
+    @Test
+    fun `every fetch queries, because the caller chooses the page`() = runTest {
+        val loader = pageLoader(AppSyncModelPage(posts, null))
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, loader)
+
+        list.fetchPage()
+        list.fetchPage()
+
+        loader.calls shouldBe 2
+    }
+
+    @Test
+    fun `a failure is reported as an AmplifyException carrying the client's own exception`() = runTest {
+        val cause = AppSyncNetworkException(message = "offline", recoverySuggestion = "reconnect")
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, failingLoader(cause))
+
+        val error = shouldThrow<AmplifyException> { list.fetchPage() }
+
+        error.cause shouldBe cause
+        error.recoverySuggestion shouldBe "reconnect"
+        error.message shouldContain "Post"
+    }
+
+    @Test
+    fun `a response with no page is a failure rather than an empty page`() = runTest {
+        // An empty page and a missing one mean different things: reporting the second as the first would
+        // silently end a caller's pagination loop.
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, pageLoader(null))
+
+        val error = shouldThrow<AmplifyException> { list.fetchPage() }
+
+        error.cause.shouldBeInstanceOf<AppSyncException>()
+    }
+
+    // ── Callback overloads ──────────────────────────────────────────────
+
+    @Test
+    fun `the callback overload delivers a page`() = runTest {
+        val loader = pageLoader(AppSyncModelPage(posts, null))
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, loader, this)
+
+        var delivered: ModelPage<Post>? = null
+        list.fetchPage({ delivered = it }, { })
+        advanceUntilIdle()
+
+        delivered?.items shouldContainExactly posts
+        loader.requests.single().variables["nextToken"].shouldBeNull()
+    }
+
+    @Test
+    fun `the callback overload with a token requests that page`() = runTest {
+        val loader = pageLoader(AppSyncModelPage(posts, null))
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, loader, this)
+
+        var delivered: ModelPage<Post>? = null
+        list.fetchPage(AppSyncPaginationToken("cursor-abc"), { delivered = it }, { })
+        advanceUntilIdle()
+
+        delivered?.items shouldContainExactly posts
+        loader.requests.single().variables["nextToken"] shouldBe "cursor-abc"
+    }
+
+    @Test
+    fun `the callback overload reports a failure on onError`() = runTest {
+        val cause = AppSyncNetworkException(message = "offline", recoverySuggestion = "reconnect")
+        val list = AppSyncLazyModelList(Post::class.java, keyMap, failingLoader(cause), this)
+
+        var reported: AmplifyException? = null
+        var delivered = 0
+        list.fetchPage({ delivered++ }, { reported = it })
+        advanceUntilIdle()
+
+        delivered shouldBe 0
+        reported?.cause shouldBe cause
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncLazyModelReferenceTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncLazyModelReferenceTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.AmplifyException
+import com.amplifyframework.testmodels.lazy.Blog
+import com.amplifyframework.testmodels.lazy.Post
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests a related model that is fetched on first access.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppSyncLazyModelReferenceTest {
+
+    private val keyMap = mapOf("id" to "b1")
+    private val blog = Blog.builder().name("My Blog").build()
+
+    @Test
+    fun `the identifier is the key the parent's response carried`() {
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, RecordingModelLoader())
+
+        reference.getIdentifier() shouldContainExactly keyMap
+    }
+
+    @Test
+    fun `fetching builds a get query for the key`() = runTest {
+        val loader = RecordingModelLoader { blog }
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, loader)
+
+        reference.fetchModel() shouldBe blog
+
+        val request = loader.requests.single()
+        request.query shouldContain "getBlog"
+        request.variables shouldContainExactly mapOf("id" to "b1")
+    }
+
+    @Test
+    fun `an empty key map resolves to null without issuing a query`() = runTest {
+        // An empty key is how the response says the parent has no related model. There is nothing to
+        // identify, so a query could only fail.
+        val loader = RecordingModelLoader { blog }
+        val reference = AppSyncLazyModelReference(Blog::class.java, emptyMap(), loader)
+
+        reference.fetchModel().shouldBeNull()
+
+        loader.calls shouldBe 0
+    }
+
+    @Test
+    fun `a loaded value is cached, so a second fetch does not query again`() = runTest {
+        val loader = RecordingModelLoader { blog }
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, loader)
+
+        reference.fetchModel() shouldBe blog
+        reference.fetchModel() shouldBe blog
+
+        loader.calls shouldBe 1
+    }
+
+    @Test
+    fun `a loaded null is cached, so a second fetch does not query again`() = runTest {
+        // The case a bare nullable cache cannot express: the model genuinely does not exist, which is a
+        // loaded answer rather than an absent one.
+        val loader = RecordingModelLoader { null }
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, loader)
+
+        reference.fetchModel().shouldBeNull()
+        reference.fetchModel().shouldBeNull()
+
+        loader.calls shouldBe 1
+    }
+
+    @Test
+    fun `concurrent fetches issue one query between them`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        val loader = RecordingModelLoader {
+            gate.await()
+            blog
+        }
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, loader)
+
+        val first = async { reference.fetchModel() }
+        val second = async { reference.fetchModel() }
+        // Both are now in flight: one is inside the loader, the other is waiting on the lock.
+        runCurrent()
+        gate.complete(Unit)
+
+        first.await() shouldBe blog
+        second.await() shouldBe blog
+        loader.calls shouldBe 1
+    }
+
+    @Test
+    fun `a failure is reported as an AmplifyException carrying the client's own exception`() = runTest {
+        // The lazy interfaces declare com.amplifyframework.AmplifyException, which the client's own
+        // hierarchy does not extend, so the typed error has to travel as the cause.
+        val cause = AppSyncNetworkException(message = "offline", recoverySuggestion = "reconnect")
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, failingLoader(cause))
+
+        val error = shouldThrow<AmplifyException> { reference.fetchModel() }
+
+        error.cause shouldBe cause
+        error.recoverySuggestion shouldBe "reconnect"
+        error.message shouldContain "Blog"
+    }
+
+    @Test
+    fun `an untyped failure is still reported with a typed cause`() = runTest {
+        val reference = AppSyncLazyModelReference(
+            Blog::class.java,
+            keyMap,
+            failingLoader(IllegalStateException("something odd"))
+        )
+
+        val error = shouldThrow<AmplifyException> { reference.fetchModel() }
+
+        error.cause.shouldBeInstanceOf<AppSyncUnknownException>()
+    }
+
+    @Test
+    fun `a failure is not cached, so a later fetch tries again`() = runTest {
+        var attempts = 0
+        val loader = RecordingModelLoader {
+            attempts++
+            if (attempts == 1) throw AppSyncNetworkException("offline") else blog
+        }
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, loader)
+
+        shouldThrow<AmplifyException> { reference.fetchModel() }
+        reference.fetchModel() shouldBe blog
+
+        loader.calls shouldBe 2
+    }
+
+    // ── Callback overload ───────────────────────────────────────────────
+
+    @Test
+    fun `the callback overload delivers a cached value exactly once`() = runTest {
+        val loader = RecordingModelLoader { blog }
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, loader, this)
+        reference.fetchModel()
+
+        var deliveries = 0
+        reference.fetchModel({ deliveries++ }, { })
+        // Anything the cache-hit path launched would deliver a second time here.
+        advanceUntilIdle()
+
+        deliveries shouldBe 1
+        loader.calls shouldBe 1
+    }
+
+    @Test
+    fun `the callback overload delivers a fetched value`() = runTest {
+        val loader = RecordingModelLoader { blog }
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, loader, this)
+
+        var delivered: Blog? = null
+        reference.fetchModel({ delivered = it }, { })
+        advanceUntilIdle()
+
+        delivered shouldBe blog
+    }
+
+    @Test
+    fun `the callback overload reports a failure on onError`() = runTest {
+        val cause = AppSyncNetworkException(message = "offline", recoverySuggestion = "reconnect")
+        val reference = AppSyncLazyModelReference(Blog::class.java, keyMap, failingLoader(cause), this)
+
+        var reported: AmplifyException? = null
+        var delivered = 0
+        reference.fetchModel({ delivered++ }, { reported = it })
+        advanceUntilIdle()
+
+        delivered shouldBe 0
+        reported?.cause shouldBe cause
+    }
+
+    @Test
+    fun `the callback overload delivers null for an empty key map without querying`() = runTest {
+        val loader = RecordingModelLoader { blog }
+        val reference = AppSyncLazyModelReference(Post::class.java, emptyMap(), loader, this)
+
+        var deliveries = 0
+        var delivered: Post? = null
+        reference.fetchModel(
+            {
+                delivered = it
+                deliveries++
+            },
+            { }
+        )
+        advanceUntilIdle()
+
+        deliveries shouldBe 1
+        delivered.shouldBeNull()
+        loader.calls shouldBe 0
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncModelListDeserializerTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncModelListDeserializerTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.LoadedModelList
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelList
+import com.amplifyframework.core.model.ModelPage
+import com.google.gson.reflect.TypeToken
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+
+/**
+ * Tests the related-list and page deserializers, through [AppSyncGson] rather than in isolation, so the
+ * registration is covered too — an adapter that is written correctly but never registered would pass any
+ * test that instantiated it directly.
+ */
+class AppSyncModelListDeserializerTest {
+
+    private val gson = AppSyncGson.instance
+
+    // ── Loaded lists ────────────────────────────────────────────────────
+
+    @Test
+    fun `a list that arrived in full is loaded, not lazy`() {
+        val list: ModelList<Todo> = gson.fromJson(
+            """{"items":[{"id":"1","name":"first"},{"id":"2","name":"second"}]}""",
+            object : TypeToken<ModelList<Todo>>() {}.type
+        )
+
+        val loaded = list.shouldBeInstanceOf<LoadedModelList<Todo>>()
+        loaded.items shouldHaveSize 2
+        loaded.items[0].name shouldBe "first"
+    }
+
+    @Test
+    fun `an empty items array is a loaded list with no items, not a failure`() {
+        val list: ModelList<Todo> = gson.fromJson(
+            """{"items":[]}""",
+            object : TypeToken<ModelList<Todo>>() {}.type
+        )
+
+        list.shouldBeInstanceOf<LoadedModelList<Todo>>().items.shouldHaveSize(0)
+    }
+
+    // ── Pages ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `a page carries its next token`() {
+        val page: ModelPage<Todo> = gson.fromJson(
+            """{"items":[{"id":"1","name":"first"}],"nextToken":"cursor-abc"}""",
+            object : TypeToken<ModelPage<Todo>>() {}.type
+        )
+
+        page.items shouldHaveSize 1
+        page.hasNextPage shouldBe true
+        page.nextToken.shouldBeInstanceOf<AppSyncPaginationToken>().nextToken shouldBe "cursor-abc"
+    }
+
+    @Test
+    fun `a final page has no next token, which is what ends pagination`() {
+        val page: ModelPage<Todo> = gson.fromJson(
+            """{"items":[{"id":"1","name":"first"}]}""",
+            object : TypeToken<ModelPage<Todo>>() {}.type
+        )
+
+        page.nextToken.shouldBeNull()
+        // hasNextPage is derived, so a caller looping on it terminates without inspecting the token.
+        page.hasNextPage shouldBe false
+    }
+
+    @Test
+    fun `a null next token is treated as absent rather than as a cursor`() {
+        val page: ModelPage<Todo> = gson.fromJson(
+            """{"items":[],"nextToken":null}""",
+            object : TypeToken<ModelPage<Todo>>() {}.type
+        )
+
+        page.nextToken.shouldBeNull()
+        page.hasNextPage shouldBe false
+    }
+
+    // ── Malformed input ─────────────────────────────────────────────────
+
+    @Test
+    fun `a payload with no items array is reported as a deserialization failure`() {
+        val error = shouldThrow<AppSyncDeserializationException> {
+            gson.fromJson<ModelList<Todo>>(
+                """{"unexpected":"shape"}""",
+                object : TypeToken<ModelList<Todo>>() {}.type
+            )
+        }
+
+        error.message shouldContain "items"
+    }
+
+    @Test
+    fun `a list requested without an element type is reported rather than silently empty`() {
+        // The element type is what tells the deserializer how to read each item, so a raw ModelList
+        // cannot be honoured — failing loudly beats returning items deserialized as the wrong type.
+        val error = shouldThrow<AppSyncDeserializationException> {
+            gson.fromJson<ModelList<*>>("""{"items":[]}""", ModelList::class.java)
+        }
+
+        error.message shouldContain "element type"
+    }
+
+    /** A minimal model: these tests exercise the list wrapper, not model deserialization. */
+    private data class Todo(val id: String, val name: String) : Model
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncModelListDeserializerTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncModelListDeserializerTest.kt
@@ -34,7 +34,7 @@ import org.junit.Test
  */
 class AppSyncModelListDeserializerTest {
 
-    private val gson = AppSyncGson.instance
+    private val gson = AppSyncGson(RecordingModelLoader()).gson
 
     // ── Loaded lists ────────────────────────────────────────────────────
 

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncModelProviderLocatorTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncModelProviderLocatorTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelProvider
+import com.amplifyframework.testmodels.lazy.Post
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+
+/**
+ * Tests the reflective search for the code-generated model provider.
+ *
+ * Every case here is a way the class path can differ from what codegen is expected to have produced,
+ * and the point of each assertion is that the failure arrives as a configuration error naming the class
+ * rather than as a reflection exception.
+ */
+class AppSyncModelProviderLocatorTest {
+
+    @Test
+    fun `locates a provider and returns its instance`() {
+        val provider = AppSyncModelProviderLocator.locate(
+            "com.amplifyframework.testmodels.lazy.AmplifyModelProvider"
+        )
+
+        provider.models() shouldContain Post::class.java
+    }
+
+    @Test
+    fun `a missing provider class is a configuration error naming the class`() {
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            AppSyncModelProviderLocator.locate("com.example.NotHere")
+        }
+
+        error.message shouldContain "com.example.NotHere"
+        error.cause.shouldBeInstanceOf<ClassNotFoundException>()
+    }
+
+    @Test
+    fun `a class that is not a model provider is a configuration error`() {
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            AppSyncModelProviderLocator.locate("java.lang.String")
+        }
+
+        error.message shouldContain "does not implement"
+    }
+
+    @Test
+    fun `a provider with no getInstance method is a configuration error`() {
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            AppSyncModelProviderLocator.locate(NoAccessor::class.java.name)
+        }
+
+        error.message shouldContain "getInstance"
+    }
+
+    @Test
+    fun `a non-static getInstance is a configuration error rather than a null receiver failure`() {
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            AppSyncModelProviderLocator.locate(InstanceAccessor::class.java.name)
+        }
+
+        error.message shouldContain "not static"
+    }
+
+    @Test
+    fun `an exception thrown out of getInstance is reported as unknown, not as misconfiguration`() {
+        // The provider is exactly where it should be and has the right shape, so nothing about the
+        // configuration is wrong — the generated code itself failed.
+        val error = shouldThrow<AppSyncUnknownException> {
+            AppSyncModelProviderLocator.locate(ThrowingAccessor::class.java.name)
+        }
+
+        error.cause.shouldBeInstanceOf<IllegalStateException>().message shouldBe "generated code failed"
+    }
+
+    @Test
+    fun `a getInstance that returns nothing is a configuration error`() {
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            AppSyncModelProviderLocator.locate(NullAccessor::class.java.name)
+        }
+
+        error.message shouldContain "returned no model provider"
+    }
+
+    // ── Providers with the shapes the cases above look for ──────────────
+
+    class NoAccessor : ModelProvider {
+        override fun models(): Set<Class<out Model>> = emptySet()
+        override fun version() = "1"
+    }
+
+    class InstanceAccessor : ModelProvider {
+        override fun models(): Set<Class<out Model>> = emptySet()
+        override fun version() = "1"
+
+        @Suppress("unused")
+        fun getInstance(): ModelProvider = this
+    }
+
+    class ThrowingAccessor : ModelProvider {
+        override fun models(): Set<Class<out Model>> = emptySet()
+        override fun version() = "1"
+
+        companion object {
+            @JvmStatic
+            @Suppress("unused")
+            fun getInstance(): ModelProvider = throw IllegalStateException("generated code failed")
+        }
+    }
+
+    class NullAccessor : ModelProvider {
+        override fun models(): Set<Class<out Model>> = emptySet()
+        override fun version() = "1"
+
+        companion object {
+            @JvmStatic
+            @Suppress("unused")
+            fun getInstance(): ModelProvider? = null
+        }
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncModelReferenceDeserializerTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncModelReferenceDeserializerTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.LoadedModelReference
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelReference
+import com.amplifyframework.testmodels.lazy.AmplifyModelProvider
+import com.amplifyframework.testmodels.lazy.Blog
+import com.google.gson.reflect.TypeToken
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests the related-model deserializer, through [AppSyncGson] rather than in isolation, so the
+ * registration is covered too — an adapter that is written correctly but never registered would pass any
+ * test that instantiated it directly.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppSyncModelReferenceDeserializerTest {
+
+    private val loader = RecordingModelLoader { Blog.builder().name("My Blog").build() }
+
+    private val gson = AppSyncGson(
+        loader = loader,
+        schemaRegistry = AppSyncSchemaRegistry { AmplifyModelProvider.getInstance() }
+    ).gson
+
+    private val blogReferenceType = object : TypeToken<ModelReference<Blog>>() {}.type
+
+    @Test
+    fun `a reference carrying more than the key is already loaded`() {
+        val reference: ModelReference<Blog> = gson.fromJson(
+            """{"id":"b1","name":"My Blog"}""",
+            blogReferenceType
+        )
+
+        reference.shouldBeInstanceOf<LoadedModelReference<Blog>>().value?.name shouldBe "My Blog"
+    }
+
+    @Test
+    fun `a reference carrying only the key is lazy, and queries on access`() = runTest {
+        val reference: ModelReference<Blog> = gson.fromJson("""{"id":"b1"}""", blogReferenceType)
+
+        val lazy = reference.shouldBeInstanceOf<AppSyncLazyModelReference<Blog>>()
+        lazy.getIdentifier() shouldContainExactly mapOf("id" to "b1")
+        loader.calls shouldBe 0
+
+        lazy.fetchModel()?.name shouldBe "My Blog"
+        loader.requests.single().variables shouldContainExactly mapOf("id" to "b1")
+    }
+
+    @Test
+    fun `an incomplete key resolves to null rather than querying with a key it does not have`() = runTest {
+        val reference: ModelReference<Blog> = gson.fromJson("""{"name":"My Blog"}""", blogReferenceType)
+
+        reference.shouldBeInstanceOf<AppSyncLazyModelReference<Blog>>().fetchModel().shouldBeNull()
+
+        loader.calls shouldBe 0
+    }
+
+    @Test
+    fun `a null relationship is a null field, so no reference is produced`() {
+        val reference: ModelReference<Blog>? = gson.fromJson("null", blogReferenceType)
+
+        reference.shouldBeNull()
+    }
+
+    @Test
+    fun `a reference requested without a model type is reported rather than silently lazy`() {
+        val error = shouldThrow<AppSyncDeserializationException> {
+            gson.fromJson<ModelReference<*>>("""{"id":"b1"}""", ModelReference::class.java)
+        }
+
+        error.message shouldContain "model type"
+    }
+
+    @Test
+    fun `a model type the provider does not know is reported as a configuration error`() {
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            gson.fromJson<ModelReference<NotGenerated>>(
+                """{"id":"b1"}""",
+                object : TypeToken<ModelReference<NotGenerated>>() {}.type
+            )
+        }
+
+        error.message shouldContain "NotGenerated"
+    }
+
+    private class NotGenerated : Model
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncRelationshipTypeAdapterFactoryTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncRelationshipTypeAdapterFactoryTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.LoadedModelReference
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelProvider
+import com.amplifyframework.core.model.temporal.Temporal
+import com.amplifyframework.testmodels.lazy.AmplifyModelProvider
+import com.amplifyframework.testmodels.lazy.Blog
+import com.amplifyframework.testmodels.lazy.Comment
+import com.amplifyframework.testmodels.lazy.Post
+import com.google.gson.reflect.TypeToken
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests the relationship fields a response leaves out, through [AppSyncGson] rather than in isolation, so
+ * that the registration is covered too — a pass that is written correctly but never registered would pass
+ * any test that invoked it directly.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppSyncRelationshipTypeAdapterFactoryTest {
+
+    private val loader = RecordingModelLoader { AppSyncModelPage(emptyList<Model>(), null) }
+
+    private val gson = gsonFor(AmplifyModelProvider.getInstance())
+
+    private fun gsonFor(provider: ModelProvider) = AppSyncGson(
+        loader = loader,
+        schemaRegistry = AppSyncSchemaRegistry { provider }
+    ).gson
+
+    /** The filter the lazy list built for itself, as the request carries it. */
+    private fun sentFilter() = gson.toJson(loader.requests.single().variables["filter"])
+
+    @Test
+    fun `a list the response left out becomes one that fetches it, keyed by the parent`() = runTest {
+        val blog: Blog = gson.fromJson("""{"id":"b1","name":"My Blog"}""", Blog::class.java)
+
+        val posts = blog.posts.shouldBeInstanceOf<AppSyncLazyModelList<Post>>()
+        // Nothing is fetched until the caller asks: the point of the field is that it defers.
+        loader.calls shouldBe 0
+
+        posts.fetchPage()
+
+        loader.requests.single().query shouldContain "listPosts"
+        sentFilter() shouldContain """"blogPostsId":{"eq":"b1"}"""
+    }
+
+    @Test
+    fun `a related model the response left out is already loaded, holding null`() = runTest {
+        val post: Post = gson.fromJson("""{"id":"p1","name":"My Post"}""", Post::class.java)
+
+        // Loaded rather than lazy: there is no key to fetch by, so the absence is the answer.
+        post.blog.shouldBeInstanceOf<LoadedModelReference<Blog>>().value.shouldBeNull()
+        loader.calls shouldBe 0
+    }
+
+    @Test
+    fun `a relationship the response carried is left as it arrived`() {
+        val post: Post = gson.fromJson(
+            """
+            {"id":"p1","name":"My Post","blog":{"id":"b1"},"comments":{"items":[{"id":"c1","text":"hi"}]}}
+            """.trimIndent(),
+            Post::class.java
+        )
+
+        post.comments.shouldBeInstanceOf<AppSyncLoadedModelList<Comment>>().items.single().text shouldBe "hi"
+        post.blog.shouldBeInstanceOf<AppSyncLazyModelReference<Blog>>()
+            .getIdentifier() shouldContainExactly mapOf("id" to "b1")
+    }
+
+    @Test
+    fun `a composite key parent keys its list by every identifying value, in order`() = runTest {
+        val gson = gsonFor(FixtureModelProvider(setOf(Order::class.java, OrderItem::class.java)))
+
+        val order: Order = gson.fromJson("""{"customerId":"c1","orderNumber":"o9"}""", Order::class.java)
+        order.items.shouldBeInstanceOf<AppSyncLazyModelList<OrderItem>>().fetchPage()
+
+        val filter = gson.toJson(loader.requests.single().variables["filter"])
+        filter shouldContain """"orderCustomerId":{"eq":"c1"}"""
+        filter shouldContain """"orderOrderNumber":{"eq":"o9"}"""
+    }
+
+    @Test
+    fun `a parent whose key the response left out keeps a null list, rather than querying for every child`() {
+        val blog: Blog = gson.fromJson("""{"name":"My Blog"}""", Blog::class.java)
+
+        blog.posts.shouldBeNull()
+        loader.calls shouldBe 0
+    }
+
+    @Test
+    fun `a child the models do not describe is reported as a configuration error`() {
+        val gson = gsonFor(FixtureModelProvider(setOf(Blog::class.java)))
+
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            gson.fromJson("""{"id":"b1","name":"My Blog"}""", Blog::class.java)
+        }
+
+        error.message shouldContain "Post"
+    }
+
+    @Test
+    fun `a relationship only the parent declares is reported as a configuration error`() {
+        val gson = gsonFor(FixtureModelProvider(setOf(Tag::class.java, Entry::class.java)))
+
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            gson.fromJson("""{"id":"t1"}""", Tag::class.java)
+        }
+
+        error.message shouldContain "Entry"
+        error.message shouldContain "Tag"
+    }
+
+    // ── Types with no relationships to fill ─────────────────────────────
+
+    @Test
+    fun `a type that is not a model is read as it would be without the pass`() {
+        val value = gson.fromJson<Map<String, Any>>(
+            """{"name":"x","count":2}""",
+            object : TypeToken<Map<String, Any>>() {}.type
+        )
+
+        value shouldContainExactly mapOf("name" to "x", "count" to 2.0)
+    }
+
+    @Test
+    fun `a type with an adapter of its own still reaches that adapter`() {
+        gson.fromJson(""""2026-01-02"""", Temporal.Date::class.java) shouldBe Temporal.Date("2026-01-02")
+    }
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncResponseDeserializerTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncResponseDeserializerTest.kt
@@ -36,11 +36,13 @@ import org.junit.Test
  */
 class AppSyncResponseDeserializerTest {
 
+    private val deserializer = AppSyncResponseDeserializer(AppSyncGson(RecordingModelLoader()).gson)
+
     // ── Scalars and errors ──────────────────────────────────────────────
 
     @Test
     fun `deserializes data`() {
-        val response = AppSyncResponseDeserializer.deserialize(stringRequest(), """{"data":"hello"}""")
+        val response = deserializer.deserialize(stringRequest(), """{"data":"hello"}""")
 
         response.data shouldBe "hello"
         response.hasErrors() shouldBe false
@@ -48,7 +50,7 @@ class AppSyncResponseDeserializerTest {
 
     @Test
     fun `deserializes errors`() {
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             stringRequest(),
             """{"errors":[{"message":"first"},{"message":"second"}]}"""
         )
@@ -60,7 +62,7 @@ class AppSyncResponseDeserializerTest {
 
     @Test
     fun `deserializes data and errors together`() {
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             stringRequest(),
             """{"data":"partial","errors":[{"message":"a field failed"}]}"""
         )
@@ -71,7 +73,7 @@ class AppSyncResponseDeserializerTest {
 
     @Test
     fun `preserves error locations and extensions`() {
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             stringRequest(),
             """
             {"errors":[{
@@ -96,21 +98,21 @@ class AppSyncResponseDeserializerTest {
         // Gson returns null instead of throwing for an empty string, so this is guarded explicitly.
         // See https://github.com/google/gson/issues/457
         shouldThrow<AppSyncDeserializationException> {
-            AppSyncResponseDeserializer.deserialize(stringRequest(), "")
+            deserializer.deserialize(stringRequest(), "")
         }.message shouldContain "empty"
     }
 
     @Test
     fun `a null body fails`() {
         shouldThrow<AppSyncDeserializationException> {
-            AppSyncResponseDeserializer.deserialize(stringRequest(), null)
+            deserializer.deserialize(stringRequest(), null)
         }
     }
 
     @Test
     fun `a malformed body fails with the response type in the message`() {
         shouldThrow<AppSyncDeserializationException> {
-            AppSyncResponseDeserializer.deserialize(stringRequest(), "{not json")
+            deserializer.deserialize(stringRequest(), "{not json")
         }.message shouldContain "String"
     }
 
@@ -123,7 +125,7 @@ class AppSyncResponseDeserializerTest {
 
     @Test
     fun `deserializes a list from the items wrapper`() {
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             listRequest(),
             """{"data":{"listTodos":{"items":["a","b","c"]}}}"""
         )
@@ -134,7 +136,7 @@ class AppSyncResponseDeserializerTest {
 
     @Test
     fun `deserializes a bare json array under the query field`() {
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             listRequest(),
             """{"data":{"listTodos":["a","b"]}}"""
         )
@@ -144,7 +146,7 @@ class AppSyncResponseDeserializerTest {
 
     @Test
     fun `a nextToken below the root is ignored, because codegen models the field as a plain List`() {
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             listRequest(),
             """{"data":{"listTodos":{"items":["a"],"nextToken":"tok"}}}"""
         )
@@ -155,7 +157,7 @@ class AppSyncResponseDeserializerTest {
     @Test
     fun `an object that is neither an array nor an items wrapper fails`() {
         shouldThrow<AppSyncDeserializationException> {
-            AppSyncResponseDeserializer.deserialize(
+            deserializer.deserialize(
                 listRequest(),
                 """{"data":{"listTodos":{"unexpected":"shape"}}}"""
             )
@@ -165,7 +167,7 @@ class AppSyncResponseDeserializerTest {
     @Test
     fun `a query with more than one top level field fails`() {
         shouldThrow<AppSyncDeserializationException> {
-            AppSyncResponseDeserializer.deserialize(
+            deserializer.deserialize(
                 listRequest(),
                 """{"data":{"listTodos":["a"],"listOther":["b"]}}"""
             )
@@ -176,7 +178,7 @@ class AppSyncResponseDeserializerTest {
 
     @Test
     fun `deserializes a PaginatedResult and its items`() {
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             paginatedRequest(),
             """{"data":{"listTodos":{"items":["a","b"],"nextToken":"tok"}}}"""
         )
@@ -188,7 +190,7 @@ class AppSyncResponseDeserializerTest {
     fun `a PaginatedResult has no next page when the request is not an AppSyncGraphQLRequest`() {
         // Only an AppSyncGraphQLRequest can be rebuilt with a nextToken variable, so a raw request
         // yields items without a follow-up request rather than failing.
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             paginatedRequest(),
             """{"data":{"listTodos":{"items":["a"],"nextToken":"tok"}}}"""
         )
@@ -198,7 +200,7 @@ class AppSyncResponseDeserializerTest {
 
     @Test
     fun `a PaginatedResult with no nextToken has no next page`() {
-        val response = AppSyncResponseDeserializer.deserialize(
+        val response = deserializer.deserialize(
             paginatedRequest(),
             """{"data":{"listTodos":{"items":["a"]}}}"""
         )

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSchemaRegistryTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSchemaRegistryTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.testmodels.lazy.AmplifyModelProvider
+import com.amplifyframework.testmodels.lazy.Post
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.Test
+
+/**
+ * Tests the model schema lookup a lazy relationship depends on for its primary key field names.
+ */
+class AppSyncSchemaRegistryTest {
+
+    private var providerLookups = 0
+    private val registry = AppSyncSchemaRegistry {
+        providerLookups++
+        AmplifyModelProvider.getInstance()
+    }
+
+    @Test
+    fun `finds the schema for a model class`() {
+        registry.schemaFor(Post::class.java).primaryIndexFields shouldContainExactly listOf("id")
+    }
+
+    @Test
+    fun `an unknown model type is reported as a configuration error`() {
+        val error = shouldThrow<AppSyncInvalidConfigException> {
+            registry.schemaFor(NotGenerated::class.java)
+        }
+
+        error.message shouldContain "NotGenerated"
+    }
+
+    @Test
+    fun `the provider is not looked up until a schema is asked for`() {
+        // The lookup is a reflective search of the class path, so a consumer whose responses carry no
+        // lazily loaded relationships must never pay for it.
+        providerLookups shouldBe 0
+
+        registry.schemaFor(Post::class.java)
+        registry.schemaFor(Post::class.java)
+
+        providerLookups shouldBe 1
+    }
+
+    private class NotGenerated : Model
+}

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/AppSyncSubscriberTest.kt
@@ -60,6 +60,7 @@ class AppSyncSubscriberTest {
 
     private val messages = MutableSharedFlow<AppSyncWebSocketMessage.Inbound>(extraBufferCapacity = 64)
     private val sentSlot = slot<AppSyncWebSocketMessage.Outbound>()
+    private val deserializer = AppSyncResponseDeserializer(AppSyncGson(RecordingModelLoader()).gson)
 
     /** The socket's settled terminal state. Completing it is how these tests simulate the socket dying. */
     private val terminated = CompletableDeferred<AppSyncException?>()
@@ -84,6 +85,7 @@ class AppSyncSubscriberTest {
         authorization = authorization,
         decorator = AppSyncRequestDecorator("us-east-1"),
         httpEndpoint = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql",
+        deserializer = deserializer,
         ioDispatcher = ioDispatcher
     )
 
@@ -615,7 +617,8 @@ class AppSyncSubscriberTest {
             },
             authorization = AppSyncAuthorization.Single(AppSyncClientAuthorizer.ApiKey("da2-fakekey")),
             decorator = AppSyncRequestDecorator("us-east-1"),
-            httpEndpoint = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql"
+            httpEndpoint = "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql",
+            deserializer = deserializer
         )
 
         failing.events.test {

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/RecordingModelLoader.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/RecordingModelLoader.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.api.graphql.GraphQLRequest
+
+/**
+ * A loader that records the requests it is asked to send and answers them from [answer].
+ *
+ * The recorded requests are how the tests assert on the query a lazy relationship built for itself,
+ * and [calls] is how they assert that a cached value was served without issuing a request at all.
+ */
+internal class RecordingModelLoader(
+    private val answer: suspend (GraphQLRequest<*>) -> Any? = { null }
+) : AppSyncModelLoader {
+
+    val requests = mutableListOf<GraphQLRequest<*>>()
+
+    val calls: Int
+        get() = requests.size
+
+    @Suppress("UNCHECKED_CAST")
+    override suspend fun <M> load(request: GraphQLRequest<M>): M? {
+        requests += request
+        return answer(request) as M?
+    }
+}
+
+/** A loader that fails every call, for the tests that exercise the error path. */
+internal fun failingLoader(error: Throwable) = RecordingModelLoader { throw error }

--- a/aws-appsync/src/test/java/com/amazonaws/appsync/RelationshipTestModels.kt
+++ b/aws-appsync/src/test/java/com/amazonaws/appsync/RelationshipTestModels.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.appsync
+
+import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelIdentifier
+import com.amplifyframework.core.model.ModelList
+import com.amplifyframework.core.model.ModelProvider
+import com.amplifyframework.core.model.ModelReference
+import com.amplifyframework.core.model.annotations.BelongsTo
+import com.amplifyframework.core.model.annotations.HasMany
+import com.amplifyframework.core.model.annotations.ModelConfig
+import com.amplifyframework.core.model.annotations.ModelField
+import java.io.Serializable
+
+/**
+ * Models for the relationships the code-generated test models do not cover: a parent identified by a
+ * composite key, and a pair whose relationship only one side declares.
+ *
+ * Shaped the way generated models are — annotated fields left null, a `resolveIdentifier` that returns a
+ * [ModelIdentifier] for a composite key — because the field-filling pass reads exactly that shape.
+ */
+
+/** A parent whose primary key is a partition key plus a sort key. */
+@ModelConfig(pluralName = "Orders", hasLazySupport = true)
+internal class Order : Model {
+    @field:ModelField(targetType = "ID", isRequired = true)
+    val customerId: String? = null
+
+    @field:ModelField(targetType = "String", isRequired = true)
+    val orderNumber: String? = null
+
+    @field:ModelField(targetType = "OrderItem")
+    @field:HasMany(associatedWith = "order", type = OrderItem::class)
+    val items: ModelList<OrderItem>? = null
+
+    override fun resolveIdentifier(): Serializable = OrderIdentifier(customerId!!, orderNumber!!)
+
+    internal class OrderIdentifier(customerId: String, orderNumber: String) :
+        ModelIdentifier<Order>(customerId, orderNumber)
+}
+
+/** The child of [Order], pointing back at it through one foreign key field per identifying value. */
+@ModelConfig(pluralName = "OrderItems", hasLazySupport = true)
+internal class OrderItem : Model {
+    @field:ModelField(targetType = "ID", isRequired = true)
+    val id: String? = null
+
+    @field:ModelField(targetType = "Order", isRequired = true)
+    @field:BelongsTo(targetNames = ["orderCustomerId", "orderOrderNumber"], type = Order::class)
+    val order: ModelReference<Order>? = null
+
+    override fun resolveIdentifier(): Serializable = id!!
+}
+
+/** A parent that claims a relationship [Entry] does not declare. */
+@ModelConfig(pluralName = "Tags", hasLazySupport = true)
+internal class Tag : Model {
+    @field:ModelField(targetType = "ID", isRequired = true)
+    val id: String? = null
+
+    @field:ModelField(targetType = "Entry")
+    @field:HasMany(associatedWith = "tag", type = Entry::class)
+    val entries: ModelList<Entry>? = null
+
+    override fun resolveIdentifier(): Serializable = id!!
+}
+
+/** The other side of [Tag]'s relationship, which it does not point back along. */
+@ModelConfig(pluralName = "Entries", hasLazySupport = true)
+internal class Entry : Model {
+    @field:ModelField(targetType = "ID", isRequired = true)
+    val id: String? = null
+
+    override fun resolveIdentifier(): Serializable = id!!
+}
+
+internal class FixtureModelProvider(private val models: Set<Class<out Model>>) : ModelProvider {
+    override fun models() = models
+    override fun version() = "fixture"
+}


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-requests) guidelines

### Description

Fifth in the AppSync client stack, on top of #3425. Lazy loading, in two commits.

**Related lists and pages that arrive complete.** A response carrying one had no adapter registered, so the client could not read it. A full list becomes a `LoadedModelList`; a page becomes a `ModelPage` with an opaque token, absent on the final page — which is what terminates a caller looping on `hasNextPage`.

**A reference that arrives as just its primary key.** It can now be fetched on access. The implementation satisfies the core lazy contract, so a generated model's field accepts it unchanged: those fields are typed as the interface, and the only implementation codegen ever constructs is the loaded one. Nothing generated is touched. The follow-up query comes from the existing key-map request factory rather than being assembled here.

Three behaviours are load-bearing rather than incidental:

- An empty key map means there is no related model, so it resolves to null without issuing a request that could not succeed.
- The cached value is wrapped, because a bare nullable reference cannot distinguish *loaded, and the value is null* from *not loaded yet*.
- Concurrent access serializes on a mutex that re-reads the cache inside the lock, so ten callers arriving together issue one query.

### The exception wrapping, and why

The contract being implemented declares a checked exception from a **different hierarchy** than the client's own — `core`'s `AmplifyException` versus the `foundation` one this client is built on. Both are checked. Throwing the client's type directly would be an undeclared checked exception: legal on the JVM, but invisible to a Java caller's `catch (AmplifyException e)`, and the compiler would never have forced them to handle it.

So failures are wrapped, with the typed exception carried as `cause` and its recovery suggestion preserved. The KDoc states that the cause is always an `AppSyncException`, so a Kotlin caller can still match on the category — which matters here, since a lazy fetch failing on authorisation is exactly a re-authenticate case.

This is worth flagging beyond this PR: the same signature sits on `LazyModelList.fetchPage`, and every V2-era `core` interface the client implements will impose `core`'s exception type the same way. The durable fix is foundation equivalents for these interfaces, which is a spec decision rather than a PR one.

### Known gap

**Lazy lists are implemented and tested but not yet reachable from a response.** A response leaves such a field null, and filling it in needs a post-deserialization pass that derives the foreign-key map from the child schema's associations. That pass is not here, so the type is currently reachable only from tests. The class carries a TODO saying so. The reference path is fully wired.

Flagging it rather than burying it: if you would rather this PR carried only what a response can actually produce, I can drop the list implementation and land it together with its wiring.

### Other notes

Locating the generated model provider gives `AppSyncInvalidConfigException` its first real throw sites — it previously had none. The schema lookup is lazy, so a consumer with no lazy relationships never triggers the class-path search.

The Gson instance is no longer a singleton, because it needs the per-client seam that reaches the query path; the response deserializer stops being one for the same reason. Both take their collaborator with no default, since a default would silently produce a client whose lazy relationships cannot load.

### Testing

266 unit tests, 0 failures — up from 221 at the base. `apiCheck`, `ktlintCheck` and `compileReleaseKotlin` pass; no public API change, as everything added is `internal`.

Two claims were mutation-tested rather than trusted: removing the `return` after a cache-hit callback makes the single-delivery test fail, and removing the re-check inside the lock makes the single-query test fail. Both were reintroduced deliberately, observed failing, and reverted.

Adapter registration is exercised through the client's own Gson instance rather than by constructing adapters directly — one written correctly but never registered would pass any test that instantiated it itself.

### Stack

```
feat/appsync-client
  └─ #3412 multi-auth
       └─ #3419 subscriptions
            └─ #3425 rate limits + logging
                 └─ this PR
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
