### PR TITLE
test: make TargetingClient endpoint update tests deterministic

### DIFF
--- a/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/ConstructTargetingClasses.kt
+++ b/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/ConstructTargetingClasses.kt
@@ -29,6 +29,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import java.util.Locale
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 internal fun constructSharedPreferences(): SharedPreferences =
     ApplicationProvider.getApplicationContext<Context>().getSharedPreferences(
@@ -80,7 +83,13 @@ internal fun constructPinpointClient(): PinpointClient {
     return pinpointClient
 }
 
-internal fun constructTargetingClient(): TargetingClient {
+// TargetingClient dispatches its updateEndpoint call with coroutineScope.launch, so a caller that
+// verifies the call has to supply a dispatcher the test controls. UnconfinedTestDispatcher runs the
+// launched coroutine eagerly, so the call has happened by the time the client method returns.
+@OptIn(ExperimentalCoroutinesApi::class)
+internal fun constructTargetingClient(
+    coroutineDispatcher: CoroutineDispatcher = UnconfinedTestDispatcher()
+): TargetingClient {
     setup()
     val prefs = constructSharedPreferences()
     return TargetingClient(
@@ -89,6 +98,7 @@ internal fun constructTargetingClient(): TargetingClient {
         store,
         prefs,
         appDetails,
-        deviceDetails
+        deviceDetails,
+        coroutineDispatcher
     )
 }

--- a/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/ConstructTargetingClasses.kt
+++ b/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/ConstructTargetingClasses.kt
@@ -83,9 +83,7 @@ internal fun constructPinpointClient(): PinpointClient {
     return pinpointClient
 }
 
-// TargetingClient dispatches its updateEndpoint call with coroutineScope.launch, so a caller that
-// verifies the call has to supply a dispatcher the test controls. UnconfinedTestDispatcher runs the
-// launched coroutine eagerly, so the call has happened by the time the client method returns.
+// Run launched updateEndpoint calls eagerly so they complete before verification.
 @OptIn(ExperimentalCoroutinesApi::class)
 internal fun constructTargetingClient(
     coroutineDispatcher: CoroutineDispatcher = UnconfinedTestDispatcher()

--- a/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/TargetingClientTest.kt
+++ b/aws-pinpoint-core/src/test/java/com/amplifyframework/pinpoint/core/TargetingClientTest.kt
@@ -26,6 +26,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -60,7 +61,7 @@ class TargetingClientTest {
     @Test
     fun testUpdateEndpointProfile() = runTest {
         setup()
-        targetingClient = constructTargetingClient()
+        targetingClient = constructTargetingClient(UnconfinedTestDispatcher(testScheduler))
 
         val expectedToken = "token123"
         every { store.get(TargetingClient.AWS_PINPOINT_PUSHNOTIFICATIONS_DEVICE_TOKEN_KEY) } returns expectedToken
@@ -87,7 +88,7 @@ class TargetingClientTest {
     @Test
     fun testUpdateEndpointProfileOptsIn() = runTest {
         setup()
-        targetingClient = constructTargetingClient()
+        targetingClient = constructTargetingClient(UnconfinedTestDispatcher(testScheduler))
         targetingClient.currentEndpoint().channelType = ChannelType.Gcm
 
         val expectedToken = "token123"
@@ -113,7 +114,7 @@ class TargetingClientTest {
     @Test
     fun testUpdateEndpointProfileOptOutNotTouched() = runTest {
         setup()
-        targetingClient = constructTargetingClient()
+        targetingClient = constructTargetingClient(UnconfinedTestDispatcher(testScheduler))
         targetingClient.currentEndpoint().channelType = null
 
         val expectedToken = ""


### PR DESCRIPTION
`TargetingClientTest.testUpdateEndpointProfileOptsIn` failed on `main` in
[run 34491135422](https://github.com/aws-amplify/amplify-android/actions/runs/34491135422)
with `Verification failed: ... updateEndpoint(matcher<UpdateEndpointRequest>(), any())) was not called`,
then passed on a re-run of the identical commit with no code change.

## Cause

`TargetingClient.executeUpdate` dispatches the SDK call asynchronously:

```kotlin
coroutineScope.launch {
    pinpointClient.updateEndpoint(updateEndpointRequest)
}
```

`coroutineScope` is built from the constructor's `coroutineDispatcher` parameter, which defaults to
`Dispatchers.Default`. `constructTargetingClient()` never supplied one, so the coroutine ran on a
real background thread pool. `runTest` only controls coroutines on the *test* dispatcher, so it
neither advanced nor awaited that work.

Three tests call `updateEndpointProfile()` and then `coVerify` the call with no synchronisation
between them, so they passed only when the background coroutine happened to win the race:

- `testUpdateEndpointProfile`
- `testUpdateEndpointProfileOptsIn`
- `testUpdateEndpointProfileOptOutNotTouched`

## Fix

Supply a dispatcher the test controls. `UnconfinedTestDispatcher` runs the launched coroutine
eagerly on the calling thread, so the SDK call has happened by the time `updateEndpointProfile()`
returns — deterministic by construction rather than by timing.

This is the pattern `AnalyticsClientTest` in this same module already uses for the same reason;
`TargetingClientTest` had simply never adopted it. No production code changes: the constructor
already accepted the parameter.

## Verification, and its limits

- `TargetingClientTest` passes; 8 consecutive `--rerun-tasks` runs all green.
- **The stress run does not prove the fix.** The unpatched code also passed 8/8 locally, so an idle
  workstation cannot reproduce a race that surfaces on a loaded 4-vCPU CI runner. The justification
  is the mechanism plus the observed CI failure, not a local reproduction.
- `ktlintCheck` clean.
