### PR TITLE
chore: add custom Android Lint rule infrastructure

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -112,7 +112,9 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Run static analysis
-        run: ./gradlew ktlintCheck checkstyle apiCheck lint
+        # `:lint-rules:test` is named explicitly because the Kover-based test gate only covers
+        # published modules, and this module is not published.
+        run: ./gradlew ktlintCheck checkstyle apiCheck lint :lint-rules:test
 
   # REQUIRED. Verifies that every external type in each published module's public
   # API surface is resolvable on the compile classpath a downstream consumer

--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -53,11 +53,11 @@ jobs:
       # `koverXmlReport` runs the unit-test suite once and emits the coverage
       # report as a byproduct. Note: Kover only aggregates modules that apply the
       # Kover plugin, which is applied via PublishingConventionPlugin — so only
-      # *published* modules have their tests run here. Every module with test
-      # sources is currently also published, so this is at parity with the old
-      # `./gradlew build` gate. A future non-published module with unit tests
-      # would silently drop out of this gate (see design doc; follow-up: a CI
-      # guard that fails if a module has test sources but no Kover plugin).
+      # *published* modules have their tests run here. `:lint-rules` is the one
+      # module with test sources that is not published; its tests are run
+      # explicitly by the `static-analysis` job instead. Any further such module
+      # must be added there too. Follow-up: a CI guard that fails if a module has
+      # test sources but no Kover plugin, so this can't be forgotten.
       - name: Run tests and generate Kover report
         run: ./gradlew koverXmlReport
 

--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -52,12 +52,10 @@ jobs:
 
       # `koverXmlReport` runs the unit-test suite once and emits the coverage
       # report as a byproduct. Note: Kover only aggregates modules that apply the
-      # Kover plugin, which is applied via PublishingConventionPlugin — so only
-      # *published* modules have their tests run here. `:lint-rules` is the one
-      # module with test sources that is not published; its tests are run
-      # explicitly by the `static-analysis` job instead. Any further such module
-      # must be added there too. Follow-up: a CI guard that fails if a module has
-      # test sources but no Kover plugin, so this can't be forgotten.
+      # Kover plugin. Most get it via PublishingConventionPlugin, so a module that
+      # is not published has to apply `amplify.kover` itself or its tests never run
+      # here — `:lint-rules` does exactly that. Follow-up: a CI guard that fails if
+      # a module has test sources but no Kover plugin, so this can't be forgotten.
       - name: Run tests and generate Kover report
         run: ./gradlew koverXmlReport
 
@@ -112,10 +110,8 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Run static analysis
-        # `:lint-rules:test` is named explicitly because the Kover-based test gate only covers
-        # published modules, and this module is not published. `--continue` keeps a lint finding
-        # anywhere in the repo from aborting the run before the detector tests execute.
-        run: ./gradlew ktlintCheck checkstyle apiCheck lint :lint-rules:test --continue
+        # `--continue` reports findings from every check rather than stopping at the first.
+        run: ./gradlew ktlintCheck checkstyle apiCheck lint --continue
 
   # REQUIRED. Verifies that every external type in each published module's public
   # API surface is resolvable on the compile classpath a downstream consumer

--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -113,8 +113,9 @@ jobs:
 
       - name: Run static analysis
         # `:lint-rules:test` is named explicitly because the Kover-based test gate only covers
-        # published modules, and this module is not published.
-        run: ./gradlew ktlintCheck checkstyle apiCheck lint :lint-rules:test
+        # published modules, and this module is not published. `--continue` keeps a lint finding
+        # anywhere in the repo from aborting the run before the detector tests execute.
+        run: ./gradlew ktlintCheck checkstyle apiCheck lint :lint-rules:test --continue
 
   # REQUIRED. Verifies that every external type in each published module's public
   # API surface is resolvable on the compile classpath a downstream consumer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,14 +28,15 @@
 ### 2. Code Style & Lint Rules
 ```bash
 # Check
-./gradlew ktlintCheck checkstyle apiCheck lint
+./gradlew ktlintCheck checkstyle apiCheck lint :lint-rules:test
 
 # Fix
 ./gradlew ktlintFormat apiDump
 ```
 
 Custom Android Lint rules live in the `lint-rules` module and apply to every module in the build,
-including the non-Android ones. To add one:
+including the non-Android ones (`build-logic` is a separate included build, so it is not covered).
+To add one:
 
 1. Write a `Detector` in `lint-rules/src/main/java/com/amplifyframework/lint/`, exposing its `Issue`
    as `ISSUE` in a companion object.
@@ -46,10 +47,17 @@ including the non-Android ones. To add one:
    than matching names. Also assert the new `ISSUE` is in `AmplifyIssueRegistry().issues`, so step 2
    can't be silently skipped.
 
+Lint also checks the detectors themselves when `./gradlew lint` reaches `:lint-rules:lint`, and two
+of those meta-checks fail the build easily: every line but the last of a multi-line `explanation`
+must end with a `\` line-join marker (`LintImplTextFormat`), and the string must not be
+`.trimIndent()`ed, because Lint trims it lazily (`LintImplTrimIndent`).
+
 Run `./gradlew :lint-rules:test` for the rule's own tests, and `./gradlew lint` to run it against
-the repo. Suppress a genuine exception at the call site with `@SuppressLint("<IssueId>")` in Android
-modules, or a `//noinspection <IssueId>` comment in the non-Android ones where `@SuppressLint` (from
-`android.annotation`) is not on the classpath. Either way, add a comment explaining why.
+the repo. Suppress a genuine exception at the call site: in Kotlin, in any module, use
+`@Suppress("<IssueId>")` — it needs no import, and it is the form the detector tests verify. In
+Java use `@SuppressLint("<IssueId>")`, which needs `android.annotation` on the classpath and so
+works only in Android modules, or a `//noinspection <IssueId>` comment where it is not. Either
+way, add a comment explaining why.
 
 Lint warnings are errors in every module, so an AGP bump that adds a new built-in check can break
 the build in modules that were previously clean — including findings against the shared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ the repo. Suppress a genuine exception at the call site with `@SuppressLint("<Is
 modules, or a `//noinspection <IssueId>` comment in the non-Android ones where `@SuppressLint` (from
 `android.annotation`) is not on the classpath. Either way, add a comment explaining why.
 
+Lint warnings are errors in every module, so an AGP bump that adds a new built-in check can break
+the build in modules that were previously clean — including findings against the shared
+`gradle/libs.versions.toml`. Fix it with a per-issue severity override in the root `lint.xml`, or a
+lint baseline; do not turn `warningsAsErrors` off, which would drop the gate for every module.
+
 Two dependency declarations in `lint-rules/build.gradle.kts` are load-bearing, so do not "simplify"
 them: `lint-api` is declared for both `compileOnly` and `testImplementation` because `lint-tests`
 exposes its own dependencies at runtime scope only, and `test-junit` is declared individually rather

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,43 +34,15 @@
 ./gradlew ktlintFormat apiDump
 ```
 
-Custom Android Lint rules live in the `lint-rules` module and apply to every module in the build,
-including the non-Android ones (`build-logic` is a separate included build, so it is not covered).
-To add one:
+Custom Android Lint rules live in the `lint-rules` module and apply to every module of the main build,
+including the non-Android ones. See [lint-rules/README.md](lint-rules/README.md) for how to add a
+rule, how to suppress a finding, and the gotchas — several of them fail the build in
+non-obvious ways.
 
-1. Write a `Detector` in `lint-rules/src/main/java/com/amplifyframework/lint/`, exposing its `Issue`
-   as `ISSUE` in a companion object.
-2. Add that `ISSUE` to the `issues` list in `AmplifyIssueRegistry` — a rule not listed there does
-   nothing.
-3. Test it in `lint-rules/src/test/java/com/amplifyframework/lint/` with `TestLintTask.lint()`.
-   Include a case that must NOT be flagged, so the test proves the detector resolves types rather
-   than matching names. Also assert the new `ISSUE` is in `AmplifyIssueRegistry().issues`, so step 2
-   can't be silently skipped.
-
-Lint also checks the detectors themselves when `./gradlew lint` reaches `:lint-rules:lint`, and two
-of those meta-checks fail the build easily: every line but the last of a multi-line `explanation`
-must end with a `\` line-join marker (`LintImplTextFormat`), and the string must not be
-`.trimIndent()`ed, because Lint trims it lazily (`LintImplTrimIndent`).
-
-Run `./gradlew :lint-rules:test` for the rule's own tests, and `./gradlew lint` to run it against
-the repo. Suppress a genuine exception at the call site: in Kotlin, in any module, use
-`@Suppress("<IssueId>")` — it needs no import, and it is the form the detector tests verify. In
-Java use `@SuppressLint("<IssueId>")`, which needs `android.annotation` on the classpath and so
-works only in Android modules, or a `//noinspection <IssueId>` comment where it is not. Either
-way, add a comment explaining why.
-
-Lint warnings are errors in every module, so an AGP bump that adds a new built-in check can break
-the build in modules that were previously clean — including findings against the shared
-`gradle/libs.versions.toml`. Fix it with a per-issue severity override in the root `lint.xml`, or a
-lint baseline; do not turn `warningsAsErrors` off, which would drop the gate for every module.
-
-Two dependency declarations in `lint-rules/build.gradle.kts` are load-bearing, so do not "simplify"
-them: `lint-api` is declared for both `compileOnly` and `testImplementation` because `lint-tests`
-exposes its own dependencies at runtime scope only, and `test-junit` is declared individually rather
-than via the `test-unit` bundle because that bundle also pulls in MockK, coroutines-test, Kotest
-assertions, and Turbine — none of which a `TestLintTask`-based test needs. The `lint` version tracks
-`agp` with a major version 23 higher; a check in that build script enforces it, so bump both together
-in `gradle/libs.versions.toml`.
+Two things to know before touching lint: warnings are errors in every module, so an AGP bump adding a
+new built-in check can break previously clean modules (fix with a per-issue override in the root
+`lint.xml` or a baseline, never by disabling `warningsAsErrors`); and the seemingly redundant
+dependency declarations in `lint-rules/build.gradle.kts` are load-bearing — the README says why.
 
 ### 3. Architecture Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,13 @@ including the non-Android ones. To add one:
    nothing.
 3. Test it in `lint-rules/src/test/java/com/amplifyframework/lint/` with `TestLintTask.lint()`.
    Include a case that must NOT be flagged, so the test proves the detector resolves types rather
-   than matching names.
+   than matching names. Also assert the new `ISSUE` is in `AmplifyIssueRegistry().issues`, so step 2
+   can't be silently skipped.
 
 Run `./gradlew :lint-rules:test` for the rule's own tests, and `./gradlew lint` to run it against
-the repo. Suppress a genuine exception at the call site with `@SuppressLint("<IssueId>")` and a
-comment explaining why.
+the repo. Suppress a genuine exception at the call site with `@SuppressLint("<IssueId>")` in Android
+modules, or a `//noinspection <IssueId>` comment in the non-Android ones where `@SuppressLint` (from
+`android.annotation`) is not on the classpath. Either way, add a comment explaining why.
 
 Two dependency declarations in `lint-rules/build.gradle.kts` are load-bearing, so do not "simplify"
 them: `lint-api` is declared for both `compileOnly` and `testImplementation` because `lint-tests`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,34 @@
 ### 2. Code Style & Lint Rules
 ```bash
 # Check
-./gradlew ktlintCheck checkstyle apiCheck
+./gradlew ktlintCheck checkstyle apiCheck lint
 
 # Fix
 ./gradlew ktlintFormat apiDump
 ```
+
+Custom Android Lint rules live in the `lint-rules` module and apply to every module in the build,
+including the non-Android ones. To add one:
+
+1. Write a `Detector` in `lint-rules/src/main/java/com/amplifyframework/lint/`, exposing its `Issue`
+   as `ISSUE` in a companion object.
+2. Add that `ISSUE` to the `issues` list in `AmplifyIssueRegistry` — a rule not listed there does
+   nothing.
+3. Test it in `lint-rules/src/test/java/com/amplifyframework/lint/` with `TestLintTask.lint()`.
+   Include a case that must NOT be flagged, so the test proves the detector resolves types rather
+   than matching names.
+
+Run `./gradlew :lint-rules:test` for the rule's own tests, and `./gradlew lint` to run it against
+the repo. Suppress a genuine exception at the call site with `@SuppressLint("<IssueId>")` and a
+comment explaining why.
+
+Two dependency declarations in `lint-rules/build.gradle.kts` are load-bearing, so do not "simplify"
+them: `lint-api` is declared for both `compileOnly` and `testImplementation` because `lint-tests`
+exposes its own dependencies at runtime scope only, and `test-junit` is declared individually rather
+than via the `test-unit` bundle because that bundle also pulls in MockK, coroutines-test, Kotest
+assertions, and Turbine — none of which a `TestLintTask`-based test needs. The `lint` version tracks
+`agp` with a major version 23 higher; a check in that build script enforces it, so bump both together
+in `gradle/libs.versions.toml`.
 
 ### 3. Architecture Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 ### 2. Code Style & Lint Rules
 ```bash
 # Check
-./gradlew ktlintCheck checkstyle apiCheck lint :lint-rules:test
+./gradlew ktlintCheck checkstyle apiCheck lint
 
 # Fix
 ./gradlew ktlintFormat apiDump

--- a/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/AppSyncProtocol.kt
+++ b/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/AppSyncProtocol.kt
@@ -131,7 +131,6 @@ class AppSyncProtocol internal constructor(
                     subscriptionAck.join()
                 }
             } catch (e: Exception) {
-                println("Error waiting for subscription to be acknowledged: $e")
                 listener.operationError(subscriptionId, null)
             } finally {
                 pendingSubscriptions.remove(subscriptionId)

--- a/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/AppSyncProtocol.kt
+++ b/apollo/apollo-appsync/src/main/java/com/amplifyframework/apollo/appsync/AppSyncProtocol.kt
@@ -130,7 +130,7 @@ class AppSyncProtocol internal constructor(
                 withTimeout(subscriptionAckTimeout.inWholeMilliseconds) {
                     subscriptionAck.join()
                 }
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 listener.operationError(subscriptionId, null)
             } finally {
                 pendingSubscriptions.remove(subscriptionId)

--- a/build-logic/plugins/build.gradle.kts
+++ b/build-logic/plugins/build.gradle.kts
@@ -62,6 +62,10 @@ gradlePlugin {
             id = libs.plugins.amplify.licenses.get().pluginId
             implementationClass = "LicensesConventionPlugin"
         }
+        register("lint") {
+            id = libs.plugins.amplify.lint.get().pluginId
+            implementationClass = "LintConventionPlugin"
+        }
         register("publishing") {
             id = libs.plugins.amplify.publishing.get().pluginId
             implementationClass = "PublishingConventionPlugin"

--- a/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -71,19 +71,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 execution = "ANDROIDX_TEST_ORCHESTRATOR"
             }
 
-            lint {
-                lintConfig = rootProject.file("lint.xml")
-                warningsAsErrors = true
-                abortOnError = true
-                enable += listOf("UnusedResources")
-                disable += listOf(
-                    "GradleDependency",
-                    "NewerVersionAvailable",
-                    "AndroidGradlePluginVersion",
-                    "CredentialDependency"
-                )
-            }
-
             compileOptions {
                 isCoreLibraryDesugaringEnabled = true
             }

--- a/build-logic/plugins/src/main/kotlin/KotlinConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/KotlinConventionPlugin.kt
@@ -33,8 +33,7 @@ class KotlinConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.jvm")
             }
 
-            // Apply other convention plugins. amplify.lint must come after the Java/Kotlin plugin
-            // above, because the standalone Lint plugin only registers its tasks once one is present.
+            // Apply other convention plugins
             apply("amplify.ktlint")
             apply("amplify.lint")
         }

--- a/build-logic/plugins/src/main/kotlin/KotlinConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/KotlinConventionPlugin.kt
@@ -33,8 +33,10 @@ class KotlinConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.jvm")
             }
 
-            // Apply other convention plugins
+            // Apply other convention plugins. amplify.lint must come after the Java/Kotlin plugin
+            // above, because the standalone Lint plugin only registers its tasks once one is present.
             apply("amplify.ktlint")
+            apply("amplify.lint")
         }
 
         with(target) {

--- a/build-logic/plugins/src/main/kotlin/KotlinMultiplatformConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/KotlinMultiplatformConventionPlugin.kt
@@ -28,8 +28,8 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
         with(target.pluginManager) {
             apply("org.jetbrains.kotlin.multiplatform")
             apply("com.android.kotlin.multiplatform.library")
-            apply("com.android.lint")
             apply("amplify.ktlint")
+            apply("amplify.lint")
         }
 
         with(target) {

--- a/build-logic/plugins/src/main/kotlin/LintConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/LintConventionPlugin.kt
@@ -25,10 +25,6 @@ import org.gradle.kotlin.dsl.withType
 
 /**
  * Runs Android Lint, with the project's custom checks, against a module.
- *
- * Android library modules get Lint from the Android plugin, which nests its configuration under the
- * `android` extension. Every other module type needs the standalone `com.android.lint` plugin,
- * which registers `lint` as a top-level extension instead.
  */
 class LintConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {

--- a/build-logic/plugins/src/main/kotlin/LintConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/LintConventionPlugin.kt
@@ -13,13 +13,14 @@
  * permissions and limitations under the License.
  */
 
-import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.Lint
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.project
 import org.gradle.kotlin.dsl.withType
 
 /**
@@ -32,27 +33,47 @@ import org.gradle.kotlin.dsl.withType
 class LintConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            if (pluginManager.hasPlugin("com.android.base")) {
-                extensions.configure<LibraryExtension> { configureLint(lint) }
+            // AGP nests the Lint DSL in the `android` extension, whatever the Android module type.
+            // Everything else needs the standalone plugin, which registers `lint` at the top level.
+            val android = extensions.findByName("android")
+            if (android is CommonExtension<*, *, *, *, *, *>) {
+                configureLint(android.lint)
             } else {
                 pluginManager.apply("com.android.lint")
                 extensions.configure<Lint> { configureLint(this) }
             }
 
-            // The standalone plugin creates `lintChecks` only once a JVM plugin is present, so react
-            // to that rather than depending on an apply order. The checks module is skipped because
-            // it cannot depend on itself.
-            if (path != CHECKS_PROJECT) {
+            // Android modules get `lintChecks` eagerly from AGP, but the standalone plugin only
+            // creates it once a JVM plugin is present — so react to that rather than assume an
+            // apply order. The checks module is skipped because it cannot depend on itself.
+            if (path != LINT_RULES_PATH) {
                 plugins.withType<JavaBasePlugin> {
                     dependencies {
-                        add("lintChecks", project(CHECKS_PROJECT))
+                        add("lintChecks", project(LINT_RULES_PATH))
                     }
                 }
             }
         }
     }
 
+    // The Lint settings shared by every module. Both the Android plugins and the standalone
+    // `com.android.lint` plugin expose this same Lint interface, so one helper serves all of them.
+    private fun Project.configureLint(lint: Lint) {
+        lint.lintConfig = rootProject.file("lint.xml")
+        lint.warningsAsErrors = true
+        lint.abortOnError = true
+        // UnusedResources is a no-op in modules without resources, but keeping one shared list is
+        // the point of this plugin.
+        lint.enable += listOf("UnusedResources")
+        lint.disable += listOf(
+            "GradleDependency",
+            "NewerVersionAvailable",
+            "AndroidGradlePluginVersion",
+            "CredentialDependency"
+        )
+    }
+
     private companion object {
-        const val CHECKS_PROJECT = ":lint-rules"
+        const val LINT_RULES_PATH = ":lint-rules"
     }
 }

--- a/build-logic/plugins/src/main/kotlin/LintConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/LintConventionPlugin.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.dsl.Lint
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.withType
+
+/**
+ * Runs Android Lint, with the project's custom checks, against a module.
+ *
+ * Android library modules get Lint from the Android plugin, which nests its configuration under the
+ * `android` extension. Every other module type needs the standalone `com.android.lint` plugin,
+ * which registers `lint` as a top-level extension instead.
+ */
+class LintConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            if (pluginManager.hasPlugin("com.android.base")) {
+                extensions.configure<LibraryExtension> { configureLint(lint) }
+            } else {
+                pluginManager.apply("com.android.lint")
+                extensions.configure<Lint> { configureLint(this) }
+            }
+
+            // The standalone plugin creates `lintChecks` only once a JVM plugin is present, so react
+            // to that rather than depending on an apply order. The checks module is skipped because
+            // it cannot depend on itself.
+            if (path != CHECKS_PROJECT) {
+                plugins.withType<JavaBasePlugin> {
+                    dependencies {
+                        add("lintChecks", project(CHECKS_PROJECT))
+                    }
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val CHECKS_PROJECT = ":lint-rules"
+    }
+}

--- a/build-logic/plugins/src/main/kotlin/Util.kt
+++ b/build-logic/plugins/src/main/kotlin/Util.kt
@@ -1,4 +1,3 @@
-import com.android.build.api.dsl.Lint
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -31,20 +30,3 @@ internal val optInAnnotations = amplifyInternalMarkers + listOf(
 
 internal val Project.libs
     get(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
-
-/**
- * The Lint settings shared by every module. Both the Android plugins and the standalone
- * `com.android.lint` plugin expose this same [Lint] interface, so one helper serves all of them.
- */
-internal fun Project.configureLint(lint: Lint) = lint.apply {
-    lintConfig = rootProject.file("lint.xml")
-    warningsAsErrors = true
-    abortOnError = true
-    enable += listOf("UnusedResources")
-    disable += listOf(
-        "GradleDependency",
-        "NewerVersionAvailable",
-        "AndroidGradlePluginVersion",
-        "CredentialDependency"
-    )
-}

--- a/build-logic/plugins/src/main/kotlin/Util.kt
+++ b/build-logic/plugins/src/main/kotlin/Util.kt
@@ -1,3 +1,4 @@
+import com.android.build.api.dsl.Lint
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -30,3 +31,20 @@ internal val optInAnnotations = amplifyInternalMarkers + listOf(
 
 internal val Project.libs
     get(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+/**
+ * The Lint settings shared by every module. Both the Android plugins and the standalone
+ * `com.android.lint` plugin expose this same [Lint] interface, so one helper serves all of them.
+ */
+internal fun Project.configureLint(lint: Lint) = lint.apply {
+    lintConfig = rootProject.file("lint.xml")
+    warningsAsErrors = true
+    abortOnError = true
+    enable += listOf("UnusedResources")
+    disable += listOf(
+        "GradleDependency",
+        "NewerVersionAvailable",
+        "AndroidGradlePluginVersion",
+        "CredentialDependency"
+    )
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,8 @@ plugins {
     alias(libs.plugins.amplify.api) apply false
     alias(libs.plugins.amplify.kover) apply false
     alias(libs.plugins.amplify.ktlint) apply false
-    alias(libs.plugins.amplify.lint) apply false
     alias(libs.plugins.amplify.licenses) apply false
+    alias(libs.plugins.amplify.lint) apply false
 
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.kotlin.multiplatform.library) apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ plugins {
     alias(libs.plugins.amplify.api) apply false
     alias(libs.plugins.amplify.kover) apply false
     alias(libs.plugins.amplify.ktlint) apply false
+    alias(libs.plugins.amplify.lint) apply false
     alias(libs.plugins.amplify.licenses) apply false
 
     alias(libs.plugins.kotlin.multiplatform) apply false

--- a/core/src/main/java/com/amplifyframework/logging/JavaLogger.java
+++ b/core/src/main/java/com/amplifyframework/logging/JavaLogger.java
@@ -15,6 +15,7 @@
 
 package com.amplifyframework.logging;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -107,6 +108,7 @@ final class JavaLogger implements Logger {
         log(level, message, null);
     }
 
+    @SuppressLint("AmplifyPrintln") // Writing to stdout is this Logger implementation's purpose.
     private void log(@NonNull LogLevel level, @Nullable String message, @Nullable Throwable throwable) {
         StringBuilder lineBuilder = new StringBuilder()
                 .append(level)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,9 +38,8 @@ kotlin-serialization = "1.6.0"
 kover = "0.9.9"
 ktlint = "14.2.0"
 licensee = "1.14.1"
-# Lint ships from the same source tree as AGP with a major version 23 higher, so AGP 8.11.1 pairs
-# with Lint 31.11.1. Bump this in lockstep with `agp` — a mismatch fails the build with a Lint API
-# version error.
+# The Lint tooling artifacts share AGP's release train with a major version 23 higher, so AGP 8.11.1
+# pairs with Lint 31.11.1. Enforced by a check in lint-rules/build.gradle.kts.
 lint = "31.11.1"
 litert = "1.4.0"
 maplibre = "11.12.1"
@@ -127,7 +126,7 @@ slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j"}
 sqlcipher= { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher" }
 uuidgen = { module = "com.fasterxml.uuid:java-uuid-generator", version.ref="uuid" }
 
-# Custom Lint checks, used by the :lint-rules module
+# Android Lint check authoring and testing APIs
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,8 +38,8 @@ kotlin-serialization = "1.6.0"
 kover = "0.9.9"
 ktlint = "14.2.0"
 licensee = "1.14.1"
-# The Lint tooling artifacts share AGP's release train with a major version 23 higher, so AGP 8.11.1
-# pairs with Lint 31.11.1. Enforced by a check in lint-rules/build.gradle.kts.
+# The Lint tooling artifacts share AGP's release train with a major version 23 higher, so this must
+# be bumped alongside `agp`. Enforced by a check in lint-rules/build.gradle.kts.
 lint = "31.11.1"
 litert = "1.4.0"
 maplibre = "11.12.1"
@@ -116,6 +116,8 @@ kotlin-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.r
 kotlin-futures = { module = "androidx.concurrent:concurrent-futures-ktx", version.ref = "androidx-concurrent" }
 kotlin-serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlin-serialization" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref="kotlin" }
+lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
+lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
 litert = { module = "com.google.ai.edge.litert:litert", version.ref = "litert" }
 maplibre-annotations = { module = "org.maplibre.gl:android-plugin-annotation-v9", version.ref = "maplibre-annotations" }
 maplibre-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre" }
@@ -125,10 +127,6 @@ rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j"}
 sqlcipher= { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher" }
 uuidgen = { module = "com.fasterxml.uuid:java-uuid-generator", version.ref="uuid" }
-
-# Android Lint check authoring and testing APIs
-lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
-lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
 
 # Testing libraries
 test-androidx-core = { module = "androidx.test:core", version.ref="androidx-test-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,10 @@ kotlin-serialization = "1.6.0"
 kover = "0.9.9"
 ktlint = "14.2.0"
 licensee = "1.14.1"
+# Lint ships from the same source tree as AGP with a major version 23 higher, so AGP 8.11.1 pairs
+# with Lint 31.11.1. Bump this in lockstep with `agp` — a mismatch fails the build with a Lint API
+# version error.
+lint = "31.11.1"
 litert = "1.4.0"
 maplibre = "11.12.1"
 maplibre-annotations = "3.0.2"
@@ -123,6 +127,10 @@ slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j"}
 sqlcipher= { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher" }
 uuidgen = { module = "com.fasterxml.uuid:java-uuid-generator", version.ref="uuid" }
 
+# Custom Lint checks, used by the :lint-rules module
+lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
+lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
+
 # Testing libraries
 test-androidx-core = { module = "androidx.test:core", version.ref="androidx-test-core" }
 test-androidx-core-ktx = { module = "androidx.test:core-ktx", version.ref="androidx-test-core" }
@@ -188,6 +196,7 @@ amplify-kmp = { id = "amplify.kotlin.multiplatform" }
 amplify-kotlin = { id = "amplify.kotlin" }
 amplify-kover = { id = "amplify.kover" }
 amplify-ktlint = { id = "amplify.ktlint" }
+amplify-lint = { id = "amplify.lint" }
 amplify-android-library = { id = "amplify.android.library" }
 amplify-licenses = { id = "amplify.licenses" }
 amplify-publishing = { id = "amplify.publishing" }

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -20,6 +20,10 @@ including the non-Android ones. (`build-logic` is a separate included build and 
 ./gradlew :core:lint          # or against one module
 ```
 
+These tests are part of the repo-wide `koverXmlReport` gate. That aggregates only modules applying the
+Kover plugin, which most get from `amplify.publishing` — so this module applies `amplify.kover`
+directly, since it is not published. A future unpublished module with tests needs the same.
+
 Lint warnings are errors in every module, so a new built-in check arriving with an AGP bump can break
 the build. The escape hatch is a per-issue severity override in the root `lint.xml`, or a Lint
 baseline — not disabling `warningsAsErrors`.

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -1,0 +1,61 @@
+# Lint Rules
+
+Custom Android Lint checks enforcing this repository's own conventions. Internal only — this module
+is not published, and Lint loads its jar from the build rather than from a consumer's classpath.
+
+The `amplify.lint` convention plugin attaches these checks to every module of the main build,
+including the non-Android ones. (`build-logic` is a separate included build and is not covered.)
+
+## Rules
+
+| Issue id | Severity | Reports |
+|---|---|---|
+| `AmplifyPrintln` | Error | `print`/`println` resolving to `kotlin.io.ConsoleKt` or a `java.io.PrintStream` subclass. Use a `Logger` instead. |
+
+## Running
+
+```bash
+./gradlew :lint-rules:test    # this module's own tests
+./gradlew lint                # run the checks against the whole repo
+./gradlew :core:lint          # or against one module
+```
+
+Lint warnings are errors in every module, so a new built-in check arriving with an AGP bump can break
+the build. The escape hatch is a per-issue severity override in the root `lint.xml`, or a Lint
+baseline — not disabling `warningsAsErrors`.
+
+## Adding a rule
+
+1. Write a `Detector` in `src/main/java/com/amplifyframework/lint/`, exposing its `Issue` as `ISSUE`
+   in a companion object.
+2. Add that `ISSUE` to the `issues` list in `AmplifyIssueRegistry`. A rule missing from that list
+   does nothing.
+3. Test it in `src/test/java/com/amplifyframework/lint/` with `TestLintTask.lint()`, and assert the
+   new `ISSUE` is present in `AmplifyIssueRegistry().issues` so step 2 cannot be silently skipped.
+   Include a case that must *not* be flagged — otherwise the test passes even if the detector only
+   matches method names instead of resolving types.
+
+Run `./gradlew :lint-rules:lint` as well as the tests. `TestLintTask` never lints detector source, so
+Lint's checks-on-checks only run through Gradle, and two of them catch easy mistakes: a multi-line
+`explanation` needs a trailing `\` on every non-final line (`LintImplTextFormat`), and it must not call
+`.trimIndent()`, since Lint trims lazily itself (`LintImplTrimIndent`).
+
+## Suppressing
+
+Suppress a genuine exception at the call site, with a comment explaining why:
+
+- Kotlin: `@Suppress("<IssueId>")`
+- Java: `@SuppressLint("<IssueId>")`, or `//noinspection <IssueId>` in modules where
+  `android.annotation` is not on the classpath.
+
+## Dependencies
+
+Two declarations in `build.gradle.kts` look redundant but are load-bearing:
+
+- `lint-api` is both `compileOnly` and `testImplementation`. Lint supplies it at runtime, and
+  `lint-tests` exposes its own dependencies at runtime scope only, so tests need it declared again.
+- `test-junit` is declared individually rather than via the `test-unit` bundle, whose other members
+  (MockK, coroutines-test, Kotest, Turbine) are unused here.
+
+The `lint` version tracks `agp` with a major version 23 higher; a `check` in `build.gradle.kts`
+enforces the pairing, so bump both together in `gradle/libs.versions.toml`.

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -13,16 +13,28 @@
  * permissions and limitations under the License.
  */
 
-// This module holds the project's custom Android Lint checks. It is intentionally not published,
-// and so does not apply amplify.publishing, amplify.api, or amplify.kover.
+// Custom Android Lint checks. Not published — Lint loads this jar from the build, so it never
+// reaches consumers.
 plugins {
     alias(libs.plugins.amplify.kotlin)
+}
+
+// The runtime copy of the Lint API comes from AGP, not from this module's classpath, so a version
+// that has drifted from AGP compiles cleanly here and then loads against a different runtime —
+// which Lint reports as "usually fine" rather than as an error. Fail configuration instead.
+val agpVersion = libs.versions.agp.get()
+val expectedLintVersion = "${agpVersion.substringBefore('.').toInt() + 23}.${agpVersion.substringAfter('.')}"
+check(libs.versions.lint.get() == expectedLintVersion) {
+    "lint ${libs.versions.lint.get()} does not match agp $agpVersion (expected $expectedLintVersion)"
 }
 
 dependencies {
     // Lint provides this API to checks at runtime. Bundling a second copy breaks check loading.
     compileOnly(libs.lint.api)
 
+    // lint-tests declares its own dependencies at runtime scope only, so the API has to be
+    // requested again to compile tests against it.
+    testImplementation(libs.lint.api)
     testImplementation(libs.lint.tests)
     testImplementation(libs.test.junit)
 }

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// This module holds the project's custom Android Lint checks. It is intentionally not published,
+// and so does not apply amplify.publishing, amplify.api, or amplify.kover.
+plugins {
+    alias(libs.plugins.amplify.kotlin)
+}
+
+dependencies {
+    // Lint provides this API to checks at runtime. Bundling a second copy breaks check loading.
+    compileOnly(libs.lint.api)
+
+    testImplementation(libs.lint.tests)
+    testImplementation(libs.test.junit)
+}
+
+tasks.jar {
+    manifest {
+        // How Lint locates the checks in this jar.
+        attributes("Lint-Registry-v2" to "com.amplifyframework.lint.AmplifyIssueRegistry")
+    }
+}

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -17,6 +17,9 @@
 // reaches consumers.
 plugins {
     alias(libs.plugins.amplify.kotlin)
+    // Kover is normally applied by amplify.publishing, which this module deliberately does not use.
+    // Applied directly so these tests run in the koverXmlReport gate alongside every other module's.
+    alias(libs.plugins.amplify.kover)
 }
 
 // The runtime copy of the Lint API comes from AGP, not from this module's classpath, so a version

--- a/lint-rules/src/main/java/com/amplifyframework/lint/AmplifyIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/amplifyframework/lint/AmplifyIssueRegistry.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.lint
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.client.api.Vendor
+import com.android.tools.lint.detector.api.CURRENT_API
+import com.android.tools.lint.detector.api.Issue
+
+/**
+ * The custom checks this project enforces. Lint finds this class through the `Lint-Registry-v2`
+ * manifest attribute declared in this module's build script; every new detector must be listed in
+ * [issues] to take effect.
+ */
+class AmplifyIssueRegistry : IssueRegistry() {
+
+    override val issues: List<Issue> = listOf(
+        NoPrintlnDetector.ISSUE
+    )
+
+    override val api: Int = CURRENT_API
+
+    override val vendor = Vendor(
+        vendorName = "Amplify Android",
+        identifier = "com.amplifyframework:lint-rules",
+        feedbackUrl = "https://github.com/aws-amplify/amplify-android/issues"
+    )
+}

--- a/lint-rules/src/main/java/com/amplifyframework/lint/NoPrintlnDetector.kt
+++ b/lint-rules/src/main/java/com/amplifyframework/lint/NoPrintlnDetector.kt
@@ -34,6 +34,9 @@ class NoPrintlnDetector : Detector(), SourceCodeScanner {
     override fun getApplicableMethodNames() = listOf("print", "println")
 
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        // Tests may print freely; this rule is about library code.
+        if (context.isTestSource) return
+
         val evaluator = context.evaluator
         val printsToConsole = evaluator.isMemberInClass(method, KOTLIN_CONSOLE_CLASS) ||
             evaluator.isMemberInSubClassOf(method, PRINT_STREAM_CLASS, false)
@@ -54,9 +57,11 @@ class NoPrintlnDetector : Detector(), SourceCodeScanner {
         val ISSUE: Issue = Issue.create(
             id = "AmplifyPrintln",
             briefDescription = "Console printing in library code",
+            // The trailing backslashes are Lint markup meaning "join with the next line". Without
+            // them Lint treats each source newline as a hard break and wraps the text mid-sentence.
             explanation = """
-                Writing to stdout or stderr bypasses the logging configuration, so consumers of
-                the SDK cannot filter, redirect, or disable the output. Emit the message through a
+                Writing to stdout or stderr bypasses the logging configuration, so consumers of \
+                the SDK cannot filter, redirect, or disable the output. Emit the message through a \
                 `Logger` instead, which routes it to the configured logging plugin.
             """,
             category = Category.CORRECTNESS,

--- a/lint-rules/src/main/java/com/amplifyframework/lint/NoPrintlnDetector.kt
+++ b/lint-rules/src/main/java/com/amplifyframework/lint/NoPrintlnDetector.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+
+/**
+ * Reports calls that write directly to the console instead of going through a Logger.
+ */
+class NoPrintlnDetector : Detector(), SourceCodeScanner {
+
+    // Lint consults its method name index for these, rather than visiting every call in the source.
+    override fun getApplicableMethodNames() = listOf("print", "println")
+
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        val evaluator = context.evaluator
+        val printsToConsole = evaluator.isMemberInClass(method, KOTLIN_CONSOLE_CLASS) ||
+            evaluator.isMemberInSubClassOf(method, PRINT_STREAM_CLASS, false)
+
+        // A method merely named print/println is fine; only the console ones are reported.
+        if (!printsToConsole) return
+
+        context.report(ISSUE, node, context.getLocation(node), MESSAGE)
+    }
+
+    companion object {
+        // kotlin.io.println and print compile to static members of this class.
+        private const val KOTLIN_CONSOLE_CLASS = "kotlin.io.ConsoleKt"
+        private const val PRINT_STREAM_CLASS = "java.io.PrintStream"
+
+        private const val MESSAGE = "Do not print to the console in library code. Use a `Logger` instead."
+
+        val ISSUE: Issue = Issue.create(
+            id = "AmplifyPrintln",
+            briefDescription = "Console printing in library code",
+            explanation = """
+                Writing to stdout or stderr bypasses the logging configuration, so consumers of
+                the SDK cannot filter, redirect, or disable the output. Emit the message through a
+                `Logger` instead, which routes it to the configured logging plugin.
+            """,
+            category = Category.CORRECTNESS,
+            priority = 5,
+            severity = Severity.ERROR,
+            implementation = Implementation(NoPrintlnDetector::class.java, Scope.JAVA_FILE_SCOPE)
+        )
+    }
+}

--- a/lint-rules/src/test/java/com/amplifyframework/lint/NoPrintlnDetectorTest.kt
+++ b/lint-rules/src/test/java/com/amplifyframework/lint/NoPrintlnDetectorTest.kt
@@ -155,6 +155,37 @@ class NoPrintlnDetectorTest {
         ).expectClean()
     }
 
+    // This case cannot use the check() helper: reaching the detector's isTestSource guard needs the
+    // driver configured, because otherwise Lint only hands test sources to detectors that declare
+    // Scope.TEST_SOURCES, and this one declares JAVA_FILE_SCOPE. The build sets checkTestSources
+    // false, so the guard is a safety net for the day that changes.
+    @Test
+    fun `allows println in test sources`() {
+        lint()
+            .files(
+                // TestLintTask treats the project's top-level `test` directory as a unit test
+                // source folder, which is what makes isTestSource true for this file. Java rather
+                // than Kotlin because kotlin.io.println does not resolve outside src/.
+                java(
+                    "test/com/amplifyframework/test/WorkerTest.java",
+                    """
+                    package com.amplifyframework.test;
+
+                    class WorkerTest {
+                        void testDoWork() {
+                            System.out.println("hello");
+                        }
+                    }
+                    """
+                ).indented()
+            )
+            .issues(NoPrintlnDetector.ISSUE)
+            .allowMissingSdk()
+            .configureDriver { driver -> driver.checkTestSources = true }
+            .run()
+            .expectClean()
+    }
+
     // Catches the issue being dropped from the registry. It cannot catch a future detector being
     // left unregistered, since it only checks the issue it names.
     @Test

--- a/lint-rules/src/test/java/com/amplifyframework/lint/NoPrintlnDetectorTest.kt
+++ b/lint-rules/src/test/java/com/amplifyframework/lint/NoPrintlnDetectorTest.kt
@@ -19,6 +19,7 @@ import com.android.tools.lint.checks.infrastructure.TestFiles.java
 import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
 import com.android.tools.lint.checks.infrastructure.TestLintResult
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NoPrintlnDetectorTest {
@@ -41,7 +42,16 @@ class NoPrintlnDetectorTest {
                 }
                 """
             ).indented()
-        ).expectErrorCount(1).expectContains("AmplifyPrintln")
+        ).expect(
+            // The one golden assertion, locking the message and the reported location. The other
+            // tests use expectErrorCount because exact report text is brittle across Lint versions.
+            """
+            src/com/amplifyframework/test/test.kt:4: Error: Do not print to the console in library code. Use a Logger instead. [AmplifyPrintln]
+                println("hello")
+                ~~~~~~~~~~~~~~~~
+            1 error
+            """
+        )
     }
 
     @Test
@@ -53,6 +63,21 @@ class NoPrintlnDetectorTest {
 
                 fun doWork() {
                     print("hello")
+                }
+                """
+            ).indented()
+        ).expectErrorCount(1)
+    }
+
+    @Test
+    fun `flags System out println from kotlin`() {
+        check(
+            kotlin(
+                """
+                package com.amplifyframework.test
+
+                fun doWork() {
+                    System.out.println("hello")
                 }
                 """
             ).indented()
@@ -112,6 +137,29 @@ class NoPrintlnDetectorTest {
                 """
             ).indented()
         ).expectClean()
+    }
+
+    @Test
+    fun `honors kotlin Suppress`() {
+        check(
+            kotlin(
+                """
+                package com.amplifyframework.test
+
+                @Suppress("AmplifyPrintln")
+                fun doWork() {
+                    println("hello")
+                }
+                """
+            ).indented()
+        ).expectClean()
+    }
+
+    // Catches the issue being dropped from the registry. It cannot catch a future detector being
+    // left unregistered, since it only checks the issue it names.
+    @Test
+    fun `registry exposes the issue`() {
+        assertTrue(AmplifyIssueRegistry().issues.contains(NoPrintlnDetector.ISSUE))
     }
 
     private companion object {

--- a/lint-rules/src/test/java/com/amplifyframework/lint/NoPrintlnDetectorTest.kt
+++ b/lint-rules/src/test/java/com/amplifyframework/lint/NoPrintlnDetectorTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amplifyframework.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestFiles.java
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintResult
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class NoPrintlnDetectorTest {
+
+    private fun check(vararg files: TestFile): TestLintResult = lint()
+        .files(*files)
+        .issues(NoPrintlnDetector.ISSUE)
+        .allowMissingSdk()
+        .run()
+
+    @Test
+    fun `flags kotlin println`() {
+        check(
+            kotlin(
+                """
+                package com.amplifyframework.test
+
+                fun doWork() {
+                    println("hello")
+                }
+                """
+            ).indented()
+        ).expectErrorCount(1).expectContains("AmplifyPrintln")
+    }
+
+    @Test
+    fun `flags kotlin print`() {
+        check(
+            kotlin(
+                """
+                package com.amplifyframework.test
+
+                fun doWork() {
+                    print("hello")
+                }
+                """
+            ).indented()
+        ).expectErrorCount(1)
+    }
+
+    @Test
+    fun `flags java System out println`() {
+        check(
+            java(
+                """
+                package com.amplifyframework.test;
+
+                class Worker {
+                    void doWork() {
+                        System.out.println("hello");
+                    }
+                }
+                """
+            ).indented()
+        ).expectErrorCount(1)
+    }
+
+    @Test
+    fun `allows a user-defined function named println`() {
+        check(
+            kotlin(
+                """
+                package com.amplifyframework.test
+
+                private fun println(message: String) = Unit
+
+                fun doWork() {
+                    println("hello")
+                }
+                """
+            ).indented()
+        ).expectClean()
+    }
+
+    @Test
+    fun `honors SuppressLint`() {
+        check(
+            SUPPRESS_LINT_STUB,
+            java(
+                """
+                package com.amplifyframework.test;
+
+                import android.annotation.SuppressLint;
+
+                class Worker {
+                    @SuppressLint("AmplifyPrintln")
+                    void doWork() {
+                        System.out.println("hello");
+                    }
+                }
+                """
+            ).indented()
+        ).expectClean()
+    }
+
+    private companion object {
+        // allowMissingSdk() means the real android.jar is absent, so @SuppressLint would not
+        // resolve without a stub.
+        private val SUPPRESS_LINT_STUB: TestFile = java(
+            """
+            package android.annotation;
+
+            public @interface SuppressLint {
+                String[] value();
+            }
+            """
+        ).indented()
+    }
+}

--- a/maplibre-adapter/build.gradle.kts
+++ b/maplibre-adapter/build.gradle.kts
@@ -22,9 +22,6 @@ apply(from = rootProject.file("configuration/checkstyle.gradle"))
 
 android {
     namespace = "com.amplifyframework.geo.maplibre"
-    lint {
-        disable += "GradleDependency"
-    }
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,6 +55,9 @@ include(":aws-push-notifications-pinpoint")
 include(":aws-storage-s3")
 include(":aws-logging-cloudwatch")
 
+// Build tooling
+include(":lint-rules")
+
 // Test Utilities and assets
 include(":testutils")
 include(":testmodels")


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:*

Adds the infrastructure for repo-specific Android Lint rules, so that a future rule requires writing only a detector and its test — no build wiring. Ships one real rule to prove the pipeline end to end.

**New `:lint-rules` module** holds detectors plus an `IssueRegistry`, which Lint discovers via a `Lint-Registry-v2` jar manifest attribute (rather than `@AutoService`, which would pull KSP in for one annotation). The module is deliberately unpublished and stays out of the API and coverage surfaces by not applying `amplify.publishing`, `amplify.api`, or `amplify.kover`.

**New `amplify.lint` convention plugin** makes Lint's configuration uniform across every module type and attaches the checks via `lintChecks`. This also fixes three pre-existing inconsistencies:

| Module type | Before | After |
|---|---|---|
| Android library | Lint configured inline in `AndroidLibraryConventionPlugin` | shared config |
| KMP (`foundation`, `foundation-bridge`) | bare `com.android.lint`, **no** config — no `lint.xml`, no `warningsAsErrors` | shared config |
| Kotlin-JVM (`annotations`, `apollo-appsync`, `aws-sdk-appsync-core`) | **no Lint at all** | shared config |

Only two convention plugins apply it: `KotlinConventionPlugin` and `KotlinMultiplatformConventionPlugin`. Android library modules inherit it because `amplify.android.library` applies `amplify.kotlin`.

**The rule — `AmplifyPrintln`** (ERROR): reports `print`/`println` that resolve to `kotlin.io.ConsoleKt` or a `java.io.PrintStream` subclass. It resolves types rather than matching names, so a user-defined function called `println` is not flagged.

### Reviewer notes — deliberate decisions you may want to question

**The rule found a real defect on its first run.** `AppSyncProtocol.kt` had a stray debug `println` in a subscription-error path in a published library. This PR deletes it. The failure is still reported through `listener.operationError(subscriptionId, null)` on the following line, so no error *signal* is lost — but the exception *detail* is, because that call passes a `null` payload. Fixing that properly means either giving `apollo-appsync` a logging facility (it has none; its only dependency is `apollo-runtime`) or changing what `operationError` reports to consumers. Both are product decisions outside lint plumbing, so this is left as a **follow-up**.

**`JavaLogger` is suppressed, not fixed.** It writes to stdout by design — that is the whole purpose of that logging plugin — so it carries a method-scoped `@SuppressLint("AmplifyPrintln")` with a comment. Method-scoped rather than line-scoped means a future print added to that same 14-line method would be silently allowed; accepted as a reasonable trade for discoverability.

**Two behaviour changes worth knowing about:**
1. `warningsAsErrors = true` and `abortOnError = true` now reach the KMP modules and the three Kotlin-JVM modules for the first time. A future AGP bump can therefore introduce a built-in check that breaks modules which have never had a Lint gate. `AGENTS.md` documents the escape hatch: a per-issue severity override in the root `lint.xml`, or a Lint baseline — **not** turning `warningsAsErrors` off.
2. `check` (and so `build`) in `annotations`, `apollo-appsync`, and `aws-sdk-appsync-core` now depends on `lint`, which depends on `:lint-rules:jar`. Local builds in those modules get slightly slower and can now fail on Lint.

**Rule scope, to pre-empt "it missed X":** `AmplifyPrintln` intentionally covers only `print`/`println` on `kotlin.io.ConsoleKt` and `PrintStream` subclasses. `System.out.printf`, `PrintWriter.println` (not a `PrintStream` subclass), and `printStackTrace` are *not* caught.

**Caching:** every module's `lintAnalyze*` task now takes the `:lint-rules` jar as a classpath input, so editing a detector invalidates Lint analysis repo-wide. That only triggers on detector changes, not ordinary source edits.

**Version coupling is enforced, not documented.** Lint's version tracks AGP's with a major offset of 23 (AGP 8.11.1 → Lint 31.11.1). This does not fail loudly on its own: because `lint-api` is `compileOnly` and the runtime copy comes from AGP, bumping `agp` and forgetting `lint` leaves the registry compiled against an older Lint, which Lint reports as "usually fine". A `check()` in `lint-rules/build.gradle.kts` derives the expected version from `agp` and fails configuration on a mismatch.

*How did you test these changes?*

- **9 unit tests** for the detector via `TestLintTask`. Coverage includes both flagged forms in both languages, three clean cases (user-defined `println`, Java `@SuppressLint`, Kotlin `@Suppress`), a test-source case, and a registry-membership assertion. One test uses a golden `expect()` locking the message, line, and column; the rest use `expectErrorCount` to stay robust across Lint versions.
- **Mutation-tested the load-bearing assertions.** Forcing the detector's type check to always pass fails exactly the user-defined-`println` test, confirming that test proves type resolution rather than name matching. Deleting the `isTestSource` guard fails exactly the test-source test.
- **Proved the rule fires through Gradle on all three module types**, which the unit tests structurally cannot do since they run the detector in-process. A temporary `println` was added to `annotations` (Kotlin-JVM), `foundation` (KMP `commonMain`), and confirmed against the pre-existing violation in `core` (Android library); each failed with `[AmplifyPrintln from com.amplifyframework:lint-rules]`, then was reverted.
- `./gradlew lint --continue` green across all 35 modules; `ktlintCheck`, `checkstyle`, `apiCheck`, `:apollo-appsync:test` all green.
- Verified `:lint-rules` has no `apiCheck` task and appears in no published POM.

CI note: `:lint-rules:test` is added to the static-analysis job, because `koverXmlReport` is the only test execution in CI and Kover is applied solely by `PublishingConventionPlugin` — so an unpublished module's tests would otherwise never run. The workflow's own comment predicted exactly this case.

*Documentation update required?*
- [x] No

*General Checklist*
- [x] Added Unit Tests
- [ ] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
