### PR TITLE
chore: enable cloudwatch integration tests

### DIFF
--- a/aws-cloudwatch/src/androidTest/kotlin/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientInstrumentationTest.kt
+++ b/aws-cloudwatch/src/androidTest/kotlin/com/amplifyframework/cloudwatch/AmplifyCloudWatchClientInstrumentationTest.kt
@@ -23,6 +23,7 @@ import aws.sdk.kotlin.services.cloudwatchlogs.model.FilterLogEventsRequest
 import com.amplifyframework.annotations.ExperimentalAmplifyApi
 import com.amplifyframework.auth.CognitoCredentialsProvider
 import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
+import com.amplifyframework.cloudwatch.test.R
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.Resources
 import com.amplifyframework.core.configuration.AmplifyOutputs
@@ -81,12 +82,12 @@ class AmplifyCloudWatchClientInstrumentationTest : DeviceFarmTestBase() {
             val context = ApplicationProvider.getApplicationContext<Context>()
             Amplify.Auth.addPlugin(AWSCognitoAuthPlugin())
             Amplify.configure(
-                AmplifyOutputs(Resources.getRawResourceId(context, "amplify_outputs")),
+                AmplifyOutputs(R.raw.amplify_outputs),
                 context
             )
             credentialsProvider = CognitoCredentialsProvider().toAwsCredentialsProvider()
 
-            val config = Resources.readJsonResource(context, "amplifyconfiguration_logging")
+            val config = Resources.readJsonResourceFromId(context, R.raw.amplifyconfiguration_logging)
                 .getJSONObject("cloudWatchClient")
             testRegion = config.getString("region")
             testLogGroupName = config.getString("logGroupName")

--- a/configuration/instrumentation-tests.gradle
+++ b/configuration/instrumentation-tests.gradle
@@ -12,7 +12,8 @@ def module_backends = [
         'core'                  : 'NONE',
         'aws-auth-cognito'      : 'AuthIntegrationTests',
         'aws-sdk-appsync-events': 'NONE',
-        'aws-kinesis'           : 'KinesisIntegrationTests'
+        'aws-kinesis'           : 'KinesisIntegrationTests',
+        'aws-cloudwatch'        : 'NONE'
 ]
 
 def module_subpaths = [

--- a/scripts/pull_backend_config_from_s3
+++ b/scripts/pull_backend_config_from_s3
@@ -69,6 +69,10 @@ readonly config_files=(
     "aws-kinesis/src/androidTest/res/raw/amplify_outputs.json"
     "aws-kinesis/src/androidTest/res/raw/credentials.json"
 
+    # CloudWatch
+    "aws-cloudwatch/src/androidTest/res/raw/amplify_outputs.json"
+    "aws-cloudwatch/src/androidTest/res/raw/amplifyconfiguration_logging.json"
+
     # Events
     "appsync/aws-sdk-appsync-events/src/androidTest/res/raw/amplify_outputs.json"
     "appsync/aws-sdk-appsync-events/src/androidTest/res/raw/credentials.json"


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:* N/A

*Description of changes:*

Enables the `aws-cloudwatch` module's instrumentation (integration) tests in CI.

- **`configuration/instrumentation-tests.gradle`**: Registers `aws-cloudwatch` in the `module_backends` map (with backend `NONE`) so its `androidTest` suite is picked up by the instrumentation test runner.
- **`scripts/pull_backend_config_from_s3`**: Adds the two CloudWatch config files to the S3 pull list so CI can hydrate them into `aws-cloudwatch/src/androidTest/res/raw/` before running the tests:
  - `amplify_outputs.json` (Auth — Cognito user pool + identity pool)
  - `amplifyconfiguration_logging.json` (`cloudWatchClient` config — region, log group, flush settings)

The corresponding config files have been uploaded to the CI config S3 bucket at the matching keys.

*How did you test these changes?*

Ran the `aws-cloudwatch` instrumentation tests (`AmplifyCloudWatchClientInstrumentationTest`, `CloudWatchDatabaseInstrumentationTest`) against a dedicated test backend (Cognito + CloudWatch log group `cloudwatch-integration-test-log-group` in `us-east-1`) with the config files pulled from S3; suite passes.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [x] Added Integration Tests
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Ensure commit message has the appropriate scope (e.g `fix(storage): message`, `feat(auth): message`, `chore(all): message`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
