### PR TITLE
docs: record which JSON library new code should use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,13 +115,21 @@ Options options = Options.builder().foo("something").build();
 - SHOULD NOT use `GlobalScope` or `runBlocking` (except bridging legacy blocking APIs on background threads)
 - Every `CoroutineScope` MUST have a defined lifetime and be canceled when done
 
-### 8. Custom Annotations
+### 8. JSON Serialization
+- New code MUST use `kotlinx.serialization` (`libs.kotlin.serializationJson`). It is the default for any module that owns its own wire format
+- Gson is REQUIRED where code touches Amplify's model serialization: `aws-api-appsync` exposes Gson in its public API and owns the only adapters for `Temporal.*`, `SerializedModel`, `SerializedCustomType`, `QueryPredicate`, `ModelWithMetadata` and `GraphQLResponse`. This is a dependency constraint, not a preference — porting those adapters is what would remove it
+- Modules on Gson for that reason: `aws-api`, `aws-api-appsync`, `aws-appsync`, `aws-datastore`, `aws-storage-s3`
+- A module SHOULD NOT declare both libraries. Use whichever its dependencies already force, in preference to consistency within a single file
+- Both libraries have tree APIs (`buildJsonObject`, `JsonObject`) and neither requires `@Serializable`. Prefer the tree API for a format that is polymorphic on a type discriminator and must not throw on an unrecognised one — sealed polymorphic decoding fails on an unknown discriminator, so modelling "unknown" as a value needs a custom serializer either way
+- Published modules that map JSON reflectively MUST keep the mapped types under R8, or minification renames the fields (see `aws-api/consumer-rules.pro`)
+
+### 9. Custom Annotations
 - `@InternalAmplifyApi` — ERROR-level opt-in; internal API not for external use
 - `@InternalApiWarning` — WARNING-level opt-in; same intent, softer enforcement
 - `@AmplifyFlutterApi` — ERROR-level opt-in; visible only for Amplify Flutter bridge
 - All three are excluded from the public API surface by the binary compatibility validator
 
-### 9. Testing Patterns
+### 10. Testing Patterns
 - New tests MUST be written in Kotlin
 - Unit tests use backtick names: `` `flush should handle mixed record states correctly` ``
 - Connected Android tests MUST NOT use backticks (unsupported pre-API 30)
@@ -134,14 +142,14 @@ Options options = Options.builder().foo("something").build();
 - Custom test assertions in `testutils` module (e.g., `shouldBeSuccess`, `shouldBeFailure`)
 - Connected Android tests MUST extend `DeviceFarmTestBase` to get automatic retries on network errors
 
-### 10. Gradle Build System
+### 11. Gradle Build System
 - New Gradle files MUST use Kotlin DSL (`.gradle.kts`)
 - Build logic shared via convention plugins in `build-logic/plugins/` — NOT via `subprojects`/`allprojects`
 - Convention plugins are hierarchical: `amplify.android.library` applies `amplify.kotlin` which applies `amplify.ktlint`
 - All dependencies declared in `gradle/libs.versions.toml` using type-safe accessors
 - Convention plugins included via `includeBuild("build-logic")` in `settings.gradle.kts`
 
-### 11. Module Structure
+### 12. Module Structure
 Key modules:
 - `core` — Framework categories, plugin interfaces, `AmplifyException` (Java)
 - `core-kotlin` — Kotlin coroutine facades (`suspend fun` wrappers around callback APIs)


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:*

Adds a JSON serialization section to `AGENTS.md`. Documentation only — the rest of the diff is renumbering the sections that follow.

The repo uses two JSON libraries with no written rule, so the choice gets re-litigated per PR. The split turns out not to be arbitrary:

| Library | Modules |
|---|---|
| `kotlinx-serialization-json` (13) | `core` (published in its API), `aws-sdk-appsync-events`, pinpoint ×3, `aws-kinesis`, `aws-connect`, `aws-logging-cloudwatch`, `aws-predictions`, `aws-event-enrichment`, `aws-auth-cognito`, `aws-auth-plugins-core`, `testutils` |
| Gson (8) | `aws-api`, `aws-api-appsync`, `aws-appsync`, `aws-datastore`, `aws-storage-s3`, `maplibre-adapter`, `aws-auth-cognito`, `core` (test-only) |

kotlinx appears wherever a module owns its own wire format. Gson appears wherever code touches Amplify's model serialization — and there it isn't a preference: `aws-api-appsync` declares `api(libs.gson)` and owns the only adapters for `Temporal.*`, `SerializedModel`, `SerializedCustomType`, `QueryPredicate`, `ModelWithMetadata` and `GraphQLResponse`. There are no kotlinx equivalents, so anything depending on that module inherits Gson whether it wants to or not.

The new section records:

- kotlinx.serialization for new code, as the default for a module that owns its wire format
- Gson where the model layer forces it, with the constraint named — and that porting those adapters is what would remove it, rather than leaving a future reader to rediscover why
- a module should not declare both; take whichever its dependencies already force over consistency inside a single file
- neither library requires `@Serializable` to read or build JSON. Both have tree APIs, and the tree API is the better fit for a format that is polymorphic on a type discriminator and must not throw on an unrecognised one, since sealed polymorphic decoding fails there and modelling "unknown" as a value needs a custom serializer either way
- reflective JSON mapping in a published module needs R8 keep rules or minification renames the fields — `aws-api/consumer-rules.pro` exists because an obfuscated bundled `org.json` broke `connection_ack` parsing

*How did you test these changes?*

Documentation only; no code path is touched, so there is nothing to execute. Every factual claim in the section was verified by reading the repo rather than from memory: the module counts come from the `libs.gson` / `kotlin.serializationJson` declarations in each `build.gradle.kts`, and each of the seven adapter classes was located to confirm all of them live in `aws-api-appsync`.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests — n/a, no code changes
- [ ] Added Integration Tests — n/a, no code changes
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
