### PR TITLE
perf: speed up PR verification with debug-only unit tests and the Gradle build cache

### DIFF
--- a/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -14,6 +14,8 @@
  */
 
 import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.variant.HostTestBuilder
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -43,6 +45,16 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 afterEvaluate {
                     val sdkVersionName = findProperty("VERSION_NAME") ?: rootProject.findProperty("VERSION_NAME")
                     this@configure.defaultConfig.buildConfigField("String", "VERSION_NAME", "\"$sdkVersionName\"")
+                }
+            }
+
+            // Unit tests only run against the debug variant. No module declares a
+            // release-specific source set, build type, or BuildConfig field, and R8 does
+            // not apply to JVM unit tests, so the release variant compiled and ran an
+            // identical test suite against identical library code for no added signal.
+            extensions.configure<LibraryAndroidComponentsExtension> {
+                beforeVariants(selector().withBuildType("release")) { variant ->
+                    variant.hostTests[HostTestBuilder.UNIT_TEST_TYPE]?.enable = false
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,3 +34,7 @@ POM_DEVELOPER_ORGANIZATION_URL=http://aws.amazon.com
 android.useAndroidX=true
 android.enableJetifier=true
 
+# Reuse task outputs whose inputs have not changed. CI seeds the cache on main
+# and pull requests restore from it, so a change confined to one module does not
+# re-run compilation and tests for the whole graph.
+org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,6 @@ POM_DEVELOPER_ORGANIZATION=Amazon Web Services
 POM_DEVELOPER_ORGANIZATION_URL=http://aws.amazon.com
 
 android.useAndroidX=true
-android.enableJetifier=true
 
 # Reuse task outputs whose inputs have not changed. CI seeds the cache on main
 # and pull requests restore from it, so a change confined to one module does not


### PR DESCRIPTION
Cuts PR verification wall-clock time. Two independent changes plus one config cleanup.

### 1. Unit tests only run against the debug variant

`testDebugUnitTest` and `testReleaseUnitTest` were both running for all 26 Android
modules. No module declares a release-specific source set, build type, or
`BuildConfigField`, and R8 does not apply to JVM unit tests, so the two runs compiled
and executed identical test code against identical library code.

### 2. Gradle build cache enabled

Every run reported `1924 actionable tasks: 1924 executed` — nothing was ever reused,
so a one-line change recompiled and retested the whole graph. `setup-gradle` already
persists `build-cache-1` and is already read-only on non-default branches, so `main`
seeds the cache and PRs restore from it. No new infrastructure.

### 3. Jetifier disabled

`./gradlew checkJetifier` reports all 29 projects use no legacy support libraries.

## Measured on CI

Each row is a real workflow run on `ubuntu-latest`, timings from `--profile`.

| | unit-tests wall | CPU | actionable tasks | from cache |
|---|---|---|---|---|
| baseline | 16m32s | 2185s | 1924 | 0 |
| + debug-only tests | 11m02s | 1514s | 1297 | 0 |
| + build cache (cold) | 9m02s | 1296s | 1297 | 338 |
| + build cache (warm, no-op) | 1m08s | — | 1297 | 803 |
| + build cache, one-module change | **1m08s** | — | 1297 | **799** |

The build cache helps even on a cold run: debug and release compilations of identical
sources hash to the same key, so the second is a hit within the same build.

## Verification that the gate still gates

- **Coverage unchanged.** Kover line coverage 62.89% → 62.88–62.90% across every run,
  with identical counter totals (33834 lines, 2691 classes, 180 packages). Kover merges
  the release classes with debug by class ID, so dropping release test data changes nothing.
- **Test reports still produced on cache hits.** A fully-cached run restored 361 JUnit
  XML files, so the annotator still has input.
- **Task counts confirmed locally.** `testReleaseUnitTest` 26 → 0; `testDebugUnitTest`
  unchanged.

## Notes for reviewers

- The `enableUnitTest` property AGP suggests first is deprecated and removed in AGP 9.0;
  this uses `hostTests[HostTestBuilder.UNIT_TEST_TYPE].enable` instead.
- `scope-check` (~2.9m) is now the workflow's critical path and is unaffected by these
  changes. Follow-up.
